### PR TITLE
[AMDAIE] Add getExecutableTargets function in AIETarget.cpp

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -23,6 +23,14 @@ class AIETargetBackend final : public IREE::HAL::TargetBackend {
       MLIRContext *context) const override {
     Builder b(context);
     SmallVector<NamedAttribute> configItems;
+
+    // Indicates that the runtime HAL driver operates only in the legacy
+    // synchronous mode.
+    configItems.emplace_back(b.getStringAttr("legacy_sync"), b.getUnitAttr());
+
+    configItems.emplace_back(b.getStringAttr("executable_targets"),
+                             getExecutableTargets(context));
+
     auto configAttr = b.getDictionaryAttr(configItems);
     return IREE::HAL::DeviceTargetAttr::get(
         context, b.getStringAttr(deviceID()), configAttr);
@@ -37,6 +45,31 @@ class AIETargetBackend final : public IREE::HAL::TargetBackend {
                                     IREE::HAL::ExecutableVariantOp variantOp,
                                     OpBuilder &executableBuilder) override {
     return variantOp.emitError() << "AIE serialization NYI";
+  }
+
+ private:
+  ArrayAttr getExecutableTargets(MLIRContext *context) const {
+    SmallVector<Attribute> targetAttrs;
+    // If we had multiple target environments we would generate one target attr
+    // per environment, with each setting its own environment attribute.
+    targetAttrs.push_back(getExecutableTarget(context));
+    return ArrayAttr::get(context, targetAttrs);
+  }
+
+  IREE::HAL::ExecutableTargetAttr getExecutableTarget(
+      MLIRContext *context) const {
+    Builder b(context);
+    SmallVector<NamedAttribute> configItems;
+    // Add some configurations to the `hal.executable.target` attribute.
+    auto addConfig = [&](StringRef name, Attribute value) {
+      configItems.emplace_back(StringAttr::get(context, name), value);
+    };
+    // Set target arch
+    addConfig("target_arch", StringAttr::get(context, "chip-tbd"));
+    auto configAttr = b.getDictionaryAttr(configItems);
+    return IREE::HAL::ExecutableTargetAttr::get(
+        context, b.getStringAttr("amd-aie"), b.getStringAttr("elf"),
+        configAttr);
   }
 };
 


### PR DESCRIPTION
Adds a place holder IREE::HAL::ExecutableTargetAttr to unblock Codegen effort
Fixes: https://github.com/nod-ai/iree-amd-aie/issues/1