### PR TITLE
Add XRT device and wire it up with the driver, add event semaphore

### DIFF
--- a/runtime/src/iree-amd-aie/driver/xrt/CMakeLists.txt
+++ b/runtime/src/iree-amd-aie/driver/xrt/CMakeLists.txt
@@ -22,10 +22,6 @@ iree_add_all_subdirs()
 
 find_package(XRT REQUIRED)
 
-set(xrt_core_LIBRARY XRT::xrt_core)
-set(xrt_coreutil_LIBRARY XRT::xrt_coreutil)
-set(xrt_xilinxopencl_LIBRARY XRT::xilinxopencl)
-
 iree_cc_library(
   NAME
     xrt
@@ -37,7 +33,9 @@ iree_cc_library(
     "direct_allocator.cc"
     "xrt_buffer.h"
     "xrt_buffer.cc"
+    "xrt_device.cc"
     "xrt_driver.cc"
+    "nop_semaphore.cc"
   INCLUDES
     "${XRT_INCLUDE_DIRS}"
   DEPS
@@ -47,8 +45,10 @@ iree_cc_library(
     iree::hal::utils::buffer_transfer
     # TODO (nirvedhmeshram) : Figure out the flatbuffer format for this runtime
     # iree::schemas::xrt_executable_def_c_fbs
-    ${xrt_core_LIBRARY}
-    ${xrt_coreutil_LIBRARY}
-    ${xrt_xilinxopencl_LIBRARY}
+    XRT::xrt_coreutil
+  COPTS
+  # currenly this is needed, it can be removed after this issue is resolved
+  # https://github.com/Xilinx/XRT/issues/7810
+   -frtti
   PUBLIC
 )

--- a/runtime/src/iree-amd-aie/driver/xrt/direct_allocator.h
+++ b/runtime/src/iree-amd-aie/driver/xrt/direct_allocator.h
@@ -17,8 +17,8 @@ extern "C" {
 
 // Creates an XRT memory allocator.
 iree_status_t iree_hal_xrt_allocator_create(
-    xrt::device device, iree_allocator_t host_allocator,
-    iree_hal_allocator_t** out_allocator);
+    iree_hal_device_t* base_device, xrt::device device,
+    iree_allocator_t host_allocator, iree_hal_allocator_t** out_allocator);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree-amd-aie/driver/xrt/nop_semaphore.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/nop_semaphore.cc
@@ -1,0 +1,115 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-amd-aie/driver/xrt/nop_semaphore.h"
+
+#include <stddef.h>
+
+#include "iree/base/api.h"
+#include "iree/hal/utils/semaphore_base.h"
+
+typedef struct iree_hal_xrt_semaphore_t {
+  iree_hal_semaphore_t base;
+  iree_atomic_int64_t value;
+  iree_allocator_t host_allocator;
+} iree_hal_xrt_semaphore_t;
+
+namespace {
+extern const iree_hal_semaphore_vtable_t iree_hal_xrt_semaphore_vtable;
+}  // namespace
+
+static iree_hal_xrt_semaphore_t* iree_hal_xrt_semaphore_cast(
+    iree_hal_semaphore_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_xrt_semaphore_vtable);
+  return (iree_hal_xrt_semaphore_t*)base_value;
+}
+
+iree_status_t iree_hal_xrt_semaphore_create(
+    iree_allocator_t host_allocator, uint64_t initial_value,
+    iree_hal_semaphore_t** out_semaphore) {
+  IREE_ASSERT_ARGUMENT(out_semaphore);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_xrt_semaphore_t* semaphore = NULL;
+  iree_status_t status = iree_allocator_malloc(
+      host_allocator, sizeof(*semaphore), (void**)&semaphore);
+  if (iree_status_is_ok(status)) {
+    iree_hal_semaphore_initialize(&iree_hal_xrt_semaphore_vtable,
+                                  &semaphore->base);
+    semaphore->host_allocator = host_allocator;
+    iree_atomic_store_int64(&semaphore->value, initial_value,
+                            iree_memory_order_release);
+    *out_semaphore = &semaphore->base;
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static void iree_hal_xrt_semaphore_destroy(
+    iree_hal_semaphore_t* base_semaphore) {
+  iree_hal_xrt_semaphore_t* semaphore =
+      iree_hal_xrt_semaphore_cast(base_semaphore);
+  iree_allocator_t host_allocator = semaphore->host_allocator;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_semaphore_deinitialize(&semaphore->base);
+  iree_allocator_free(host_allocator, semaphore);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static iree_status_t iree_hal_xrt_semaphore_query(
+    iree_hal_semaphore_t* base_semaphore, uint64_t* out_value) {
+  iree_hal_xrt_semaphore_t* semaphore =
+      iree_hal_xrt_semaphore_cast(base_semaphore);
+  // TODO: Support semaphores completely.
+  *out_value =
+      iree_atomic_load_int64(&semaphore->value, iree_memory_order_acquire);
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_xrt_semaphore_signal(
+    iree_hal_semaphore_t* base_semaphore, uint64_t new_value) {
+  iree_hal_xrt_semaphore_t* semaphore =
+      iree_hal_xrt_semaphore_cast(base_semaphore);
+  // TODO: Support semaphores completely. Return OK currently as everything is
+  // synchronized for each submit to allow things to run.
+  iree_atomic_store_int64(&semaphore->value, new_value,
+                          iree_memory_order_release);
+  iree_hal_semaphore_poll(&semaphore->base);
+  return iree_ok_status();
+}
+
+static void iree_hal_xrt_semaphore_fail(iree_hal_semaphore_t* base_semaphore,
+                                        iree_status_t status) {
+  iree_hal_xrt_semaphore_t* semaphore =
+      iree_hal_xrt_semaphore_cast(base_semaphore);
+  // TODO: save status and mark timepoint as failed.
+  iree_status_ignore(status);
+  iree_hal_semaphore_poll(&semaphore->base);
+}
+
+static iree_status_t iree_hal_xrt_semaphore_wait(
+    iree_hal_semaphore_t* base_semaphore, uint64_t value,
+    iree_timeout_t timeout) {
+  iree_hal_xrt_semaphore_t* semaphore =
+      iree_hal_xrt_semaphore_cast(base_semaphore);
+  // TODO: Support semaphores completely. Return OK currently as everything is
+  // synchronized for each submit to allow things to run.
+  iree_hal_semaphore_poll(&semaphore->base);
+  return iree_ok_status();
+}
+
+namespace {
+const iree_hal_semaphore_vtable_t iree_hal_xrt_semaphore_vtable = {
+    /*.destroy = */ iree_hal_xrt_semaphore_destroy,
+    /*.query = */ iree_hal_xrt_semaphore_query,
+    /*.signal = */ iree_hal_xrt_semaphore_signal,
+    /*.fail = */ iree_hal_xrt_semaphore_fail,
+    /*.wait = */ iree_hal_xrt_semaphore_wait,
+};
+}  // namespace

--- a/runtime/src/iree-amd-aie/driver/xrt/nop_semaphore.h
+++ b/runtime/src/iree-amd-aie/driver/xrt/nop_semaphore.h
@@ -1,0 +1,27 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_AMD_AIE_DRIVER_XRT_NOP_SEMAPHORE_H_
+#define IREE_AMD_AIE_DRIVER_XRT_NOP_SEMAPHORE_H_
+
+#include <stdint.h>
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+iree_status_t iree_hal_xrt_semaphore_create(
+    iree_allocator_t host_allocator, uint64_t initial_value,
+    iree_hal_semaphore_t** out_semaphore);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_DRIVERS_XRT_NOP_SEMAPHORE_H_

--- a/runtime/src/iree-amd-aie/driver/xrt/xrt_device.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/xrt_device.cc
@@ -1,0 +1,353 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-amd-aie/driver/xrt/xrt_device.h"
+
+#include "iree-amd-aie/driver/xrt/direct_allocator.h"
+#include "iree-amd-aie/driver/xrt/nop_semaphore.h"
+#include "iree/base/api.h"
+#include "iree/base/tracing.h"
+#include "iree/hal/api.h"
+#include "iree/hal/utils/buffer_transfer.h"
+#include "iree/hal/utils/file_transfer.h"
+#include "iree/hal/utils/memory_file.h"
+
+typedef struct iree_hal_xrt_device_t {
+  // Abstract resource used for injecting reference counting and vtable; must be
+  // at offset 0.
+  iree_hal_resource_t resource;
+
+  iree_string_view_t identifier;
+
+  // Original driver that owns this device.
+  iree_hal_driver_t* driver;
+
+  iree_allocator_t host_allocator;
+  iree_hal_allocator_t* device_allocator;
+
+  xrt::device device;
+} iree_hal_xrt_device_t;
+
+namespace {
+extern const iree_hal_device_vtable_t iree_hal_xrt_device_vtable;
+}  // namespace
+
+static iree_hal_xrt_device_t* iree_hal_xrt_device_cast(
+    iree_hal_device_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_xrt_device_vtable);
+  return (iree_hal_xrt_device_t*)base_value;
+}
+
+static iree_status_t iree_hal_xrt_device_create_internal(
+    iree_hal_driver_t* driver, iree_string_view_t identifier,
+    xrt::device xrt_device, iree_allocator_t host_allocator,
+    iree_hal_device_t** out_device) {
+  iree_hal_xrt_device_t* device = NULL;
+
+  iree_host_size_t total_size = iree_sizeof_struct(*device) + identifier.size;
+  IREE_RETURN_IF_ERROR(
+      iree_allocator_malloc(host_allocator, total_size, (void**)&device));
+
+  iree_status_t status =
+      iree_hal_xrt_allocator_create((iree_hal_device_t*)device, xrt_device,
+                                    host_allocator, &device->device_allocator);
+  if (iree_status_is_ok(status)) {
+    iree_hal_resource_initialize(&iree_hal_xrt_device_vtable,
+                                 &device->resource);
+    iree_string_view_append_to_buffer(
+        identifier, &device->identifier,
+        (char*)device + iree_sizeof_struct(*device));
+    device->driver = driver;
+    iree_hal_driver_retain(device->driver);
+    device->host_allocator = host_allocator;
+    device->device = xrt_device;
+
+    *out_device = (iree_hal_device_t*)device;
+  } else {
+    iree_hal_device_release((iree_hal_device_t*)device);
+  }
+  return status;
+}
+
+iree_status_t iree_hal_xrt_device_create(iree_hal_driver_t* driver,
+                                         iree_string_view_t identifier,
+                                         xrt::device device,
+                                         iree_allocator_t host_allocator,
+                                         iree_hal_device_t** out_device) {
+  IREE_ASSERT_ARGUMENT(out_device);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status = iree_hal_xrt_device_create_internal(
+      driver, identifier, device, host_allocator, out_device);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+static void iree_hal_xrt_device_destroy(iree_hal_device_t* base_device) {
+  iree_hal_xrt_device_t* device = iree_hal_xrt_device_cast(base_device);
+  iree_allocator_t host_allocator = iree_hal_device_host_allocator(base_device);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_hal_allocator_release(device->device_allocator);
+  iree_hal_driver_release(device->driver);
+
+  iree_allocator_free(host_allocator, device);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+static iree_string_view_t iree_hal_xrt_device_id(
+    iree_hal_device_t* base_device) {
+  iree_hal_xrt_device_t* device = iree_hal_xrt_device_cast(base_device);
+  return device->identifier;
+}
+
+static iree_allocator_t iree_hal_xrt_device_host_allocator(
+    iree_hal_device_t* base_device) {
+  iree_hal_xrt_device_t* device = iree_hal_xrt_device_cast(base_device);
+  return device->host_allocator;
+}
+
+static iree_hal_allocator_t* iree_hal_xrt_device_allocator(
+    iree_hal_device_t* base_device) {
+  iree_hal_xrt_device_t* device = iree_hal_xrt_device_cast(base_device);
+  return device->device_allocator;
+}
+
+static void iree_hal_xrt_replace_device_allocator(
+    iree_hal_device_t* base_device, iree_hal_allocator_t* new_allocator) {
+  iree_hal_xrt_device_t* device = iree_hal_xrt_device_cast(base_device);
+  iree_hal_allocator_retain(new_allocator);
+  iree_hal_allocator_release(device->device_allocator);
+  device->device_allocator = new_allocator;
+}
+
+static void iree_hal_xrt_replace_channel_provider(
+    iree_hal_device_t* base_device, iree_hal_channel_provider_t* new_provider) {
+  iree_status_from_code(IREE_STATUS_UNIMPLEMENTED);
+}
+
+static iree_status_t iree_hal_xrt_device_trim(iree_hal_device_t* base_device) {
+  iree_hal_xrt_device_t* device = iree_hal_xrt_device_cast(base_device);
+  return iree_hal_allocator_trim(device->device_allocator);
+}
+
+static iree_status_t iree_hal_xrt_device_query_i64(
+    iree_hal_device_t* base_device, iree_string_view_t category,
+    iree_string_view_t key, int64_t* out_value) {
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "unimplmented device i64 query");
+}
+
+static iree_status_t iree_hal_xrt_device_create_channel(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_channel_params_t params, iree_hal_channel_t** out_channel) {
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "collectives not yet supported");
+}
+
+static iree_status_t iree_hal_xrt_device_create_command_buffer(
+    iree_hal_device_t* base_device, iree_hal_command_buffer_mode_t mode,
+    iree_hal_command_category_t command_categories,
+    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t binding_capacity,
+    iree_hal_command_buffer_t** out_command_buffer) {
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "unimplmented command buffer create");
+}
+
+static iree_status_t iree_hal_xrt_device_create_descriptor_set_layout(
+    iree_hal_device_t* base_device,
+    iree_hal_descriptor_set_layout_flags_t flags,
+    iree_host_size_t binding_count,
+    const iree_hal_descriptor_set_layout_binding_t* bindings,
+    iree_hal_descriptor_set_layout_t** out_descriptor_set_layout) {
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "unimplmented descriptor set create");
+}
+
+static iree_status_t iree_hal_xrt_device_create_event(
+    iree_hal_device_t* base_device, iree_hal_event_t** out_event) {
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "unimplmented event create");
+}
+
+static iree_status_t iree_hal_xrt_device_create_executable_cache(
+    iree_hal_device_t* base_device, iree_string_view_t identifier,
+    iree_loop_t loop, iree_hal_executable_cache_t** out_executable_cache) {
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "unimplmented executable cache create");
+}
+
+static iree_status_t iree_hal_xrt_device_import_file(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    iree_hal_memory_access_t access, iree_io_file_handle_t* handle,
+    iree_hal_external_file_flags_t flags, iree_hal_file_t** out_file) {
+  if (iree_io_file_handle_type(handle) !=
+      IREE_IO_FILE_HANDLE_TYPE_HOST_ALLOCATION) {
+    return iree_make_status(
+        IREE_STATUS_UNAVAILABLE,
+        "implementation does not support the external file type");
+  }
+  return iree_hal_memory_file_wrap(
+      queue_affinity, access, handle, iree_hal_device_allocator(base_device),
+      iree_hal_device_host_allocator(base_device), out_file);
+}
+
+static iree_status_t iree_hal_xrt_device_create_pipeline_layout(
+    iree_hal_device_t* base_device, iree_host_size_t push_constants,
+    iree_host_size_t set_layout_count,
+    iree_hal_descriptor_set_layout_t* const* set_layouts,
+    iree_hal_pipeline_layout_t** out_pipeline_layout) {
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "unimplmented pipeline layout create");
+}
+
+static iree_status_t iree_hal_xrt_device_create_semaphore(
+    iree_hal_device_t* base_device, uint64_t initial_value,
+    iree_hal_semaphore_t** out_semaphore) {
+  iree_hal_xrt_device_t* device = iree_hal_xrt_device_cast(base_device);
+  return iree_hal_xrt_semaphore_create(device->host_allocator, initial_value,
+                                       out_semaphore);
+}
+
+static iree_hal_semaphore_compatibility_t
+iree_hal_xrt_device_query_semaphore_compatibility(
+    iree_hal_device_t* base_device, iree_hal_semaphore_t* semaphore) {
+  return IREE_HAL_SEMAPHORE_COMPATIBILITY_NONE;
+}
+
+static iree_status_t iree_hal_xrt_device_queue_alloca(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_allocator_pool_t pool, iree_hal_buffer_params_t params,
+    iree_device_size_t allocation_size,
+    iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "unimplmented queue alloca");
+}
+
+static iree_status_t iree_hal_xrt_device_queue_dealloca(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_buffer_t* buffer) {
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "unimplmented queue dealloca");
+}
+
+static iree_status_t iree_hal_xrt_device_queue_read(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_file_t* source_file, uint64_t source_offset,
+    iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
+    iree_device_size_t length, uint32_t flags) {
+  // TODO: expose streaming chunk count/size options.
+  iree_status_t loop_status = iree_ok_status();
+  iree_hal_file_transfer_options_t options = {
+      /*.loop=*/iree_loop_inline(&loop_status),
+      /*.chunk_count=*/IREE_HAL_FILE_TRANSFER_CHUNK_COUNT_DEFAULT,
+      /*.chunk_size=*/IREE_HAL_FILE_TRANSFER_CHUNK_SIZE_DEFAULT,
+  };
+  IREE_RETURN_IF_ERROR(iree_hal_device_queue_read_streaming(
+      base_device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
+      source_file, source_offset, target_buffer, target_offset, length, flags,
+      options));
+  return loop_status;
+}
+
+static iree_status_t iree_hal_xrt_device_queue_write(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_buffer_t* source_buffer, iree_device_size_t source_offset,
+    iree_hal_file_t* target_file, uint64_t target_offset,
+    iree_device_size_t length, uint32_t flags) {
+  // TODO: expose streaming chunk count/size options.
+  iree_status_t loop_status = iree_ok_status();
+  iree_hal_file_transfer_options_t options = {
+      /*.loop=*/iree_loop_inline(&loop_status),
+      /*.chunk_count=*/IREE_HAL_FILE_TRANSFER_CHUNK_COUNT_DEFAULT,
+      /*.chunk_size=*/IREE_HAL_FILE_TRANSFER_CHUNK_SIZE_DEFAULT,
+  };
+  IREE_RETURN_IF_ERROR(iree_hal_device_queue_write_streaming(
+      base_device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
+      source_buffer, source_offset, target_file, target_offset, length, flags,
+      options));
+  return loop_status;
+}
+
+static iree_status_t iree_hal_xrt_device_queue_execute(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_host_size_t command_buffer_count,
+    iree_hal_command_buffer_t* const* command_buffers) {
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "unimplmented queue execute");
+}
+
+static iree_status_t iree_hal_xrt_device_queue_flush(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity) {
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "unimplmented queue flush");
+}
+
+static iree_status_t iree_hal_xrt_device_wait_semaphores(
+    iree_hal_device_t* base_device, iree_hal_wait_mode_t wait_mode,
+    const iree_hal_semaphore_list_t semaphore_list, iree_timeout_t timeout) {
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                          "unimplmented semaphore wait");
+}
+
+static iree_status_t iree_hal_xrt_device_profiling_begin(
+    iree_hal_device_t* device,
+    const iree_hal_device_profiling_options_t* options) {
+  // Unimplemented (and that's ok).
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_xrt_device_profiling_end(
+    iree_hal_device_t* device) {
+  // Unimplemented (and that's ok).
+  return iree_ok_status();
+}
+
+namespace {
+const iree_hal_device_vtable_t iree_hal_xrt_device_vtable = {
+    /*.destroy = */ iree_hal_xrt_device_destroy,
+    /*.id = */ iree_hal_xrt_device_id,
+    /*.host_allocator = */ iree_hal_xrt_device_host_allocator,
+    /*.device_allocator = */ iree_hal_xrt_device_allocator,
+    /*.replace_device_allocator = */ iree_hal_xrt_replace_device_allocator,
+    /*.replace_channel_provider = */ iree_hal_xrt_replace_channel_provider,
+    /*.trim = */ iree_hal_xrt_device_trim,
+    /*.query_i64 = */ iree_hal_xrt_device_query_i64,
+    /*.create_channel = */ iree_hal_xrt_device_create_channel,
+    /*.create_command_buffer = */ iree_hal_xrt_device_create_command_buffer,
+    /*.create_descriptor_set_layout = */
+    iree_hal_xrt_device_create_descriptor_set_layout,
+    /*.create_event = */ iree_hal_xrt_device_create_event,
+    /*.create_executable_cache = */ iree_hal_xrt_device_create_executable_cache,
+    /*.import_file = */ iree_hal_xrt_device_import_file,
+    /*.create_pipeline_layout = */ iree_hal_xrt_device_create_pipeline_layout,
+    /*.create_semaphore = */ iree_hal_xrt_device_create_semaphore,
+    /*.query_semaphore_compatibility = */
+    iree_hal_xrt_device_query_semaphore_compatibility,
+    /*.transfer_range = */ iree_hal_device_submit_transfer_range_and_wait,
+    /*.queue_alloca = */ iree_hal_xrt_device_queue_alloca,
+    /*.queue_dealloca = */ iree_hal_xrt_device_queue_dealloca,
+    /*.queue_read=*/iree_hal_xrt_device_queue_read,
+    /*.queue_write = */ iree_hal_xrt_device_queue_write,
+    /*.queue_execute = */ iree_hal_xrt_device_queue_execute,
+    /*.queue_flush = */ iree_hal_xrt_device_queue_flush,
+    /*.wait_semaphores = */ iree_hal_xrt_device_wait_semaphores,
+    /*.profiling_begin = */ iree_hal_xrt_device_profiling_begin,
+    /*.profiling_end = */ iree_hal_xrt_device_profiling_end,
+};
+}  // namespace

--- a/runtime/src/iree-amd-aie/driver/xrt/xrt_device.h
+++ b/runtime/src/iree-amd-aie/driver/xrt/xrt_device.h
@@ -1,0 +1,29 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_AMD_AIE_DRIVER_XRT_XRT_DEVICE_H_
+#define IREE_AMD_AIE_DRIVER_XRT_XRT_DEVICE_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "xrt/xrt_device.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Creates a XRT device.
+iree_status_t iree_hal_xrt_device_create(iree_hal_driver_t* driver,
+                                         iree_string_view_t identifier,
+                                         xrt::device device,
+                                         iree_allocator_t host_allocator,
+                                         iree_hal_device_t** out_device);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_AMD_AIE_DRIVER_XRT_XRT_DEVICE_H_

--- a/runtime/src/iree-amd-aie/driver/xrt/xrt_driver.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/xrt_driver.cc
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree-amd-aie/driver/xrt/api.h"
+#include "iree-amd-aie/driver/xrt/xrt_device.h"
 #include "iree/base/api.h"
 #include "iree/base/target_platform.h"
 #include "iree/base/tracing.h"
@@ -103,21 +104,99 @@ static void iree_hal_xrt_driver_destroy(iree_hal_driver_t* base_driver) {
 static iree_status_t iree_hal_xrt_driver_dump_device_info(
     iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
     iree_string_builder_t* builder) {
-  return iree_status_from_code(IREE_STATUS_UNIMPLEMENTED);
+  iree_hal_xrt_driver_t* driver = iree_hal_xrt_driver_cast(base_driver);
+  xrt::device device = driver->device;
+  IREE_RETURN_IF_ERROR(
+      iree_string_builder_append_cstring(builder, "\n- Platform:"));
+
+  std::string platform_info = device.get_info<xrt::info::device::platform>();
+  const char* platform_info_str = platform_info.c_str();
+  if (platform_info_str) {
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(builder, " "));
+    IREE_RETURN_IF_ERROR(
+        iree_string_builder_append_cstring(builder, platform_info_str));
+  }
+  IREE_RETURN_IF_ERROR(iree_string_builder_append_cstring(builder, "\n"));
+  return iree_ok_status();
+}
+
+// Populates device information from the given XRT physical device handle.
+// |out_device_info| must point to valid memory and additional data will be
+// appended to |buffer_ptr| and the new pointer is returned.
+static iree_status_t iree_hal_xrt_populate_device_info(
+    xrt::device device, uint8_t* buffer_ptr, uint8_t** out_buffer_ptr,
+    iree_hal_device_info_t* out_device_info) {
+  *out_buffer_ptr = buffer_ptr;
+
+  memset(out_device_info, 0, sizeof(*out_device_info));
+
+  // We currenly only work with one XRT device and its device id is 0.
+  out_device_info->device_id = 0;
+  // TODO (nirvedhmeshram) : Add device path, initial attempt below to use the
+  // info api for this gave an error.
+  /*std::string device_path =
+      device.get_info<xrt::info::device::interface_uuid>().to_string();
+  const size_t path_len = strlen(device_path.c_str());
+  buffer_ptr += iree_string_view_append_to_buffer(
+      iree_make_string_view(device_path.c_str(), path_len),
+      &out_device_info->path, (char*)buffer_ptr);*/
+  std::string device_name = device.get_info<xrt::info::device::name>();
+  const size_t name_len = strlen(device_name.c_str());
+  if (name_len >= IREE_HAL_XRT_MAX_DEVICE_NAME_LENGTH) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "device name out of range");
+  }
+  buffer_ptr += iree_string_view_append_to_buffer(
+      iree_make_string_view(device_name.c_str(), name_len),
+      &out_device_info->name, (char*)buffer_ptr);
+
+  *out_buffer_ptr = buffer_ptr;
+
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_xrt_driver_query_available_devices(
     iree_hal_driver_t* base_driver, iree_allocator_t host_allocator,
     iree_host_size_t* out_device_info_count,
     iree_hal_device_info_t** out_device_infos) {
-  return iree_status_from_code(IREE_STATUS_UNIMPLEMENTED);
+  iree_hal_xrt_driver_t* driver = iree_hal_xrt_driver_cast(base_driver);
+  xrt::device device = driver->device;
+  // Allocate the return infos and populate with the devices.
+  iree_hal_device_info_t* device_infos = NULL;
+  iree_host_size_t single_info_size =
+      sizeof(iree_hal_device_info_t) + (IREE_HAL_XRT_MAX_DEVICE_PATH_LENGTH +
+                                        IREE_HAL_XRT_MAX_DEVICE_NAME_LENGTH) *
+                                           sizeof(char);
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(host_allocator, single_info_size,
+                                             (void**)&device_infos));
+
+  // Append all path and name strings at the end of the struct.
+  uint8_t* buffer_ptr = (uint8_t*)device_infos + sizeof(iree_hal_device_info_t);
+  iree_status_t status = iree_hal_xrt_populate_device_info(
+      device, buffer_ptr, &buffer_ptr, device_infos);
+  if (iree_status_is_ok(status)) {
+    // We currenly only work with one XRT device.
+    *out_device_info_count = 1;
+    *out_device_infos = device_infos;
+  } else {
+    iree_allocator_free(host_allocator, device_infos);
+  }
+  return status;
 }
 
 static iree_status_t iree_hal_xrt_driver_create_device_by_id(
     iree_hal_driver_t* base_driver, iree_hal_device_id_t device_id,
     iree_host_size_t param_count, const iree_string_pair_t* params,
     iree_allocator_t host_allocator, iree_hal_device_t** out_device) {
-  return iree_status_from_code(IREE_STATUS_UNIMPLEMENTED);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_hal_xrt_driver_t* driver = iree_hal_xrt_driver_cast(base_driver);
+  iree_string_view_t device_name = iree_make_cstring_view("xrt");
+
+  iree_status_t status = iree_hal_xrt_device_create(
+      base_driver, device_name, driver->device, host_allocator, out_device);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
 }
 
 static iree_status_t iree_hal_xrt_driver_create_device_by_path(
@@ -125,7 +204,15 @@ static iree_status_t iree_hal_xrt_driver_create_device_by_path(
     iree_string_view_t device_path, iree_host_size_t param_count,
     const iree_string_pair_t* params, iree_allocator_t host_allocator,
     iree_hal_device_t** out_device) {
-  return iree_status_from_code(IREE_STATUS_UNIMPLEMENTED);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_hal_xrt_driver_t* driver = iree_hal_xrt_driver_cast(base_driver);
+  iree_string_view_t device_name = iree_make_cstring_view("xrt");
+
+  iree_status_t status = iree_hal_xrt_device_create(
+      base_driver, device_name, driver->device, host_allocator, out_device);
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
 }
 
 namespace {


### PR DESCRIPTION
- Add device
- Add some dump information and driver query functions
- Add event semaphore and creates it from device, although I dont think these will be used by the runtime in the near future
- (we will add a blocking sync call in queue execute in the near future when we implement queue functions next, provide thread per queue in the mid future and eventually do a full async execution