### PR TITLE
Add more passes to enable AIE -> Binary translation.

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aie/AIETransformPasses.cpp
+++ b/compiler/plugins/target/AMD-AIE/aie/AIETransformPasses.cpp
@@ -1,0 +1,23 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "aie/Dialect/AIE/Transforms/AIEPasses.h"
+
+namespace {
+#define GEN_PASS_REGISTRATION
+#include "aie/Dialect/AIE/Transforms/AIEPasses.h.inc"
+}  // namespace
+
+namespace mlir::iree_compiler::AMDAIE {
+void registerAIETransformPasses() {
+  registerAIEAssignLockIDs();
+  registerAIEAssignBufferAddresses();
+  registerAIECanonicalizeDevice();
+  registerAIEObjectFifoRegisterProcess();
+  registerAIEObjectFifoStatefulTransform();
+  registerAIERoutePacketFlows();
+}
+}  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/aie/AIEXTransformPasses.cpp
+++ b/compiler/plugins/target/AMD-AIE/aie/AIEXTransformPasses.cpp
@@ -1,0 +1,19 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
+
+namespace {
+#define GEN_PASS_REGISTRATION
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h.inc"
+}  // namespace
+
+namespace mlir::iree_compiler::AMDAIE {
+void registerAIEXTransformPasses() {
+  registerAIEBroadcastPacket();
+  registerAIEMulticast();
+}
+}  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/aie/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/aie/CMakeLists.txt
@@ -125,3 +125,83 @@ iree_tablegen_library(
     -gen-op-decls Dialect/AIEX/IR/AIEX.h.inc
     -gen-op-defs Dialect/AIEX/IR/AIEX.cpp.inc
 )
+
+###############################################################################
+# AIE Transform Passes
+###############################################################################
+
+iree_tablegen_library(
+  NAME
+    AIETransformPassesIncGen
+  TD_FILE
+    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIE/Transforms/AIEPasses.td"
+  OUTS
+    -gen-pass-decls Dialect/AIE/Transforms/AIEPasses.h.inc
+)
+
+iree_cc_library(
+  NAME
+    AIETransformPassHeaders
+  HDRS
+    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIE/Transforms/Passes.h"
+    "Passes.h.inc"
+  DEPS
+    ::AIETransformPassesIncGen
+    MLIRPass
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    AIETransformPasses
+  SRCS
+    "AIETransformPasses.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIECanonicalizeDevice.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIECreatePacketFlows.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp"
+  DEPS
+    ::defs
+    ::AIEDialectIR
+    ::AIETransformPassHeaders
+)
+
+###############################################################################
+# AIEX Transform Passes
+###############################################################################
+
+iree_tablegen_library(
+  NAME
+    AIEXTransformPassesIncGen
+  TD_FILE
+    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td"
+  OUTS
+    -gen-pass-decls Dialect/AIEX/Transforms/AIEXPasses.h.inc
+)
+
+iree_cc_library(
+  NAME
+    AIEXTransformPassHeaders
+  HDRS
+    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIEX/Transforms/Passes.h"
+    "Passes.h.inc"
+  DEPS
+    ::AIEXTransformPassesIncGen
+    MLIRPass
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    AIEXTransformPasses
+  SRCS
+    "AIEXTransformPasses.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/Transforms/AIELowerMulticast.cpp"
+  DEPS
+    ::defs
+    ::AIEXDialectIR
+    ::AIEXTransformPassHeaders
+)

--- a/compiler/plugins/target/AMD-AIE/aie/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/aie/Passes.h
@@ -1,0 +1,20 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef AIE_PASSES_H_
+#define AIE_PASSES_H_
+
+namespace mlir::iree_compiler::AMDAIE {
+
+/// Registration for AIE Transform passes.
+void registerAIETransformPasses();
+
+/// Registration for AIE Transform passes.
+void registerAIEXTransformPasses();
+
+}  // namespace mlir::iree_compiler::AMDAIE
+
+#endif  // AIE_PASSES_H_

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/CMakeLists.txt
@@ -18,7 +18,9 @@ iree_cc_library(
     iree::target::amd-aie::Target
     iree::target::amd-aie::Transforms
     iree::target::amd-aie::aie::AIEDialectIR
+    iree::target::amd-aie::aie::AIETransformPasses
     iree::target::amd-aie::aie::AIEXDialectIR
+    iree::target::amd-aie::aie::AIEXTransformPasses
     iree::target::amd-aie::air::AIRDialectIR
     iree::target::amd-aie::air::AIRPasses
   PUBLIC

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/PluginRegistration.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/PluginRegistration.cpp
@@ -4,6 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Passes.h"
 #include "air/Dialect/AIR/AIRDialect.h"
 #include "air/Passes.h"
 #include "iree-amd-aie/Target/AIETarget.h"
@@ -29,12 +31,14 @@ struct AMDAIESession
                            PluginActivationPolicy::DefaultActivated> {
   static void registerPasses() {
     AMDAIE::registerAMDAIEPasses();
+    AMDAIE::registerAIETransformPasses();
+    AMDAIE::registerAIEXTransformPasses();
     AMDAIE::registerAIRConversionPasses();
     AMDAIE::registerAIRTransformPasses();
   }
 
   void onRegisterDialects(DialectRegistry &registry) override {
-    registry.insert<xilinx::air::airDialect>();
+    registry.insert<xilinx::AIE::AIEDialect, xilinx::air::airDialect>();
   }
 
   void populateHALTargetBackends(

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
@@ -43,6 +43,7 @@ iree_cc_library(
     iree::compiler::Codegen::Dialect::IREECodegenDialect
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Utils
+    iree::target::amd-aie::aie::AIETransformPasses
     iree::target::amd-aie::air::AIRConversionPasses
     iree::target::amd-aie::air::AIRTransformPasses
     IREELinalgExtDialect

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -16,6 +16,9 @@ namespace mlir::iree_compiler::AMDAIE {
 /// currently the default passes used for lowering after IREEs tiling.
 void addMLIRAIRAIELoweringPasses(OpPassManager &passManager);
 
+/// Add passes to lower from MLIR-AIE to just before binary generation.
+void addMLIRAIELoweringPasses(OpPassManager &passManager);
+
 /// Add passes to run the strategy specified using transform dialect
 /// file/library
 void addTransformDialectPasses(OpPassManager &passManager);


### PR DESCRIPTION
This patch adds more passes to start preparing for binary conversion (based on
https://github.com/Xilinx/mlir-aie/blob/main/python/compiler/aiecc/main.py)