### PR TITLE
Add passes to lower AIE Device code to LLVM.

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aie/AIETransformPasses.cpp
+++ b/compiler/plugins/target/AMD-AIE/aie/AIETransformPasses.cpp
@@ -16,6 +16,9 @@ void registerAIETransformPasses() {
   registerAIEAssignLockIDs();
   registerAIEAssignBufferAddresses();
   registerAIECanonicalizeDevice();
+  registerAIECoreToStandard();
+  registerAIELocalizeLocks();
+  registerAIENormalizeAddressSpaces();
   registerAIEObjectFifoRegisterProcess();
   registerAIEObjectFifoStatefulTransform();
   registerAIERoutePacketFlows();

--- a/compiler/plugins/target/AMD-AIE/aie/AIEXTransformPasses.cpp
+++ b/compiler/plugins/target/AMD-AIE/aie/AIEXTransformPasses.cpp
@@ -15,5 +15,6 @@ namespace mlir::iree_compiler::AMDAIE {
 void registerAIEXTransformPasses() {
   registerAIEBroadcastPacket();
   registerAIEMulticast();
+  registerAIEXToStandard();
 }
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/aie/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/aie/CMakeLists.txt
@@ -101,6 +101,15 @@ iree_tablegen_library(
     -gen-typedef-defs -typedefs-dialect=AIE Dialect/AIE/IR/AIETypesGen.cpp.inc
 )
 
+iree_tablegen_library(
+  NAME
+    AIENormalizeAddressSpacesGen
+  TD_FILE
+    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIE/Transforms/AIENormalizeAddressSpaces.td"
+  OUTS
+    -gen-rewriters Dialect/AIE/Transforms/AIENormalizeAddressSpaces.inc
+)
+
 ###############################################################################
 # AIEX Dialect
 ###############################################################################
@@ -159,12 +168,16 @@ iree_cc_library(
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIECanonicalizeDevice.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIECreatePacketFlows.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIELocalizeLocks.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIENormalizeAddressSpaces.cpp"
   DEPS
     ::defs
     ::AIEDialectIR
+    ::AIENormalizeAddressSpacesGen
     ::AIETransformPassHeaders
 )
 
@@ -200,6 +213,8 @@ iree_cc_library(
     "AIEXTransformPasses.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/Transforms/AIELowerMulticast.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/Transforms/AIEXToStandard.cpp"
   DEPS
     ::defs
     ::AIEXDialectIR

--- a/tests/samples/matmul_fill_static_i32.mlir
+++ b/tests/samples/matmul_fill_static_i32.mlir
@@ -1,15 +1,10 @@
 // RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-codegen-transform-dialect-library=%S/matmul_fill_spec_pad.mlir | FileCheck %s
 
 // CHECK-LABEL: hal.executable.export public @matmul_static_dispatch_0_matmul_8x8x16_i32
-//       CHECK:    AIE.device(ipu)
-//       CHECK:    AIE.shimDMAAllocation
-//       CHECK:    AIE.shimDMAAllocation
-//       CHECK:    AIE.shimDMAAllocation
-//       CHECK:    func.func @matmul_static_dispatch_0_matmul_8x8x16_i32(%arg0: memref<8x16xi32>, %arg1: memref<16x8xi32>, %arg2: memref<8x8xi32>)
-//       CHECK:      AIEX.ipu.dma_memcpy_nd
-//       CHECK:      AIEX.ipu.dma_memcpy_nd
-//       CHECK:      AIEX.ipu.dma_memcpy_nd
-//       CHECK:      AIEX.ipu.sync
+//       CHECK:   llvm.func @core_0_2()
+//       CHECK:   llvm.func @core_0_3()
+//       CHECK:   llvm.func @core_0_4()
+//       CHECK:   llvm.func @core_0_5()
 func.func @matmul_static(%lhs : tensor<8x16xi32>,
     %rhs : tensor<16x8xi32>) -> tensor<8x8xi32> {
   %empty = tensor.empty() : tensor<8x8xi32>


### PR DESCRIPTION
This does not get us all the way to binary, but the sample lowers to LLVM successfully.
Next step is to generate the actual binaries.