### PR TITLE
[XRT] Add native executable

### DIFF
--- a/runtime/src/iree-amd-aie/CMakeLists.txt
+++ b/runtime/src/iree-amd-aie/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 if(IREE_AMD_AIE_ENABLE_XRT_DRIVER)
     add_subdirectory(driver/xrt)
+    add_subdirectory(tools)
+    add_subdirectory(schemas)
 endif()
 
-add_subdirectory(tools)

--- a/runtime/src/iree-amd-aie/driver/xrt/CMakeLists.txt
+++ b/runtime/src/iree-amd-aie/driver/xrt/CMakeLists.txt
@@ -35,6 +35,8 @@ iree_cc_library(
     "xrt_buffer.cc"
     "xrt_device.cc"
     "xrt_driver.cc"
+    "native_executable.h"
+    "native_executable.cc"
     "nop_semaphore.cc"
     "nop_executable_cache.h"
     "nop_executable_cache.cc"
@@ -47,12 +49,12 @@ iree_cc_library(
     iree::base::core_headers
     iree::hal
     iree::hal::utils::buffer_transfer
-    # TODO (nirvedhmeshram) : Figure out the flatbuffer format for this runtime
-    # iree::schemas::xrt_executable_def_c_fbs
+    iree-amd-aie::schemas::xrt_executable_def_c_fbs
     XRT::xrt_coreutil
   COPTS
   # currenly this is needed, it can be removed after this issue is resolved
   # https://github.com/Xilinx/XRT/issues/7810
    -frtti
+   -fexceptions
   PUBLIC
 )

--- a/runtime/src/iree-amd-aie/driver/xrt/native_executable.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/native_executable.cc
@@ -1,0 +1,257 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-amd-aie/driver/xrt/native_executable.h"
+
+#include <stddef.h>
+
+#include "iree-amd-aie/schemas/xrt_executable_def_reader.h"
+#include "iree-amd-aie/schemas/xrt_executable_def_verifier.h"
+#include "iree/base/api.h"
+#include "iree/base/internal/flatcc/parsing.h"
+
+typedef struct iree_hal_xrt_native_executable_t {
+  // Abstract resource used for injecting reference counting and vtable; must be
+  // at offset 0.
+  iree_hal_resource_t resource;
+
+  iree_allocator_t host_allocator;
+
+  iree_host_size_t entry_point_count;
+  iree_hal_xrt_kernel_params_t entry_points[];
+} iree_hal_xrt_native_executable_t;
+
+namespace {
+extern const iree_hal_executable_vtable_t iree_hal_xrt_native_executable_vtable;
+}  // namespace
+
+static iree_hal_xrt_native_executable_t* iree_hal_xrt_native_executable_cast(
+    iree_hal_executable_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_xrt_native_executable_vtable);
+  return (iree_hal_xrt_native_executable_t*)base_value;
+}
+
+// Verifies the structure of the flatbuffer so that we can avoid doing so during
+// runtime.
+//
+// There are still some conditions we must be aware of (such as omitted names on
+// functions with internal linkage), however we shouldn't need to bounds check
+// anything within the flatbuffer after this succeeds.
+static iree_status_t iree_amd_aie_hal_xrt_native_executable_flatbuffer_verify(
+    iree_const_byte_span_t flatbuffer_data) {
+  if (!flatbuffer_data.data || flatbuffer_data.data_length < 16) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "flatbuffer data is not present or less than 16 bytes (%zu total)",
+        flatbuffer_data.data_length);
+  }
+
+  // Run flatcc generated verification. This ensures all pointers are in-bounds
+  // and that we can safely walk the file, but not that the actual contents of
+  // the flatbuffer meet our expectations.
+  int verify_ret = iree_amd_aie_hal_xrt_ExecutableDef_verify_as_root(
+      flatbuffer_data.data, flatbuffer_data.data_length);
+  if (verify_ret != flatcc_verify_ok) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "flatbuffer verification failed: %s",
+                            flatcc_verify_error_string(verify_ret));
+  }
+
+  iree_amd_aie_hal_xrt_ExecutableDef_table_t executable_def =
+      iree_amd_aie_hal_xrt_ExecutableDef_as_root(flatbuffer_data.data);
+
+  flatbuffers_string_vec_t entry_points_vec =
+      iree_amd_aie_hal_xrt_ExecutableDef_entry_points_get(executable_def);
+  size_t entry_point_count = flatbuffers_string_vec_len(entry_points_vec);
+  for (size_t i = 0; i < entry_point_count; ++i) {
+    if (!flatbuffers_string_len(
+            flatbuffers_string_vec_at(entry_points_vec, i))) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "executable entry point %zu has no name", i);
+    }
+  }
+
+  flatbuffers_string_t xclbin =
+      iree_amd_aie_hal_xrt_ExecutableDef_xclbin_get(executable_def);
+  if (flatbuffers_string_len(xclbin) == 0) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "no xclbin present");
+  }
+
+  iree_amd_aie_hal_xrt_AsmInstDef_vec_t asm_instr =
+      iree_amd_aie_hal_xrt_ExecutableDef_asm_instrs_get(executable_def);
+  if (iree_amd_aie_hal_xrt_AsmInstDef_vec_len(asm_instr) != entry_point_count) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "number of entry points and asm instructions mismatched");
+  }
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_xrt_native_executable_create(
+    xrt::device device, const iree_hal_executable_params_t* executable_params,
+    iree_allocator_t host_allocator, iree_hal_executable_t** out_executable) {
+  IREE_ASSERT_ARGUMENT(executable_params);
+  IREE_ASSERT_ARGUMENT(out_executable);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  *out_executable = NULL;
+  iree_hal_xrt_native_executable_t* executable = NULL;
+
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_amd_aie_hal_xrt_native_executable_flatbuffer_verify(
+              executable_params->executable_data));
+
+  iree_amd_aie_hal_xrt_ExecutableDef_table_t executable_def =
+      iree_amd_aie_hal_xrt_ExecutableDef_as_root(
+          executable_params->executable_data.data);
+
+  flatbuffers_string_vec_t entry_points_vec =
+      iree_amd_aie_hal_xrt_ExecutableDef_entry_points_get(executable_def);
+  iree_host_size_t entry_count = flatbuffers_string_vec_len(entry_points_vec);
+
+  flatbuffers_string_t xclbin_fb =
+      iree_amd_aie_hal_xrt_ExecutableDef_xclbin_get(executable_def);
+
+  iree_amd_aie_hal_xrt_AsmInstDef_vec_t asm_instrs_vec =
+      iree_amd_aie_hal_xrt_ExecutableDef_asm_instrs_get(executable_def);
+
+  iree_host_size_t entry_point_count =
+      flatbuffers_string_vec_len(entry_points_vec);
+  // Calculate the total number of characters across all entry point names. This
+  // is only required when tracing so that we can store copies of the names as
+  // the flatbuffer storing the strings may be released while the executable is
+  // still live.
+  iree_host_size_t total_entry_point_name_chars = 0;
+  IREE_TRACE({
+    for (iree_host_size_t i = 0; i < entry_count; i++) {
+      const char* entry_name = flatbuffers_string_vec_at(entry_points_vec, i);
+      total_entry_point_name_chars += flatbuffers_string_len(entry_name);
+    }
+  });
+
+  iree_host_size_t total_size =
+      sizeof(*executable) + entry_count * sizeof(executable->entry_points[0]) +
+      total_entry_point_name_chars;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_allocator_malloc(host_allocator, total_size, (void**)&executable));
+  IREE_TRACE(
+      char* string_table_buffer =
+          (char*)((char*)executable + sizeof(*executable) +
+                  entry_point_count * sizeof(executable->entry_points[0])));
+
+  iree_hal_resource_initialize(&iree_hal_xrt_native_executable_vtable,
+                               &executable->resource);
+
+  xrt::xclbin xclbin = xrt::xclbin(xclbin_fb);
+  device.register_xclbin(xclbin);
+  xrt::hw_context context(device, xclbin.get_uuid());
+  executable->host_allocator = host_allocator;
+  executable->entry_point_count = entry_point_count;
+  for (iree_host_size_t i = 0; i < entry_point_count; i++) {
+    std::string entry_name = flatbuffers_string_vec_at(entry_points_vec, i);
+    iree_amd_aie_hal_xrt_AsmInstDef_table_t asminst_def =
+        iree_amd_aie_hal_xrt_AsmInstDef_vec_at(asm_instrs_vec, i);
+    flatbuffers_uint32_vec_t asm_inst =
+        iree_amd_aie_hal_xrt_AsmInstDef_asm_inst_get(asminst_def);
+    uint32_t num_instr = flatbuffers_uint32_vec_len(asm_inst);
+    std::unique_ptr<xrt::kernel> kernel;
+    std::unique_ptr<xrt::bo> instr;
+    try {
+      auto kernel = std::make_unique<xrt::kernel>(context, entry_name);
+      auto instr = std::make_unique<xrt::bo>(
+          device, num_instr * sizeof(uint32_t), XCL_BO_FLAGS_CACHEABLE,
+          kernel.get()->group_id(0));
+    } catch (...) {
+      iree_hal_executable_destroy((iree_hal_executable_t*)executable);
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(
+          IREE_STATUS_RESOURCE_EXHAUSTED,
+          "could not allocate memory for kernel or instr buffer");
+    }
+    uint32_t* instr_buffer = instr->map<uint32_t*>();
+    for (int j = 0; j < num_instr; j++) {
+      instr_buffer[j] = flatbuffers_uint32_vec_at(asm_inst, j);
+    }
+    iree_hal_xrt_kernel_params_t* params = &executable->entry_points[i];
+    params->kernel = kernel.release();
+    params->instr = instr.release();
+    params->num_instr = num_instr;
+    params->layout = executable_params->pipeline_layouts[i];
+
+    // Stash the entry point name in the string table for use when tracing.
+    IREE_TRACE({
+      iree_host_size_t entry_name_length = flatbuffers_string_len(entry_name);
+      memcpy(string_table_buffer, entry_name, entry_name_length);
+      params->kernel_name =
+          iree_make_string_view(string_table_buffer, entry_name_length);
+      string_table_buffer += entry_name_length;
+    });
+
+    IREE_TRACE({
+      if (iree_amd_aie_hal_xrt_ExecutableDef_source_locations_is_present(
+              executable_def)) {
+        iree_amd_aie_hal_xrt_FileLineLocDef_vec_t source_locs_vec =
+            iree_amd_aie_hal_xrt_ExecutableDef_source_locations_get(
+                executable_def);
+        iree_smd_aie_hal_xrt_FileLineLocDef_table_t source_loc =
+            iree_amd_aie_hal_xrt_FileLineLocDef_vec_at(source_locs_vec, i);
+        flatbuffers_string_t filename =
+            iree_amd_aie_hal_xrt_FileLineLocDef_filename_get(source_loc);
+        uint32_t line =
+            iree_amd_aie_hal_xrt_FileLineLocDef_line_get(source_loc);
+        params->source_filename =
+            iree_make_string_view(filename, flatbuffers_string_len(filename));
+        params->source_line = line;
+      }
+    });
+  }
+  *out_executable = (iree_hal_executable_t*)executable;
+  return iree_ok_status();
+}
+
+static void iree_hal_xrt_native_executable_destroy(
+    iree_hal_executable_t* base_executable) {
+  iree_hal_xrt_native_executable_t* executable =
+      iree_hal_xrt_native_executable_cast(base_executable);
+  iree_allocator_t host_allocator = executable->host_allocator;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  for (iree_host_size_t i = 0; i < executable->entry_point_count; ++i) {
+    try {
+      delete executable->entry_points[i].kernel;
+      delete executable->entry_points[i].instr;
+    } catch (...) {
+      iree_status_from_code(IREE_STATUS_DATA_LOSS);
+    }
+    iree_hal_pipeline_layout_release(executable->entry_points[i].layout);
+  }
+  iree_allocator_free(host_allocator, executable);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+iree_status_t iree_hal_xrt_native_executable_entry_point_kernel_params(
+    iree_hal_executable_t* base_executable, int32_t entry_point,
+    iree_hal_xrt_kernel_params_t* out_params) {
+  iree_hal_xrt_native_executable_t* executable =
+      iree_hal_xrt_native_executable_cast(base_executable);
+  if (entry_point >= executable->entry_point_count) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "entry point ordinal %d out of range; executable "
+                            "only contains %" PRIhsz " entry points",
+                            entry_point, executable->entry_point_count);
+  }
+  memcpy(out_params, &executable->entry_points[entry_point],
+         sizeof(*out_params));
+  return iree_ok_status();
+}
+
+namespace {
+const iree_hal_executable_vtable_t iree_hal_xrt_native_executable_vtable = {
+    /*.destroy=*/iree_hal_xrt_native_executable_destroy,
+};
+}  // namespace

--- a/runtime/src/iree-amd-aie/driver/xrt/native_executable.h
+++ b/runtime/src/iree-amd-aie/driver/xrt/native_executable.h
@@ -1,0 +1,48 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_AMD_AIE_DRIVER_XRT_NATIVE_EXECUTABLE_H_
+#define IREE_AMD_AIE_DRIVER_XRT_NATIVE_EXECUTABLE_H_
+
+#include <stdint.h>
+
+#include "iree/base/api.h"
+#include "iree/base/tracing.h"
+#include "iree/hal/api.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Object and launch parameters for a compute kernel.
+typedef struct iree_hal_xrt_kernel_params_t {
+  xrt::kernel* kernel;
+  xrt::bo* instr;      // buffer with ASM Instr stream
+  uint32_t num_instr;  // number of instructions
+  iree_hal_pipeline_layout_t* layout;
+  IREE_TRACE(iree_string_view_t kernel_name;)
+  IREE_TRACE(iree_string_view_t source_filename;)
+  IREE_TRACE(uint32_t source_line;)
+} iree_hal_xrt_kernel_params_t;
+
+// |out_executable| must be released by the caller (see
+// iree_hal_executable_release).
+iree_status_t iree_hal_xrt_native_executable_create(
+    xrt::device device, const iree_hal_executable_params_t* executable_params,
+    iree_allocator_t host_allocator, iree_hal_executable_t** out_executable);
+
+// Returns the kernel launch parameters for the given |entry_point|.
+iree_status_t iree_hal_xrt_native_executable_entry_point_kernel_params(
+    iree_hal_executable_t* executable, int32_t entry_point,
+    iree_hal_xrt_kernel_params_t* out_params);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_AMD_AIE_DRIVER_XRT_NATIVE_EXECUTABLE_H_

--- a/runtime/src/iree-amd-aie/driver/xrt/nop_executable_cache.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/nop_executable_cache.cc
@@ -9,6 +9,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+#include "iree-amd-aie/driver/xrt/native_executable.h"
 #include "iree/base/api.h"
 #include "iree/base/tracing.h"
 
@@ -79,8 +80,11 @@ static iree_status_t iree_hal_xrt_nop_executable_cache_prepare_executable(
     iree_hal_executable_cache_t* base_executable_cache,
     const iree_hal_executable_params_t* executable_params,
     iree_hal_executable_t** out_executable) {
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                          "unimplmented executable cache prepare executable");
+  iree_hal_xrt_nop_executable_cache_t* executable_cache =
+      iree_hal_xrt_nop_executable_cache_cast(base_executable_cache);
+  return iree_hal_xrt_native_executable_create(
+      executable_cache->device, executable_params,
+      executable_cache->host_allocator, out_executable);
 }
 
 namespace {

--- a/runtime/src/iree-amd-aie/schemas/CMakeLists.txt
+++ b/runtime/src/iree-amd-aie/schemas/CMakeLists.txt
@@ -1,0 +1,14 @@
+iree_add_all_subdirs()
+
+flatbuffer_c_library(
+  NAME
+    xrt_executable_def_c_fbs
+  SRCS
+    "xrt_executable_def.fbs"
+  FLATCC_ARGS
+    "--reader"
+    "--builder"
+    "--verifier"
+    "--json"
+  PUBLIC
+)

--- a/runtime/src/iree-amd-aie/schemas/xrt_executable_def.fbs
+++ b/runtime/src/iree-amd-aie/schemas/xrt_executable_def.fbs
@@ -1,0 +1,37 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+namespace iree.amd.aie.hal.xrt;
+
+// 'XRT Executable'.
+file_identifier "XRTR";
+file_extension "xrtr";
+
+// Source code location denoted by a file name and line within that file.
+table FileLineLocDef {
+  filename:string;
+  line:int32;
+}
+
+// assembly instructions
+table AsmInstDef {
+  asm_inst:[uint32];
+}
+
+table ExecutableDef {
+  // A map of entry point ordinals to string names as used by XRT
+  entry_points:[string];
+
+  // XCLBIN string of the module.
+  xclbin:string;
+
+  // assembly instructions to run for each kernel
+  asm_instrs:[AsmInstDef];
+
+  source_locations:[FileLineLocDef];
+}
+
+root_type ExecutableDef;


### PR DESCRIPTION
A flatbuffer format that allows multiple entry points for each xclbin is added here. Each entry point will have a xrt::kernel associated with it which will be extracted from the xclbin. Similarly, each entry point will have a assembly instruction stream that needs to be passed to the kernel call that is loaded in the flatbuffer as well.

The parameters required for executable include xrt::kernel and xrt::bo C++ objects with the asm instructions. Since these cant be saved in the POD struct we save pointers to these and support exception handling of this memory allocation process.