### PR TITLE
Initial commit for generating binaries for AIE target. 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aie/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/aie/CMakeLists.txt
@@ -212,6 +212,7 @@ iree_cc_library(
   SRCS
     "AIEXTransformPasses.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/Transforms/AIEDmaToIpu.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/Transforms/AIELowerMulticast.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/Transforms/AIEXToStandard.cpp"
@@ -219,4 +220,18 @@ iree_cc_library(
     ::defs
     ::AIEXDialectIR
     ::AIEXTransformPassHeaders
+)
+
+###############################################################################
+# AIE Translation passes.
+###############################################################################
+
+iree_cc_library(
+  NAME
+    AIETranslationPasses
+  SRCS
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Targets/AIETargetIPU.cpp"
+  DEPS
+    ::AIEDialectIR
+    ::AIEXDialectIR
 )

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/PluginRegistration.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/PluginRegistration.cpp
@@ -16,18 +16,8 @@
 namespace mlir::iree_compiler {
 namespace {
 
-struct AMDAIEOptions {
-  void bindOptions(OptionsBinder &binder) {
-    static llvm::cl::OptionCategory category("AMD AIE Options");
-    // binder.opt<bool>(
-    //     "amd-aie-sample-flag", sampleFlag,
-    //     llvm::cl::cat(category),
-    //     llvm::cl::desc("Sample flag"));
-  }
-};
-
 struct AMDAIESession
-    : public PluginSession<AMDAIESession, AMDAIEOptions,
+    : public PluginSession<AMDAIESession, AMDAIE::AMDAIEOptions,
                            PluginActivationPolicy::DefaultActivated> {
   static void registerPasses() {
     AMDAIE::registerAMDAIEPasses();
@@ -45,17 +35,14 @@ struct AMDAIESession
       IREE::HAL::TargetBackendList &targets) override {
     // #hal.device.target<"amd-aie", ...
     // #hal.executable.target<"amd-aie", ...
-    targets.add("amd-aie", [&]() {
-      return AMDAIE::createTarget();
-      // return std::make_shared<CUDATargetBackend>(options);
-    });
+    targets.add("amd-aie", [&]() { return AMDAIE::createTarget(options); });
   }
 };
 
 }  // namespace
 }  // namespace mlir::iree_compiler
 
-IREE_DEFINE_COMPILER_OPTION_FLAGS(::mlir::iree_compiler::AMDAIEOptions);
+IREE_DEFINE_COMPILER_OPTION_FLAGS(::mlir::iree_compiler::AMDAIE::AMDAIEOptions);
 
 extern "C" bool iree_register_compiler_plugin_amd_aie(
     mlir::iree_compiler::PluginRegistrar *registrar) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -7,17 +7,46 @@
 #include "iree-amd-aie/Target/AIETarget.h"
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIE/Transforms/AIEPasses.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 #include "air/Dialect/AIR/AIRDialect.h"
 #include "air/Dialect/AIRRt/AIRRtDialect.h"
+#include "iree-amd-aie/Target/PeanoToolKit.h"
 #include "iree-amd-aie/Transforms/Passes.h"
 #include "iree/compiler/Codegen/Dialect/IREECodegenDialect.h"
+#include "llvm/Bitcode/BitcodeWriter.h"
+#include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
+#include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
+#include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
+#include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVMPass.h"
+#include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
+#include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
+#include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
+#include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
+#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Target/LLVMIR/ModuleTranslation.h"
+#include "mlir/Transforms/Passes.h"
+
+// Forward declaration of some translate methods from AIE. THis is done
+// here since the headers in MLIR-AIE repo are in a place that is
+// not where you would expect.
+namespace xilinx::AIE {
+mlir::LogicalResult AIETranslateToIPU(mlir::ModuleOp module,
+                                      llvm::raw_ostream &output);
+}
 
 namespace mlir::iree_compiler::AMDAIE {
 
 class AIETargetBackend final : public IREE::HAL::TargetBackend {
  public:
+  explicit AIETargetBackend(const AMDAIEOptions &options) : options(options) {}
+
   std::string name() const override { return "amd-aie"; }
 
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -51,9 +80,7 @@ class AIETargetBackend final : public IREE::HAL::TargetBackend {
 
   LogicalResult serializeExecutable(const SerializationOptions &serOptions,
                                     IREE::HAL::ExecutableVariantOp variantOp,
-                                    OpBuilder &executableBuilder) override {
-    return variantOp.emitError() << "AIE serialization NYI";
-  }
+                                    OpBuilder &executableBuilder) override;
 
  private:
   ArrayAttr getExecutableTargets(MLIRContext *context) const {
@@ -79,10 +106,214 @@ class AIETargetBackend final : public IREE::HAL::TargetBackend {
         context, b.getStringAttr("amd-aie"), b.getStringAttr("elf"),
         configAttr);
   }
+
+  AMDAIEOptions options;
 };
 
-std::shared_ptr<IREE::HAL::TargetBackend> createTarget() {
-  return std::make_shared<AIETargetBackend>();
+/// Generate the IPU instructions into `output`.
+static LogicalResult generateIPUInstructions(ModuleOp moduleOp,
+                                             OpBuilder &builder,
+                                             raw_ostream &output) {
+  OpBuilder::InsertionGuard g(builder);
+
+  // Clone the module for generating the IPU instructions.
+  builder.setInsertionPoint(moduleOp);
+  auto clonedModuleOp =
+      dyn_cast<ModuleOp>(builder.clone(*moduleOp.getOperation()));
+  PassManager passManager(builder.getContext(), ModuleOp::getOperationName());
+  passManager.addNestedPass<xilinx::AIE::DeviceOp>(
+      xilinx::AIEX::createAIEDmaToIpuPass());
+
+  if (failed(passManager.run(clonedModuleOp))) {
+    return clonedModuleOp->emitOpError(
+        "failed preprocessing pass before IPU instrs generation");
+  }
+
+  if (failed(xilinx::AIE::AIETranslateToIPU(clonedModuleOp, output))) {
+    return moduleOp.emitOpError("failed to translate to IPU instructions");
+  }
+
+  clonedModuleOp->erase();
+  return success();
+}
+
+/// Convert AIE device code to LLVM Dialect
+static LogicalResult convertToLLVMDialect(MLIRContext *context,
+                                          ModuleOp moduleOp) {
+  PassManager passManager(context, ModuleOp::getOperationName());
+
+  // Run lowering passes to prepare for LLVM Dialect lowering.
+  passManager.addPass(createLowerAffinePass());
+  passManager.addPass(xilinx::AIE::createAIECanonicalizeDevicePass());
+
+  {
+    OpPassManager &devicePassManager =
+        passManager.nest<xilinx::AIE::DeviceOp>();
+    devicePassManager.addPass(xilinx::AIE::createAIEAssignLockIDsPass());
+    devicePassManager.addPass(
+        xilinx::AIE::createAIEObjectFifoRegisterProcessPass());
+    devicePassManager.addPass(
+        xilinx::AIE::createAIEObjectFifoStatefulTransformPass());
+    devicePassManager.addPass(xilinx::AIEX::createAIEBroadcastPacketPass());
+    devicePassManager.addPass(xilinx::AIE::createAIERoutePacketFlowsPass());
+    devicePassManager.addPass(xilinx::AIEX::createAIELowerMulticastPass());
+    devicePassManager.addPass(
+        xilinx::AIE::createAIEAssignBufferAddressesPass());
+  }
+
+  // Convert to LLVM.
+  passManager.addPass(createConvertSCFToCFPass());
+  {
+    OpPassManager &devicePassManager =
+        passManager.nest<xilinx::AIE::DeviceOp>();
+    devicePassManager.addPass(xilinx::AIE::createAIELocalizeLocksPass());
+  }
+  passManager.addPass(xilinx::AIE::createAIECoreToStandardPass());
+  passManager.addPass(xilinx::AIEX::createAIEXToStandardPass());
+  passManager.addNestedPass<xilinx::AIE::DeviceOp>(
+      xilinx::AIE::createAIENormalizeAddressSpacesPass());
+  passManager.addPass(createCanonicalizerPass());
+  passManager.addPass(createCSEPass());
+  passManager.addPass(createConvertVectorToLLVMPass());
+  passManager.addPass(memref::createExpandStridedMetadataPass());
+  passManager.addPass(createLowerAffinePass());
+  passManager.addPass(createConvertMathToLLVMPass());
+  passManager.addPass(createArithToLLVMConversionPass());
+  passManager.addPass(createFinalizeMemRefToLLVMConversionPass());
+  {
+    ConvertFuncToLLVMPassOptions options;
+    options.useBarePtrCallConv = true;
+    passManager.addPass(createConvertFuncToLLVMPass(options));
+  }
+  passManager.addPass(createConvertControlFlowToLLVMPass());
+  passManager.addPass(createReconcileUnrealizedCastsPass());
+  passManager.addPass(createCanonicalizerPass());
+  passManager.addPass(createCSEPass());
+
+  if (failed(passManager.run(moduleOp))) {
+    return moduleOp.emitOpError("failed to lower to LLVM dialect");
+  }
+  return success();
+}
+
+static void dumpBitcodeToPath(StringRef path, StringRef baseName,
+                              StringRef suffix, StringRef extension,
+                              llvm::Module &module) {
+  llvm::SmallVector<char, 0> data;
+  llvm::raw_svector_ostream ostream(data);
+  llvm::WriteBitcodeToFile(module, ostream);
+  IREE::HAL::dumpDataToPath(path, baseName, suffix, extension,
+                            StringRef(data.data(), data.size()));
+}
+
+// Compile using Peano.
+LogicalResult compileUsingPeano(std::string peanoInstallDir, Location loc,
+                                std::string libraryName,
+                                llvm::Module &llvmModule) {
+  Artifact llFile = Artifact::createTemporary(libraryName, "bc");
+  {
+    auto &llFileOs = llFile.outputFile->os();
+    llvm::SmallVector<char, 0> llFileString;
+    llvm::raw_svector_ostream ostream(llFileString);
+    llvm::WriteBitcodeToFile(llvmModule, ostream);
+    llFileOs << llFileString;
+    llFileOs.flush();
+    llFileOs.close();
+  }
+  llFile.keep();
+
+  PeanoToolKit toolkit(peanoInstallDir);
+  Artifact optFile = Artifact::createTemporary(libraryName, "opt.bc");
+  {
+    SmallVector<std::string, 8> flags;
+    flags.push_back("-O2");
+    flags.push_back("--inline-threshold=10");
+
+    if (failed(toolkit.runOptCommand(flags, llFile, optFile))) {
+      return failure();
+    }
+  }
+
+  Artifact llcFile = Artifact::createTemporary(libraryName, "o");
+  {
+    SmallVector<std::string, 8> flags;
+    flags.push_back("-O2");
+    flags.push_back("--march=aie2");
+    flags.push_back("--function-sections");
+    flags.push_back("--filetype=obj");
+
+    if (failed(toolkit.runLlcCommand(flags, optFile, llcFile))) {
+      return failure();
+    }
+  }
+  return success();
+}
+
+LogicalResult AIETargetBackend::serializeExecutable(
+    const SerializationOptions &serOptions,
+    IREE::HAL::ExecutableVariantOp variantOp, OpBuilder &executableBuilder) {
+  ModuleOp moduleOp = variantOp.getInnerModule();
+
+  // Generate the ipu instructions.
+  llvm::SmallVector<char, 0> ipuInstrs;
+  {
+    llvm::raw_svector_ostream ostream(ipuInstrs);
+    if (failed(generateIPUInstructions(moduleOp, executableBuilder, ostream))) {
+      return failure();
+    }
+  }
+  if (!serOptions.dumpIntermediatesPath.empty()) {
+    IREE::HAL::dumpDataToPath(serOptions.dumpIntermediatesPath,
+                              serOptions.dumpBaseName, variantOp.getName(),
+                              ".insts.txt",
+                              StringRef(ipuInstrs.data(), ipuInstrs.size()));
+  }
+
+  // Generate the LLVM IR
+  MLIRContext *context = executableBuilder.getContext();
+  // Convert to LLVM dialect.
+  if (failed(convertToLLVMDialect(context, moduleOp))) {
+    return failure();
+  }
+  if (!serOptions.dumpIntermediatesPath.empty()) {
+    SmallVector<char, 0> llvmDialectModule;
+    llvm::raw_svector_ostream ostream(llvmDialectModule);
+    moduleOp.print(ostream, OpPrintingFlags().useLocalScope());
+    IREE::HAL::dumpDataToPath(
+        serOptions.dumpIntermediatesPath, serOptions.dumpBaseName,
+        variantOp.getName(), ".llvm.mlir",
+        StringRef(llvmDialectModule.data(), llvmDialectModule.size()));
+  }
+
+  // Generate the LLVM IR. We name our files after the executable name so that
+  // they are easy to track both during compilation (logs/artifacts/etc), as
+  // outputs (final intermediate code/binary files), and at runtime (loaded
+  // libraries/symbols/etc).
+  auto executableOp = moduleOp->getParentOfType<IREE::HAL::ExecutableOp>();
+  auto libraryName = executableOp.getName().str();
+  llvm::LLVMContext llvmContext;
+
+  std::unique_ptr<llvm::Module> llvmModule =
+      mlir::translateModuleToLLVMIR(moduleOp, llvmContext, libraryName);
+  if (!llvmModule) {
+    return moduleOp.emitOpError("failed to translate to LLVM");
+  }
+  if (!serOptions.dumpIntermediatesPath.empty()) {
+    dumpBitcodeToPath(serOptions.dumpIntermediatesPath, serOptions.dumpBaseName,
+                      variantOp.getName(), ".codegen.bc", *llvmModule);
+  }
+
+  if (failed(compileUsingPeano(options.peanoInstallDir, variantOp.getLoc(),
+                               libraryName, *llvmModule.get()))) {
+    return moduleOp.emitOpError("failed binary conversion using Peano");
+  }
+
+  return variantOp.emitError() << "AIE serialization NYI";
+}
+
+std::shared_ptr<IREE::HAL::TargetBackend> createTarget(
+    const AMDAIEOptions &options) {
+  return std::make_shared<AIETargetBackend>(options);
 }
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
@@ -15,6 +15,8 @@ namespace mlir::iree_compiler::AMDAIE {
 struct AMDAIEOptions {
   // Path to Peano installation directory.
   std::string peanoInstallDir;
+  // Dump to stdout system commands used during compilation
+  bool showInvokedCommands;
 
   void bindOptions(OptionsBinder &binder) {
     static llvm::cl::OptionCategory category("AMD AIE Options");
@@ -23,6 +25,11 @@ struct AMDAIEOptions {
         "iree-amd-aie-peano-install-dir", peanoInstallDir,
         llvm::cl::cat(category),
         llvm::cl::desc("Path to Peano installation directory"));
+
+    binder.opt<bool>(
+        "iree-amd-aie-show-invoked-commands", showInvokedCommands,
+        llvm::cl::cat(category),
+        llvm::cl::desc("Show commands invoked during binary generation"));
   }
 };
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
@@ -4,11 +4,32 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#ifndef IREE_AMD_AIE_TARGET_AIETARGET_H_
+#define IREE_AMD_AIE_TARGET_AIETARGET_H_
+
 #include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
+#include "iree/compiler/PluginAPI/Client.h"
 
 namespace mlir::iree_compiler::AMDAIE {
 
+struct AMDAIEOptions {
+  // Path to Peano installation directory.
+  std::string peanoInstallDir;
+
+  void bindOptions(OptionsBinder &binder) {
+    static llvm::cl::OptionCategory category("AMD AIE Options");
+
+    binder.opt<std::string>(
+        "iree-amd-aie-peano-install-dir", peanoInstallDir,
+        llvm::cl::cat(category),
+        llvm::cl::desc("Path to Peano installation directory"));
+  }
+};
+
 // Creates the default AIE target.
-std::shared_ptr<IREE::HAL::TargetBackend> createTarget();
+std::shared_ptr<IREE::HAL::TargetBackend> createTarget(
+    const AMDAIEOptions &options);
 
 }  // namespace mlir::iree_compiler::AMDAIE
+
+#endif  // IREE_AMD_AIE_TARGET_AIETARGET_H_

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
@@ -9,11 +9,15 @@ iree_cc_library(
     Target
   HDRS
     "AIETarget.h"
+    "PeanoToolKit.h"
   SRCS
     "AIETarget.cpp"
+    "PeanoToolKit.cpp"
   DEPS
     iree::compiler::Dialect::HAL::Target
     iree::target::amd-aie::Transforms
+    iree::target::amd-aie::aie::AIETranslationPasses
+    iree::target::amd-aie::aie::AIEXTransformPasses
     iree::target::amd-aie::air::AIRDialectIR
   PUBLIC
 )

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/PeanoToolKit.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/PeanoToolKit.cpp
@@ -131,7 +131,8 @@ PeanoToolKit::PeanoToolKit(std::string cmdLinePeanoInstallDir) {
 /// with result in `outputFile`.
 static LogicalResult runCommand(std::string toolPath,
                                 ArrayRef<std::string> flags,
-                                Artifact &inputFile, Artifact &outputFile) {
+                                Artifact &inputFile, Artifact &outputFile,
+                                bool verbose = false) {
   SmallVector<std::string, 8> cmdLine;
   cmdLine.push_back(toolPath);
   cmdLine.append(flags.begin(), flags.end());
@@ -141,9 +142,10 @@ static LogicalResult runCommand(std::string toolPath,
 
   std::string cmdLineStr = escapeCommandLineComponent(llvm::join(cmdLine, " "));
 
-  // LLVM_DEBUG({
-  llvm::errs() << "Running command : " << cmdLineStr << "\n";
-  // })
+  if (verbose) {
+    llvm::errs() << "Running command : " << cmdLineStr << "\n";
+  };
+  LLVM_DEBUG({ llvm::errs() << "Running command : " << cmdLineStr << "\n"; });
 
   int exitCode = system(cmdLineStr.c_str());
   if (exitCode != 0) {
@@ -156,18 +158,18 @@ static LogicalResult runCommand(std::string toolPath,
 
 LogicalResult PeanoToolKit::runOptCommand(ArrayRef<std::string> flags,
                                           Artifact &inputFile,
-                                          Artifact &outputFile) {
+                                          Artifact &outputFile, bool verbose) {
   std::filesystem::path optPath(peanoInstallDir);
   optPath.append("bin").append("opt");
-  return runCommand(optPath.string(), flags, inputFile, outputFile);
+  return runCommand(optPath.string(), flags, inputFile, outputFile, verbose);
 }
 
 LogicalResult PeanoToolKit::runLlcCommand(ArrayRef<std::string> flags,
                                           Artifact &inputFile,
-                                          Artifact &outputFile) {
+                                          Artifact &outputFile, bool verbose) {
   std::filesystem::path llcPath(peanoInstallDir);
   llcPath.append("bin").append("llc");
-  return runCommand(llcPath.string(), flags, inputFile, outputFile);
+  return runCommand(llcPath.string(), flags, inputFile, outputFile, verbose);
 }
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/PeanoToolKit.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/PeanoToolKit.cpp
@@ -1,0 +1,173 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-amd-aie/Target/PeanoToolKit.h"
+
+#include <filesystem>
+
+#include "iree/compiler/Utils/StringUtils.h"
+#include "iree/compiler/Utils/ToolUtils.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/Process.h"
+
+#define DEBUG_TYPE "peano-tools"
+
+namespace mlir::iree_compiler::AMDAIE {
+
+//===---------------------------------------------------------------------===//
+// Artifact(s) class implementation from
+// iree/compiler/Dialect/HAL/Target/LLVMCPU/LinkerTool.cpp.
+// DO NOT MODIFY. To be replaced after moving above to a common place.
+//===---------------------------------------------------------------------===//
+
+// static
+Artifact Artifact::fromFile(StringRef path) { return {path.str(), nullptr}; }
+
+// static
+Artifact Artifact::createTemporary(StringRef prefix, StringRef suffix) {
+  auto sanitizedPrefix = sanitizeFileName(prefix);
+  auto sanitizedSuffix = sanitizeFileName(suffix);
+
+  llvm::SmallString<32> filePath;
+  if (std::error_code error = llvm::sys::fs::createTemporaryFile(
+          sanitizedPrefix, sanitizedSuffix, filePath)) {
+    llvm::errs() << "failed to generate temporary file: " << error.message();
+    return {};
+  }
+  std::error_code error;
+  auto file = std::make_unique<llvm::ToolOutputFile>(filePath, error,
+                                                     llvm::sys::fs::OF_None);
+  if (error) {
+    llvm::errs() << "failed to open temporary file '" << filePath
+                 << "': " << error.message();
+    return {};
+  }
+  return {filePath.str().str(), std::move(file)};
+}
+
+// static
+Artifact Artifact::createVariant(StringRef basePath, StringRef suffix) {
+  SmallString<32> filePath(basePath);
+  llvm::sys::path::replace_extension(filePath, suffix);
+  std::error_code error;
+  auto file = std::make_unique<llvm::ToolOutputFile>(filePath, error,
+                                                     llvm::sys::fs::OF_Append);
+  if (error) {
+    llvm::errs() << "failed to open temporary file '" << filePath
+                 << "': " << error.message();
+    return {};
+  }
+  return {filePath.str().str(), std::move(file)};
+}
+
+void Artifact::keep() const {
+  if (outputFile) outputFile->keep();
+}
+
+std::optional<std::vector<int8_t>> Artifact::read() const {
+  auto fileData = llvm::MemoryBuffer::getFile(path);
+  if (!fileData) {
+    llvm::errs() << "failed to load library output file '" << path << "'";
+    return std::nullopt;
+  }
+  auto sourceBuffer = fileData.get()->getBuffer();
+  std::vector<int8_t> resultBuffer(sourceBuffer.size());
+  std::memcpy(resultBuffer.data(), sourceBuffer.data(), sourceBuffer.size());
+  return resultBuffer;
+}
+
+bool Artifact::readInto(raw_ostream &targetStream) const {
+  // NOTE: we could make this much more efficient if we read in the file a
+  // chunk at a time and piped it along to targetStream. I couldn't find
+  // anything in LLVM that did this, for some crazy reason, but since we are
+  // dealing with binaries that can be 10+MB here it'd be nice if we could avoid
+  // reading them all into memory.
+  auto fileData = llvm::MemoryBuffer::getFile(path);
+  if (!fileData) {
+    llvm::errs() << "failed to load library output file '" << path << "'";
+    return false;
+  }
+  auto sourceBuffer = fileData.get()->getBuffer();
+  targetStream.write(sourceBuffer.data(), sourceBuffer.size());
+  return true;
+}
+
+void Artifact::close() { outputFile->os().close(); }
+
+void Artifacts::keepAllFiles() {
+  libraryFile.keep();
+  debugFile.keep();
+  for (auto &file : otherFiles) {
+    file.keep();
+  }
+}
+
+//===---------------------------------------------------------------------===//
+// End of Artifact(s) class implementation from
+// iree/compiler/Dialect/HAL/Target/LLVMCPU/LinkerTool.cpp.
+// DO NOT MODIFY. To be replaced after moving above to a common place.
+//===---------------------------------------------------------------------===//
+
+PeanoToolKit::PeanoToolKit(std::string cmdLinePeanoInstallDir) {
+  // Check if environment variable is set. Override flags provided with
+  // environment variable
+  char *installDir = std::getenv("IREE_AMDAIE_PEANO_INSTALL_PATH");
+  if (installDir) {
+    peanoInstallDir = std::string(installDir);
+    return;
+  }
+  peanoInstallDir = cmdLinePeanoInstallDir;
+}
+
+/// Implementation of running binary at `toolPath` with `flags` and `inputFile`
+/// with result in `outputFile`.
+static LogicalResult runCommand(std::string toolPath,
+                                ArrayRef<std::string> flags,
+                                Artifact &inputFile, Artifact &outputFile) {
+  SmallVector<std::string, 8> cmdLine;
+  cmdLine.push_back(toolPath);
+  cmdLine.append(flags.begin(), flags.end());
+  cmdLine.push_back(inputFile.path);
+  cmdLine.push_back("-o");
+  cmdLine.push_back(outputFile.path);
+
+  std::string cmdLineStr = escapeCommandLineComponent(llvm::join(cmdLine, " "));
+
+  // LLVM_DEBUG({
+  llvm::errs() << "Running command : " << cmdLineStr << "\n";
+  // })
+
+  int exitCode = system(cmdLineStr.c_str());
+  if (exitCode != 0) {
+    llvm::errs() << "Failed : " << cmdLineStr
+                 << "\n Failure Code : " << exitCode << "\n";
+    return failure();
+  }
+  return success();
+}
+
+LogicalResult PeanoToolKit::runOptCommand(ArrayRef<std::string> flags,
+                                          Artifact &inputFile,
+                                          Artifact &outputFile) {
+  std::filesystem::path optPath(peanoInstallDir);
+  optPath.append("bin").append("opt");
+  return runCommand(optPath.string(), flags, inputFile, outputFile);
+}
+
+LogicalResult PeanoToolKit::runLlcCommand(ArrayRef<std::string> flags,
+                                          Artifact &inputFile,
+                                          Artifact &outputFile) {
+  std::filesystem::path llcPath(peanoInstallDir);
+  llcPath.append("bin").append("llc");
+  return runCommand(llcPath.string(), flags, inputFile, outputFile);
+}
+
+}  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/PeanoToolKit.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/PeanoToolKit.h
@@ -80,11 +80,11 @@ class PeanoToolKit {
 
   // Run the `opt` tool for Peano with given `flags`.
   LogicalResult runOptCommand(ArrayRef<std::string> flags, Artifact &inputFile,
-                              Artifact &outputFile);
+                              Artifact &outputFile, bool verbose = false);
 
   // Run the `llc` tool for Peano with given `flags`.
   LogicalResult runLlcCommand(ArrayRef<std::string> flags, Artifact &inputFile,
-                              Artifact &outputFile);
+                              Artifact &outputFile, bool verbose = false);
 
  private:
   std::string peanoInstallDir;

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/PeanoToolKit.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/PeanoToolKit.h
@@ -1,0 +1,95 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_AMD_AIE_TARGET_PEANTOTOOLKIT_H_
+#define IREE_AMD_AIE_TARGET_PEANTOTOOLKIT_H_
+
+#include <optional>
+
+#include "llvm/Support/ToolOutputFile.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::iree_compiler::AMDAIE {
+
+/// Artifact object copied over from
+/// iree/compiler/Dialect/HAL/Target/LLVMCPU/LinkerTool.h. Copied over right now
+/// but to be replaced with the above after moving to a commonly accessible
+/// place. DO NOT MODIFY
+struct Artifact {
+  // Wraps an existing file on the file system.
+  // The file will not be deleted when the artifact is destroyed.
+  static Artifact fromFile(StringRef path);
+
+  // Creates an output file path/container pair.
+  // By default the file will be deleted when the link completes; callers must
+  // use llvm::ToolOutputFile::keep() to prevent deletion upon success (or if
+  // leaving artifacts for debugging).
+  static Artifact createTemporary(StringRef prefix, StringRef suffix);
+
+  // Creates an output file derived from the given file's path with a new
+  // suffix.
+  static Artifact createVariant(StringRef basePath, StringRef suffix);
+
+  Artifact() = default;
+  Artifact(std::string path, std::unique_ptr<llvm::ToolOutputFile> outputFile)
+      : path(std::move(path)), outputFile(std::move(outputFile)) {}
+
+  std::string path;
+  std::unique_ptr<llvm::ToolOutputFile> outputFile;
+
+  // Preserves the file contents on disk after the artifact has been destroyed.
+  void keep() const;
+
+  // Reads the artifact file contents as bytes.
+  std::optional<std::vector<int8_t>> read() const;
+
+  // Reads the artifact file and writes it into the given |stream|.
+  bool readInto(raw_ostream &targetStream) const;
+
+  // Closes the ostream of the file while preserving the temporary entry on
+  // disk. Use this if files need to be modified by external tools that may
+  // require exclusive access.
+  void close();
+};
+
+struct Artifacts {
+  // File containing the linked library (DLL, ELF, etc).
+  Artifact libraryFile;
+
+  // Optional file containing associated debug information (if stored
+  // separately, such as PDB files).
+  Artifact debugFile;
+
+  // Other files associated with linking.
+  SmallVector<Artifact> otherFiles;
+
+  // Keeps all of the artifacts around after linking completes. Useful for
+  // debugging.
+  void keepAllFiles();
+};
+
+// Base class for all Peano based tools
+class PeanoToolKit {
+ public:
+  explicit PeanoToolKit(std::string cmdLinePeanoInstallDir);
+
+  virtual ~PeanoToolKit() = default;
+
+  // Run the `opt` tool for Peano with given `flags`.
+  LogicalResult runOptCommand(ArrayRef<std::string> flags, Artifact &inputFile,
+                              Artifact &outputFile);
+
+  // Run the `llc` tool for Peano with given `flags`.
+  LogicalResult runLlcCommand(ArrayRef<std::string> flags, Artifact &inputFile,
+                              Artifact &outputFile);
+
+ private:
+  std::string peanoInstallDir;
+};
+
+}  // namespace mlir::iree_compiler::AMDAIE
+
+#endif  // IREE_AMD_AIE_TARGET_PEANTOTOOLKIT_H_

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -16,9 +16,6 @@ namespace mlir::iree_compiler::AMDAIE {
 /// currently the default passes used for lowering after IREEs tiling.
 void addMLIRAIRAIELoweringPasses(OpPassManager &passManager);
 
-/// Add passes to lower from MLIR-AIE to just before binary generation.
-void addMLIRAIELoweringPasses(OpPassManager &passManager);
-
 /// Add passes to run the strategy specified using transform dialect
 /// file/library
 void addTransformDialectPasses(OpPassManager &passManager);

--- a/tests/samples/matmul_fill_static_i32.mlir
+++ b/tests/samples/matmul_fill_static_i32.mlir
@@ -1,10 +1,15 @@
 // RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-codegen-transform-dialect-library=%S/matmul_fill_spec_pad.mlir | FileCheck %s
 
 // CHECK-LABEL: hal.executable.export public @matmul_static_dispatch_0_matmul_8x8x16_i32
-//       CHECK:   llvm.func @core_0_2()
-//       CHECK:   llvm.func @core_0_3()
-//       CHECK:   llvm.func @core_0_4()
-//       CHECK:   llvm.func @core_0_5()
+//       CHECK:    AIE.device(ipu)
+//       CHECK:    AIE.shimDMAAllocation
+//       CHECK:    AIE.shimDMAAllocation
+//       CHECK:    AIE.shimDMAAllocation
+//       CHECK:    func.func @matmul_static_dispatch_0_matmul_8x8x16_i32(%arg0: memref<8x16xi32>, %arg1: memref<16x8xi32>, %arg2: memref<8x8xi32>)
+//       CHECK:      AIEX.ipu.dma_memcpy_nd
+//       CHECK:      AIEX.ipu.dma_memcpy_nd
+//       CHECK:      AIEX.ipu.dma_memcpy_nd
+//       CHECK:      AIEX.ipu.sync
 func.func @matmul_static(%lhs : tensor<8x16xi32>,
     %rhs : tensor<16x8xi32>) -> tensor<8x8xi32> {
   %empty = tensor.empty() : tensor<8x8xi32>


### PR DESCRIPTION
This commits adds the initial plumbing to generate binaries for AIE target using Peano.

1) Adds an option iree-amd-aie-peano-install-dir which can point to
   the Peano installation directory. The serialization then uses `opt`
   and `llc` from the installation directory to generate the core binary.
2) Generates the binary that represents the ShimDMA instructions.
3) Adds all the passes used in
   https://github.com/Xilinx/mlir-aie/blob/main/python/compiler/aiecc/main.py
   to prepare for lowering to LLVM and the actual translation to LLVM
   IR to AIETarget. They are moved out of the translation passes to
   keep the flow consistent with what is done in AIR-AIE.