### PR TITLE
Add core elf-generation methods. 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aie/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/aie/CMakeLists.txt
@@ -231,6 +231,7 @@ iree_cc_library(
     AIETranslationPasses
   SRCS
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Targets/AIETargetIPU.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Targets/AIETargetLdScript.cpp"
   DEPS
     ::AIEDialectIR
     ::AIEXDialectIR

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
@@ -13,13 +13,23 @@
 namespace mlir::iree_compiler::AMDAIE {
 
 struct AMDAIEOptions {
+  // Path to MLIR-AIE installation directory.
+  // TODO(MaheshRavishankar): Remove this dependency.
+  std::string mlirAieInstallDir;
+
   // Path to Peano installation directory.
   std::string peanoInstallDir;
+
   // Dump to stdout system commands used during compilation
   bool showInvokedCommands;
 
   void bindOptions(OptionsBinder &binder) {
     static llvm::cl::OptionCategory category("AMD AIE Options");
+
+    binder.opt<std::string>(
+        "iree-amd-aie-mlir-aie-install-dir", mlirAieInstallDir,
+        llvm::cl::cat(category),
+        llvm::cl::desc("Path to MLIR-AIE installation directory"));
 
     binder.opt<std::string>(
         "iree-amd-aie-peano-install-dir", peanoInstallDir,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/PeanoToolKit.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/PeanoToolKit.cpp
@@ -129,17 +129,8 @@ PeanoToolKit::PeanoToolKit(std::string cmdLinePeanoInstallDir) {
 
 /// Implementation of running binary at `toolPath` with `flags` and `inputFile`
 /// with result in `outputFile`.
-static LogicalResult runCommand(std::string toolPath,
-                                ArrayRef<std::string> flags,
-                                Artifact &inputFile, Artifact &outputFile,
+static LogicalResult runCommand(ArrayRef<std::string> cmdLine,
                                 bool verbose = false) {
-  SmallVector<std::string, 8> cmdLine;
-  cmdLine.push_back(toolPath);
-  cmdLine.append(flags.begin(), flags.end());
-  cmdLine.push_back(inputFile.path);
-  cmdLine.push_back("-o");
-  cmdLine.push_back(outputFile.path);
-
   std::string cmdLineStr = escapeCommandLineComponent(llvm::join(cmdLine, " "));
 
   if (verbose) {
@@ -161,7 +152,13 @@ LogicalResult PeanoToolKit::runOptCommand(ArrayRef<std::string> flags,
                                           Artifact &outputFile, bool verbose) {
   std::filesystem::path optPath(peanoInstallDir);
   optPath.append("bin").append("opt");
-  return runCommand(optPath.string(), flags, inputFile, outputFile, verbose);
+  SmallVector<std::string, 8> cmdLine;
+  cmdLine.push_back(optPath.string());
+  cmdLine.append(flags.begin(), flags.end());
+  cmdLine.push_back(inputFile.path);
+  cmdLine.push_back("-o");
+  cmdLine.push_back(outputFile.path);
+  return runCommand(cmdLine, verbose);
 }
 
 LogicalResult PeanoToolKit::runLlcCommand(ArrayRef<std::string> flags,
@@ -169,7 +166,26 @@ LogicalResult PeanoToolKit::runLlcCommand(ArrayRef<std::string> flags,
                                           Artifact &outputFile, bool verbose) {
   std::filesystem::path llcPath(peanoInstallDir);
   llcPath.append("bin").append("llc");
-  return runCommand(llcPath.string(), flags, inputFile, outputFile, verbose);
+  SmallVector<std::string, 8> cmdLine;
+  cmdLine.push_back(llcPath.string());
+  cmdLine.append(flags.begin(), flags.end());
+  cmdLine.push_back(inputFile.path);
+  cmdLine.push_back("-o");
+  cmdLine.push_back(outputFile.path);
+  return runCommand(cmdLine, verbose);
+}
+
+LogicalResult PeanoToolKit::runClangCommand(ArrayRef<std::string> flags,
+                                            Artifact &outputFile,
+                                            bool verbose) {
+  std::filesystem::path clangPath(peanoInstallDir);
+  clangPath.append("bin").append("clang");
+  SmallVector<std::string, 8> cmdLine;
+  cmdLine.push_back(clangPath.string());
+  cmdLine.append(flags.begin(), flags.end());
+  cmdLine.push_back("-o");
+  cmdLine.push_back(outputFile.path);
+  return runCommand(cmdLine, verbose);
 }
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/PeanoToolKit.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/PeanoToolKit.h
@@ -86,6 +86,10 @@ class PeanoToolKit {
   LogicalResult runLlcCommand(ArrayRef<std::string> flags, Artifact &inputFile,
                               Artifact &outputFile, bool verbose = false);
 
+  // Run the `clang` tool for Peano with given `flags`
+  LogicalResult runClangCommand(ArrayRef<std::string> flags,
+                                Artifact &outputFile, bool verbose = false);
+
  private:
   std::string peanoInstallDir;
 };


### PR DESCRIPTION
The AIE Core elf generation needs mlir-aie installation. So this PR
adds a flag `iree-amd-aie-mlir-aie-install-dir` that needs to point to
the MLIR-AIE installation path. This is meant to be a temporary
situation for initial binary generation prototyping.

Refactor some of the serialization logic to allow for cloning of the
ModuleOp. This is required since the same initial module is used in
multiple binary generation flows.