### PR TITLE
Finishing up xclbin generation.

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aie/AIETransformPasses.cpp
+++ b/compiler/plugins/target/AMD-AIE/aie/AIETransformPasses.cpp
@@ -17,6 +17,7 @@ void registerAIETransformPasses() {
   registerAIEAssignBufferAddresses();
   registerAIECanonicalizeDevice();
   registerAIECoreToStandard();
+  registerAIERoutePathfinderFlows();
   registerAIELocalizeLocks();
   registerAIENormalizeAddressSpaces();
   registerAIEObjectFifoRegisterProcess();

--- a/compiler/plugins/target/AMD-AIE/aie/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/aie/CMakeLists.txt
@@ -170,10 +170,12 @@ iree_cc_library(
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIECanonicalizeDevice.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIECreatePacketFlows.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIELocalizeLocks.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIENormalizeAddressSpaces.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp"
   DEPS
     ::defs
     ::AIEDialectIR
@@ -230,8 +232,11 @@ iree_cc_library(
   NAME
     AIETranslationPasses
   SRCS
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Targets/AIETargetCDO.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Targets/AIETargetIPU.cpp"
     "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Targets/AIETargetLdScript.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Targets/AIETargetShared.cpp"
+    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Targets/AIETargetXAIEV2.cpp"
   DEPS
     ::AIEDialectIR
     ::AIEXDialectIR

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -14,7 +14,7 @@
 #include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 #include "air/Dialect/AIR/AIRDialect.h"
 #include "air/Dialect/AIRRt/AIRRtDialect.h"
-#include "iree-amd-aie/Target/PeanoToolKit.h"
+#include "iree-amd-aie/Target/XclBinGeneratorKit.h"
 #include "iree-amd-aie/Transforms/Passes.h"
 #include "iree/compiler/Codegen/Dialect/IREECodegenDialect.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
@@ -39,11 +39,15 @@
 // here since the headers in MLIR-AIE repo are in a place that is
 // not where you would expect.
 namespace xilinx::AIE {
+mlir::LogicalResult AIETranslateToCDO(mlir::ModuleOp module,
+                                      llvm::raw_ostream &output);
 mlir::LogicalResult AIETranslateToIPU(mlir::ModuleOp module,
                                       llvm::raw_ostream &output);
 mlir::LogicalResult AIETranslateToLdScript(mlir::ModuleOp module,
                                            llvm::raw_ostream &output, int col,
                                            int row);
+mlir::LogicalResult AIETranslateToXAIEV2(mlir::ModuleOp module,
+                                         llvm::raw_ostream &output);
 }  // namespace xilinx::AIE
 
 namespace mlir::iree_compiler::AMDAIE {
@@ -228,29 +232,26 @@ static void dumpBitcodeToPath(StringRef path, StringRef baseName,
 
 /// Compile using Peano.
 FailureOr<Artifact> compileUsingPeano(const AMDAIEOptions &options,
+                                      const XclBinGeneratorKit &toolkit,
                                       Location loc, std::string libraryName,
                                       llvm::Module &llvmModule) {
   Artifact llFile = Artifact::createTemporary(libraryName, "bc");
   {
-    auto &llFileOs = llFile.outputFile->os();
     llvm::SmallVector<char, 0> llFileString;
     llvm::raw_svector_ostream ostream(llFileString);
     llvm::WriteBitcodeToFile(llvmModule, ostream);
-    llFileOs << llFileString;
-    llFileOs.flush();
-    llFileOs.close();
+    llFile.write(llFileString);
   }
+  llFile.close();
   llFile.keep();
 
-  PeanoToolKit toolkit(options.peanoInstallDir);
   Artifact optFile = Artifact::createTemporary(libraryName, "opt.bc");
   {
     SmallVector<std::string, 8> flags;
     flags.push_back("-O2");
     flags.push_back("--inline-threshold=10");
 
-    if (failed(toolkit.runOptCommand(flags, llFile, optFile,
-                                     options.showInvokedCommands))) {
+    if (failed(toolkit.runOptCommand(flags, llFile, optFile))) {
       return failure();
     }
   }
@@ -263,8 +264,7 @@ FailureOr<Artifact> compileUsingPeano(const AMDAIEOptions &options,
     flags.push_back("--function-sections");
     flags.push_back("--filetype=obj");
 
-    if (failed(toolkit.runLlcCommand(flags, optFile, llcFile,
-                                     options.showInvokedCommands))) {
+    if (failed(toolkit.runLlcCommand(flags, optFile, llcFile))) {
       return failure();
     }
   }
@@ -274,6 +274,7 @@ FailureOr<Artifact> compileUsingPeano(const AMDAIEOptions &options,
 // Generate the object file from the ModuleOp
 FailureOr<Artifact> generateObjectFile(MLIRContext *context, ModuleOp moduleOp,
                                        const AMDAIEOptions &options,
+                                       const XclBinGeneratorKit &toolkit,
                                        std::string intermediatesPath,
                                        std::string baseName) {
   // Convert to LLVM dialect.
@@ -306,7 +307,7 @@ FailureOr<Artifact> generateObjectFile(MLIRContext *context, ModuleOp moduleOp,
 
   // Compile using Peano.
   FailureOr<Artifact> objFile = compileUsingPeano(
-      options, variantOp.getLoc(), libraryName, *llvmModule.get());
+      options, toolkit, variantOp.getLoc(), libraryName, *llvmModule.get());
   if (failed(objFile)) {
     return moduleOp.emitOpError("failed binary conversion using Peano");
   }
@@ -314,8 +315,10 @@ FailureOr<Artifact> generateObjectFile(MLIRContext *context, ModuleOp moduleOp,
 }
 
 // Generate the elf files for the core
-FailureOr<SmallVector<Artifact>> generateCoreElfFiles(
-    ModuleOp moduleOp, Artifact &objFile, const AMDAIEOptions &options) {
+LogicalResult generateCoreElfFiles(ModuleOp moduleOp, Artifact &objFile,
+                                   std::string workDir,
+                                   const AMDAIEOptions &options,
+                                   const XclBinGeneratorKit &toolkit) {
   auto deviceOps = moduleOp.getOps<xilinx::AIE::DeviceOp>();
   if (!llvm::hasSingleElement(deviceOps)) {
     return moduleOp.emitOpError("expected a single device op");
@@ -324,6 +327,7 @@ FailureOr<SmallVector<Artifact>> generateCoreElfFiles(
   SmallVector<Artifact> coreElfFiles;
   xilinx::AIE::DeviceOp deviceOp = *deviceOps.begin();
   auto tileOps = deviceOp.getOps<xilinx::AIE::TileOp>();
+
   for (auto tileOp : tileOps) {
     int col = tileOp.colIndex();
     int row = tileOp.rowIndex();
@@ -343,15 +347,16 @@ FailureOr<SmallVector<Artifact>> generateCoreElfFiles(
       return coreOp.emitOpError("failed to generate ld script for core (")
              << col << "," << row << ")";
     }
-    auto &ldScriptFileOs = ldScriptFile.outputFile->os();
-    ldScriptFileOs << ldScriptString;
-    ldScriptFileOs.flush();
-    ldScriptFileOs.close();
+    ldScriptFile.write(ldScriptString);
+    ldScriptFile.close();
 
     // We are running a clang command for now, but really this is an lld
     // command.
-    PeanoToolKit peanoToolKit(options.peanoInstallDir);
-    Artifact elfFile = Artifact::createTemporary(elfFileName, "");
+    FailureOr<Artifact> elfFile = Artifact::createFile(workDir, elfFileName);
+    if (failed(elfFile)) {
+      return coreOp.emitOpError("failed to create artifact for elf file : ")
+             << elfFileName << " at " << workDir;
+    }
     {
       SmallVector<std::string, 8> flags;
       flags.push_back("-O2");
@@ -366,15 +371,265 @@ FailureOr<SmallVector<Artifact>> generateCoreElfFiles(
       flags.push_back("-Wl,--gc-sections");
       std::string ldScriptFlag = "-Wl,-T," + ldScriptFile.path;
       flags.push_back(ldScriptFlag);
-      if (failed(peanoToolKit.runClangCommand(flags, elfFile,
-                                              options.showInvokedCommands))) {
+      if (failed(toolkit.runClangCommand(flags, elfFile.value()))) {
         return coreOp.emitOpError("failed to generate elf file for core(")
                << col << "," << row << ")";
       }
     }
-    coreElfFiles.emplace_back(std::move(elfFile));
+    elfFile->close();
+    elfFile->keep();
   }
-  return coreElfFiles;
+  return success();
+}
+
+FailureOr<Artifact> generateXCLBin(MLIRContext *context, ModuleOp moduleOp,
+                                   std::string workDir,
+                                   const AMDAIEOptions &options,
+                                   const XclBinGeneratorKit &toolkit,
+                                   raw_ostream &xclBin) {
+  // This corresponds to `process_host_cgen`, which is listed as host
+  // compilation in aiecc.py... not sure we need this.
+  PassManager passManager(context, ModuleOp::getOperationName());
+  passManager.addNestedPass<xilinx::AIE::DeviceOp>(
+      xilinx::AIE::createAIEPathfinderPass());
+  passManager.addNestedPass<xilinx::AIE::DeviceOp>(
+      xilinx::AIEX::createAIEBroadcastPacketPass());
+  passManager.addNestedPass<xilinx::AIE::DeviceOp>(
+      xilinx::AIE::createAIERoutePacketFlowsPass());
+  passManager.addNestedPass<xilinx::AIE::DeviceOp>(
+      xilinx::AIEX::createAIELowerMulticastPass());
+  if (failed(passManager.run(moduleOp))) {
+    return moduleOp.emitOpError(
+        "failed to run passes to prepare of XCLBin generation");
+  }
+
+  // Generate aie_inc.cpp file.
+  FailureOr<Artifact> incFile = Artifact::createFile(workDir, "aie_inc.cpp");
+  if (failed(incFile)) {
+    return moduleOp.emitOpError("failed to create aie_inc.cpp");
+  }
+  {
+    SmallVector<char, 0> aieIncString;
+    llvm::raw_svector_ostream ostream(aieIncString);
+    if (failed(xilinx::AIE::AIETranslateToXAIEV2(moduleOp, ostream))) {
+      return moduleOp.emitOpError("failed translation to XAIEV2");
+    }
+    incFile->write(aieIncString);
+  }
+  incFile->close();
+  incFile->keep();
+
+  // Generate aie_control.cpp
+  FailureOr<Artifact> controlFile =
+      Artifact::createFile(workDir, "aie_control.cpp");
+  if (failed(controlFile)) {
+    return moduleOp.emitOpError("failed to create aie_control.cpp");
+  }
+  {
+    SmallVector<char, 0> aieControlString;
+    llvm::raw_svector_ostream ostream(aieControlString);
+    if (failed(xilinx::AIE::AIETranslateToCDO(moduleOp, ostream))) {
+      return moduleOp.emitOpError("failed translation to CDO");
+    }
+    controlFile->write(aieControlString);
+  }
+  controlFile->close();
+  controlFile->keep();
+
+  // Invoke clang++ commands to generate the final XCL bin
+  std::string incWorkDir("-I");
+  incWorkDir += workDir;
+
+  std::string cdoIncludes("-I");
+  std::filesystem::path cdoIncludesPath(options.mlirAieInstallDir);
+  cdoIncludesPath.append("runtime_lib")
+      .append("x86_64")
+      .append("xaiengine")
+      .append("cdo")
+      .append("include");
+  cdoIncludes += cdoIncludesPath.string();
+
+  std::string aietoolsIncludes("-I");
+  std::filesystem::path aietoolsIncludesPath(options.vitisInstallDir);
+  aietoolsIncludesPath.append("aietools").append("include");
+  aietoolsIncludes += aietoolsIncludesPath.string();
+
+  SmallVector<Artifact> objFiles;
+
+  // Generate gen_cdo.o
+  {
+    FailureOr<Artifact> genCdoObj = Artifact::createFile(workDir, "gen_cdo.o");
+    if (failed(genCdoObj)) {
+      return moduleOp.emitOpError("failed to create gen_cdo.o");
+    }
+    SmallVector<std::string, 8> flags = {"-fPIC",
+                                         "-c",
+                                         "-std=c++17",
+                                         "-D__AIEARCH__=20",
+                                         "-D__AIESIM__",
+                                         "-D__CDO__",
+                                         "-D__PS_INIT_AIE__",
+                                         "-D__LOCK_FENCE_MODE__=2",
+                                         "-DAIE_OPTION_SCALAR_FLOAT_ON_VECTOR",
+                                         "-DAIE2_FP32_EMULATION_ACCURACY_FAST",
+                                         "-Wno-deprecated-declarations"};
+    flags.push_back(incWorkDir);
+    flags.push_back(cdoIncludes);
+    flags.push_back(aietoolsIncludes);
+    std::filesystem::path inputFilePath(options.mlirAieInstallDir);
+    inputFilePath.append("data")
+        .append("generated-source")
+        .append("gen_cdo.cpp");
+    FailureOr<Artifact> inputFile = Artifact::fromFile(inputFilePath.string());
+    if (failed(inputFile)) {
+      return moduleOp.emitOpError("failed to find gen_cdo.cpp");
+    }
+    if (failed(toolkit.runClangppCommand(flags, inputFile.value(),
+                                         genCdoObj.value()))) {
+      return moduleOp.emitOpError("failed to compile gen_cdo.o");
+    }
+    genCdoObj->close();
+    objFiles.emplace_back(std::move(genCdoObj.value()));
+  }
+
+  // Generate cdo_main.o
+  {
+    FailureOr<Artifact> cdoMainObj =
+        Artifact::createFile(workDir, "cdo_main.o");
+    if (failed(cdoMainObj)) {
+      return moduleOp.emitOpError("failed to create cdo_main.o");
+    }
+    SmallVector<std::string, 8> flags = {"-fPIC", "-c", "-std=c++17"};
+    flags.push_back(incWorkDir);
+    flags.push_back(cdoIncludes);
+    flags.push_back(aietoolsIncludes);
+    std::filesystem::path inputFilePath(options.mlirAieInstallDir);
+    inputFilePath.append("data")
+        .append("generated-source")
+        .append("cdo_main.cpp");
+    FailureOr<Artifact> inputFile = Artifact::fromFile(inputFilePath.string());
+    if (failed(inputFile)) {
+      return moduleOp.emitOpError("failed to find cdo_main.cpp");
+    }
+    if (failed(toolkit.runClangppCommand(flags, inputFile.value(),
+                                         cdoMainObj.value()))) {
+      return moduleOp.emitOpError("failed to compile cdo_main.o");
+    }
+    cdoMainObj->close();
+    objFiles.emplace_back(std::move(cdoMainObj.value()));
+  }
+
+  // Generate cdo_main.out
+  FailureOr<Artifact> cdoBinary = Artifact::createFile(workDir, "cdo_main");
+  SmallVector<EnvVars> envVars;
+  if (failed(cdoBinary)) {
+    return moduleOp.emitOpError("failed to create cdo_main binary");
+  }
+  {
+    SmallVector<std::string> flags;
+
+    std::string cdoLibPathString("-L");
+    std::filesystem::path cdoLibPath(options.mlirAieInstallDir);
+    cdoLibPath.append("runtime_lib")
+        .append("x86_64")
+        .append("xaiengine")
+        .append("cdo");
+    cdoLibPathString += cdoLibPath.string();
+    flags.push_back(cdoLibPathString);
+
+    std::string aietoolLibPathString("-L");
+    std::filesystem::path aietoolLibPath(options.vitisInstallDir);
+    aietoolLibPath.append("aietools").append("lib").append("lnx64.o");
+    aietoolLibPathString += aietoolLibPath.string();
+    flags.push_back(aietoolLibPathString);
+
+    flags.push_back("-lxaienginecdo");
+    flags.push_back("-lcdo_driver");
+
+    envVars.push_back(EnvVars{"LD_LIBRARY_PATH",
+                              {cdoLibPath.string(), aietoolLibPath.string()}});
+
+    if (failed(toolkit.runClangppCommand(flags, objFiles, cdoBinary.value()))) {
+      return moduleOp.emitOpError("failed to generate cdo_binary");
+    }
+    cdoBinary->close();
+  }
+  cdoBinary->keep();
+
+  // Execute the cdo_main binary.
+  {
+    SmallVector<std::string> flags;
+    flags.push_back(cdoBinary->path);
+    flags.push_back("--work-dir-path");
+    flags.push_back(workDir + "/");
+    if (failed(toolkit.runCommand(flags, envVars))) {
+      return moduleOp.emitOpError("failed to execute cdo_main binary");
+    }
+  }
+
+  // Execute the bootgen command.
+  {
+    SmallVector<std::string> flags = {"-arch", "versal"};
+
+    std::filesystem::path bifFilePath(workDir);
+    bifFilePath.append("design.bif");
+    FailureOr<Artifact> input = Artifact::fromFile(bifFilePath.string());
+    if (failed(input)) {
+      return moduleOp.emitOpError("failed to find bif file at : ")
+             << bifFilePath.string();
+    }
+
+    FailureOr<Artifact> pdiFile = Artifact::createFile(workDir, "design.pdi");
+    if (failed(pdiFile)) {
+      return moduleOp.emitOpError("failed to create pdi file at : ") << workDir;
+    }
+    if (failed(toolkit.runBootGen(flags, input.value(), pdiFile.value()))) {
+      return moduleOp.emitOpError("failed to execute bootgen");
+    }
+    pdiFile->close();
+    pdiFile->keep();
+  }
+
+  // Execute the xclbinutile command.
+  FailureOr<Artifact> xclbinFile =
+      Artifact::createFile(workDir, "final.xclbin");
+  if (failed(xclbinFile)) {
+    return moduleOp.emitOpError("failed to create final.xclbin at ") << workDir;
+  }
+  {
+    std::filesystem::path xclbinInputPath(options.mlirAieInstallDir);
+    xclbinInputPath.append("data").append("1x4.xclbin");
+    FailureOr<Artifact> input = Artifact::fromFile(xclbinInputPath.string());
+    if (failed(input)) {
+      return moduleOp.emitOpError("failed to get input xclbin");
+    }
+
+    SmallVector<std::string> flags;
+    flags.push_back("--add-kernel");
+
+    std::filesystem::path kernelsFilePath(workDir);
+    kernelsFilePath.append("kernels.json");
+    flags.push_back(kernelsFilePath.string());
+
+    flags.push_back("--add-replace-section");
+
+    std::filesystem::path aiePartitionsPath(workDir);
+    aiePartitionsPath.append("aie_partition.json");
+    flags.push_back(std::string("AIE_PARTITION:JSON:") +
+                    aiePartitionsPath.string());
+
+    if (failed(
+            toolkit.runXclBinUtil(flags, input.value(), xclbinFile.value()))) {
+      return moduleOp.emitOpError("failed to run xclbinutil");
+    }
+  }
+  xclbinFile->close();
+  xclbinFile->keep();
+
+  if (!xclbinFile->readInto(xclBin)) {
+    return moduleOp.emitOpError("failed to get xlcbin bits");
+  }
+  return success();
 }
 
 LogicalResult AIETargetBackend::serializeExecutable(
@@ -413,13 +668,16 @@ LogicalResult AIETargetBackend::serializeExecutable(
                               StringRef(ipuInstrs.data(), ipuInstrs.size()));
   }
 
+  XclBinGeneratorKit toolkit(options.peanoInstallDir, options.vitisInstallDir,
+                             options.showInvokedCommands);
+
   FailureOr<Artifact> objFile;
   {
     OpBuilder::InsertionGuard g(executableBuilder);
     executableBuilder.setInsertionPoint(moduleOp);
     auto clonedModuleOp =
         dyn_cast<ModuleOp>(executableBuilder.clone(*moduleOp.getOperation()));
-    objFile = generateObjectFile(context, clonedModuleOp, getOptions(),
+    objFile = generateObjectFile(context, clonedModuleOp, getOptions(), toolkit,
                                  serOptions.dumpIntermediatesPath,
                                  serOptions.dumpBaseName);
     if (failed(objFile)) {
@@ -428,14 +686,35 @@ LogicalResult AIETargetBackend::serializeExecutable(
     clonedModuleOp->erase();
   }
 
-  // Generate the core elf file.
-  FailureOr<SmallVector<Artifact>> coreElfFiles =
-      generateCoreElfFiles(moduleOp, objFile.value(), getOptions());
-  if (failed(coreElfFiles)) {
-    return failure();
+  // Create a temporary work directory needed for subsequent commands.
+  FailureOr<std::string> workDir =
+      Artifact::createTemporaryDirectory(variantOp.getName());
+  if (failed(workDir)) {
+    return moduleOp.emitOpError(
+        "failed to create temporary working directory for xclbin generation");
   }
-  for (auto &coreElfFile : coreElfFiles.value()) {
-    coreElfFile.keep();
+  llvm::outs() << "Temporary WorkDir : " << workDir.value() << "\n";
+
+  // Generate the core elf file.
+  {
+    OpBuilder::InsertionGuard g(executableBuilder);
+    executableBuilder.setInsertionPoint(moduleOp);
+    auto clonedModuleOp =
+        dyn_cast<ModuleOp>(executableBuilder.clone(*moduleOp.getOperation()));
+    if (failed(generateCoreElfFiles(moduleOp, objFile.value(), workDir.value(),
+                                    getOptions(), toolkit))) {
+      return failure();
+    }
+    clonedModuleOp->erase();
+  }
+
+  llvm::SmallVector<char, 0> xclbin;
+  {
+    llvm::raw_svector_ostream ostream(xclbin);
+    if (failed(generateXCLBin(context, moduleOp, workDir.value(), getOptions(),
+                              toolkit, ostream))) {
+      return moduleOp.emitOpError() << "failed to generate XCLbin";
+    }
   }
 
   return variantOp.emitError() << "AIE serialization NYI";

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
@@ -20,6 +20,9 @@ struct AMDAIEOptions {
   // Path to Peano installation directory.
   std::string peanoInstallDir;
 
+  // Path to Vitis installation directory.
+  std::string vitisInstallDir;
+
   // Dump to stdout system commands used during compilation
   bool showInvokedCommands;
 
@@ -40,6 +43,11 @@ struct AMDAIEOptions {
         "iree-amd-aie-show-invoked-commands", showInvokedCommands,
         llvm::cl::cat(category),
         llvm::cl::desc("Show commands invoked during binary generation"));
+
+    binder.opt<std::string>(
+        "iree-amd-aie-vitis-install-dir", vitisInstallDir,
+        llvm::cl::cat(category),
+        llvm::cl::desc("Path to aietools in Vitis installation"));
   }
 };
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
@@ -9,10 +9,10 @@ iree_cc_library(
     Target
   HDRS
     "AIETarget.h"
-    "PeanoToolKit.h"
+    "XclBinGeneratorKit.h"
   SRCS
     "AIETarget.cpp"
-    "PeanoToolKit.cpp"
+    "XclBinGeneratorKit.cpp"
   DEPS
     iree::compiler::Dialect::HAL::Target
     iree::target::amd-aie::Transforms

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XclBinGeneratorKit.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XclBinGeneratorKit.cpp
@@ -288,7 +288,6 @@ LogicalResult XclBinGeneratorKit::runXclBinUtil(ArrayRef<std::string> flags,
 
   SmallVector<std::string, 8> cmdLine;
   cmdLine.push_back(xclbinutilPath.string());
-  cmdLine.append(flags.begin(), flags.end());
 
   cmdLine.push_back("--input");
   cmdLine.push_back(input.path);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XclBinGeneratorKit.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XclBinGeneratorKit.h
@@ -4,24 +4,28 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef IREE_AMD_AIE_TARGET_PEANTOTOOLKIT_H_
-#define IREE_AMD_AIE_TARGET_PEANTOTOOLKIT_H_
+#ifndef IREE_AMD_AIE_TARGET_XCLBINGENERATORKIT_H_
+#define IREE_AMD_AIE_TARGET_XCLBINGENERATORKIT_H_
 
 #include <optional>
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "mlir/Support/LogicalResult.h"
 
 namespace mlir::iree_compiler::AMDAIE {
 
 /// Artifact object copied over from
-/// iree/compiler/Dialect/HAL/Target/LLVMCPU/LinkerTool.h. Copied over right now
-/// but to be replaced with the above after moving to a commonly accessible
-/// place. DO NOT MODIFY
+/// iree/compiler/Dialect/HAL/Target/LLVMCPU/LinkerTool.h. Copied over +
+/// modified right now but to be replaced with the above after moving to a
+/// commonly accessible place.
 struct Artifact {
   // Wraps an existing file on the file system.
   // The file will not be deleted when the artifact is destroyed.
-  static Artifact fromFile(StringRef path);
+  static FailureOr<Artifact> fromFile(StringRef path);
+
+  // Create a file with a given path and name.
+  static FailureOr<Artifact> createFile(StringRef path, StringRef name);
 
   // Creates an output file path/container pair.
   // By default the file will be deleted when the link completes; callers must
@@ -32,6 +36,9 @@ struct Artifact {
   // Creates an output file derived from the given file's path with a new
   // suffix.
   static Artifact createVariant(StringRef basePath, StringRef suffix);
+
+  // Create a temporary directory for putting Artifacts.
+  static FailureOr<std::string> createTemporaryDirectory(StringRef prefix);
 
   Artifact() = default;
   Artifact(std::string path, std::unique_ptr<llvm::ToolOutputFile> outputFile)
@@ -48,6 +55,9 @@ struct Artifact {
 
   // Reads the artifact file and writes it into the given |stream|.
   bool readInto(raw_ostream &targetStream) const;
+
+  // Writes a string into the artifact file.
+  void write(SmallVectorImpl<char> &data);
 
   // Closes the ostream of the file while preserving the temporary entry on
   // disk. Use this if files need to be modified by external tools that may
@@ -71,29 +81,59 @@ struct Artifacts {
   void keepAllFiles();
 };
 
-// Base class for all Peano based tools
-class PeanoToolKit {
- public:
-  explicit PeanoToolKit(std::string cmdLinePeanoInstallDir);
+// Helper class to carry environment variables;
+struct EnvVars {
+  std::string varName;
+  SmallVector<std::string> value;
+};
 
-  virtual ~PeanoToolKit() = default;
+// Class to handle calling binaries from Peano and Vitis.
+class XclBinGeneratorKit {
+ public:
+  explicit XclBinGeneratorKit(std::string cmdLinePeanoInstallDir,
+                              std::string cmdLineVisitInstallDir,
+                              bool verbose = false);
+
+  virtual ~XclBinGeneratorKit() = default;
+
+  // Helper function to run any command
+  LogicalResult runCommand(
+      ArrayRef<std::string> commandLine,
+      ArrayRef<EnvVars> envVars = ArrayRef<EnvVars>{}) const;
 
   // Run the `opt` tool for Peano with given `flags`.
   LogicalResult runOptCommand(ArrayRef<std::string> flags, Artifact &inputFile,
-                              Artifact &outputFile, bool verbose = false);
+                              Artifact &outputFile) const;
 
   // Run the `llc` tool for Peano with given `flags`.
   LogicalResult runLlcCommand(ArrayRef<std::string> flags, Artifact &inputFile,
-                              Artifact &outputFile, bool verbose = false);
+                              Artifact &outputFile) const;
 
   // Run the `clang` tool for Peano with given `flags`
   LogicalResult runClangCommand(ArrayRef<std::string> flags,
-                                Artifact &outputFile, bool verbose = false);
+                                Artifact &outputFile) const;
+
+  // Run the `clang++` tool for Peano with given `flags`
+  LogicalResult runClangppCommand(ArrayRef<std::string> flags,
+                                  ArrayRef<Artifact> inputFiles,
+                                  Artifact &outputFile) const;
+
+  // Run the `bootgen` tool from Vitis with given flags
+  LogicalResult runBootGen(ArrayRef<std::string> flags, Artifact &input,
+                           Artifact &output) const;
+
+  // Run the `xclbinutil` tool from Vitis with given flags.
+  LogicalResult runXclBinUtil(ArrayRef<std::string> flags, Artifact &input,
+                              Artifact &output) const;
 
  private:
   std::string peanoInstallDir;
+
+  std::string vitisInstallDir;
+
+  bool verbose;
 };
 
 }  // namespace mlir::iree_compiler::AMDAIE
 
-#endif  // IREE_AMD_AIE_TARGET_PEANTOTOOLKIT_H_
+#endif  // IREE_AMD_AIE_TARGET_XCLBINGENERATORKIT_H_


### PR DESCRIPTION
With this PR the binary translation adds all the functionality needed to generate the two binary pieces that IREE needs to generate. To get here  a new option, `--iree-amd-aie-vitis-install-dir`, was needed to point to the Vitis installation directory to pick up the libraries and binaries needed for the final xclbin generation.
This effectively now is capable of replicating the flow in aiecc.py using the following command

```
SAMPLES_DIR=<iree-amd-aie source dir>/tests/samples
iree-compile  --iree-hal-target-backends=amd-aie  \
 ${SAMPLES_DIR}/matmul_fill_static_i32.mlir \
  --iree-codegen-transform-dialect-library=${SAMPLES_DIR}/matmul_fill_spec_pad.mlir \
  --iree-amd-aie-peano-install-dir=<peano installation directory> \
  --iree-amd-aie-mlir-aie-install-dir=<mlir-aie installation directory> \
  --iree-amd-aie-vitis-install-dir=<vitis installation directory> \
  --iree-hal-dump-executable-files-to=$PWD  --iree-amd-aie-show-invoked-commands
```
