### PR TITLE
Change the mlir-air submodule branch (from iree_fixes to iree_fixes_3)

### DIFF
--- a/compiler/plugins/target/AMD-AIE/air/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/air/CMakeLists.txt
@@ -158,6 +158,7 @@ iree_cc_library(
     "${IREE_MLIR_AIR_SOURCE_DIR}/include/air/Util/Util.h"
   SRCS
     "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Util/Dependency.cpp"
+    "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Util/DirectedAdjacencyMap.cpp"
     "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Util/Util.cpp"
     "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Util/Outliner.cpp"
     "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Util/CostModel.cpp"


### PR DESCRIPTION
Steps taken:

- Moved nod.ai/mlir-air/iree_fixes changes to xilinx/mlir-air/main where possible : https://github.com/Xilinx/mlir-air/pull/359
- Squashed remaining changes into a single commit, created branch iree_fixes_3 which has this commit on top of xilinx/mlir-air/main : https://github.com/nod-ai/mlir-air/tree/iree_fixes_3 
- Created this PR