### PR TITLE
Flatbuffer executable serialization (xlcbin, lx6 instructions)

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/CMakeLists.txt
@@ -23,6 +23,9 @@ iree_cc_library(
     iree::target::amd-aie::aie::AIEXTransformPasses
     iree::target::amd-aie::air::AIRDialectIR
     iree::target::amd-aie::air::AIRPasses
+    iree::base::core_headers
+    iree::base::internal::flatcc::building
+    iree-amd-aie::schemas::xrt_executable_def_c_fbs
   PUBLIC
 )
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -837,13 +837,6 @@ LogicalResult generateXCLBin(MLIRContext *context, ModuleOp moduleOp,
 LogicalResult AIETargetBackend::serializeExecutable(
     const SerializationOptions &serOptions,
     IREE::HAL::ExecutableVariantOp variantOp, OpBuilder &executableBuilder) {
-  // Create a flatbuffer containing xclbin and lx6 instructions, which gets
-  // insertered into the IR as an op attribute. The design here is copied from
-  // the CUDA plugin implementation, see
-  // iree/compiler/plugins/target/CUDA/CUDATarget.cpp
-  FlatbufferBuilder builder;
-  iree_amd_aie_hal_xrt_ExecutableDef_start_as_root(builder);
-
   ModuleOp moduleOp = variantOp.getInnerModule();
   if (!serOptions.dumpIntermediatesPath.empty()) {
     dumpMLIRModuleToPath(serOptions.dumpIntermediatesPath,
@@ -876,10 +869,6 @@ LogicalResult AIETargetBackend::serializeExecutable(
                               ".insts.txt",
                               StringRef(dumpString.data(), dumpString.size()));
   }
-
-  // Serialize lx6 control instructions into flatbuffer.
-  auto ipuInstrsRef = builder.createInt32Vec(ipuInstrs);
-  iree_amd_aie_hal_xrt_ExecutableDef_asm_instrs_add(builder, ipuInstrsRef);
 
   XclBinGeneratorKit toolkit(options.peanoInstallDir, options.vitisInstallDir,
                              options.showInvokedCommands);
@@ -921,21 +910,22 @@ LogicalResult AIETargetBackend::serializeExecutable(
     clonedModuleOp->erase();
   }
 
+  // Create a flatbuffer containing (for now) lx6 instructions and xclbin.
+  FlatbufferBuilder builder;
+  iree_amd_aie_hal_xrt_ExecutableDef_start_as_root(builder);
+
+  auto ipuInstrsRef = builder.createInt32Vec(ipuInstrs);
+  iree_amd_aie_hal_xrt_ExecutableDef_asm_instrs_add(builder, ipuInstrsRef);
+
   llvm::SmallVector<char, 0> xclbin;
-  {
-    llvm::raw_svector_ostream ostream(xclbin);
-    if (failed(generateXCLBin(context, moduleOp, workDir.value(), getOptions(),
-                              toolkit, ostream))) {
-      return moduleOp.emitOpError() << "failed to generate XCLbin";
-    }
-
-    // Serialize xclbin into flatbuffer.
-    llvm::StringRef xclbinStringView(xclbin.begin(), xclbin.size());
-    auto xclbinStringRef = builder.createString(xclbinStringView);
-    iree_amd_aie_hal_xrt_ExecutableDef_xclbin_add(builder, xclbinStringRef);
+  llvm::raw_svector_ostream ostream(xclbin);
+  if (failed(generateXCLBin(context, moduleOp, workDir.value(), getOptions(),
+                            toolkit, ostream))) {
+    return moduleOp.emitOpError() << "failed to generate XCLbin";
   }
-
-  // Copied from CUDA plugin (end as root, insert Flatbuffer into the module).
+  llvm::StringRef xclbinStringView(xclbin.begin(), xclbin.size());
+  auto xclbinStringRef = builder.createString(xclbinStringView);
+  iree_amd_aie_hal_xrt_ExecutableDef_xclbin_add(builder, xclbinStringRef);
   iree_amd_aie_hal_xrt_ExecutableDef_end_as_root(builder);
 
   auto binaryOp = executableBuilder.create<IREE::HAL::ExecutableBinaryOp>(
@@ -945,8 +935,8 @@ LogicalResult AIETargetBackend::serializeExecutable(
   binaryOp.setMimeTypeAttr(
       executableBuilder.getStringAttr("application/x-flatbuffers"));
 
-  // TODO(JamesNewling) We really need to test that the above logic is correct,
-  // returning success to enable runtime testing.
+  // TODO(JamesNewling) We need to test that the above logic is correct,
+  // returning success here to enable runtime testing.
   return success();
 }
 

--- a/runtime/src/iree-amd-aie/CMakeLists.txt
+++ b/runtime/src/iree-amd-aie/CMakeLists.txt
@@ -7,6 +7,10 @@
 if(IREE_AMD_AIE_ENABLE_XRT_DRIVER)
     add_subdirectory(driver/xrt)
     add_subdirectory(tools)
-    add_subdirectory(schemas)
 endif()
 
+# Flatbuffer schema generation does not require XRT. Moreover the generated
+# flatbuffer header files are used by the compiler to create artefacts
+# (.vmfb file), and so the schema sub-directory is required even when not
+# building the XRT driver code.
+add_subdirectory(schemas)

--- a/runtime/src/iree-amd-aie/driver/xrt/native_executable.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/native_executable.cc
@@ -93,6 +93,11 @@ static iree_status_t iree_amd_aie_hal_xrt_native_executable_flatbuffer_verify(
                             "instructions (%zu) mismatched",
                             entry_point_count, number_asm_instr);
   }
+
+  // TODO(JamesNewling) Once all the parts are connected, this assertion
+  // function might fail. If it passes, we might want to add additional
+  // assertions.
+
   return iree_ok_status();
 }
 

--- a/runtime/src/iree-amd-aie/driver/xrt/xrt_device.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/xrt_device.cc
@@ -249,7 +249,8 @@ static iree_status_t iree_hal_xrt_device_queue_alloca(
     iree_device_size_t allocation_size,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                          "unimplmented queue alloca");
+                          "Unimplemented queue alloca. Checking if this is "
+                          "required for AIE backend.");
 }
 
 static iree_status_t iree_hal_xrt_device_queue_dealloca(
@@ -258,7 +259,7 @@ static iree_status_t iree_hal_xrt_device_queue_dealloca(
     const iree_hal_semaphore_list_t signal_semaphore_list,
     iree_hal_buffer_t* buffer) {
   return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                          "unimplmented queue dealloca");
+                          "Unimplemented queue dealloca");
 }
 
 static iree_status_t iree_hal_xrt_device_queue_read(
@@ -310,20 +311,20 @@ static iree_status_t iree_hal_xrt_device_queue_execute(
     iree_host_size_t command_buffer_count,
     iree_hal_command_buffer_t* const* command_buffers) {
   return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                          "unimplmented queue execute");
+                          "Unimplemented queue execute");
 }
 
 static iree_status_t iree_hal_xrt_device_queue_flush(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity) {
   return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                          "unimplmented queue flush");
+                          "Unimplemented queue flush");
 }
 
 static iree_status_t iree_hal_xrt_device_wait_semaphores(
     iree_hal_device_t* base_device, iree_hal_wait_mode_t wait_mode,
     const iree_hal_semaphore_list_t semaphore_list, iree_timeout_t timeout) {
   return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                          "unimplmented semaphore wait");
+                          "Unimplemented semaphore wait");
 }
 
 static iree_status_t iree_hal_xrt_device_profiling_begin(


### PR DESCRIPTION
Write the xclbin and lx6 instructions to a flatbuffer, which eventually ends up in the .vmfb artefact generated by the compiler. The design for the AIE backend here is based on the CUDA plugin's design. 

This needs further testing, once the ends are connected. I can see the xclbin and lx6 control code instructions are inserted into the MLIR module, and the .vmfb file is generated, but the ultimate test requires using the runtime. In other words the compilation and artefact generation seems fine:

```
./iree-compile -o test.vmfb --mlir-print-ir-after=iree-hal-serialize-executables ... 
```

but the ultimate test requires the runtime, which still has a few missing pieces on the command buffer side

```
./iree-run-module --device=xrt --module=../scripts/scripts_2/test.vmfb --input=8x16xi32 --input=16x8xi32
```

