### PR TITLE
Bump MLIR-AIR version

### DIFF
--- a/compiler/plugins/target/AMD-AIE/air/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/air/CMakeLists.txt
@@ -154,9 +154,11 @@ iree_cc_library(
   NAME
     AIRUtil
   HDRS
+    "${IREE_MLIR_AIR_SOURCE_DIR}/include/air/Util/DirectedAdjacencyMap.h"
     "${IREE_MLIR_AIR_SOURCE_DIR}/include/air/Util/Dependency.h"
     "${IREE_MLIR_AIR_SOURCE_DIR}/include/air/Util/Util.h"
   SRCS
+    "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Util/DirectedAdjacencyMap.cpp"
     "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Util/Dependency.cpp"
     "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Util/Util.cpp"
     "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Util/Outliner.cpp"

--- a/compiler/plugins/target/AMD-AIE/air/TransformPasses.cpp
+++ b/compiler/plugins/target/AMD-AIE/air/TransformPasses.cpp
@@ -18,11 +18,13 @@ void registerAIRTransformPasses() {
   registerAIRDependencyCanonicalize();
   registerAIRDependencyScheduleOpt();
   registerAIRFuseChannels();
+  registerAIRIsolateAsyncDmaLoopNests();
   registerAIRLabelScfForLoopInAIRSegmentPattern();
   registerAIRLabelScfForLoopForPingPongPattern();
   registerAIRPingPongTransformationPattern();
   registerAIRRenumberDmaIdPass();
   registerAIRHerdPlacementPass();
+  registerAIRSpecializeChannelWrapAndStridePattern();
   registerAIRSpecializeDmaBroadcast();
   registerAIRUnrollLoopForPipeliningPattern();
   registerAIRCollapseHerdPass();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -81,13 +81,10 @@ void addMLIRAIRAIELoweringPasses(OpPassManager &passManager) {
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
 
-  passManager.addPass(xilinx::air::createAIRFuseChannels());
+  passManager.addPass(xilinx::air::createAIRIsolateAsyncDmaLoopNests());
+  passManager.addPass(xilinx::air::createAIRSpecializeChannelWrapAndStridePattern());
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
-
-  passManager.addPass(
-      xilinx::air::createAIRLabelScfForLoopInAIRSegmentPattern());
-  passManager.addPass(xilinx::air::createAIRUnrollLoopForPipeliningPattern());
 
   passManager.addNestedPass<func::FuncOp>(
       xilinx::air::createAIRCollapseHerdPass());
@@ -115,6 +112,7 @@ void addMLIRAIRAIELoweringPasses(OpPassManager &passManager) {
     options.clRowOffset = 2;
     options.clColOffset = 0;
     options.clDevice = "ipu";
+    options.clEmitWhileLoop = true;
     passManager.addPass(xilinx::air::createAIRToAIEPass(options));
   }
   passManager.addPass(xilinx::air::createAIRLoweringPass());


### PR DESCRIPTION
New MLIR-AIR features:
- air.channels can now pack parent perfectly nested loops into its sizes and strides fields.
- Packed air.channels can now lower to AIE DMA BDs to pick up the implicit loops.
- Enabled bigger lowerable matmul sizes.