### PR TITLE
Bundle the me_basic.o entry point with IREE

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -17,6 +17,7 @@
 #include "iree-amd-aie/Target/XclBinGeneratorKit.h"
 #include "iree-amd-aie/Transforms/Passes.h"
 #include "iree/compiler/Codegen/Dialect/IREECodegenDialect.h"
+#include "iree/compiler/Utils/ToolUtils.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
@@ -362,8 +363,8 @@ LogicalResult generateCoreElfFiles(ModuleOp moduleOp, Artifact &objFile,
       flags.push_back("-O2");
       flags.push_back("--target=aie2-none-elf");
       flags.push_back(objFile.path);
-      std::filesystem::path meBasicPath(options.mlirAieInstallDir);
-      meBasicPath.append("aie_runtime_lib").append("AIE2").append("me_basic.o");
+      std::filesystem::path meBasicPath(findPlatformLibDirectory("amd-aie"));
+      meBasicPath.append("me_basic.o");
       flags.push_back(meBasicPath.string());
       std::filesystem::path libcPath(options.peanoInstallDir);
       libcPath.append("lib").append("aie2-none-unknown-elf").append("libc.a");

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
@@ -65,3 +65,9 @@ set_property(GLOBAL APPEND PROPERTY IREE_COMPILER_DYLIB_DEPENDS
 # Install.
 install(FILES ${_all_device_bc_files}
   DESTINATION "${IREE_COMPILER_DYLIB_INSTALL_PREFIX}/${_platform_lib_reldir}")
+
+set(VITIS_ROOT /proj/xbuilds/2023.2_released/installs/lin64/Vitis/2023.2)
+set(VITIS_AIETOOLS_DIR /proj/xbuilds/2023.2_released/installs/lin64/Vitis/2023.2/aietools)
+set(AIE_RUNTIME_TARGETS x86_64)
+add_subdirectory(${IREE_MLIR_AIE_SOURCE_DIR}/runtime_lib runtime_lib)
+add_subdirectory(${IREE_MLIR_AIE_SOURCE_DIR}/data data)

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
@@ -21,3 +21,47 @@ iree_cc_library(
     iree::target::amd-aie::air::AIRDialectIR
   PUBLIC
 )
+
+# Set up copy rules.
+set(_platform_lib_reldir "iree_platform_libs/amd-aie")
+set(_platform_lib_absdir "${IREE_COMPILER_DYLIB_DIR}/${_platform_lib_reldir}")
+file(MAKE_DIRECTORY "${_platform_lib_absdir}")
+set(_all_device_bc_copy_commands)
+set(_all_device_bc_files)
+
+# Copy to lib/ tree.
+set(_device_bc_srcpath "${IREE_MLIR_AIE_SOURCE_DIR}/aie_runtime_lib/AIE2/me_basic.o")
+set(_device_bc_relpath "${_platform_lib_reldir}/me_basic.o")
+list(APPEND _all_device_bc_files "${IREE_COMPILER_DYLIB_DIR}/${_device_bc_relpath}")
+list(APPEND _all_device_bc_deps "${_device_bc_path}")
+list(APPEND _all_device_bc_copy_commands
+  COMMAND ${CMAKE_COMMAND} -E copy
+    "${_device_bc_srcpath}"
+    "${IREE_COMPILER_DYLIB_DIR}/${_device_bc_relpath}"
+)
+
+# Note this bc file as being part of the bundle that must be included with
+# the compiler dylib.
+set_property(GLOBAL APPEND PROPERTY IREE_COMPILER_DYLIB_RELPATHS "${_device_bc_relpath}")
+
+# Generate a custom target with all file level dependencies and commands to
+# copy to our build tree locations.
+# Our GenDeviceLibs target depends on all of the defined device lib targets.
+add_custom_command(
+  OUTPUT ${_all_device_bc_files}
+  DEPENDS ${_all_device_bc_deps}
+  POST_BUILD
+    ${_all_device_bc_copy_commands}
+)
+add_custom_target(iree_compiler_plugins_target_AMDAIE_GenDeviceLibs
+  DEPENDS
+    ${_all_device_bc_files}
+)
+
+# Ensure that the device libs are built when the compiler dylib is built.
+set_property(GLOBAL APPEND PROPERTY IREE_COMPILER_DYLIB_DEPENDS
+  iree_compiler_plugins_target_AMDAIE_GenDeviceLibs)
+
+# Install.
+install(FILES ${_all_device_bc_files}
+  DESTINATION "${IREE_COMPILER_DYLIB_INSTALL_PREFIX}/${_platform_lib_reldir}")


### PR DESCRIPTION
For now, me_basic.o is a magic binary that provides the entry point for execution on the AIE cores. It cannot be replicated (yet) by llvm-aie. So this patch fetches the binary checked in to mlir-aie and bundles it with the IREE compiler. It isn't necessary to have Vitis or a full bulid of mlir-aie for this to work.