### PR TITLE
[AMD-AIE] Add a pass to tile and fuse TileInterface ops using scf.forall

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
@@ -31,8 +31,7 @@ namespace mlir::iree_compiler::AMDAIE {
 
 namespace {
 
-/// Lowers the computation within the workgroup count region for the ops
-/// that are handled by default.
+/// Lower WorkgroupCountFromSliceOp with all 1's.
 static LogicalResult lowerWorkgroupCount(RewriterBase &rewriter,
                                          func::FuncOp entryPointFn) {
   FailureOr<IREE::HAL::ExecutableExportOp> exportOp =
@@ -54,7 +53,7 @@ static LogicalResult lowerWorkgroupCount(RewriterBase &rewriter,
   }
   if (workgroupCountOps.empty()) {
     // If there are no default handled `flow.dispatch.workgroup_count`
-    // operation, do nothing. do nothing.
+    // operation, do nothing.
     return success();
   }
   if (!llvm::hasSingleElement(workgroupCountOps)) {
@@ -386,8 +385,6 @@ void AMDAIETileAndFusePass::runOnOperation() {
       return signalPassFailure();
     }
 
-    // Check if workgroup count lowering is needed and if it is then perform it
-    // with a workgroup of (1, 1, 1)
     if (failed(lowerWorkgroupCount(rewriter, funcOp))) {
       funcOp->emitOpError("failed to lower workgroup count region");
       return signalPassFailure();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
@@ -75,6 +75,11 @@ static LogicalResult lowerWorkgroupCount(
       .Default([&](Operation *) { return success(); });
 }
 
+//===----------------------------------------------------------------------------------===//
+// Methods copied over from core to implement tile and fuse with scf.forall.
+// TODO(MaheshRavishankar) Replace them with core methods when upstream
+// can handle this natively
+//===----------------------------------------------------------------------------------===//
 /// Clones the operation and updates the destination if the operation
 /// implements the `DestinationStyleOpInterface`.
 static Operation *cloneOpAndUpdateDestinationArgs(RewriterBase &rewriter,
@@ -320,6 +325,9 @@ LogicalResult applyTileAndFuse(RewriterBase &rewriter, Operation *rootOp,
 
   return success();
 }
+//===----------------------------------------------------------------------------------===//
+// End methods copied over from core to implement tile and fuse with scf.forall.
+//===----------------------------------------------------------------------------------===//
 
 /// This pass starts with the last TilingInterface operation, tiles the op and
 /// fuses its producers recursively. The `tilingLevel` must be specified. It

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
@@ -1,0 +1,337 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-amd-aie/Transforms/PassDetail.h"
+#include "iree-amd-aie/Transforms/Passes.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/TilingInterfaceImpl.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Transforms/Patterns.h"
+#include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
+#include "mlir/Dialect/SCF/Transforms/Transforms.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/Iterators.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-amdaie-tile-and-fuse"
+
+namespace mlir::iree_compiler::AMDAIE {
+
+namespace {
+
+/// Clones the operation and updates the destination if the operation
+/// implements the `DestinationStyleOpInterface`.
+static Operation *cloneOpAndUpdateDestinationArgs(RewriterBase &rewriter,
+                                                  Operation *op,
+                                                  ValueRange newDestArgs) {
+  Operation *clonedOp = rewriter.clone(*op);
+  if (newDestArgs.empty()) return clonedOp;
+  if (auto destinationStyleOp = dyn_cast<DestinationStyleOpInterface>(clonedOp))
+    destinationStyleOp.getDpsInitsMutable().assign(newDestArgs);
+  return clonedOp;
+}
+
+/// Return the untiled producer whose slice is used in a tiled consumer. If
+/// there was no loop traversal needed, the second value of the returned tuple
+/// is empty.
+static std::tuple<OpResult, std::optional<OpOperand *>>
+getUntiledProducerFromSliceSource(OpOperand *source, scf::ForallOp loop) {
+  std::optional<OpOperand *> destinationSharedOuts;
+  if (auto sharedOuts = dyn_cast<BlockArgument>(source->get())) {
+    if (sharedOuts.getOwner()->getParentOp() == loop) {
+      source = loop.getTiedOpOperand(sharedOuts);
+      destinationSharedOuts = source;
+    }
+  }
+  return {dyn_cast<OpResult>(source->get()), destinationSharedOuts};
+}
+
+/// The following is a copy of tileAndFuseProducerOfSlice to make it work for
+/// scf.forall.
+/// Implementation of fusing producer of a single slice by computing the
+/// slice of the producer in-place.
+std::optional<scf::SCFFuseProducerOfSliceResult> tileAndFuseProducerOfSlice(
+    RewriterBase &rewriter, tensor::ExtractSliceOp candidateSliceOp,
+    scf::ForallOp &loop) {
+  // 1. Get the producer of the source.
+  auto [fusableProducer, destinationInitArg] =
+      getUntiledProducerFromSliceSource(&candidateSliceOp.getSourceMutable(),
+                                        loop);
+  if (!fusableProducer) return std::nullopt;
+  unsigned resultNumber = fusableProducer.getResultNumber();
+
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(candidateSliceOp);
+
+  // 2. Clone the fused producer
+  // 2a. Compute the destination operands to use for the cloned operation.
+  SmallVector<Value> origDestinationTensors, clonedOpDestinationTensors;
+  Operation *fusableProducerOp = fusableProducer.getOwner();
+  if (isa<DestinationStyleOpInterface>(fusableProducerOp) &&
+      failed(tensor::getOrCreateDestinations(
+          rewriter, fusableProducerOp->getLoc(), fusableProducerOp,
+          origDestinationTensors)))
+    return std::nullopt;
+
+  clonedOpDestinationTensors = origDestinationTensors;
+  if (destinationInitArg &&
+      isa<DestinationStyleOpInterface>(fusableProducerOp)) {
+    // 2b. If the producer is also destination style, then to maintain the
+    // destination passing style, update the destination of the producer to be
+    // the source of the slice.
+    clonedOpDestinationTensors[resultNumber] = candidateSliceOp.getSource();
+  }
+  // 2c. Clone the fused producer.
+  Operation *clonedProducerOp = cloneOpAndUpdateDestinationArgs(
+      rewriter, fusableProducerOp, clonedOpDestinationTensors);
+  // 2d. Update the source of the candidateSlice to be the cloned producer.
+  //     Easier to just clone the slice with different source since replacements
+  //     and DCE of cloned ops becomes easier
+  SmallVector<Value> candidateSliceOpOperands =
+      llvm::to_vector(candidateSliceOp->getOperands());
+  candidateSliceOpOperands[0] = clonedProducerOp->getResult(resultNumber);
+  tensor::ExtractSliceOp clonedCandidateSliceOp =
+      mlir::clone(rewriter, candidateSliceOp,
+                  candidateSliceOp->getResultTypes(), candidateSliceOpOperands);
+
+  // 3. Generate the tiled implementation of the producer of the source
+  FailureOr<TilingResult> tileAndFuseResult =
+      tensor::replaceExtractSliceWithTiledProducer(
+          rewriter, clonedCandidateSliceOp,
+          clonedProducerOp->getResult(resultNumber));
+  if (failed(tileAndFuseResult)) return std::nullopt;
+  // Note: Do not delete the candidateSliceOp, since its passed in from the
+  // caller.
+  rewriter.replaceAllUsesWith(candidateSliceOp,
+                              tileAndFuseResult->tiledValues[0]);
+  rewriter.eraseOp(clonedCandidateSliceOp);
+  rewriter.eraseOp(clonedProducerOp);
+
+  if (destinationInitArg &&
+      isa<DestinationStyleOpInterface>(fusableProducerOp) && loop) {
+    loop->getOpOperands()[destinationInitArg.value()->getOperandNumber()].set(
+        origDestinationTensors[resultNumber]);
+  }
+  return scf::SCFFuseProducerOfSliceResult{fusableProducer,
+                                           tileAndFuseResult->tiledValues[0],
+                                           tileAndFuseResult->tiledOps};
+}
+
+/// Starting from `op` walk all operands backwards to find all
+/// potentially fusable operations, i.e. operations that implement
+/// the `TilingInterface`.
+static void collectTiledAndFusedOps(Operation *rootOp,
+                                    llvm::SmallDenseSet<Operation *> &result) {
+  SmallVector<Operation *> worklist;
+  worklist.push_back(rootOp);
+  result.insert(rootOp);
+  while (!worklist.empty()) {
+    Operation *current = worklist.pop_back_val();
+    for (OpOperand &operand : current->getOpOperands()) {
+      Operation *producer = operand.get().getDefiningOp();
+      if (!producer || !isa<TilingInterface>(producer) ||
+          result.count(producer))
+        continue;
+      worklist.push_back(producer);
+      result.insert(producer);
+    }
+  }
+}
+
+/// Tiling of `tensor.pad` operation generates
+///
+/// ```mlir
+/// scf.if {
+///   ...
+/// } else {
+///    tensor.pad
+/// }
+/// ```
+///
+/// For IREEs use case we dont need this. So this folds away the `if` condition.
+/// Note this is a fairly hacky workaround, but the current pad operation
+/// semantics force us down this path.
+static FailureOr<tensor::PadOp> foldIfGeneratedFromPadding(
+    RewriterBase &rewriter, tensor::PadOp untiledPadOp,
+    tensor::PadOp tiledPadOp) {
+  auto ifOp = dyn_cast<scf::IfOp>(tiledPadOp->getParentOp());
+  if (!ifOp) {
+    return failure();
+  };
+  Block *block = tiledPadOp->getBlock();
+  Operation *terminator = block->getTerminator();
+  ValueRange results = terminator->getOperands();
+  rewriter.inlineBlockBefore(block, ifOp, /*blockArgs=*/{});
+  rewriter.replaceOp(ifOp, results);
+  rewriter.eraseOp(terminator);
+  return tiledPadOp;
+}
+
+LogicalResult applyTileAndFuse(RewriterBase &rewriter, Operation *rootOp,
+                               DominanceInfo &dominanceInfo,
+                               scf::SCFTilingOptions options) {
+  llvm::SmallDenseSet<Operation *> origTiledAndFusedOps;
+  collectTiledAndFusedOps(rootOp, origTiledAndFusedOps);
+  auto isIgnoredUser = [&](Operation *user) {
+    return origTiledAndFusedOps.count(user) || isa<tensor::DimOp>(user);
+  };
+
+  // 1. Tile the consumer.
+  SmallVector<OpResult> yieldedValuesToOrigValues;
+  SmallVector<Operation *> tiledOps;
+  rewriter.setInsertionPointAfter(rootOp);
+  FailureOr<scf::SCFTilingResult> tilingResult = scf::tileUsingSCFForallOp(
+      rewriter, cast<TilingInterface>(rootOp), options);
+  if (failed(tilingResult)) {
+    return failure();
+  }
+  auto forallLoop = cast<scf::ForallOp>(tilingResult->loops[0]);
+  yieldedValuesToOrigValues.append(rootOp->result_begin(),
+                                   rootOp->result_end());
+  // A map from untiled value to scf.forall shared_outs. The shared_outs is used
+  // for DPS init operand if they use the same init operands.
+  llvm::DenseMap<Value, Value> mapToSharedOuts;
+
+  // WAR for `if` ops generating `scf.if` operations.
+  if (auto rootPadOp = dyn_cast<tensor::PadOp>(rootOp)) {
+    assert(tilingResult->tiledOps.size() == 1 &&
+           "expected tiling of `pad` op to return only one operation");
+    FailureOr<Operation *> replacementTiledOp = foldIfGeneratedFromPadding(
+        rewriter, rootPadOp, cast<tensor::PadOp>(tilingResult->tiledOps[0]));
+    if (!failed(replacementTiledOp)) {
+      tilingResult->tiledOps[0] = replacementTiledOp.value();
+    }
+  } else if (auto dpsOp = dyn_cast<DestinationStyleOpInterface>(rootOp)) {
+    for (auto [init, sharedOuts] :
+         llvm::zip_equal(dpsOp.getDpsInits(), forallLoop.getRegionOutArgs())) {
+      mapToSharedOuts[init] = sharedOuts;
+    }
+  }
+  tiledOps.append(tilingResult->tiledOps);
+
+  // 2. Tiling each operation results in generation of slices. The source of
+  // these slices could be producers that can be fused into the tiled loops by
+  // computing the slices of these producers in-place. This results in more
+  // slices created for operands of the "fused producer". This open up more
+  // opportunities for fusion. Use a worklist to fuse greedily.
+  auto addCandidateSlices =
+      [&](Operation *fusedOp, std::deque<tensor::ExtractSliceOp> &candidates) {
+        for (OpOperand &operand : fusedOp->getOpOperands()) {
+          auto sliceOp = operand.get().getDefiningOp<tensor::ExtractSliceOp>();
+          if (!sliceOp) continue;
+          candidates.push_back(sliceOp);
+
+          auto dpsOp = dyn_cast<DestinationStyleOpInterface>(fusedOp);
+          if (!dpsOp) continue;
+
+          if (dpsOp.isDpsInit(&operand) &&
+              mapToSharedOuts.contains(sliceOp.getSource())) {
+            rewriter.startRootUpdate(sliceOp);
+            sliceOp.getSourceMutable().assign(
+                mapToSharedOuts[sliceOp.getSource()]);
+            rewriter.finalizeRootUpdate(sliceOp);
+          }
+        }
+      };
+
+  std::deque<tensor::ExtractSliceOp> candidates;
+  addCandidateSlices(tilingResult->tiledOps.back(), candidates);
+  OpBuilder::InsertionGuard g(rewriter);
+  while (!candidates.empty()) {
+    // Traverse the slices in BFS fashion.
+    tensor::ExtractSliceOp candidateSliceOp = candidates.front();
+    candidates.pop_front();
+
+    // Materialize the slice of the producer in place.
+    std::optional<scf::SCFFuseProducerOfSliceResult> fusedProducer =
+        tileAndFuseProducerOfSlice(rewriter, candidateSliceOp, forallLoop);
+    if (!fusedProducer) continue;
+
+    // Add more fusion candidates to the worklist.
+    for (auto tiledOp : fusedProducer->tiledOps) {
+      addCandidateSlices(tiledOp, candidates);
+      tiledOps.push_back(tiledOp);
+    }
+  }
+
+  for (auto [index, origVal] : llvm::enumerate(yieldedValuesToOrigValues)) {
+    Value replacement = forallLoop.getResult(index);
+    rewriter.replaceUsesWithIf(origVal, replacement, [&](OpOperand &use) {
+      return !isIgnoredUser(use.getOwner()) &&
+             dominanceInfo.properlyDominates(forallLoop, use.getOwner());
+    });
+  }
+
+  return success();
+}
+
+/// This pass starts with the last TilingInterface operation, tiles the op and
+/// fuses its producers recursively. The `tilingLevel` must be specified. It
+/// picks the `tilingLevel`-th list as tiling sizes from lowering_config.
+class AMDAIETileAndFusePass
+    : public AMDAIETileAndFuseBase<AMDAIETileAndFusePass> {
+ public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<gpu::GPUDialect, scf::SCFDialect>();
+  }
+
+  AMDAIETileAndFusePass() = default;
+  AMDAIETileAndFusePass(int64_t tilingLevel = -1) {
+    this->tilingLevel.setValue(tilingLevel);
+  }
+  AMDAIETileAndFusePass(const AMDAIETileAndFusePass &pass){};
+
+  void runOnOperation() override;
+};
+
+void AMDAIETileAndFusePass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  auto funcOp = getOperation();
+
+  TilingInterface consumerOp;
+  funcOp->walk<WalkOrder::PostOrder, ReverseIterator>([&](TilingInterface op) {
+    // Find the next consumer op if it does not have loops.
+    if (op.getLoopIteratorTypes().empty()) return WalkResult::advance();
+    consumerOp = op;
+    return WalkResult::interrupt();
+  });
+  if (!consumerOp) {
+    LLVM_DEBUG(llvm::dbgs() << "----- skip, no consumer op -----\n");
+    return;
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "consumerOp: " << consumerOp << "\n");
+  LLVM_DEBUG(llvm::dbgs() << "tilingLevel: " << tilingLevel << "\n");
+  // TODO: Currently hardcoding the tile size to make the tile and fuse run for
+  //       at least the first level. So, we can generalize this by adding tile
+  //       level, similar to LLVMCPUTileAndFuse.cpp.
+  SmallVector<OpFoldResult> tileSizes = getAsIndexOpFoldResult(context, {8, 8});
+  auto options = scf::SCFTilingOptions().setTileSizes(tileSizes);
+  options.setMapping(
+      {gpu::GPUBlockMappingAttr::get(context, gpu::MappingId::DimY),
+       gpu::GPUBlockMappingAttr::get(context, gpu::MappingId::DimX)});
+
+  IRRewriter rewriter(context);
+  DominanceInfo dominanceInfo(funcOp);
+  if (failed(applyTileAndFuse(rewriter, consumerOp, dominanceInfo, options))) {
+    LLVM_DEBUG(llvm::dbgs() << "----- tile and fuse failed -----\n");
+    return signalPassFailure();
+  }
+}
+
+}  // namespace
+
+std::unique_ptr<OperationPass<>> createAMDAIETileAndFusePass(
+    int64_t tilingLevel) {
+  return std::make_unique<AMDAIETileAndFusePass>(tilingLevel);
+}
+
+}  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_cc_library(
   SRCS
     "Passes.cpp"
     "AMDAIELowerExecutableTarget.cpp"
+    "AMDAIETileAndFuse.cpp"
     "BridgeToAIRPass.cpp"
   DEPS
     ::PassHeaders

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -21,7 +21,17 @@ namespace mlir::iree_compiler::AMDAIE {
 
 void buildAMDAIETransformPassPipeline(OpPassManager &pm) {
   addCommonTargetExecutablePreprocessingPasses(pm);
+  // TODO: Current we don't include C++ equivalent of Transform
+  //       dialect scripts. We are thus guarding their inclusion
+  //       with a bool `useCPlusPlusTransformPasses` which would
+  //       be used during development efforts. Once the C++ passes
+  //       are ready, we will include these passes by default and
+  //       take away the guarding.
+  bool useCPlusPlusTransformPasses = false;
+  if (useCPlusPlusTransformPasses)
+    pm.addPass(createTileAndDistributeToWorkgroupsPass());
   pm.addPass(createEraseHALDescriptorTypeFromMemRefPass());
+  if (useCPlusPlusTransformPasses) pm.addPass(createAMDAIETileAndFusePass());
   pm.addPass(createAMDAIELowerExecutableTargetPass());
 
   auto &modulePassManager = pm.nest<ModuleOp>();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -17,21 +17,25 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
 
+/// Command line options used purely for development purposes. Not to be relied
+/// on in any way.
+static llvm::cl::opt<bool> clUseCPlusPlusTransformPasses(
+    "iree-amd-aie-cpp-passes",
+    llvm::cl::desc(
+        "Runs the cpp passes instead of transform dialect when possible"),
+    llvm::cl::init(false));
+
 namespace mlir::iree_compiler::AMDAIE {
 
 void buildAMDAIETransformPassPipeline(OpPassManager &pm) {
   addCommonTargetExecutablePreprocessingPasses(pm);
-  // TODO: Current we don't include C++ equivalent of Transform
-  //       dialect scripts. We are thus guarding their inclusion
-  //       with a bool `useCPlusPlusTransformPasses` which would
-  //       be used during development efforts. Once the C++ passes
-  //       are ready, we will include these passes by default and
-  //       take away the guarding.
-  bool useCPlusPlusTransformPasses = false;
-  if (useCPlusPlusTransformPasses)
-    pm.addPass(createTileAndDistributeToWorkgroupsPass());
+  // TODO: Current we don't include C++ equivalent of Transform dialect scripts.
+  // We are thus guarding their inclusion with a bool
+  // `useCPlusPlusTransformPasses` which would be used during development
+  // efforts. Once the C++ passes are ready, we will include these passes by
+  // default and take away the guarding.
+  if (clUseCPlusPlusTransformPasses) pm.addPass(createAMDAIETileAndFusePass());
   pm.addPass(createEraseHALDescriptorTypeFromMemRefPass());
-  if (useCPlusPlusTransformPasses) pm.addPass(createAMDAIETileAndFusePass());
   pm.addPass(createAMDAIELowerExecutableTargetPass());
 
   auto &modulePassManager = pm.nest<ModuleOp>();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -33,6 +33,10 @@ std::unique_ptr<OperationPass<>> createAMDAIEBridgeToAIRPass();
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createAMDAIELowerExecutableTargetPass();
 
+/// Create pass to tile and fuse TilingInterface operations.
+std::unique_ptr<OperationPass<>> createAMDAIETileAndFusePass(
+    int64_t tilingLevel = -1);
+
 void registerAMDAIEPasses();
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -34,8 +34,8 @@ std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createAMDAIELowerExecutableTargetPass();
 
 /// Create pass to tile and fuse TilingInterface operations.
-std::unique_ptr<OperationPass<>> createAMDAIETileAndFusePass(
-    int64_t tilingLevel = -1);
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createAMDAIETileAndFusePass(int64_t tilingLevel = -1);
 
 void registerAMDAIEPasses();
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -20,4 +20,14 @@ def AMDAIELowerExecutableTarget :
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIELowerExecutableTargetPass()";
 }
 
+def AMDAIETileAndFuse :
+    Pass<"iree-amdaie-tile-and-fuse", ""> {
+  let summary = "Pass to tile and fuse TilingInterface operations.";
+  let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIETileAndFusePass()";
+  let options = [
+    Option<"tilingLevel", "tiling-level", "int64_t", /*default=*/"-1",
+      "Use default tiling level used to retrieve the configuration from lowering_config">
+  ];
+}
+
 #endif // IREE_AMD_AIE_TRANSFORMS_PASSES

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -21,7 +21,7 @@ def AMDAIELowerExecutableTarget :
 }
 
 def AMDAIETileAndFuse :
-    Pass<"iree-amdaie-tile-and-fuse", ""> {
+    Pass<"iree-amdaie-tile-and-fuse", "IREE::HAL::ExecutableVariantOp"> {
   let summary = "Pass to tile and fuse TilingInterface operations.";
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIETileAndFusePass()";
   let options = [

--- a/tests/samples/CMakeLists.txt
+++ b/tests/samples/CMakeLists.txt
@@ -9,6 +9,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "matmul_fill_static_i32.mlir"
+    "tile_and_fuse.mlir"
   TOOLS
     ${IREE_LLD_TARGET}
     FileCheck

--- a/tests/samples/matmul_fill_spec_pad_new.mlir
+++ b/tests/samples/matmul_fill_spec_pad_new.mlir
@@ -1,0 +1,129 @@
+// This script shows an example lowering matmul through IREE for a special accelerator.
+//
+// ```
+//   export IREE_DIR=${HOME}/iree/iree; \
+//   export IREE_AMD_AIE_DIR=${IREE_AMD_AIE_DIR:-${HOME}/iree/iree-amd-aie}
+//   ${IREE_DIR}/build/tools/iree-opt \
+//     ${IREE_AMD_AIE_DIR}/tests/samples/matmul_fill_static.mlir \
+//     --iree-hal-target-backends=amd-aie \
+//     --iree-abi-transformation-pipeline \
+//     --iree-flow-transformation-pipeline \
+//     --iree-stream-transformation-pipeline \
+//     --iree-hal-configuration-pipeline | \
+//   ${IREE_DIR}/build/tools/iree-opt \
+//      --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))' \
+//      --iree-codegen-transform-dialect-library=${IREE_AMD_AIE_DIR}/tests/samples/matmul_fill_spec_pad.mlir
+// ```
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @cleanup(%variant_op: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+      transform.apply_patterns to %func {
+      transform.apply_patterns.linalg.tiling_canonicalization
+      transform.apply_patterns.iree.fold_fill_into_pad
+      transform.apply_patterns.scf.for_loop_canonicalization
+      transform.apply_patterns.canonicalization
+    } : !transform.any_op
+    transform.iree.apply_licm %func : !transform.any_op
+    transform.iree.apply_cse %func : !transform.any_op
+    transform.yield
+  }
+
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.read_only}) {
+    // Run canonicalizations.
+    transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()  
+    %ops = transform.structured.match ops{["scf.forall"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    %fused_for_all = transform.split_handle %ops : (!transform.any_op) -> (!transform.any_op)
+
+    %ops2 = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    %tiled_matmul = transform.split_handle %ops2 : (!transform.any_op) -> (!transform.any_op)
+    // Pad operation.
+    %padded, %pad, %__ = transform.structured.pad %tiled_matmul {
+      padding_values=[0 : i32, 0 : i32, 0 : i32],
+      padding_dimensions=[0, 1, 2],
+      pack_paddings=[1, 1, 1],
+      copy_back_op="linalg.copy"
+    } : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    %pad_dps = transform.structured.rewrite_in_destination_passing_style %pad : (!transform.any_op) -> !transform.any_op
+
+    // Promote the operands to shared memory.
+    %padded_lhs = transform.get_producer_of_operand %padded[0] : (!transform.any_op) -> (!transform.any_op)
+    %padded_lhs_buffer, %padded_lhs_new = transform.structured.bufferize_to_allocation %padded_lhs
+        {memory_space = 1, bufferize_destination_only, emit_dealloc} : !transform.any_op
+
+    %padded_rhs = transform.get_producer_of_operand %padded[1] : (!transform.any_op) -> (!transform.any_op)
+    %padded_rhs_buffer, %padded_rhs_new = transform.structured.bufferize_to_allocation %padded_rhs
+        {memory_space = 1, bufferize_destination_only, emit_dealloc} : !transform.any_op
+
+    // Promote the result to shared memrory
+    %padded_result = transform.get_producer_of_operand %padded[2] : (!transform.any_op) -> (!transform.any_op)
+    %padded_result_buffer, %padded_result_new = transform.structured.bufferize_to_allocation %padded_result
+        {memory_space = 1, bufferize_destination_only, emit_dealloc} : !transform.any_op
+
+    // Run canonicalizations.
+    transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()
+
+    // Find the matmul and fill again
+    %tiled_ops = transform.structured.match ops{["linalg.fill", "linalg.matmul"]} in %fused_for_all : (!transform.any_op) -> !transform.any_op
+    %tiled_fill_op, %tiled_padded_matmul = transform.split_handle %tiled_ops : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+    // Second level tile to forall with tile_sizes [4, 4].
+    %tiled_matmul_1, %forall_1 =
+      transform.structured.tile_using_forall %tiled_padded_matmul tile_sizes [4, 4]
+        ( mapping = [#gpu.thread<y>, #gpu.thread<x>] ) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    %fused_fill_2, %fused_for_all_2 = transform.structured.fuse_into_containing_op %tiled_fill_op into %forall_1 : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+    // Pad operation.
+    %padded_1, %pad_1, %_ = transform.structured.pad %tiled_matmul_1 {
+      padding_values=[0 : i32, 0 : i32, 0 : i32],
+      padding_dimensions=[0, 1, 2],
+      pack_paddings=[0, 0, 1],
+      copy_back_op="linalg.copy"
+    } : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    %pad_1_dps = transform.structured.rewrite_in_destination_passing_style %pad_1 : (!transform.any_op) -> !transform.any_op
+
+    // Promote the result to local memory.
+    %padded_result_local = transform.get_producer_of_operand %padded_1[2] : (!transform.any_op) -> (!transform.any_op)
+    %padded_result_local_buffer, %padded_result_local_new = transform.structured.bufferize_to_allocation %padded_result_local
+        {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
+
+    // Run canonicalizations.
+    transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()
+
+    // Tile reduction dimension.
+    %tiled_reduction, %loop =
+      transform.structured.tile_using_for %padded_1 [0, 0, 4]
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+    // Clean up.
+    transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()
+
+    // Pad operation.
+    %padded_reduction, %pad_reduction, %___ = transform.structured.pad %tiled_reduction {
+      padding_values=[0 : i32, 0 : i32, 0 : i32],
+      padding_dimensions=[0, 1, 2],
+      pack_paddings=[1, 1, 0],
+      copy_back_op="linalg.copy"
+    } : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+    %pad_2_dps = transform.structured.rewrite_in_destination_passing_style %pad_reduction : (!transform.any_op) -> !transform.any_op
+
+    // Promote to local memory
+    %padded_reduction_lhs = transform.get_producer_of_operand %padded_reduction[0] : (!transform.any_op) -> (!transform.any_op)
+    %padded_reduction_lhs_buffer, %padded_reduction_lhs_new = transform.structured.bufferize_to_allocation %padded_reduction_lhs
+        {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
+
+    %padded_reduction_rhs = transform.get_producer_of_operand %padded_reduction[1] : (!transform.any_op) -> (!transform.any_op)
+    %padded_reduction_rhs_buffer, %padded_reduction_rhs_new = transform.structured.bufferize_to_allocation %padded_reduction_rhs
+        {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
+
+    // Clean up.
+    transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()
+
+    // Bufferize and drop HAL decriptor from memref ops.
+    transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+    %variant_op_3 = transform.iree.bufferize %variant_op : (!transform.any_op) -> !transform.any_op
+
+    transform.include @cleanup failures(propagate) (%variant_op_3) : (!transform.any_op) -> ()
+    transform.yield
+  }
+}

--- a/tests/samples/matmul_fill_spec_pad_new.mlir
+++ b/tests/samples/matmul_fill_spec_pad_new.mlir
@@ -12,9 +12,12 @@
 //     --iree-hal-configuration-pipeline | \
 //   ${IREE_DIR}/build/tools/iree-opt \
 //      --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))' \
-//      --iree-codegen-transform-dialect-library=${IREE_AMD_AIE_DIR}/tests/samples/matmul_fill_spec_pad.mlir
+//      --iree-codegen-transform-dialect-library=${IREE_AMD_AIE_DIR}/tests/samples/matmul_fill_spec_pad_new.mlir \
+//      --iree-amd-aie-cpp-passes
 // ```
 
+
+// The first level tiling and fusion is done in a C++ pass compared to base script
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @cleanup(%variant_op: !transform.any_op {transform.readonly}) {
     %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op

--- a/tests/samples/tile_and_fuse.mlir
+++ b/tests/samples/tile_and_fuse.mlir
@@ -1,55 +1,72 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=0}))" --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-amdaie-tile-and-fuse{tiling-level=0})))' --split-input-file %s | FileCheck %s
 
-func.func @matmul_static(%lhs : tensor<8x16xi32>,
-    %rhs : tensor<16x8xi32>) -> tensor<8x8xi32> {
-  %empty = tensor.empty() : tensor<8x8xi32>
-  %cst = arith.constant 0 : i32
-  %fill = linalg.fill ins(%cst : i32) outs(%empty : tensor<8x8xi32>) -> tensor<8x8xi32>
-  %2 = linalg.matmul ins(%lhs, %rhs : tensor<8x16xi32>, tensor<16x8xi32>)
-      outs(%fill : tensor<8x8xi32>) -> tensor<8x8xi32>
-  return %2 : tensor<8x8xi32>
+hal.executable private @matmul_tensors {
+  hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd"}>) {
+    hal.executable.export public @matmul_static ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {translation_info = #iree_codegen.translation_info<TransformDialectCodegen codegen_spec = @__transform_main>} {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_static() {
+        %c0 = arith.constant 0 : index
+        %c0_i32 = arith.constant 0 : i32
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<8x16xi32>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x8xi32>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x16xi32>> -> tensor<8x16xi32>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [16, 8], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x8xi32>> -> tensor<16x8xi32>
+        %5 = tensor.empty() : tensor<8x8xi32>
+        %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<8x8xi32>) -> tensor<8x8xi32>
+        %7 = linalg.matmul ins(%3, %4 : tensor<8x16xi32>, tensor<16x8xi32>) outs(%6 : tensor<8x8xi32>) -> tensor<8x8xi32>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [8, 8], strides = [1, 1] : tensor<8x8xi32> -> !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
+        return
+      }
+    }
+  }
 }
-// CHECK-LABEL: @matmul_static
-// CHECK-SAME: (%[[LHS:.+]]: tensor<8x16xi32>, %[[RHS:.+]]: tensor<16x8xi32>)
-// CHECK-SAME: {
-// CHECK:         %[[EMPTY_TENSOR:.+]] = tensor.empty() : tensor<8x8xi32>
-// CHECK:         %[[ZERO_CST:.+]] = arith.constant 0 : i32
-// CHECK:         %[[OUTPUT:.+]] = scf.forall (%[[I:.+]], %[[J:.+]]) = (0, 0) to (8, 8) step (8, 8) shared_outs(%[[SHARED_EMPTY_TENSOR:.+]] = %[[EMPTY_TENSOR]]) -> (tensor<8x8xi32>) {
-// CHECK:            %[[TILED_LHS:.+]] = tensor.extract_slice %[[LHS]][%[[I]], 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
-// CHECK:            %[[TILED_RHS:.+]] = tensor.extract_slice %[[RHS]][0, %[[J]]] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
-// CHECK:            %[[TILED_EMPTY_TENSOR:.+]] = tensor.extract_slice %[[SHARED_EMPTY_TENSOR]][%[[I]], %[[J]]] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
-// CHECK:            %[[FILL:.+]] = linalg.fill ins(%[[ZERO_CST]] : i32) outs(%[[TILED_EMPTY_TENSOR]] : tensor<8x8xi32>) -> tensor<8x8xi32>
-// CHECK:            %[[MATMUL:.+]] = linalg.matmul ins(%[[TILED_LHS]], %[[TILED_RHS]] : tensor<8x16xi32>, tensor<16x8xi32>) outs(%[[FILL]] : tensor<8x8xi32>) -> tensor<8x8xi32>
-// CHECK:            scf.forall.in_parallel {
-// CHECK:              tensor.parallel_insert_slice %[[MATMUL]] into %[[SHARED_EMPTY_TENSOR]][%[[I]], %[[J]]] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
-// CHECK:            }
-// CHECK:         } {mapping = [#gpu.block<y>, #gpu.block<x>]}
-// CHECK:         return %[[OUTPUT]] : tensor<8x8xi32>
-// CHECK:      }
+//      CHECK: @matmul_static
+//      CHECK:   scf.forall
+// CHECK-SAME:   {
+//      CHECK:       linalg.fill
+//      CHECK:       linalg.matmul
+//      CHECK:   }
 
 // -----
 
-func.func @matmul_bias_add(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %arg2 : tensor<?xf32>) -> tensor<?x?xf32> {
-  %cst = arith.constant 0.0 : f32
-  %c0 = arith.constant 0 : index
-  %c1 = arith.constant 1 : index
-  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
-  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf32>
-  %init = tensor.empty(%d0, %d1) : tensor<?x?xf32>
-  %0 = linalg.fill ins(%cst : f32) outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
-  %1 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[10, 20, 30]]>}
-      ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
-      outs(%0 : tensor<?x?xf32>) -> tensor<?x?xf32>
-  %2 = linalg.generic {
-    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1)-> (d0, d1)>],
-    iterator_types = ["parallel", "parallel"]}
-    ins(%1, %arg2 : tensor<?x?xf32>, tensor<?xf32>)
-    outs(%init : tensor<?x?xf32>) {
-      ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
-        %3 = arith.addf %arg3, %arg4 : f32
-        linalg.yield %3 : f32
-    } -> tensor<?x?xf32>
-  return %2 : tensor<?x?xf32>
+hal.executable private @matmul_tensors {
+  hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd"}>) {
+    hal.executable.export public @matmul_bias_add ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {translation_info = #iree_codegen.translation_info<TransformDialectCodegen codegen_spec = @__transform_main>} {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+      hal.return %x, %y, %z : index, index, index
+    }
+
+    builtin.module {
+      func.func @matmul_bias_add(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %arg2 : tensor<?xf32>) -> tensor<?x?xf32> {
+        %cst = arith.constant 0.0 : f32
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+        %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf32>
+        %init = tensor.empty(%d0, %d1) : tensor<?x?xf32>
+        %0 = linalg.fill ins(%cst : f32) outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
+        %1 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[10, 20, 30]]>}
+            ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
+            outs(%0 : tensor<?x?xf32>) -> tensor<?x?xf32>
+        %2 = linalg.generic {
+          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1)-> (d0, d1)>],
+          iterator_types = ["parallel", "parallel"]}
+          ins(%1, %arg2 : tensor<?x?xf32>, tensor<?xf32>)
+          outs(%init : tensor<?x?xf32>) {
+            ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
+              %3 = arith.addf %arg3, %arg4 : f32
+              linalg.yield %3 : f32
+          } -> tensor<?x?xf32>
+        return %2 : tensor<?x?xf32>
+      }
+    }
+  }
 }
 //      CHECK: @matmul_bias_add
 //      CHECK:   scf.forall

--- a/tests/samples/tile_and_fuse.mlir
+++ b/tests/samples/tile_and_fuse.mlir
@@ -1,0 +1,60 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=0}))" --split-input-file %s | FileCheck %s
+
+func.func @matmul_static(%lhs : tensor<8x16xi32>,
+    %rhs : tensor<16x8xi32>) -> tensor<8x8xi32> {
+  %empty = tensor.empty() : tensor<8x8xi32>
+  %cst = arith.constant 0 : i32
+  %fill = linalg.fill ins(%cst : i32) outs(%empty : tensor<8x8xi32>) -> tensor<8x8xi32>
+  %2 = linalg.matmul ins(%lhs, %rhs : tensor<8x16xi32>, tensor<16x8xi32>)
+      outs(%fill : tensor<8x8xi32>) -> tensor<8x8xi32>
+  return %2 : tensor<8x8xi32>
+}
+// CHECK-LABEL: @matmul_static
+// CHECK-SAME: (%[[LHS:.+]]: tensor<8x16xi32>, %[[RHS:.+]]: tensor<16x8xi32>)
+// CHECK-SAME: {
+// CHECK:         %[[EMPTY_TENSOR:.+]] = tensor.empty() : tensor<8x8xi32>
+// CHECK:         %[[ZERO_CST:.+]] = arith.constant 0 : i32
+// CHECK:         %[[OUTPUT:.+]] = scf.forall (%[[I:.+]], %[[J:.+]]) = (0, 0) to (8, 8) step (8, 8) shared_outs(%[[SHARED_EMPTY_TENSOR:.+]] = %[[EMPTY_TENSOR]]) -> (tensor<8x8xi32>) {
+// CHECK:            %[[TILED_LHS:.+]] = tensor.extract_slice %[[LHS]][%[[I]], 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
+// CHECK:            %[[TILED_RHS:.+]] = tensor.extract_slice %[[RHS]][0, %[[J]]] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
+// CHECK:            %[[TILED_EMPTY_TENSOR:.+]] = tensor.extract_slice %[[SHARED_EMPTY_TENSOR]][%[[I]], %[[J]]] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
+// CHECK:            %[[FILL:.+]] = linalg.fill ins(%[[ZERO_CST]] : i32) outs(%[[TILED_EMPTY_TENSOR]] : tensor<8x8xi32>) -> tensor<8x8xi32>
+// CHECK:            %[[MATMUL:.+]] = linalg.matmul ins(%[[TILED_LHS]], %[[TILED_RHS]] : tensor<8x16xi32>, tensor<16x8xi32>) outs(%[[FILL]] : tensor<8x8xi32>) -> tensor<8x8xi32>
+// CHECK:            scf.forall.in_parallel {
+// CHECK:              tensor.parallel_insert_slice %[[MATMUL]] into %[[SHARED_EMPTY_TENSOR]][%[[I]], %[[J]]] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
+// CHECK:            }
+// CHECK:         } {mapping = [#gpu.block<y>, #gpu.block<x>]}
+// CHECK:         return %[[OUTPUT]] : tensor<8x8xi32>
+// CHECK:      }
+
+// -----
+
+func.func @matmul_bias_add(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %arg2 : tensor<?xf32>) -> tensor<?x?xf32> {
+  %cst = arith.constant 0.0 : f32
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf32>
+  %init = tensor.empty(%d0, %d1) : tensor<?x?xf32>
+  %0 = linalg.fill ins(%cst : f32) outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %1 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[10, 20, 30]]>}
+      ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
+      outs(%0 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1)-> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%1, %arg2 : tensor<?x?xf32>, tensor<?xf32>)
+    outs(%init : tensor<?x?xf32>) {
+      ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
+        %3 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %3 : f32
+    } -> tensor<?x?xf32>
+  return %2 : tensor<?x?xf32>
+}
+//      CHECK: @matmul_bias_add
+//      CHECK:   scf.forall
+// CHECK-SAME:   {
+//      CHECK:       linalg.fill
+//      CHECK:       linalg.matmul
+//      CHECK:       linalg.generic
+//      CHECK:   }


### PR DESCRIPTION
-- This commit adds the initial effort for tiling + fusing TileInterface ops using scf.forall by creating a new pass `--iree-amdaie-tile-and-fuse`.
-- It creates a new concise transform dialect script and adds a `--iree-amdaie-tile-and-fuse` test case to demo the generalised feature.

Co-authored-by: Nirvedh Meshram <nmeshram@amd.com>
Co-authored-by: Abhishek Varma <abhvarma@amd.com>