### PR TITLE
[AMD-AIE] Add initial transform and padding strategy for Matmul + cleanup

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPadAndBufferize.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPadAndBufferize.cpp
@@ -1,0 +1,172 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-amd-aie/Transforms/PassDetail.h"
+#include "iree-amd-aie/Transforms/Passes.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/Transforms/TilingInterfaceImpl.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
+#include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
+#include "mlir/Dialect/SCF/Transforms/Transforms.h"
+#include "mlir/IR/Iterators.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-amdaie-pad-and-bufferize"
+
+namespace mlir::iree_compiler::AMDAIE {
+
+namespace {
+
+static LogicalResult applyBufferizeToAllocation(RewriterBase &rewriter,
+                                                Operation *op,
+                                                Attribute memorySpace) {
+  linalg::BufferizeToAllocationOptions options;
+  options.memcpyOp =
+      linalg::BufferizeToAllocationOptions::MemcpyOp::MaterializeInDestination;
+  options.allocOp = linalg::BufferizeToAllocationOptions::AllocOp::MemrefAlloc;
+  options.bufferizeDestinationOnly = true;
+  options.emitDealloc = true;
+
+  // Bufferize ops.
+  Value buffer =
+      linalg::bufferizeToAllocation(rewriter, options, op, memorySpace);
+  if (!buffer) {
+    LLVM_DEBUG(llvm::dbgs() << "----- failed to bufferize operation -----\n");
+    return failure();
+  }
+  return success();
+}
+
+static LogicalResult applyPadAndConvertToDPS(
+    RewriterBase &rewriter, linalg::MatmulOp linalgTarget,
+    linalg::LinalgPaddingOptions &options) {
+  linalg::LinalgOp paddedOp;
+  SmallVector<Value> replacements;
+  SmallVector<tensor::PadOp> newPadOps;
+  if (failed(rewriteAsPaddedOp(rewriter, linalgTarget, options, paddedOp,
+                               replacements, newPadOps))) {
+    LLVM_DEBUG(llvm::dbgs() << "----- failed to pad op -----\n");
+    return failure();
+  }
+
+  // We need to perform our own replacement here because this API is still
+  // used in patterns that "pad and hoist", for which the replacement values
+  // need to be different.
+  // TODO: clean this up and stop "pad and hoist" behavior more globally now
+  // that we have more composable abstractions.
+  rewriter.replaceOp(linalgTarget, replacements);
+  // We rewrite each operand of the linalgOp (currently, MatmulOp) into DSP.
+  for (auto newPadOp : newPadOps) {
+    rewriter.setInsertionPointAfter(newPadOp);
+    if (failed(linalg::rewriteInDestinationPassingStyle(rewriter, newPadOp))) {
+      LLVM_DEBUG(llvm::dbgs() << "----- failed to rewrite in DPS -----\n");
+      return failure();
+    }
+  }
+
+  return success();
+}
+
+class AMDAIEPadAndBufferizePass
+    : public AMDAIEPadAndBufferizeBase<AMDAIEPadAndBufferizePass> {
+ public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<bufferization::BufferizationDialect, tensor::TensorDialect,
+                    linalg::LinalgDialect>();
+  }
+  void runOnOperation() override;
+};
+
+void AMDAIEPadAndBufferizePass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  IREE::HAL::ExecutableVariantOp variantOp = getOperation();
+  ModuleOp innerModule = variantOp.getInnerModule();
+  for (func::FuncOp funcOp : innerModule.getOps<func::FuncOp>()) {
+    linalg::MatmulOp matmulOp;
+    funcOp->walk<WalkOrder::PostOrder, ReverseIterator>(
+        [&](TilingInterface op) {
+          // Find the next matmul op if it does not have loops.
+          if (op.getLoopIteratorTypes().empty() || !isa<linalg::MatmulOp>(op))
+            return WalkResult::advance();
+          matmulOp = cast<linalg::MatmulOp>(op);
+          return WalkResult::interrupt();
+        });
+    if (!matmulOp) {
+      LLVM_DEBUG(llvm::dbgs() << "----- skip, no matmul op -----\n");
+      return;
+    }
+
+    IRRewriter rewriter(context);
+    linalg::LinalgPaddingOptions options;
+    SmallVector<Attribute> paddingValues;
+    auto i64Type = rewriter.getI64Type();
+    for (auto operand : matmulOp->getOperands()) {
+      auto type = dyn_cast<RankedTensorType>(operand.getType());
+      if (!type) {
+        funcOp->emitOpError("failed to lower workgroup count region");
+        return signalPassFailure();
+      }
+      Type elementType = type.getElementType();
+      if (isa<IntegerType>(elementType)) {
+        paddingValues.push_back(rewriter.getIntegerAttr(elementType, 0));
+      } else {
+        paddingValues.push_back(rewriter.getFloatAttr(elementType, 0));
+      }
+    }
+    options.paddingValues = paddingValues;
+    SmallVector<bool> packPaddings(matmulOp->getNumOperands(), true);
+    options.packPaddings = packPaddings;
+
+    SmallVector<int64_t> paddingDimensions;
+    for (unsigned i = 0, n = matmulOp.getNumLoops(); i < n; i++)
+      paddingDimensions.push_back(i);
+    options.paddingDimensions = paddingDimensions;
+
+    SmallVector<int64_t> padToMultipleOf(options.paddingDimensions.size(), 1);
+    options.padToMultipleOf = padToMultipleOf;
+    options.copyBackOp = linalg::LinalgPaddingOptions::CopyBackOp::LinalgCopy;
+
+    if (failed(applyPadAndConvertToDPS(rewriter, matmulOp, options))) {
+      funcOp->emitOpError("failed to apply pad");
+      return signalPassFailure();
+    }
+
+    // TODO: This part can be coded better instead of againg walking the FuncOp.
+    funcOp->walk<WalkOrder::PostOrder, ReverseIterator>(
+        [&](TilingInterface op) {
+          // Find the next matmul op if it does not have loops.
+          if (op.getLoopIteratorTypes().empty() || !isa<linalg::MatmulOp>(op))
+            return WalkResult::advance();
+          matmulOp = cast<linalg::MatmulOp>(op);
+          return WalkResult::interrupt();
+        });
+    if (!matmulOp) {
+      LLVM_DEBUG(llvm::dbgs() << "----- skip, no matmul op -----\n");
+      return;
+    }
+    for (auto operand : matmulOp->getOperands()) {
+      auto memorySpace = rewriter.getIntegerAttr(i64Type, 1);
+      rewriter.setInsertionPointAfter(operand.getDefiningOp());
+      if (failed(applyBufferizeToAllocation(rewriter, operand.getDefiningOp(),
+                                            memorySpace))) {
+        funcOp->emitOpError("failed bufferizing to allocations");
+        return signalPassFailure();
+      }
+    }
+  }
+}
+
+}  // namespace
+
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createAMDAIEPadAndBufferizePass() {
+  return std::make_unique<AMDAIEPadAndBufferizePass>();
+}
+}  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_cc_library(
   SRCS
     "Passes.cpp"
     "AMDAIELowerExecutableTarget.cpp"
+    "AMDAIEPadAndBufferize.cpp"
     "AMDAIETileAndFuse.cpp"
     "BridgeToAIRPass.cpp"
   DEPS

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
@@ -37,6 +37,7 @@ iree_cc_library(
     "AMDAIEPadAndBufferize.cpp"
     "AMDAIETileAndFuse.cpp"
     "BridgeToAIRPass.cpp"
+    "Cleanup.cpp"
   DEPS
     ::PassHeaders
     ::PassesIncGen

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Cleanup.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Cleanup.cpp
@@ -1,0 +1,102 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-amd-aie/Transforms/PassDetail.h"
+#include "iree-amd-aie/Transforms/Passes.h"
+#include "iree/compiler/Codegen/Common/Transforms.h"
+#include "iree/compiler/Codegen/Transforms/Transforms.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/TilingInterfaceImpl.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Transforms/Patterns.h"
+#include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
+#include "mlir/Dialect/SCF/Transforms/Transforms.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/Iterators.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/LoopInvariantCodeMotionUtils.h"
+
+#define DEBUG_TYPE "iree-cleanup"
+
+namespace mlir::iree_compiler::AMDAIE {
+
+namespace {
+
+static void loopIndependentCodeMotion(Operation *funcOp, IRRewriter &rewriter) {
+  // This assumes LICM never removes operations so we don't need tracking.
+  // TODO: confirm / revisit this assumption and plumb a rewriter through
+  // upstream moveLoopInvariantCode if necessary.
+  funcOp->walk([](LoopLikeOpInterface loopLike) {
+    // Do not hoist from scf.forall ops. These capture isolated computations
+    // that will be mapped to a certain level in the GPU hierarchy (e.g.,
+    // GPU blocks), so hoisting is not desired.
+    if (!isa<scf::ForallOp>(loopLike.getOperation()))
+      moveLoopInvariantCode(loopLike);
+  });
+  // For now, put single loop promotion as part of licm. Underlying
+  // implementations perform splice operations which shouldn't need
+  // tracking.
+  // TODO: confirm / revisit this assumption and plumb a rewriter through
+  // upstream moveLoopInvariantCode if necessary.
+  funcOp->walk([&](Operation *op) {
+    (void)llvm::TypeSwitch<Operation *, LogicalResult>(op)
+        .Case<affine::AffineForOp, scf::ForOp>(
+            [&](auto loop) { return loop.promoteIfSingleIteration(rewriter); })
+        .Default([](Operation *) { return success(); });
+  });
+}
+
+static void populateCleanupPatterns(RewritePatternSet &patterns) {
+  MLIRContext *context = patterns.getContext();
+  linalg::populateLinalgTilingCanonicalizationPatterns(patterns);
+  linalg::FillOp::getCanonicalizationPatterns(patterns, context);
+  // Pulling in upstream scf.for and affine.min canonicalization patterns.
+  // They work on tiled (but not distributed) loops.
+  scf::populateSCFForLoopCanonicalizationPatterns(patterns);
+}
+
+class CleanupPass : public CleanupBase<CleanupPass> {
+ public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<gpu::GPUDialect, scf::SCFDialect>();
+  }
+
+  CleanupPass() = default;
+  CleanupPass(const CleanupPass &pass){};
+
+  void runOnOperation() override;
+};
+
+void CleanupPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  IREE::HAL::ExecutableVariantOp variantOp = getOperation();
+  ModuleOp innerModule = variantOp.getInnerModule();
+  IRRewriter rewriter(context);
+  for (func::FuncOp funcOp : innerModule.getOps<func::FuncOp>()) {
+    RewritePatternSet patterns(context);
+    populateCleanupPatterns(patterns);
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+    loopIndependentCodeMotion(funcOp, rewriter);
+  }
+}
+
+}  // namespace
+
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createCleanupPass() {
+  return std::make_unique<CleanupPass>();
+}
+
+}  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -23,7 +23,7 @@ static llvm::cl::opt<bool> clUseCPlusPlusTransformPasses(
     "iree-amd-aie-cpp-passes",
     llvm::cl::desc(
         "Runs the cpp passes instead of transform dialect when possible"),
-    llvm::cl::init(false));
+    llvm::cl::init(true));
 
 namespace mlir::iree_compiler::AMDAIE {
 
@@ -34,7 +34,10 @@ void buildAMDAIETransformPassPipeline(OpPassManager &pm) {
   // `useCPlusPlusTransformPasses` which would be used during development
   // efforts. Once the C++ passes are ready, we will include these passes by
   // default and take away the guarding.
-  if (clUseCPlusPlusTransformPasses) pm.addPass(createAMDAIETileAndFusePass());
+  if (clUseCPlusPlusTransformPasses) {
+    pm.addPass(createAMDAIETileAndFusePass());
+    pm.addPass(createAMDAIEPadAndBufferizePass());
+  }
   pm.addPass(createEraseHALDescriptorTypeFromMemRefPass());
   pm.addPass(createAMDAIELowerExecutableTargetPass());
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -35,8 +35,12 @@ void buildAMDAIETransformPassPipeline(OpPassManager &pm) {
   // efforts. Once the C++ passes are ready, we will include these passes by
   // default and take away the guarding.
   if (clUseCPlusPlusTransformPasses) {
-    pm.addPass(createAMDAIETileAndFusePass());
+    pm.addPass(createAMDAIETileAndFusePass(1));
     pm.addPass(createAMDAIEPadAndBufferizePass());
+    pm.addPass(createCleanupPass());
+    pm.addPass(createCanonicalizerPass());
+    pm.addPass(createCSEPass());
+    // pm.addPass(createAMDAIETileAndFusePass(2));
   }
   pm.addPass(createEraseHALDescriptorTypeFromMemRefPass());
   pm.addPass(createAMDAIELowerExecutableTargetPass());

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -41,6 +41,10 @@ createAMDAIETileAndFusePass(int64_t tilingLevel = -1);
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createAMDAIEPadAndBufferizePass();
 
+/// Create pass to invoke several cleanup and canonicalization patterns.
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createCleanupPass();
+
 void registerAMDAIEPasses();
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -37,6 +37,10 @@ createAMDAIELowerExecutableTargetPass();
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createAMDAIETileAndFusePass(int64_t tilingLevel = -1);
 
+/// Pass to pad and bufferize matmul op.
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createAMDAIEPadAndBufferizePass();
+
 void registerAMDAIEPasses();
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -30,4 +30,11 @@ def AMDAIETileAndFuse :
   ];
 }
 
+def AMDAIEPadAndBufferize :
+    Pass<"iree-amdaie-pad-and-bufferize", "IREE::HAL::ExecutableVariantOp"> {
+  let summary = "Pass to pad operations on tensors in top-down order.";
+  let constructor =
+      "mlir::iree_compiler::AMDAIE::createAMDAIEPadAndBufferizePass()";
+}
+
 #endif // IREE_AMD_AIE_TRANSFORMS_PASSES

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -37,4 +37,11 @@ def AMDAIEPadAndBufferize :
       "mlir::iree_compiler::AMDAIE::createAMDAIEPadAndBufferizePass()";
 }
 
+def Cleanup :
+    Pass<"iree-cleanup", "IREE::HAL::ExecutableVariantOp"> {
+  let summary = "Pass to invoke several cleanup and canonicalization patterns.";
+  let constructor =
+      "mlir::iree_compiler::AMDAIE::createCleanupPass()";
+}
+
 #endif // IREE_AMD_AIE_TRANSFORMS_PASSES

--- a/tests/samples/CMakeLists.txt
+++ b/tests/samples/CMakeLists.txt
@@ -9,6 +9,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "matmul_fill_static_i32.mlir"
+    "pad_and_bufferize.mlir"
     "tile_and_fuse.mlir"
   TOOLS
     ${IREE_LLD_TARGET}

--- a/tests/samples/matmul_fill_spec_pad_new.mlir
+++ b/tests/samples/matmul_fill_spec_pad_new.mlir
@@ -17,7 +17,8 @@
 // ```
 
 
-// The first level tiling and fusion is done in a C++ pass compared to base script
+// The first level tiling + fusion + padding + DSP + bufferization + cleanup is done in a C++ pass
+// compared to base script.
 module attributes { transform.with_named_sequence } {
   transform.named_sequence @cleanup(%variant_op: !transform.any_op {transform.readonly}) {
     %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
@@ -37,9 +38,6 @@ module attributes { transform.with_named_sequence } {
     transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()  
     %ops = transform.structured.match ops{["scf.forall"]} in %variant_op : (!transform.any_op) -> !transform.any_op
     %fused_for_all = transform.split_handle %ops : (!transform.any_op) -> (!transform.any_op)
-
-    // Run canonicalizations.
-    transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()
 
     // Find the matmul and fill again
     %tiled_ops = transform.structured.match ops{["linalg.fill", "linalg.matmul"]} in %fused_for_all : (!transform.any_op) -> !transform.any_op

--- a/tests/samples/matmul_fill_static_i32.mlir
+++ b/tests/samples/matmul_fill_static_i32.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-codegen-transform-dialect-library=%S/matmul_fill_spec_pad.mlir | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-codegen-transform-dialect-library=%S/matmul_fill_spec_pad_new.mlir | FileCheck %s
 
 // CHECK-LABEL: hal.executable.export public @matmul_static_dispatch_0_matmul_8x8x16_i32
 //       CHECK:    AIE.device(ipu)

--- a/tests/samples/pad_and_bufferize.mlir
+++ b/tests/samples/pad_and_bufferize.mlir
@@ -1,0 +1,63 @@
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-amdaie-pad-and-bufferize)))' --split-input-file %s | FileCheck %s
+
+hal.executable private @matmul_static_tensors {
+    hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd"}>) {
+        hal.executable.export public @matmul_bias_add ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {translation_info = #iree_codegen.translation_info<TransformDialectCodegen codegen_spec = @__transform_main>} {
+        ^bb0(%arg0: !hal.device):
+        %x, %y, %z = flow.dispatch.workgroup_count_from_slice
+        hal.return %x, %y, %z : index, index, index
+        }
+        builtin.module {
+            func.func @matmul_static() {
+                %c0 = arith.constant 0 : index
+                %c0_i32 = arith.constant 0 : i32
+                %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<8x16xi32>>
+                %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x8xi32>>
+                %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
+                %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x16xi32>> -> tensor<8x16xi32>
+                %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [16, 8], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x8xi32>> -> tensor<16x8xi32>
+                %5 = tensor.empty() : tensor<8x8xi32>
+                %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<8x8xi32>) -> tensor<8x8xi32>
+                %7 = linalg.matmul ins(%3, %4 : tensor<8x16xi32>, tensor<16x8xi32>) outs(%6 : tensor<8x8xi32>) -> tensor<8x8xi32>
+                %8 = scf.forall (%arg0, %arg1) = (0, 0) to (8, 8) step (8, 8) shared_outs(%arg2 = %5) -> (tensor<8x8xi32>) {
+                    %9 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x16xi32>> -> tensor<8x16xi32>
+                    %extracted_slice = tensor.extract_slice %9[%arg0, 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
+                    %extracted_slice_0 = tensor.extract_slice %3[%arg0, 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
+                    %10 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [16, 8], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x8xi32>> -> tensor<16x8xi32>
+                    %extracted_slice_1 = tensor.extract_slice %10[0, %arg1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
+                    %extracted_slice_2 = tensor.extract_slice %4[0, %arg1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
+                    %11 = tensor.empty() : tensor<8x8xi32>
+                    %extracted_slice_3 = tensor.extract_slice %11[%arg0, %arg1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
+                    %extracted_slice_4 = tensor.extract_slice %arg2[%arg0, %arg1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
+                    %12 = linalg.fill ins(%c0_i32 : i32) outs(%extracted_slice_4 : tensor<8x8xi32>) -> tensor<8x8xi32>
+                    %extracted_slice_5 = tensor.extract_slice %arg2[%arg0, %arg1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
+                    %13 = linalg.matmul ins(%extracted_slice_0, %extracted_slice_2 : tensor<8x16xi32>, tensor<16x8xi32>) outs(%12 : tensor<8x8xi32>) -> tensor<8x8xi32>
+                    scf.forall.in_parallel {
+                        tensor.parallel_insert_slice %13 into %arg2[%arg0, %arg1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
+                    }
+                } {mapping = [#gpu.block<y>, #gpu.block<x>]}
+                flow.dispatch.tensor.store %8, %2, offsets = [0, 0], sizes = [8, 8], strides = [1, 1] : tensor<8x8xi32> -> !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
+                return
+            }
+        }
+    }
+}
+//      CHECK: @matmul_static_tensors
+//      CHECK:   scf.forall
+// CHECK-SAME:   {
+//      CHECK:       linalg.fill
+//      CHECK:       memref.alloc() : memref<8x16xi32, 1>
+//      CHECK:       bufferization.to_tensor %{{.*}} restrict writable
+//      CHECK:       linalg.copy
+//      CHECK:       memref.alloc() : memref<16x8xi32, 1>
+//      CHECK:       bufferization.to_tensor %{{.*}} restrict writable
+//      CHECK:       linalg.copy
+//      CHECK:       memref.alloc() : memref<8x8xi32, 1>
+//      CHECK:       bufferization.to_tensor %{{.*}} restrict writable
+//      CHECK:       linalg.copy
+//      CHECK:       linalg.matmul
+//      CHECK:       linalg.copy
+//      CHECK:       memref.dealloc
+//      CHECK:       memref.dealloc
+//      CHECK:       memref.dealloc
+//      CHECK:   }


### PR DESCRIPTION
-- This commit introduces a pass which would pad a MatmulOp, for now, and would rewrite/transform its input operands for 1st level.
-- It also introduces a clean up pass.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>