### PR TITLE
Add bufferization to compiler pass pipeline 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -65,6 +65,8 @@ void addMLIRAIRAIELoweringPasses(OpPassManager &passManager) {
   passManager.addPass(createEraseHALDescriptorTypeFromMemRefPass());
   passManager.addPass(createAMDAIEBridgeToAIRPass());
   passManager.addPass(memref::createFoldMemRefAliasOpsPass());
+  passManager.addPass(
+      mlir::iree_compiler::createIREEComprehensiveBufferizePass());
 
   {
     xilinx::air::ParallelToHerdOptions options;
@@ -103,7 +105,8 @@ void addMLIRAIRAIELoweringPasses(OpPassManager &passManager) {
   passManager.addPass(createCSEPass());
 
   passManager.addPass(xilinx::air::createAIRIsolateAsyncDmaLoopNests());
-  passManager.addPass(xilinx::air::createAIRSpecializeChannelWrapAndStridePattern());
+  passManager.addPass(
+      xilinx::air::createAIRSpecializeChannelWrapAndStridePattern());
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
 


### PR DESCRIPTION
This allows compilation to proceed further. Testing on the simple example:

```
export IREE_BUILD_DIR=~/iree_build
$IREE_BUILD_DIR/tools/iree-compile --iree-hal-target-backends=amd-aie simple_abs.mlir --mlir-print-ir-before-all --print-module-scope > dump.mlir
```

Before this patch, this failed in the --air-dependency pass, which assumes input is bufferized. With the addition of bufferization in the main pipeline in this PR, compilation proceeds to the --airrt-to-ipu. 


I guess we could remove bufferization from the transform dialect tests now, although there is no harm in bufferizing twice I assume? 