### PR TITLE
implicit convolution (a single top-level im2col)

### DIFF
--- a/tests/samples/CMakeLists.txt
+++ b/tests/samples/CMakeLists.txt
@@ -11,6 +11,7 @@ iree_lit_test_suite(
     "matmul_fill_static_i32.mlir"
     "pad_and_bufferize.mlir"
     "tile_and_fuse.mlir"
+    "implicit_convolution.mlir"
   TOOLS
     ${IREE_LLD_TARGET}
     FileCheck

--- a/tests/samples/implicit_convolution.mlir
+++ b/tests/samples/implicit_convolution.mlir
@@ -1,0 +1,36 @@
+// RUN: iree-compile \
+// RUN: --iree-preprocessing-pass-pipeline='builtin.module(func.func(iree-global-opt-convert-1x1-filter-conv2d-to-matmul,iree-preprocessing-convert-conv2d-to-img2col))' \
+// RUN: --iree-hal-target-backends=amd-aie \
+// RUN: --compile-to=executable-sources %s | FileCheck %s
+
+// An illustration of how we can replace a linalg.conv_* operation with a
+// linalg.matmul operation, using existing IREE infrastucture and passes.
+
+// Using --iree-preprocessing-pass-pipline='...' in iree-compile makes
+// it possible to insert passes just after the lowering from the ML dialects
+// (torch-mlir, etc.) to the linalg dialect. It is important to do the
+// decomposition of convolution before dispatch creation, so that the IREE
+// compiler can choose to separate data rearrangement (im2col) and
+// computation (matmul in this case) into different dispatches.
+
+// CHECK-LABEL: conv_2d_example
+func.func @conv_2d_example(%arg0: tensor<1x16x16x4xf32>,
+                      %arg1: tensor<3x2x4x16xf32>,
+                      %arg2: tensor<1x14x15x16xf32>) -> tensor<1x14x15x16xf32> {
+
+// CHECK-NOT: linalg.conv
+// CHECK: linalg.matmul
+// CHECK-NOT: linalg.conv
+  %0 = linalg.conv_2d_nhwc_hwcf
+        {dilations = dense<1> : tensor<2xi64>,
+         strides = dense<1> : tensor<2xi64> }
+        ins(%arg0, %arg1: tensor<1x16x16x4xf32>, tensor<3x2x4x16xf32>)
+        outs(%arg2: tensor<1x14x15x16xf32>) -> tensor<1x14x15x16xf32>
+
+// CHECK: return
+  return %0 : tensor<1x14x15x16xf32>
+}
+
+
+
+


### PR DESCRIPTION
This is the simplest form of implicit convolution we can do. It performs the transformation before any tiling, and so the data rearrangement and duplicating (9x duplication for a 3x3 kernel window)  happens in L3 (DDR) before any matmul. 

Note that batch size = 1 converts convolution to matmul, but batch size > 1 converts convolution to linalg.generic which may require more work to support on AIE. 

Thanks @qedawkins for pointing me to the preprocessing pipeline! 

