### PR TITLE
[AMD-AIE] Add amenities for setting and using TranslationInfo and LoweringConfig

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerExecutableTarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerExecutableTarget.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree-amd-aie/Transforms/KernelDispatch.h"
 #include "iree-amd-aie/Transforms/PassDetail.h"
 #include "iree-amd-aie/Transforms/Passes.h"
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
@@ -62,6 +63,11 @@ void AMDAIELowerExecutableTargetPass::runOnOperation() {
         "Expected a variantOp root with an inner ModuleOp");
     return signalPassFailure();
   }
+  // TODO (nmeshram): ADD a LoweringStrategy pass where this should be moved and
+  // then the lowering startegy should be verified
+  if (failed(initAIELaunchConfig(moduleOp))) {
+    return signalPassFailure();
+  }
 
   OpPassManager executableLoweringPipeline(
       IREE::HAL::ExecutableVariantOp::getOperationName());
@@ -97,7 +103,7 @@ void AMDAIELowerExecutableTargetPass::runOnOperation() {
         addTransformDialectPasses(executableLoweringPipeline);
         break;
       default:
-        moduleOp.emitOpError("Unsupported pipeline on CPU target.");
+        moduleOp.emitOpError("Unsupported pipeline on AIE target.");
         return signalPassFailure();
     }
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
@@ -44,6 +44,7 @@ iree_cc_library(
     "AMDAIETileAndFuse.cpp"
     "BridgeToAIRPass.cpp"
     "Cleanup.cpp"
+    "KernelDispatch.cpp"
   DEPS
     ::PassHeaders
     ::PassesIncGen

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -1,0 +1,115 @@
+// Copyright 2020 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-amd-aie/Transforms/KernelDispatch.h"
+
+#include "iree/compiler/Codegen/Utils/CPUUtils.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "kernel-dispatch"
+
+namespace mlir::iree_compiler::AMDAIE {
+
+/// Sets the lowering configuration for dispatch region with root op that
+/// implements the contraction operation interface.
+static LogicalResult setRootConfig(func::FuncOp entryPointFn,
+                                   linalg::MatmulOp matmulOp) {
+  assert(!getLoweringConfig(matmulOp) && "expected lowering_config is not set");
+  auto linalgOp = cast<linalg::LinalgOp>(matmulOp.getOperation());
+  unsigned numLoops = linalgOp.getNumLoops();
+  {
+    SmallVector<unsigned> dims;
+    linalgOp.getReductionDims(dims);
+    if (dims.size() != 1 || dims[0] != numLoops - 1) {
+      return matmulOp.emitOpError(
+          "expected to have exactly one reduction dim, and it is the innermost "
+          "dim");
+    }
+  }
+  // TODO (nmeshram) : This needs to be moved in a separate more generalized
+  // logic. Also, need a flag to experiment between pad based and pack based
+  // approach which will have different tile sizes and pass pipelines
+  SmallVector<int64_t> TileSizeLevel0 = {8, 8};
+  SmallVector<int64_t> TileSizeLevel1 = {4, 4};
+  SmallVector<int64_t> TileSizeLevel2 = {0, 0, 4};
+  TileSizesListType tileSizes = {TileSizeLevel0, TileSizeLevel1,
+                                 TileSizeLevel2};
+  return setOpConfigAndEntryPointFnTranslation(
+      entryPointFn, matmulOp, tileSizes,
+      IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault);
+}
+
+/// Redirects to methods that set the configuration based on operation type.
+static LogicalResult setRootConfigImpl(func::FuncOp entryPointFn,
+                                       Operation *op) {
+  auto setRootConfigFn = [&](Operation *op) -> LogicalResult {
+    return TypeSwitch<Operation *, LogicalResult>(op)
+        // TODO (nmeshram): This is very limited for now, plan is to
+        // let it first crash for all the other ops and then consiously
+        // add support for them, this way we can verify our work.
+        .Case<linalg::MatmulOp>(
+            [&](auto op) { return setRootConfig(entryPointFn, op); })
+        .Default([&](Operation *op) { return success(); });
+  };
+  return setRootConfigFn(op);
+}
+
+/// Sets the translation information to use for a dispatch region.
+static LogicalResult setTranslationInfoAndRootConfig(
+    func::FuncOp entryPointFn, ArrayRef<Operation *> computeOps) {
+  // Make sure that lowering_config is not preset on any compute ops.
+  for (auto computeOp : computeOps) {
+    if (getLoweringConfig(computeOp)) return failure();
+  }
+
+  FailureOr<Operation *> rootOp = getRootOperation(computeOps);
+  if (failed(rootOp)) return failure();
+  Operation *rootOperation = rootOp.value();
+
+  // TODO (nmeshram): Handle the case with no known root operation.
+  if (!rootOperation) {
+    return entryPointFn.emitError("Case with no root ops not yet supported.");
+  }
+
+  if (failed(setRootConfigImpl(entryPointFn, rootOperation))) {
+    return failure();
+  }
+
+  // TODO (nmeshram): // Set vector level tile sizes for other operations
+  // individually.
+
+  return success();
+}
+
+LogicalResult initAIELaunchConfig(ModuleOp moduleOp) {
+  llvm::StringMap<IREE::HAL::ExecutableExportOp> exportOps =
+      getAllEntryPoints(moduleOp);
+  for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
+    auto exportOp = exportOps.lookup(funcOp.getName());
+    if (!exportOp) continue;
+    if (getTranslationInfo(exportOp)) continue;
+
+    // TODO (nmeshram): Need a default pipeline for control flow cases.
+    if (funcOp.getBody().empty() || !llvm::hasSingleElement(funcOp.getBody())) {
+      return funcOp.emitError("control flow not yet supported.");
+    }
+
+    SmallVector<Operation *> computeOps = getComputeOps(funcOp);
+    if (failed(setTranslationInfoAndRootConfig(funcOp, computeOps))) {
+      return failure();
+    }
+  }
+
+  // The root configuration setting introduces `tensor.dim` operations.
+  // Resolve those away.
+  RewritePatternSet patterns(moduleOp.getContext());
+  memref::populateResolveRankedShapedTypeResultDimsPatterns(patterns);
+  return applyPatternsAndFoldGreedily(moduleOp, std::move(patterns));
+}
+
+}  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
@@ -1,0 +1,19 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_AMD_AIE_TRANSFORMS_KERNELDISPATCH_H_
+#define IREE_AMD_AIE_TRANSFORMS_KERNELDISPATCH_H_
+
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "mlir/IR/BuiltinOps.h"
+
+namespace mlir::iree_compiler::AMDAIE {
+
+LogicalResult initAIELaunchConfig(ModuleOp moduleOp);
+
+}  // namespace mlir::iree_compiler::AMDAIE
+
+#endif  // IREE_AMD_AIE_TRANSFORMS_KERNELDISPATCH_H_

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -7,6 +7,7 @@
 #ifndef IREE_AMD_AIE_TRANSFORMS_PASSES_H_
 #define IREE_AMD_AIE_TRANSFORMS_PASSES_H_
 
+#include "iree/compiler/Codegen/Common/TileSizeSelection.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "mlir/Pass/Pass.h"
 
@@ -24,6 +25,10 @@ void addTransformDialectPasses(OpPassManager &passManager);
 /// the structured ops path. The pass manager `pm` here operate on the module
 /// within the IREE::HAL::ExecutableOp.
 void buildAMDAIETransformPassPipeline(OpPassManager &pm);
+
+/// Populates passes needed to lower the IR via a Pad based approach.
+void addPadBasedPassPipeline(OpPassManager &passManager,
+                             TilingConfig &tilingConfig);
 
 /// Create a pass to do some rewrites that help bridging the path to AIR/AIE
 /// lowering.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pad_and_bufferize.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pad_and_bufferize.mlir
@@ -1,6 +1,6 @@
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-pad-and-bufferize{padding-level=0}))' --split-input-file %s | FileCheck %s --check-prefix=PAD-LEVEL-0
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-pad-and-bufferize{padding-level=1}))' --split-input-file %s | FileCheck %s --check-prefix=PAD-LEVEL-1
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-pad-and-bufferize{padding-level=2}))' --split-input-file %s | FileCheck %s --check-prefix=PAD-LEVEL-2
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-pad-and-bufferize{padding-level=3}))' --split-input-file %s | FileCheck %s --check-prefix=PAD-LEVEL-3
 
 func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> tensor<8x8xi32> {
   %c0 = arith.constant 0 : index
@@ -23,24 +23,24 @@ func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> 
   } {mapping = [#gpu.block<y>, #gpu.block<x>]}
   return %6 : tensor<8x8xi32>
 }
-//      PAD-LEVEL-1:   scf.forall
-// PAD-LEVEL-1-SAME:   {
-//      PAD-LEVEL-1:       linalg.fill
-//      PAD-LEVEL-1:       memref.alloc() : memref<8x16xi32, 1>
-//      PAD-LEVEL-1:       bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-1:       linalg.copy
-//      PAD-LEVEL-1:       memref.alloc() : memref<16x8xi32, 1>
-//      PAD-LEVEL-1:       bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-1:       linalg.copy
-//      PAD-LEVEL-1:       memref.alloc() : memref<8x8xi32, 1>
-//      PAD-LEVEL-1:       bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-1:       linalg.copy
-//      PAD-LEVEL-1:       linalg.matmul
-//      PAD-LEVEL-1:       linalg.copy
-//      PAD-LEVEL-1:       memref.dealloc
-//      PAD-LEVEL-1:       memref.dealloc
-//      PAD-LEVEL-1:       memref.dealloc
-//      PAD-LEVEL-1:   }
+//      PAD-LEVEL-0:   scf.forall
+// PAD-LEVEL-0-SAME:   {
+//      PAD-LEVEL-0:       linalg.fill
+//      PAD-LEVEL-0:       memref.alloc() : memref<8x16xi32, 1>
+//      PAD-LEVEL-0:       bufferization.to_tensor %{{.*}} restrict writable
+//      PAD-LEVEL-0:       linalg.copy
+//      PAD-LEVEL-0:       memref.alloc() : memref<16x8xi32, 1>
+//      PAD-LEVEL-0:       bufferization.to_tensor %{{.*}} restrict writable
+//      PAD-LEVEL-0:       linalg.copy
+//      PAD-LEVEL-0:       memref.alloc() : memref<8x8xi32, 1>
+//      PAD-LEVEL-0:       bufferization.to_tensor %{{.*}} restrict writable
+//      PAD-LEVEL-0:       linalg.copy
+//      PAD-LEVEL-0:       linalg.matmul
+//      PAD-LEVEL-0:       linalg.copy
+//      PAD-LEVEL-0:       memref.dealloc
+//      PAD-LEVEL-0:       memref.dealloc
+//      PAD-LEVEL-0:       memref.dealloc
+//      PAD-LEVEL-0:   }
 
 // -----
 
@@ -86,30 +86,30 @@ func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> t
   } {mapping = [#gpu.block<y>, #gpu.block<x>]}
   return %6 : tensor<8x8xi32>
 }
-//      PAD-LEVEL-2:   scf.forall
-// PAD-LEVEL-2-SAME:   {
-//      PAD-LEVEL-2:       linalg.fill
-//      PAD-LEVEL-2:       memref.alloc() : memref<8x16xi32, 1>
-//      PAD-LEVEL-2:       bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-2:       linalg.copy
-//      PAD-LEVEL-2:       memref.alloc() : memref<16x8xi32, 1>
-//      PAD-LEVEL-2:       bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-2:       linalg.copy
-//      PAD-LEVEL-2:       memref.alloc() : memref<8x8xi32, 1>
-//      PAD-LEVEL-2:       bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-2:       scf.forall
-// PAD-LEVEL-2-SAME:       {
-//      PAD-LEVEL-2:            memref.alloc() : memref<4x4xi32, 2>
-//      PAD-LEVEL-2:            bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-2:            linalg.copy
-//      PAD-LEVEL-2:            linalg.matmul
-//      PAD-LEVEL-2:            linalg.copy
-//      PAD-LEVEL-2:            memref.dealloc
-//      PAD-LEVEL-2:       }
-//      PAD-LEVEL-2:       memref.dealloc
-//      PAD-LEVEL-2:       memref.dealloc
-//      PAD-LEVEL-2:       memref.dealloc
-//      PAD-LEVEL-2:   }
+//      PAD-LEVEL-1:   scf.forall
+// PAD-LEVEL-1-SAME:   {
+//      PAD-LEVEL-1:       linalg.fill
+//      PAD-LEVEL-1:       memref.alloc() : memref<8x16xi32, 1>
+//      PAD-LEVEL-1:       bufferization.to_tensor %{{.*}} restrict writable
+//      PAD-LEVEL-1:       linalg.copy
+//      PAD-LEVEL-1:       memref.alloc() : memref<16x8xi32, 1>
+//      PAD-LEVEL-1:       bufferization.to_tensor %{{.*}} restrict writable
+//      PAD-LEVEL-1:       linalg.copy
+//      PAD-LEVEL-1:       memref.alloc() : memref<8x8xi32, 1>
+//      PAD-LEVEL-1:       bufferization.to_tensor %{{.*}} restrict writable
+//      PAD-LEVEL-1:       scf.forall
+// PAD-LEVEL-1-SAME:       {
+//      PAD-LEVEL-1:            memref.alloc() : memref<4x4xi32, 2>
+//      PAD-LEVEL-1:            bufferization.to_tensor %{{.*}} restrict writable
+//      PAD-LEVEL-1:            linalg.copy
+//      PAD-LEVEL-1:            linalg.matmul
+//      PAD-LEVEL-1:            linalg.copy
+//      PAD-LEVEL-1:            memref.dealloc
+//      PAD-LEVEL-1:       }
+//      PAD-LEVEL-1:       memref.dealloc
+//      PAD-LEVEL-1:       memref.dealloc
+//      PAD-LEVEL-1:       memref.dealloc
+//      PAD-LEVEL-1:   }
 
 // -----
 
@@ -164,36 +164,36 @@ func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> 
   } {mapping = [#gpu.block<y>, #gpu.block<x>]}
   return %6 : tensor<8x8xi32>
 }
-//      PAD-LEVEL-3:   scf.forall
-// PAD-LEVEL-3-SAME:   {
-//      PAD-LEVEL-3:       linalg.fill
-//      PAD-LEVEL-3:       memref.alloc() : memref<8x16xi32, 1>
-//      PAD-LEVEL-3:       bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-3:       linalg.copy
-//      PAD-LEVEL-3:       memref.alloc() : memref<16x8xi32, 1>
-//      PAD-LEVEL-3:       bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-3:       linalg.copy
-//      PAD-LEVEL-3:       memref.alloc() : memref<8x8xi32, 1>
-//      PAD-LEVEL-3:       bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-3:       scf.forall
-// PAD-LEVEL-3-SAME:       {
-//      PAD-LEVEL-3:            memref.alloc() : memref<4x4xi32, 2>
-//      PAD-LEVEL-3:            bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-3:            scf.for
-// PAD-LEVEL-3-SAME:            {
-//      PAD-LEVEL-3:                memref.alloc() : memref<4x4xi32, 2>
-//      PAD-LEVEL-3:                bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-3:                linalg.copy
-//      PAD-LEVEL-3:                memref.alloc() : memref<4x4xi32, 2>
-//      PAD-LEVEL-3:                bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-3:                linalg.copy
-//      PAD-LEVEL-3:                linalg.matmul
-//      PAD-LEVEL-3:                linalg.copy
-//      PAD-LEVEL-3:                memref.dealloc
-//      PAD-LEVEL-3:                memref.dealloc
-//      PAD-LEVEL-3:            }
-//      PAD-LEVEL-3:       }
-//      PAD-LEVEL-3:       memref.dealloc
-//      PAD-LEVEL-3:       memref.dealloc
-//      PAD-LEVEL-3:       memref.dealloc
-//      PAD-LEVEL-3:   }
+//      PAD-LEVEL-2:   scf.forall
+// PAD-LEVEL-2-SAME:   {
+//      PAD-LEVEL-2:       linalg.fill
+//      PAD-LEVEL-2:       memref.alloc() : memref<8x16xi32, 1>
+//      PAD-LEVEL-2:       bufferization.to_tensor %{{.*}} restrict writable
+//      PAD-LEVEL-2:       linalg.copy
+//      PAD-LEVEL-2:       memref.alloc() : memref<16x8xi32, 1>
+//      PAD-LEVEL-2:       bufferization.to_tensor %{{.*}} restrict writable
+//      PAD-LEVEL-2:       linalg.copy
+//      PAD-LEVEL-2:       memref.alloc() : memref<8x8xi32, 1>
+//      PAD-LEVEL-2:       bufferization.to_tensor %{{.*}} restrict writable
+//      PAD-LEVEL-2:       scf.forall
+// PAD-LEVEL-2-SAME:       {
+//      PAD-LEVEL-2:            memref.alloc() : memref<4x4xi32, 2>
+//      PAD-LEVEL-2:            bufferization.to_tensor %{{.*}} restrict writable
+//      PAD-LEVEL-2:            scf.for
+// PAD-LEVEL-2-SAME:            {
+//      PAD-LEVEL-2:                memref.alloc() : memref<4x4xi32, 2>
+//      PAD-LEVEL-2:                bufferization.to_tensor %{{.*}} restrict writable
+//      PAD-LEVEL-2:                linalg.copy
+//      PAD-LEVEL-2:                memref.alloc() : memref<4x4xi32, 2>
+//      PAD-LEVEL-2:                bufferization.to_tensor %{{.*}} restrict writable
+//      PAD-LEVEL-2:                linalg.copy
+//      PAD-LEVEL-2:                linalg.matmul
+//      PAD-LEVEL-2:                linalg.copy
+//      PAD-LEVEL-2:                memref.dealloc
+//      PAD-LEVEL-2:                memref.dealloc
+//      PAD-LEVEL-2:            }
+//      PAD-LEVEL-2:       }
+//      PAD-LEVEL-2:       memref.dealloc
+//      PAD-LEVEL-2:       memref.dealloc
+//      PAD-LEVEL-2:       memref.dealloc
+//      PAD-LEVEL-2:   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_using_scf_forall.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_using_scf_forall.mlir
@@ -1,5 +1,5 @@
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=0}))' --split-input-file %s | FileCheck %s --check-prefix=TILE-LEVEL-0
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=1}))' --split-input-file %s | FileCheck %s --check-prefix=TILE-LEVEL-1
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=2}))' --split-input-file %s | FileCheck %s --check-prefix=TILE-LEVEL-2
 
 func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> tensor<8x8xi32> {
   %c0 = arith.constant 0 : index
@@ -9,12 +9,12 @@ func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> t
   %7 = linalg.matmul ins(%arg0, %arg1 : tensor<8x16xi32>, tensor<16x8xi32>) outs(%6 : tensor<8x8xi32>) -> tensor<8x8xi32>
   return %7 : tensor<8x8xi32>
 }
-//      TILE-LEVEL-1: @matmul_static
-//      TILE-LEVEL-1:   scf.forall
-// TILE-LEVEL-1-SAME:   {
-//      TILE-LEVEL-1:       linalg.fill
-//      TILE-LEVEL-1:       linalg.matmul
-//      TILE-LEVEL-1:   }
+//      TILE-LEVEL-0: @matmul_static
+//      TILE-LEVEL-0:   scf.forall
+// TILE-LEVEL-0-SAME:   {
+//      TILE-LEVEL-0:       linalg.fill
+//      TILE-LEVEL-0:       linalg.matmul
+//      TILE-LEVEL-0:   }
 
 // -----
 
@@ -49,15 +49,15 @@ func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> t
   } {mapping = [#gpu.block<y>, #gpu.block<x>]}
   return %6 : tensor<8x8xi32>
 }
-//      TILE-LEVEL-2: @matmul_static
-//      TILE-LEVEL-2:   scf.forall
-// TILE-LEVEL-2-SAME:   {
-//      TILE-LEVEL-2:       scf.forall
-// TILE-LEVEL-2-SAME:       {
-//      TILE-LEVEL-2:           linalg.fill
-//      TILE-LEVEL-2:           linalg.matmul
-//      TILE-LEVEL-2:       }
-//      TILE-LEVEL-2:   }
+//      TILE-LEVEL-1: @matmul_static
+//      TILE-LEVEL-1:   scf.forall
+// TILE-LEVEL-1-SAME:   {
+//      TILE-LEVEL-1:       scf.forall
+// TILE-LEVEL-1-SAME:       {
+//      TILE-LEVEL-1:           linalg.fill
+//      TILE-LEVEL-1:           linalg.matmul
+//      TILE-LEVEL-1:       }
+//      TILE-LEVEL-1:   }
 
 // -----
 
@@ -83,10 +83,10 @@ func.func @matmul_bias_add(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %ar
     } -> tensor<?x?xf32>
   return %2 : tensor<?x?xf32>
 }
-//      TILE-LEVEL-1: @matmul_bias_add
-//      TILE-LEVEL-1:   scf.forall
-// TILE-LEVEL-1-SAME:   {
-//      TILE-LEVEL-1:       linalg.fill
-//      TILE-LEVEL-1:       linalg.matmul
-//      TILE-LEVEL-1:       linalg.generic
-//      TILE-LEVEL-1:   }
+//      TILE-LEVEL-0: @matmul_bias_add
+//      TILE-LEVEL-0:   scf.forall
+// TILE-LEVEL-0-SAME:   {
+//      TILE-LEVEL-0:       linalg.fill
+//      TILE-LEVEL-0:       linalg.matmul
+//      TILE-LEVEL-0:       linalg.generic
+//      TILE-LEVEL-0:   }

--- a/tests/samples/CMakeLists.txt
+++ b/tests/samples/CMakeLists.txt
@@ -9,6 +9,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "matmul_fill_static_i32.mlir"
+    "matmul_fill_static_i32_config.mlir"
   TOOLS
     ${IREE_LLD_TARGET}
     FileCheck

--- a/tests/samples/matmul_fill_static_i32.mlir
+++ b/tests/samples/matmul_fill_static_i32.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-codegen-transform-dialect-library=%S/matmul_fill_spec_pad.mlir | FileCheck %s --check-prefix=TRANSFORM
-// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amd-aie-cpp-passes | FileCheck %s --check-prefix=CPP
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" | FileCheck %s --check-prefix=CPP
 
 // To check the transform dialect script path.
 // TRANSFORM-LABEL: hal.executable.export public @matmul_static_dispatch_0_matmul_8x8x16_i32

--- a/tests/samples/matmul_fill_static_i32_config.mlir
+++ b/tests/samples/matmul_fill_static_i32_config.mlir
@@ -1,0 +1,41 @@
+// RUN: iree-opt %s --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" | FileCheck %s
+
+// This test case is just to demonstrate that TransformDialectCodegen is not being set
+// and the e2e still works.
+// CHECK-LABEL: hal.executable.export public @matmul_static_dispatch_0_matmul_8x8x16_i32
+//       CHECK:    aie.device(ipu)
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    func.func @matmul_static_dispatch_0_matmul_8x8x16_i32(%arg0: memref<8x16xi32>, %arg1: memref<16x8xi32>, %arg2: memref<8x8xi32>)
+//       CHECK:      aiex.ipu.dma_memcpy_nd
+//       CHECK:      aiex.ipu.dma_memcpy_nd
+//       CHECK:      aiex.ipu.dma_memcpy_nd
+//       CHECK:      aiex.ipu.sync
+#config = #iree_codegen.lowering_config<tile_sizes = [[8, 8], [4, 4], [0, 0, 4]]>
+#translation = #iree_codegen.translation_info<CPUDefault>
+hal.executable private @matmul_static {
+  hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd"}>) {
+    hal.executable.export public @matmul_static_dispatch_0_matmul_8x8x16_i32 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice 
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_static_dispatch_0_matmul_8x8x16_i32() {
+        %c0 = arith.constant 0 : index
+        %c0_i32 = arith.constant 0 : i32
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<8x16xi32>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x8xi32>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x16xi32>> -> tensor<8x16xi32>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [16, 8], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x8xi32>> -> tensor<16x8xi32>
+        %5 = tensor.empty() : tensor<8x8xi32>
+        %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<8x8xi32>) -> tensor<8x8xi32>
+        %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<8x16xi32>, tensor<16x8xi32>) outs(%6 : tensor<8x8xi32>) -> tensor<8x8xi32>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [8, 8], strides = [1, 1] : tensor<8x8xi32> -> !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
+        return
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR consists of two commits :-

**Commit 1 (Create TranslationInfo and LoweringConfig):**
-- This commit adds tile sizes and pass pipelines via lowering_config
   and translation_info respectively.
-- This is the initial effort towards generalizing the AIE codegen
   pipeline. Currently setting tile sizes suiting the Matmul pad based
   approach.

Signed-off-by: Nirvedh Meshram <nmeshram@amd.com>

**Commit 2 (Use TranslationInfo and LoweringConfig):**
-- This commit adapts the codegen flow to use lowering_config and
   translation_info.
-- This basically involves :-
   a. Adapting `--iree-amdaie-tile-and-fuse` to use lowering_config
      in order to fetch the tile size for a particular tiling level.
   b. Segregate the AMDAIE codegen flow to have two separate pipelines:
      i. Transform dialect pipeline ii. Multi level tiling C++ pipeline.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>