### PR TITLE
NFC: General cleanup of IREE-AMD-AIE code and tests.

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerExecutableTarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerExecutableTarget.cpp
@@ -92,7 +92,7 @@ void AMDAIELowerExecutableTargetPass::runOnOperation() {
 
   if (translationInfo.has_value()) {
     switch (translationInfo.value().getDispatchLoweringPassPipeline()) {
-        // Transform-dialect pipelines.
+      // Transform-dialect pipelines.
       case IREE::Codegen::DispatchLoweringPassPipeline::TransformDialectCodegen:
         addTransformDialectPasses(executableLoweringPipeline);
         break;

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerWorkgroupCount.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerWorkgroupCount.cpp
@@ -1,0 +1,59 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#include "iree-amd-aie/Transforms/PassDetail.h"
+#include "iree-amd-aie/Transforms/Passes.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir::iree_compiler::AMDAIE {
+
+namespace {
+class AMDAIELowerWorkgroupCountPass
+    : public AMDAIELowerWorkgroupCountBase<AMDAIELowerWorkgroupCountPass> {
+  void runOnOperation() override;
+};
+}  // namespace
+
+/// Lower workgroup count operations to all 1s.
+static LogicalResult lowerWorkgroupCount(
+    RewriterBase &rewriter, IREE::HAL::ExecutableExportOp exportOp) {
+  Block *body = exportOp.getWorkgroupCountBody();
+  if (!body) {
+    return exportOp.emitOpError("unexpected empty workgroup count region");
+  }
+  OpBuilder::InsertionGuard g(rewriter);
+  for (auto workgroupCountOp : llvm::make_early_inc_range(
+           body->getOps<IREE::Flow::DispatchWorkgroupCountFromSliceOp>())) {
+    rewriter.setInsertionPoint(workgroupCountOp);
+    Location loc = workgroupCountOp.getLoc();
+    SmallVector<OpFoldResult> results;
+    results.resize(workgroupCountOp.getNumResults(), rewriter.getIndexAttr(1));
+    rewriter.replaceOp(workgroupCountOp,
+                       getValueOrCreateConstantIndexOp(rewriter, loc, results));
+  }
+  return success();
+}
+
+void AMDAIELowerWorkgroupCountPass::runOnOperation() {
+  IREE::HAL::ExecutableVariantOp variantOp = getOperation();
+  MLIRContext *context = &getContext();
+  IRRewriter rewriter(context);
+  for (auto entryPointOp : variantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
+    if (failed(lowerWorkgroupCount(rewriter, entryPointOp))) {
+      return signalPassFailure();
+    }
+  }
+}
+
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createAMDAIELowerWorkgroupCountPass() {
+  return std::make_unique<AMDAIELowerWorkgroupCountPass>();
+}
+
+}  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
@@ -38,9 +38,10 @@ iree_cc_library(
   SRCS
     "Passes.cpp"
     "AMDAIELowerExecutableTarget.cpp"
+    "AMDAIELowerWorkgroupCount.cpp"
+    "AMDAIEPackAndTranspose.cpp"
     "AMDAIEPadAndBufferize.cpp"
     "AMDAIETileAndFuse.cpp"
-    "AMDAIEPackAndTranspose.cpp"
     "BridgeToAIRPass.cpp"
     "Cleanup.cpp"
   DEPS

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -29,25 +29,28 @@ void buildAMDAIETransformPassPipeline(OpPassManager &pm);
 /// lowering.
 std::unique_ptr<OperationPass<>> createAMDAIEBridgeToAIRPass();
 
+/// Create pass to invoke several cleanup and canonicalization patterns.
+std::unique_ptr<OperationPass<func::FuncOp>> createAMDAIECleanupPass();
+
 /// Create pass calling the dynamic pipeline for AMDAIE.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createAMDAIELowerExecutableTargetPass();
 
-/// Create pass to tile and fuse TilingInterface operations.
+/// Create a pass to lower workgroup count region of entry point operations.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
-createAMDAIETileAndFusePass(int64_t tilingLevel = -1);
-
-/// Create a pass to pad MatmulOp and bufferize its operands.
-std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
-createAMDAIEPadAndBufferizePass(int64_t paddingLevel = -1);
-
-/// Create pass to invoke several cleanup and canonicalization patterns.
-std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
-createCleanupPass();
+createAMDAIELowerWorkgroupCountPass();
 
 /// Create a pass to pack and transpose the linalg op.
-std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
-createAMDAIEPackAndTransposePass(int64_t packLevel = 1);
+std::unique_ptr<OperationPass<func::FuncOp>> createAMDAIEPackAndTransposePass(
+    int64_t packLevel = 1);
+
+/// Create a pass to pad MatmulOp and bufferize its operands.
+std::unique_ptr<OperationPass<func::FuncOp>> createAMDAIEPadAndBufferizePass(
+    int64_t paddingLevel = -1);
+
+/// Create pass to tile and fuse TilingInterface operations.
+std::unique_ptr<OperationPass<func::FuncOp>> createAMDAIETileAndFusePass(
+    int64_t tilingLevel = -1);
 
 void registerAMDAIEPasses();
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -14,24 +14,38 @@ def AMDAIEBridgeToAIR : Pass<"iree-amdaie-bridge-to-air", ""> {
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIEBridgeToAIRPass()";
 }
 
+def AMDAIECleanup :
+    Pass<"iree-amdaie-cleanup", "func::FuncOp"> {
+  let summary = "Pass to invoke several cleanup and canonicalization patterns.";
+  let constructor =
+      "mlir::iree_compiler::AMDAIE::createAMDAIECleanupPass()";
+}
+
 def AMDAIELowerExecutableTarget :
     Pass<"iree-amdaie-lower-executable-target", "mlir::iree_compiler::IREE::HAL::ExecutableVariantOp"> {
   let summary = "Perform lowering of executable target using one of the IREE::HAL::DispatchLoweringPassPipeline";
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIELowerExecutableTargetPass()";
 }
 
-def AMDAIETileAndFuse :
-    Pass<"iree-amdaie-tile-and-fuse", "IREE::HAL::ExecutableVariantOp"> {
-  let summary = "Pass to tile and fuse TilingInterface operations.";
-  let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIETileAndFusePass()";
+def AMDAIELowerWorkgroupCount :
+    Pass<"iree-amdaie-lower-workgroup-count", "mlir::iree_compiler::IREE::HAL::ExecutableVariantOp"> {
+  let summary = "Lower the workgroup count region";
+  let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIELowerWorkgroupCountPass()";
+}
+
+def AMDAIEPackAndTranspose :
+    Pass<"iree-amdaie-pack-and-transpose", "func::FuncOp"> {
+  let summary = "Pass to pack and transpose the linalg operations.";
+  let constructor =
+      "mlir::iree_compiler::AMDAIE::createAMDAIEPackAndTransposePass()";
   let options = [
-    Option<"tilingLevel", "tiling-level", "int64_t", /*default=*/"-1",
-      "Use default tiling level used to retrieve the configuration from lowering_config">
+    Option<"packLevel", "pack-level", "int64_t", /*default=*/"1",
+      "Set the packing level number">
   ];
 }
 
 def AMDAIEPadAndBufferize :
-    Pass<"iree-amdaie-pad-and-bufferize", "IREE::HAL::ExecutableVariantOp"> {
+    Pass<"iree-amdaie-pad-and-bufferize", "func::FuncOp"> {
   let summary = "Pass to pad operations on tensors in top-down order.";
   let constructor =
       "mlir::iree_compiler::AMDAIE::createAMDAIEPadAndBufferizePass()";
@@ -41,21 +55,13 @@ def AMDAIEPadAndBufferize :
   ];
 }
 
-def Cleanup :
-    Pass<"iree-cleanup", "IREE::HAL::ExecutableVariantOp"> {
-  let summary = "Pass to invoke several cleanup and canonicalization patterns.";
-  let constructor =
-      "mlir::iree_compiler::AMDAIE::createCleanupPass()";
-}
-
-def AMDAIEPackAndTranspose :
-    Pass<"iree-amdaie-pack-and-transpose", "IREE::HAL::ExecutableVariantOp"> {
-  let summary = "Pass to pack and transpose the linalg operations.";
-  let constructor =
-      "mlir::iree_compiler::AMDAIE::createAMDAIEPackAndTransposePass()";
+def AMDAIETileAndFuse :
+    Pass<"iree-amdaie-tile-and-fuse", "func::FuncOp"> {
+  let summary = "Pass to tile and fuse TilingInterface operations.";
+  let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIETileAndFusePass()";
   let options = [
-    Option<"packLevel", "pack-level", "int64_t", /*default=*/"1",
-      "Set the packing level number">
+    Option<"tilingLevel", "tiling-level", "int64_t", /*default=*/"-1",
+      "Use default tiling level used to retrieve the configuration from lowering_config">
   ];
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
@@ -8,11 +8,12 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "lower_workgroup_count.mlir"
+    "pack_and_transpose_level1.mlir"
+    "pack_and_transpose_level2.mlir"
     "pad_and_bufferize.mlir"
     "tile_and_fuse_using_scf_for.mlir"
     "tile_and_fuse_using_scf_forall.mlir"
-    "pack_and_transpose_level1.mlir"
-    "pack_and_transpose_level2.mlir"
   TOOLS
     ${IREE_LLD_TARGET}
     FileCheck

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_workgroup_count.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_workgroup_count.mlir
@@ -1,0 +1,18 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-amdaie-lower-workgroup-count, cse)))" %s | FileCheck %s
+hal.executable private @test {
+  hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd"}>) {
+    hal.executable.export public @test_export ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>]>]>) {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice 
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @test_export() {
+        return
+      }
+    }
+  }
+}
+// CHECK-LABEL: hal.executable.export public @test_export
+//       CHECK:   %[[C1:.+]] = arith.constant 1 : index
+//       CHECK:   hal.return %[[C1]], %[[C1]], %[[C1]]

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pack_and_transpose_level1.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pack_and_transpose_level1.mlir
@@ -1,30 +1,13 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-amdaie-pack-and-transpose{pack-level=1})))' --split-input-file %s | FileCheck --check-prefix=CHECK-1 %s
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-pack-and-transpose{pack-level=1}))' --split-input-file %s | FileCheck --check-prefix=CHECK-1 %s
 
-hal.executable private @matmul_pack_example_1 {
-  hal.executable.variant public @elf target(<"amd-aie", "elf", {target_arch = "chip-tbd"}>) {
-    hal.executable.export public @matmul_example_dispatch_0_matmul_16x256x256_i8xi8xi32 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {translation_info = #iree_codegen.translation_info<TransformDialectCodegen codegen_spec = @__transform_main>} {
-    ^bb0(%arg0: !hal.device):
-      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @matmul_example_dispatch_0_matmul_16x256x256_i8xi8xi32() {
-        %c0 = arith.constant 0 : index
-        %c0_i32 = arith.constant 0 : i32
-        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x256xi8>>
-        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<256x256xi8>>
-        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<16x256xi32>>
-        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [16, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x256xi8>> -> tensor<16x256xi8>
-        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
-        %5 = tensor.empty() : tensor<16x256xi32>
-        %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<16x256xi32>) -> tensor<16x256xi32>
-        // CHECK-1: tensor.pack %{{.*}} inner_dims_pos = [0, 1] inner_tiles = [16, 64] into %{{.*}} : tensor<16x256xi8> -> tensor<1x4x16x64xi8>
-        // CHECK-1: tensor.pack %{{.*}} outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [64, 64] into %{{.*}} : tensor<256x256xi8> -> tensor<4x4x64x64xi8>
-        // CHECK-1: tensor.pack %{{.*}} inner_dims_pos = [0, 1] inner_tiles = [16, 64] into %{{.*}} : tensor<16x256xi32> -> tensor<1x4x16x64xi32>
-        %7 = linalg.matmul ins(%3, %4 : tensor<16x256xi8>, tensor<256x256xi8>) outs(%6 : tensor<16x256xi32>) -> tensor<16x256xi32>
-        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [16, 256], strides = [1, 1] : tensor<16x256xi32> -> !flow.dispatch.tensor<writeonly:tensor<16x256xi32>>
-        return
-      }
-    }
-  }
+func.func @matmul_example_dispatch_0_matmul_16x256x256_i8xi8xi32(%arg0 : tensor<16x256xi8>, %arg1 : tensor<256x256xi8>) -> tensor<16x256xi32> {
+  %c0 = arith.constant 0 : index
+  %c0_i32 = arith.constant 0 : i32
+  %5 = tensor.empty() : tensor<16x256xi32>
+  %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<16x256xi32>) -> tensor<16x256xi32>
+  // CHECK-1: tensor.pack %{{.*}} inner_dims_pos = [0, 1] inner_tiles = [16, 64] into %{{.*}} : tensor<16x256xi8> -> tensor<1x4x16x64xi8>
+  // CHECK-1: tensor.pack %{{.*}} outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [64, 64] into %{{.*}} : tensor<256x256xi8> -> tensor<4x4x64x64xi8>
+  // CHECK-1: tensor.pack %{{.*}} inner_dims_pos = [0, 1] inner_tiles = [16, 64] into %{{.*}} : tensor<16x256xi32> -> tensor<1x4x16x64xi32>
+  %7 = linalg.matmul ins(%arg0, %arg1 : tensor<16x256xi8>, tensor<256x256xi8>) outs(%6 : tensor<16x256xi32>) -> tensor<16x256xi32>
+  return %7 : tensor<16x256xi32>
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pack_and_transpose_level2.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pack_and_transpose_level2.mlir
@@ -1,67 +1,49 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-amdaie-pack-and-transpose{pack-level=2})))' --split-input-file %s | FileCheck --check-prefix=CHECK-2 %s
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-pack-and-transpose{pack-level=2}))' --split-input-file %s | FileCheck --check-prefix=CHECK-2 %s
 
 #map = affine_map<(d0) -> (d0 * 16)>
 #map1 = affine_map<(d0) -> (d0 * 64)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
 #map3 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d1, d5, d4)>
 #map4 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>
-hal.executable private @matmul_pack_example_2 {
-  hal.executable.variant public @elf target(<"amd-aie", "elf", {target_arch = "chip-tbd"}>) {
-    hal.executable.export public @matmul_example_dispatch_0_matmul_16x256x256_i8xi8xi32 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {translation_info = #iree_codegen.translation_info<TransformDialectCodegen codegen_spec = @__transform_main>} {
-    ^bb0(%arg0: !hal.device):
-      %c4 = arith.constant 4 : index
-      %c1 = arith.constant 1 : index
-      hal.return %c4, %c1, %c1 : index, index, index
-    }
-    builtin.module {
-      func.func @matmul_example_dispatch_0_matmul_16x256x256_i8xi8xi32() {
-        %c0 = arith.constant 0 : index
-        %c0_i32 = arith.constant 0 : i32
-        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x256xi8>>
-        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<256x256xi8>>
-        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<16x256xi32>>
-        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [16, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x256xi8>> -> tensor<16x256xi8>
-        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
-        %5 = tensor.empty() : tensor<16x256xi32>
-        %6 = scf.forall (%arg0, %arg1) in (1, 4) shared_outs(%arg2 = %5) -> (tensor<16x256xi32>) {
-          %7 = affine.apply #map(%arg0)
-          %8 = affine.apply #map1(%arg1)
-          %extracted_slice = tensor.extract_slice %3[%7, 0] [16, 256] [1, 1] : tensor<16x256xi8> to tensor<16x256xi8>
-          %extracted_slice_0 = tensor.extract_slice %4[0, %8] [256, 64] [1, 1] : tensor<256x256xi8> to tensor<256x64xi8>
-          %extracted_slice_1 = tensor.extract_slice %arg2[%7, %8] [16, 64] [1, 1] : tensor<16x256xi32> to tensor<16x64xi32>
-          %9 = tensor.empty() : tensor<1x4x16x64xi8>
-          %pack = tensor.pack %extracted_slice inner_dims_pos = [0, 1] inner_tiles = [16, 64] into %9 : tensor<16x256xi8> -> tensor<1x4x16x64xi8>
-          %10 = tensor.empty() : tensor<4x1x64x64xi8>
-          %pack_2 = tensor.pack %extracted_slice_0 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [64, 64] into %10 : tensor<256x64xi8> -> tensor<4x1x64x64xi8>
-          %11 = tensor.empty() : tensor<1x1x16x64xi32>
-          %12 = scf.forall (%arg3, %arg4) in (1, 1) shared_outs(%arg5 = %11) -> (tensor<1x1x16x64xi32>) {
-            %extracted_slice_3 = tensor.extract_slice %pack[%arg3, 0, 0, 0] [1, 4, 16, 64] [1, 1, 1, 1] : tensor<1x4x16x64xi8> to tensor<1x4x16x64xi8>
-            %extracted_slice_4 = tensor.extract_slice %pack_2[0, %arg4, 0, 0] [4, 1, 64, 64] [1, 1, 1, 1] : tensor<4x1x64x64xi8> to tensor<4x1x64x64xi8>
-            %extracted_slice_5 = tensor.extract_slice %arg5[%arg3, %arg4, 0, 0] [1, 1, 16, 64] [1, 1, 1, 1] : tensor<1x1x16x64xi32> to tensor<1x1x16x64xi32>
-            %13 = linalg.fill ins(%c0_i32 : i32) outs(%extracted_slice_5 : tensor<1x1x16x64xi32>) -> tensor<1x1x16x64xi32>
-            // CHECK-2: tensor.pack %{{.*}} outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [4, 8] into %{{.*}} : tensor<1x4x16x64xi8> -> tensor<1x4x8x4x4x8xi8>
-            // CHECK-2: tensor.pack %{{.*}} outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [8, 8] into %{{.*}} : tensor<4x1x64x64xi8> -> tensor<4x1x8x8x8x8xi8>
-            // CHECK-2: tensor.pack %{{.*}} outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [4, 8] into %{{.*}} : tensor<1x1x16x64xi32> -> tensor<1x1x8x4x4x8xi32>
-            %14 = linalg.generic {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%extracted_slice_3, %extracted_slice_4 : tensor<1x4x16x64xi8>, tensor<4x1x64x64xi8>) outs(%13 : tensor<1x1x16x64xi32>) {
-            ^bb0(%in: i8, %in_6: i8, %out: i32):
-              %15 = arith.extsi %in : i8 to i32
-              %16 = arith.extsi %in_6 : i8 to i32
-              %17 = arith.muli %15, %16 : i32
-              %18 = arith.addi %out, %17 : i32
-              linalg.yield %18 : i32
-            } -> tensor<1x1x16x64xi32>
-            scf.forall.in_parallel {
-              tensor.parallel_insert_slice %14 into %arg5[%arg3, %arg4, 0, 0] [1, 1, 16, 64] [1, 1, 1, 1] : tensor<1x1x16x64xi32> into tensor<1x1x16x64xi32>
-            }
-          } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
-          %unpack = tensor.unpack %12 inner_dims_pos = [0, 1] inner_tiles = [16, 64] into %extracted_slice_1 : tensor<1x1x16x64xi32> -> tensor<16x64xi32>
-          scf.forall.in_parallel {
-            tensor.parallel_insert_slice %unpack into %arg2[%7, %8] [16, 64] [1, 1] : tensor<16x64xi32> into tensor<16x256xi32>
-          }
-        } {mapping = [#gpu.block<y>, #gpu.block<x>]}
-        flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [16, 256], strides = [1, 1] : tensor<16x256xi32> -> !flow.dispatch.tensor<writeonly:tensor<16x256xi32>>
-        return
+func.func @matmul_example_dispatch_0_matmul_16x256x256_i8xi8xi32(%arg0: tensor<16x256xi8>, %arg1 : tensor<256x256xi8>) -> tensor<16x256xi32> {
+  %c0 = arith.constant 0 : index
+  %c0_i32 = arith.constant 0 : i32
+  %5 = tensor.empty() : tensor<16x256xi32>
+  %6 = scf.forall (%iv0, %iv1) in (1, 4) shared_outs(%arg2 = %5) -> (tensor<16x256xi32>) {
+    %7 = affine.apply #map(%iv0)
+    %8 = affine.apply #map1(%iv1)
+    %extracted_slice = tensor.extract_slice %arg0[%7, 0] [16, 256] [1, 1] : tensor<16x256xi8> to tensor<16x256xi8>
+    %extracted_slice_0 = tensor.extract_slice %arg1[0, %8] [256, 64] [1, 1] : tensor<256x256xi8> to tensor<256x64xi8>
+    %extracted_slice_1 = tensor.extract_slice %arg2[%7, %8] [16, 64] [1, 1] : tensor<16x256xi32> to tensor<16x64xi32>
+    %9 = tensor.empty() : tensor<1x4x16x64xi8>
+    %pack = tensor.pack %extracted_slice inner_dims_pos = [0, 1] inner_tiles = [16, 64] into %9 : tensor<16x256xi8> -> tensor<1x4x16x64xi8>
+    %10 = tensor.empty() : tensor<4x1x64x64xi8>
+    %pack_2 = tensor.pack %extracted_slice_0 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [64, 64] into %10 : tensor<256x64xi8> -> tensor<4x1x64x64xi8>
+    %11 = tensor.empty() : tensor<1x1x16x64xi32>
+    %12 = scf.forall (%arg3, %arg4) in (1, 1) shared_outs(%arg5 = %11) -> (tensor<1x1x16x64xi32>) {
+      %extracted_slice_3 = tensor.extract_slice %pack[%arg3, 0, 0, 0] [1, 4, 16, 64] [1, 1, 1, 1] : tensor<1x4x16x64xi8> to tensor<1x4x16x64xi8>
+      %extracted_slice_4 = tensor.extract_slice %pack_2[0, %arg4, 0, 0] [4, 1, 64, 64] [1, 1, 1, 1] : tensor<4x1x64x64xi8> to tensor<4x1x64x64xi8>
+      %extracted_slice_5 = tensor.extract_slice %arg5[%arg3, %arg4, 0, 0] [1, 1, 16, 64] [1, 1, 1, 1] : tensor<1x1x16x64xi32> to tensor<1x1x16x64xi32>
+      %13 = linalg.fill ins(%c0_i32 : i32) outs(%extracted_slice_5 : tensor<1x1x16x64xi32>) -> tensor<1x1x16x64xi32>
+      // CHECK-2: tensor.pack %{{.*}} outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [4, 8] into %{{.*}} : tensor<1x4x16x64xi8> -> tensor<1x4x8x4x4x8xi8>
+      // CHECK-2: tensor.pack %{{.*}} outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [8, 8] into %{{.*}} : tensor<4x1x64x64xi8> -> tensor<4x1x8x8x8x8xi8>
+      // CHECK-2: tensor.pack %{{.*}} outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [4, 8] into %{{.*}} : tensor<1x1x16x64xi32> -> tensor<1x1x8x4x4x8xi32>
+      %14 = linalg.generic {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%extracted_slice_3, %extracted_slice_4 : tensor<1x4x16x64xi8>, tensor<4x1x64x64xi8>) outs(%13 : tensor<1x1x16x64xi32>) {
+      ^bb0(%in: i8, %in_6: i8, %out: i32):
+        %15 = arith.extsi %in : i8 to i32
+        %16 = arith.extsi %in_6 : i8 to i32
+        %17 = arith.muli %15, %16 : i32
+        %18 = arith.addi %out, %17 : i32
+        linalg.yield %18 : i32
+      } -> tensor<1x1x16x64xi32>
+      scf.forall.in_parallel {
+        tensor.parallel_insert_slice %14 into %arg5[%arg3, %arg4, 0, 0] [1, 1, 16, 64] [1, 1, 1, 1] : tensor<1x1x16x64xi32> into tensor<1x1x16x64xi32>
       }
+    } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
+    %unpack = tensor.unpack %12 inner_dims_pos = [0, 1] inner_tiles = [16, 64] into %extracted_slice_1 : tensor<1x1x16x64xi32> -> tensor<16x64xi32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %unpack into %arg2[%7, %8] [16, 64] [1, 1] : tensor<16x64xi32> into tensor<16x256xi32>
     }
-  }
+  } {mapping = [#gpu.block<y>, #gpu.block<x>]}
+  return %6 : tensor<16x256xi32>
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pad_and_bufferize.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pad_and_bufferize.mlir
@@ -1,48 +1,28 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-amdaie-pad-and-bufferize{padding-level=1})))' --split-input-file %s | FileCheck %s --check-prefix=PAD-LEVEL-1
-// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-amdaie-pad-and-bufferize{padding-level=2})))' --split-input-file %s | FileCheck %s --check-prefix=PAD-LEVEL-2
-// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-amdaie-pad-and-bufferize{padding-level=3})))' --split-input-file %s | FileCheck %s --check-prefix=PAD-LEVEL-3
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-pad-and-bufferize{padding-level=1}))' --split-input-file %s | FileCheck %s --check-prefix=PAD-LEVEL-1
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-pad-and-bufferize{padding-level=2}))' --split-input-file %s | FileCheck %s --check-prefix=PAD-LEVEL-2
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-pad-and-bufferize{padding-level=3}))' --split-input-file %s | FileCheck %s --check-prefix=PAD-LEVEL-3
 
-hal.executable private @matmul_static_tensors {
-    hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd"}>) {
-        hal.executable.export public @matmul_bias_add ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {translation_info = #iree_codegen.translation_info<TransformDialectCodegen codegen_spec = @__transform_main>} {
-        ^bb0(%arg0: !hal.device):
-        %x, %y, %z = flow.dispatch.workgroup_count_from_slice
-        hal.return %x, %y, %z : index, index, index
-        }
-        builtin.module {
-            func.func @matmul_static() {
-                %c0 = arith.constant 0 : index
-                %c0_i32 = arith.constant 0 : i32
-                %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<8x16xi32>>
-                %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x8xi32>>
-                %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
-                %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x16xi32>> -> tensor<8x16xi32>
-                %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [16, 8], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x8xi32>> -> tensor<16x8xi32>
-                %5 = tensor.empty() : tensor<8x8xi32>
-                %6 = scf.forall (%arg0, %arg1) = (0, 0) to (8, 8) step (8, 8) shared_outs(%arg2 = %5) -> (tensor<8x8xi32>) {
-                    %9 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x16xi32>> -> tensor<8x16xi32>
-                    %extracted_slice = tensor.extract_slice %9[%arg0, 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
-                    %extracted_slice_0 = tensor.extract_slice %3[%arg0, 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
-                    %10 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [16, 8], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x8xi32>> -> tensor<16x8xi32>
-                    %extracted_slice_1 = tensor.extract_slice %10[0, %arg1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
-                    %extracted_slice_2 = tensor.extract_slice %4[0, %arg1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
-                    %11 = tensor.empty() : tensor<8x8xi32>
-                    %extracted_slice_3 = tensor.extract_slice %11[%arg0, %arg1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
-                    %extracted_slice_4 = tensor.extract_slice %arg2[%arg0, %arg1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
-                    %12 = linalg.fill ins(%c0_i32 : i32) outs(%extracted_slice_4 : tensor<8x8xi32>) -> tensor<8x8xi32>
-                    %extracted_slice_5 = tensor.extract_slice %arg2[%arg0, %arg1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
-                    %13 = linalg.matmul ins(%extracted_slice_0, %extracted_slice_2 : tensor<8x16xi32>, tensor<16x8xi32>) outs(%12 : tensor<8x8xi32>) -> tensor<8x8xi32>
-                    scf.forall.in_parallel {
-                        tensor.parallel_insert_slice %13 into %arg2[%arg0, %arg1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
-                    }
-                } {mapping = [#gpu.block<y>, #gpu.block<x>]}
-                flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [8, 8], strides = [1, 1] : tensor<8x8xi32> -> !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
-                return
-            }
-        }
+func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> tensor<8x8xi32> {
+  %c0 = arith.constant 0 : index
+  %c0_i32 = arith.constant 0 : i32
+  %5 = tensor.empty() : tensor<8x8xi32>
+  %6 = scf.forall (%iv0, %iv1) = (0, 0) to (8, 8) step (8, 8) shared_outs(%arg2 = %5) -> (tensor<8x8xi32>) {
+    %extracted_slice = tensor.extract_slice %arg0[%iv0, 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
+    %extracted_slice_0 = tensor.extract_slice %arg0[%iv0, 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
+    %extracted_slice_1 = tensor.extract_slice %arg1[0, %iv1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
+    %extracted_slice_2 = tensor.extract_slice %arg1[0, %iv1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
+    %11 = tensor.empty() : tensor<8x8xi32>
+    %extracted_slice_3 = tensor.extract_slice %11[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
+    %extracted_slice_4 = tensor.extract_slice %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
+    %12 = linalg.fill ins(%c0_i32 : i32) outs(%extracted_slice_4 : tensor<8x8xi32>) -> tensor<8x8xi32>
+    %extracted_slice_5 = tensor.extract_slice %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
+    %13 = linalg.matmul ins(%extracted_slice_0, %extracted_slice_2 : tensor<8x16xi32>, tensor<16x8xi32>) outs(%12 : tensor<8x8xi32>) -> tensor<8x8xi32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %13 into %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
     }
+  } {mapping = [#gpu.block<y>, #gpu.block<x>]}
+  return %6 : tensor<8x8xi32>
 }
-//      PAD-LEVEL-1: @matmul_static_tensors
 //      PAD-LEVEL-1:   scf.forall
 // PAD-LEVEL-1-SAME:   {
 //      PAD-LEVEL-1:       linalg.fill
@@ -64,66 +44,48 @@ hal.executable private @matmul_static_tensors {
 
 // -----
 
-hal.executable private @matmul_static_tensors {
-    hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd"}>) {
-        hal.executable.export public @matmul_static ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
-        ^bb0(%arg0: !hal.device):
-            %c1 = arith.constant 1 : index
-            hal.return %c1, %c1, %c1 : index, index, index
-        }
-        builtin.module {
-            func.func @matmul_static() {
-            %c0 = arith.constant 0 : index
-            %c0_i32 = arith.constant 0 : i32
-            %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<8x16xi32>>
-            %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x8xi32>>
-            %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
-            %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x16xi32>> -> tensor<8x16xi32>
-            %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [16, 8], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x8xi32>> -> tensor<16x8xi32>
-            %5 = tensor.empty() : tensor<8x8xi32>
-            %6 = scf.forall (%arg0, %arg1) = (0, 0) to (8, 8) step (8, 8) shared_outs(%arg2 = %5) -> (tensor<8x8xi32>) {
-                %extracted_slice = tensor.extract_slice %3[%arg0, 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
-                %extracted_slice_0 = tensor.extract_slice %4[0, %arg1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
-                %extracted_slice_1 = tensor.extract_slice %arg2[%arg0, %arg1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
-                %7 = bufferization.alloc_tensor() : tensor<8x16xi32>
-                %alloc = memref.alloc() : memref<8x16xi32, 1>
-                %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1>
-                %9 = linalg.copy ins(%extracted_slice : tensor<8x16xi32>) outs(%8 : tensor<8x16xi32>) -> tensor<8x16xi32>
-                %10 = bufferization.alloc_tensor() : tensor<16x8xi32>
-                %alloc_2 = memref.alloc() : memref<16x8xi32, 1>
-                %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1>
-                %12 = linalg.copy ins(%extracted_slice_0 : tensor<16x8xi32>) outs(%11 : tensor<16x8xi32>) -> tensor<16x8xi32>
-                %13 = bufferization.alloc_tensor() : tensor<8x8xi32>
-                %alloc_3 = memref.alloc() : memref<8x8xi32, 1>
-                %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
-                %17 = scf.forall (%arg3, %arg4) = (0, 0) to (8, 8) step (4, 4) shared_outs(%arg5 = %14) -> (tensor<8x8xi32>) {
-                    %extracted_slice_4 = tensor.extract_slice %9[%arg3, 0] [4, 16] [1, 1] : tensor<8x16xi32> to tensor<4x16xi32>
-                    %extracted_slice_5 = tensor.extract_slice %12[0, %arg4] [16, 4] [1, 1] : tensor<16x8xi32> to tensor<16x4xi32>
-                    %19 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
-                    %extracted_slice_6 = tensor.extract_slice %19[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
-                    %extracted_slice_7 = tensor.extract_slice %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
-                    %20 = linalg.fill ins(%c0_i32 : i32) outs(%extracted_slice_7 : tensor<4x4xi32>) -> tensor<4x4xi32>
-                    %extracted_slice_8 = tensor.extract_slice %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
-                    %21 = linalg.matmul ins(%extracted_slice_4, %extracted_slice_5 : tensor<4x16xi32>, tensor<16x4xi32>) outs(%20 : tensor<4x4xi32>) -> tensor<4x4xi32>
-                    scf.forall.in_parallel {
-                        tensor.parallel_insert_slice %21 into %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<4x4xi32> into tensor<8x8xi32>
-                    }
-                } {mapping = [#gpu.block<y>, #gpu.block<x>]}
-                %18 = linalg.copy ins(%17 : tensor<8x8xi32>) outs(%extracted_slice_1 : tensor<8x8xi32>) -> tensor<8x8xi32>
-                memref.dealloc %alloc : memref<8x16xi32, 1>
-                memref.dealloc %alloc_2 : memref<16x8xi32, 1>
-                memref.dealloc %alloc_3 : memref<8x8xi32, 1>
-                scf.forall.in_parallel {
-                tensor.parallel_insert_slice %18 into %arg2[%arg0, %arg1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
-                }
-            } {mapping = [#gpu.block<y>, #gpu.block<x>]}
-            flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [8, 8], strides = [1, 1] : tensor<8x8xi32> -> !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
-            return
-            }
-        }
+func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> tensor<8x8xi32> {
+  %c0 = arith.constant 0 : index
+  %c0_i32 = arith.constant 0 : i32
+  %5 = tensor.empty() : tensor<8x8xi32>
+  %6 = scf.forall (%iv0, %iv1) = (0, 0) to (8, 8) step (8, 8) shared_outs(%arg2 = %5) -> (tensor<8x8xi32>) {
+    %extracted_slice = tensor.extract_slice %arg0[%iv0, 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
+    %extracted_slice_0 = tensor.extract_slice %arg1[0, %iv1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
+    %extracted_slice_1 = tensor.extract_slice %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
+    %7 = bufferization.alloc_tensor() : tensor<8x16xi32>
+    %alloc = memref.alloc() : memref<8x16xi32, 1>
+    %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1>
+    %9 = linalg.copy ins(%extracted_slice : tensor<8x16xi32>) outs(%8 : tensor<8x16xi32>) -> tensor<8x16xi32>
+    %10 = bufferization.alloc_tensor() : tensor<16x8xi32>
+    %alloc_2 = memref.alloc() : memref<16x8xi32, 1>
+    %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1>
+    %12 = linalg.copy ins(%extracted_slice_0 : tensor<16x8xi32>) outs(%11 : tensor<16x8xi32>) -> tensor<16x8xi32>
+    %13 = bufferization.alloc_tensor() : tensor<8x8xi32>
+    %alloc_3 = memref.alloc() : memref<8x8xi32, 1>
+    %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
+    %17 = scf.forall (%arg3, %arg4) = (0, 0) to (8, 8) step (4, 4) shared_outs(%arg5 = %14) -> (tensor<8x8xi32>) {
+      %extracted_slice_4 = tensor.extract_slice %9[%arg3, 0] [4, 16] [1, 1] : tensor<8x16xi32> to tensor<4x16xi32>
+      %extracted_slice_5 = tensor.extract_slice %12[0, %arg4] [16, 4] [1, 1] : tensor<16x8xi32> to tensor<16x4xi32>
+      %19 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
+      %extracted_slice_6 = tensor.extract_slice %19[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
+      %extracted_slice_7 = tensor.extract_slice %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
+      %20 = linalg.fill ins(%c0_i32 : i32) outs(%extracted_slice_7 : tensor<4x4xi32>) -> tensor<4x4xi32>
+      %extracted_slice_8 = tensor.extract_slice %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
+      %21 = linalg.matmul ins(%extracted_slice_4, %extracted_slice_5 : tensor<4x16xi32>, tensor<16x4xi32>) outs(%20 : tensor<4x4xi32>) -> tensor<4x4xi32>
+      scf.forall.in_parallel {
+        tensor.parallel_insert_slice %21 into %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<4x4xi32> into tensor<8x8xi32>
+      }
+    } {mapping = [#gpu.block<y>, #gpu.block<x>]}
+    %18 = linalg.copy ins(%17 : tensor<8x8xi32>) outs(%extracted_slice_1 : tensor<8x8xi32>) -> tensor<8x8xi32>
+    memref.dealloc %alloc : memref<8x16xi32, 1>
+    memref.dealloc %alloc_2 : memref<16x8xi32, 1>
+    memref.dealloc %alloc_3 : memref<8x8xi32, 1>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %18 into %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
     }
+  } {mapping = [#gpu.block<y>, #gpu.block<x>]}
+  return %6 : tensor<8x8xi32>
 }
-//      PAD-LEVEL-2: @matmul_static
 //      PAD-LEVEL-2:   scf.forall
 // PAD-LEVEL-2-SAME:   {
 //      PAD-LEVEL-2:       linalg.fill
@@ -151,75 +113,57 @@ hal.executable private @matmul_static_tensors {
 
 // -----
 
-hal.executable private @matmul_static_tensors {
-    hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd"}>) {
-        hal.executable.export public @matmul_static ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
-        ^bb0(%arg0: !hal.device):
-            %c1 = arith.constant 1 : index
-            hal.return %c1, %c1, %c1 : index, index, index
+func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> tensor<8x8xi32> {
+    %c16 = arith.constant 16 : index
+    %c4 = arith.constant 4 : index
+    %c0 = arith.constant 0 : index
+    %c0_i32 = arith.constant 0 : i32
+    %5 = tensor.empty() : tensor<8x8xi32>
+    %6 = scf.forall (%iv0, %iv1) = (0, 0) to (8, 8) step (8, 8) shared_outs(%arg2 = %5) -> (tensor<8x8xi32>) {
+      %extracted_slice = tensor.extract_slice %arg0[%iv0, 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
+      %extracted_slice_0 = tensor.extract_slice %arg1[0, %iv1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
+      %extracted_slice_1 = tensor.extract_slice %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
+      %7 = bufferization.alloc_tensor() : tensor<8x16xi32>
+      %alloc = memref.alloc() : memref<8x16xi32, 1>
+      %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1>
+      %9 = linalg.copy ins(%extracted_slice : tensor<8x16xi32>) outs(%8 : tensor<8x16xi32>) -> tensor<8x16xi32>
+      %10 = bufferization.alloc_tensor() : tensor<16x8xi32>
+      %alloc_2 = memref.alloc() : memref<16x8xi32, 1>
+      %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1>
+      %12 = linalg.copy ins(%extracted_slice_0 : tensor<16x8xi32>) outs(%11 : tensor<16x8xi32>) -> tensor<16x8xi32>
+      %13 = bufferization.alloc_tensor() : tensor<8x8xi32>
+      %alloc_3 = memref.alloc() : memref<8x8xi32, 1>
+      %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
+      %15 = scf.forall (%arg3, %arg4) = (0, 0) to (8, 8) step (4, 4) shared_outs(%arg5 = %14) -> (tensor<8x8xi32>) {
+        %extracted_slice_4 = tensor.extract_slice %9[%arg3, 0] [4, 16] [1, 1] : tensor<8x16xi32> to tensor<4x16xi32>
+        %extracted_slice_5 = tensor.extract_slice %12[0, %arg4] [16, 4] [1, 1] : tensor<16x8xi32> to tensor<16x4xi32>
+        %extracted_slice_6 = tensor.extract_slice %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
+        %17 = bufferization.alloc_tensor() : tensor<4x4xi32>
+        %alloc_7 = memref.alloc() : memref<4x4xi32, 2>
+        %18 = bufferization.to_tensor %alloc_7 restrict writable : memref<4x4xi32, 2>
+        %19 = linalg.fill ins(%c0_i32 : i32) outs(%18 : tensor<4x4xi32>) -> tensor<4x4xi32>
+        %20 = scf.for %arg6 = %c0 to %c16 step %c4 iter_args(%arg7 = %19) -> (tensor<4x4xi32>) {
+          %extracted_slice_8 = tensor.extract_slice %extracted_slice_4[0, %arg6] [4, 4] [1, 1] : tensor<4x16xi32> to tensor<4x4xi32>
+          %extracted_slice_9 = tensor.extract_slice %extracted_slice_5[%arg6, 0] [4, 4] [1, 1] : tensor<16x4xi32> to tensor<4x4xi32>
+          %22 = linalg.matmul ins(%extracted_slice_8, %extracted_slice_9 : tensor<4x4xi32>, tensor<4x4xi32>) outs(%arg7 : tensor<4x4xi32>) -> tensor<4x4xi32>
+          scf.yield %22 : tensor<4x4xi32>
         }
-        builtin.module {
-            func.func @matmul_static() {
-            %c16 = arith.constant 16 : index
-            %c4 = arith.constant 4 : index
-            %c0 = arith.constant 0 : index
-            %c0_i32 = arith.constant 0 : i32
-            %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<8x16xi32>>
-            %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x8xi32>>
-            %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
-            %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x16xi32>> -> tensor<8x16xi32>
-            %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [16, 8], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x8xi32>> -> tensor<16x8xi32>
-            %5 = tensor.empty() : tensor<8x8xi32>
-            %6 = scf.forall (%arg0, %arg1) = (0, 0) to (8, 8) step (8, 8) shared_outs(%arg2 = %5) -> (tensor<8x8xi32>) {
-                %extracted_slice = tensor.extract_slice %3[%arg0, 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
-                %extracted_slice_0 = tensor.extract_slice %4[0, %arg1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
-                %extracted_slice_1 = tensor.extract_slice %arg2[%arg0, %arg1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
-                %7 = bufferization.alloc_tensor() : tensor<8x16xi32>
-                %alloc = memref.alloc() : memref<8x16xi32, 1>
-                %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1>
-                %9 = linalg.copy ins(%extracted_slice : tensor<8x16xi32>) outs(%8 : tensor<8x16xi32>) -> tensor<8x16xi32>
-                %10 = bufferization.alloc_tensor() : tensor<16x8xi32>
-                %alloc_2 = memref.alloc() : memref<16x8xi32, 1>
-                %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1>
-                %12 = linalg.copy ins(%extracted_slice_0 : tensor<16x8xi32>) outs(%11 : tensor<16x8xi32>) -> tensor<16x8xi32>
-                %13 = bufferization.alloc_tensor() : tensor<8x8xi32>
-                %alloc_3 = memref.alloc() : memref<8x8xi32, 1>
-                %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
-                %15 = scf.forall (%arg3, %arg4) = (0, 0) to (8, 8) step (4, 4) shared_outs(%arg5 = %14) -> (tensor<8x8xi32>) {
-                    %extracted_slice_4 = tensor.extract_slice %9[%arg3, 0] [4, 16] [1, 1] : tensor<8x16xi32> to tensor<4x16xi32>
-                    %extracted_slice_5 = tensor.extract_slice %12[0, %arg4] [16, 4] [1, 1] : tensor<16x8xi32> to tensor<16x4xi32>
-                    %extracted_slice_6 = tensor.extract_slice %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
-                    %17 = bufferization.alloc_tensor() : tensor<4x4xi32>
-                    %alloc_7 = memref.alloc() : memref<4x4xi32, 2>
-                    %18 = bufferization.to_tensor %alloc_7 restrict writable : memref<4x4xi32, 2>
-                    %19 = linalg.fill ins(%c0_i32 : i32) outs(%18 : tensor<4x4xi32>) -> tensor<4x4xi32>
-                    %20 = scf.for %arg6 = %c0 to %c16 step %c4 iter_args(%arg7 = %19) -> (tensor<4x4xi32>) {
-                        %extracted_slice_8 = tensor.extract_slice %extracted_slice_4[0, %arg6] [4, 4] [1, 1] : tensor<4x16xi32> to tensor<4x4xi32>
-                        %extracted_slice_9 = tensor.extract_slice %extracted_slice_5[%arg6, 0] [4, 4] [1, 1] : tensor<16x4xi32> to tensor<4x4xi32>
-                        %22 = linalg.matmul ins(%extracted_slice_8, %extracted_slice_9 : tensor<4x4xi32>, tensor<4x4xi32>) outs(%arg7 : tensor<4x4xi32>) -> tensor<4x4xi32>
-                        scf.yield %22 : tensor<4x4xi32>
-                    }
-                    %21 = linalg.copy ins(%20 : tensor<4x4xi32>) outs(%extracted_slice_6 : tensor<4x4xi32>) -> tensor<4x4xi32>
-                    memref.dealloc %alloc_7 : memref<4x4xi32, 2>
-                    scf.forall.in_parallel {
-                        tensor.parallel_insert_slice %21 into %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<4x4xi32> into tensor<8x8xi32>
-                    }
-                } {mapping = [#gpu.block<y>, #gpu.block<x>]}
-                %16 = linalg.copy ins(%15 : tensor<8x8xi32>) outs(%extracted_slice_1 : tensor<8x8xi32>) -> tensor<8x8xi32>
-                memref.dealloc %alloc : memref<8x16xi32, 1>
-                memref.dealloc %alloc_2 : memref<16x8xi32, 1>
-                memref.dealloc %alloc_3 : memref<8x8xi32, 1>
-                scf.forall.in_parallel {
-                tensor.parallel_insert_slice %16 into %arg2[%arg0, %arg1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
-                }
-            } {mapping = [#gpu.block<y>, #gpu.block<x>]}
-            flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [8, 8], strides = [1, 1] : tensor<8x8xi32> -> !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
-            return
-            }
+        %21 = linalg.copy ins(%20 : tensor<4x4xi32>) outs(%extracted_slice_6 : tensor<4x4xi32>) -> tensor<4x4xi32>
+        memref.dealloc %alloc_7 : memref<4x4xi32, 2>
+        scf.forall.in_parallel {
+          tensor.parallel_insert_slice %21 into %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<4x4xi32> into tensor<8x8xi32>
         }
+    } {mapping = [#gpu.block<y>, #gpu.block<x>]}
+    %16 = linalg.copy ins(%15 : tensor<8x8xi32>) outs(%extracted_slice_1 : tensor<8x8xi32>) -> tensor<8x8xi32>
+    memref.dealloc %alloc : memref<8x16xi32, 1>
+    memref.dealloc %alloc_2 : memref<16x8xi32, 1>
+    memref.dealloc %alloc_3 : memref<8x8xi32, 1>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %16 into %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
     }
+  } {mapping = [#gpu.block<y>, #gpu.block<x>]}
+  return %6 : tensor<8x8xi32>
 }
-//      PAD-LEVEL-3: @matmul_static
 //      PAD-LEVEL-3:   scf.forall
 // PAD-LEVEL-3-SAME:   {
 //      PAD-LEVEL-3:       linalg.fill

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_using_scf_for.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_using_scf_for.mlir
@@ -1,65 +1,48 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-amdaie-tile-and-fuse{tiling-level=3})))' --split-input-file %s | FileCheck %s --check-prefix=TILE-LEVEL-3
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=3}))' --split-input-file %s | FileCheck %s --check-prefix=TILE-LEVEL-3
 
-hal.executable private @matmul_tensors {
-  hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd"}>) {
-    hal.executable.export public @matmul_static ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {translation_info = #iree_codegen.translation_info<TransformDialectCodegen codegen_spec = @__transform_main>} {
-    ^bb0(%arg0: !hal.device):
-      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @matmul_static() {
-        %c0 = arith.constant 0 : index
-        %c0_i32 = arith.constant 0 : i32
-        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<8x16xi32>>
-        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x8xi32>>
-        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
-        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x16xi32>> -> tensor<8x16xi32>
-        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [16, 8], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x8xi32>> -> tensor<16x8xi32>
-        %5 = tensor.empty() : tensor<8x8xi32>
-        %6 = scf.forall (%arg0, %arg1) = (0, 0) to (8, 8) step (8, 8) shared_outs(%arg2 = %5) -> (tensor<8x8xi32>) {
-          %extracted_slice = tensor.extract_slice %3[%arg0, 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
-          %extracted_slice_0 = tensor.extract_slice %4[0, %arg1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
-          %extracted_slice_1 = tensor.extract_slice %arg2[%arg0, %arg1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
-          %7 = bufferization.alloc_tensor() : tensor<8x16xi32>
-          %alloc = memref.alloc() : memref<8x16xi32, 1>
-          %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1>
-          %9 = linalg.copy ins(%extracted_slice : tensor<8x16xi32>) outs(%8 : tensor<8x16xi32>) -> tensor<8x16xi32>
-          %10 = bufferization.alloc_tensor() : tensor<16x8xi32>
-          %alloc_2 = memref.alloc() : memref<16x8xi32, 1>
-          %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1>
-          %12 = linalg.copy ins(%extracted_slice_0 : tensor<16x8xi32>) outs(%11 : tensor<16x8xi32>) -> tensor<16x8xi32>
-          %13 = bufferization.alloc_tensor() : tensor<8x8xi32>
-          %alloc_3 = memref.alloc() : memref<8x8xi32, 1>
-          %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
-          %15 = scf.forall (%arg3, %arg4) = (0, 0) to (8, 8) step (4, 4) shared_outs(%arg5 = %14) -> (tensor<8x8xi32>) {
-            %extracted_slice_4 = tensor.extract_slice %9[%arg3, 0] [4, 16] [1, 1] : tensor<8x16xi32> to tensor<4x16xi32>
-            %extracted_slice_5 = tensor.extract_slice %12[0, %arg4] [16, 4] [1, 1] : tensor<16x8xi32> to tensor<16x4xi32>
-            %extracted_slice_6 = tensor.extract_slice %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
-            %17 = bufferization.alloc_tensor() : tensor<4x4xi32>
-            %alloc_7 = memref.alloc() : memref<4x4xi32, 2>
-            %18 = bufferization.to_tensor %alloc_7 restrict writable : memref<4x4xi32, 2>
-            %19 = linalg.fill ins(%c0_i32 : i32) outs(%18 : tensor<4x4xi32>) -> tensor<4x4xi32>
-            %20 = linalg.matmul ins(%extracted_slice_4, %extracted_slice_5 : tensor<4x16xi32>, tensor<16x4xi32>) outs(%19 : tensor<4x4xi32>) -> tensor<4x4xi32>
-            %21 = linalg.copy ins(%20 : tensor<4x4xi32>) outs(%extracted_slice_6 : tensor<4x4xi32>) -> tensor<4x4xi32>
-            memref.dealloc %alloc_7 : memref<4x4xi32, 2>
-            scf.forall.in_parallel {
-              tensor.parallel_insert_slice %21 into %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<4x4xi32> into tensor<8x8xi32>
-            }
-          } {mapping = [#gpu.block<y>, #gpu.block<x>]}
-          %16 = linalg.copy ins(%15 : tensor<8x8xi32>) outs(%extracted_slice_1 : tensor<8x8xi32>) -> tensor<8x8xi32>
-          memref.dealloc %alloc : memref<8x16xi32, 1>
-          memref.dealloc %alloc_2 : memref<16x8xi32, 1>
-          memref.dealloc %alloc_3 : memref<8x8xi32, 1>
-          scf.forall.in_parallel {
-            tensor.parallel_insert_slice %16 into %arg2[%arg0, %arg1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
-          }
-        } {mapping = [#gpu.block<y>, #gpu.block<x>]}
-        flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [8, 8], strides = [1, 1] : tensor<8x8xi32> -> !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
-        return
+func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> tensor<8x8xi32> {
+  %c0 = arith.constant 0 : index
+  %c0_i32 = arith.constant 0 : i32
+  %5 = tensor.empty() : tensor<8x8xi32>
+  %6 = scf.forall (%iv0, %iv1) = (0, 0) to (8, 8) step (8, 8) shared_outs(%arg2 = %5) -> (tensor<8x8xi32>) {
+    %extracted_slice = tensor.extract_slice %arg0[%iv0, 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
+    %extracted_slice_0 = tensor.extract_slice %arg1[0, %iv1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
+    %extracted_slice_1 = tensor.extract_slice %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
+    %7 = bufferization.alloc_tensor() : tensor<8x16xi32>
+    %alloc = memref.alloc() : memref<8x16xi32, 1>
+    %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1>
+    %9 = linalg.copy ins(%extracted_slice : tensor<8x16xi32>) outs(%8 : tensor<8x16xi32>) -> tensor<8x16xi32>
+    %10 = bufferization.alloc_tensor() : tensor<16x8xi32>
+    %alloc_2 = memref.alloc() : memref<16x8xi32, 1>
+    %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1>
+    %12 = linalg.copy ins(%extracted_slice_0 : tensor<16x8xi32>) outs(%11 : tensor<16x8xi32>) -> tensor<16x8xi32>
+    %13 = bufferization.alloc_tensor() : tensor<8x8xi32>
+    %alloc_3 = memref.alloc() : memref<8x8xi32, 1>
+    %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
+    %15 = scf.forall (%arg3, %arg4) = (0, 0) to (8, 8) step (4, 4) shared_outs(%arg5 = %14) -> (tensor<8x8xi32>) {
+      %extracted_slice_4 = tensor.extract_slice %9[%arg3, 0] [4, 16] [1, 1] : tensor<8x16xi32> to tensor<4x16xi32>
+      %extracted_slice_5 = tensor.extract_slice %12[0, %arg4] [16, 4] [1, 1] : tensor<16x8xi32> to tensor<16x4xi32>
+      %extracted_slice_6 = tensor.extract_slice %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
+      %17 = bufferization.alloc_tensor() : tensor<4x4xi32>
+      %alloc_7 = memref.alloc() : memref<4x4xi32, 2>
+      %18 = bufferization.to_tensor %alloc_7 restrict writable : memref<4x4xi32, 2>
+      %19 = linalg.fill ins(%c0_i32 : i32) outs(%18 : tensor<4x4xi32>) -> tensor<4x4xi32>
+      %20 = linalg.matmul ins(%extracted_slice_4, %extracted_slice_5 : tensor<4x16xi32>, tensor<16x4xi32>) outs(%19 : tensor<4x4xi32>) -> tensor<4x4xi32>
+      %21 = linalg.copy ins(%20 : tensor<4x4xi32>) outs(%extracted_slice_6 : tensor<4x4xi32>) -> tensor<4x4xi32>
+      memref.dealloc %alloc_7 : memref<4x4xi32, 2>
+      scf.forall.in_parallel {
+        tensor.parallel_insert_slice %21 into %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<4x4xi32> into tensor<8x8xi32>
       }
+    } {mapping = [#gpu.block<y>, #gpu.block<x>]}
+    %16 = linalg.copy ins(%15 : tensor<8x8xi32>) outs(%extracted_slice_1 : tensor<8x8xi32>) -> tensor<8x8xi32>
+    memref.dealloc %alloc : memref<8x16xi32, 1>
+    memref.dealloc %alloc_2 : memref<16x8xi32, 1>
+    memref.dealloc %alloc_3 : memref<8x8xi32, 1>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %16 into %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
     }
-  }
+  } {mapping = [#gpu.block<y>, #gpu.block<x>]}
+  return %6 : tensor<8x8xi32>
 }
 //      TILE-LEVEL-3: @matmul_static
 //      TILE-LEVEL-3:   scf.forall

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_using_scf_forall.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_using_scf_forall.mlir
@@ -1,30 +1,13 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-amdaie-tile-and-fuse{tiling-level=1})))' --split-input-file %s | FileCheck %s --check-prefix=TILE-LEVEL-1
-// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-amdaie-tile-and-fuse{tiling-level=2})))' --split-input-file %s | FileCheck %s --check-prefix=TILE-LEVEL-2
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=1}))' --split-input-file %s | FileCheck %s --check-prefix=TILE-LEVEL-1
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=2}))' --split-input-file %s | FileCheck %s --check-prefix=TILE-LEVEL-2
 
-hal.executable private @matmul_tensors {
-  hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd"}>) {
-    hal.executable.export public @matmul_static ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {translation_info = #iree_codegen.translation_info<TransformDialectCodegen codegen_spec = @__transform_main>} {
-    ^bb0(%arg0: !hal.device):
-      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
-      hal.return %x, %y, %z : index, index, index
-    }
-    builtin.module {
-      func.func @matmul_static() {
-        %c0 = arith.constant 0 : index
-        %c0_i32 = arith.constant 0 : i32
-        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<8x16xi32>>
-        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x8xi32>>
-        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
-        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x16xi32>> -> tensor<8x16xi32>
-        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [16, 8], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x8xi32>> -> tensor<16x8xi32>
-        %5 = tensor.empty() : tensor<8x8xi32>
-        %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<8x8xi32>) -> tensor<8x8xi32>
-        %7 = linalg.matmul ins(%3, %4 : tensor<8x16xi32>, tensor<16x8xi32>) outs(%6 : tensor<8x8xi32>) -> tensor<8x8xi32>
-        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [8, 8], strides = [1, 1] : tensor<8x8xi32> -> !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
-        return
-      }
-    }
-  }
+func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> tensor<8x8xi32> {
+  %c0 = arith.constant 0 : index
+  %c0_i32 = arith.constant 0 : i32
+  %5 = tensor.empty() : tensor<8x8xi32>
+  %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<8x8xi32>) -> tensor<8x8xi32>
+  %7 = linalg.matmul ins(%arg0, %arg1 : tensor<8x16xi32>, tensor<16x8xi32>) outs(%6 : tensor<8x8xi32>) -> tensor<8x8xi32>
+  return %7 : tensor<8x8xi32>
 }
 //      TILE-LEVEL-1: @matmul_static
 //      TILE-LEVEL-1:   scf.forall
@@ -35,53 +18,36 @@ hal.executable private @matmul_tensors {
 
 // -----
 
-hal.executable private @matmul_tensors {
-  hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd"}>) {
-    hal.executable.export public @matmul_static ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {translation_info = #iree_codegen.translation_info<TransformDialectCodegen codegen_spec = @__transform_main>} {
-    ^bb0(%arg0: !hal.device):
-      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
-      hal.return %x, %y, %z : index, index, index
+func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> tensor<8x8xi32> {
+  %c0 = arith.constant 0 : index
+  %c0_i32 = arith.constant 0 : i32
+  %5 = tensor.empty() : tensor<8x8xi32>
+  %6 = scf.forall (%iv0, %iv1) = (0, 0) to (8, 8) step (8, 8) shared_outs(%arg2 = %5) -> (tensor<8x8xi32>) {
+    %extracted_slice = tensor.extract_slice %arg0[%iv0, 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
+    %extracted_slice_0 = tensor.extract_slice %arg1[0, %iv1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
+    %extracted_slice_1 = tensor.extract_slice %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
+    %7 = bufferization.alloc_tensor() : tensor<8x16xi32>
+    %alloc = memref.alloc() : memref<8x16xi32, 1>
+    %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1>
+    %9 = linalg.copy ins(%extracted_slice : tensor<8x16xi32>) outs(%8 : tensor<8x16xi32>) -> tensor<8x16xi32>
+    %10 = bufferization.alloc_tensor() : tensor<16x8xi32>
+    %alloc_2 = memref.alloc() : memref<16x8xi32, 1>
+    %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1>
+    %12 = linalg.copy ins(%extracted_slice_0 : tensor<16x8xi32>) outs(%11 : tensor<16x8xi32>) -> tensor<16x8xi32>
+    %13 = bufferization.alloc_tensor() : tensor<8x8xi32>
+    %alloc_3 = memref.alloc() : memref<8x8xi32, 1>
+    %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
+    %15 = linalg.fill ins(%c0_i32 : i32) outs(%14 : tensor<8x8xi32>) -> tensor<8x8xi32>
+    %16 = linalg.matmul ins(%9, %12 : tensor<8x16xi32>, tensor<16x8xi32>) outs(%15 : tensor<8x8xi32>) -> tensor<8x8xi32>
+    %17 = linalg.copy ins(%16 : tensor<8x8xi32>) outs(%extracted_slice_1 : tensor<8x8xi32>) -> tensor<8x8xi32>
+    memref.dealloc %alloc : memref<8x16xi32, 1>
+    memref.dealloc %alloc_2 : memref<16x8xi32, 1>
+    memref.dealloc %alloc_3 : memref<8x8xi32, 1>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %17 into %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
     }
-    builtin.module {
-      func.func @matmul_static() {
-        %c0 = arith.constant 0 : index
-        %c0_i32 = arith.constant 0 : i32
-        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<8x16xi32>>
-        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x8xi32>>
-        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
-        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x16xi32>> -> tensor<8x16xi32>
-        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [16, 8], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x8xi32>> -> tensor<16x8xi32>
-        %5 = tensor.empty() : tensor<8x8xi32>
-        %6 = scf.forall (%arg0, %arg1) = (0, 0) to (8, 8) step (8, 8) shared_outs(%arg2 = %5) -> (tensor<8x8xi32>) {
-          %extracted_slice = tensor.extract_slice %3[%arg0, 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
-          %extracted_slice_0 = tensor.extract_slice %4[0, %arg1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
-          %extracted_slice_1 = tensor.extract_slice %arg2[%arg0, %arg1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
-          %7 = bufferization.alloc_tensor() : tensor<8x16xi32>
-          %alloc = memref.alloc() : memref<8x16xi32, 1>
-          %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1>
-          %9 = linalg.copy ins(%extracted_slice : tensor<8x16xi32>) outs(%8 : tensor<8x16xi32>) -> tensor<8x16xi32>
-          %10 = bufferization.alloc_tensor() : tensor<16x8xi32>
-          %alloc_2 = memref.alloc() : memref<16x8xi32, 1>
-          %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1>
-          %12 = linalg.copy ins(%extracted_slice_0 : tensor<16x8xi32>) outs(%11 : tensor<16x8xi32>) -> tensor<16x8xi32>
-          %13 = bufferization.alloc_tensor() : tensor<8x8xi32>
-          %alloc_3 = memref.alloc() : memref<8x8xi32, 1>
-          %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
-          %15 = linalg.fill ins(%c0_i32 : i32) outs(%14 : tensor<8x8xi32>) -> tensor<8x8xi32>
-          %16 = linalg.matmul ins(%9, %12 : tensor<8x16xi32>, tensor<16x8xi32>) outs(%15 : tensor<8x8xi32>) -> tensor<8x8xi32>
-          %17 = linalg.copy ins(%16 : tensor<8x8xi32>) outs(%extracted_slice_1 : tensor<8x8xi32>) -> tensor<8x8xi32>
-          memref.dealloc %alloc : memref<8x16xi32, 1>
-          memref.dealloc %alloc_2 : memref<16x8xi32, 1>
-          memref.dealloc %alloc_3 : memref<8x8xi32, 1>
-          scf.forall.in_parallel {
-            tensor.parallel_insert_slice %17 into %arg2[%arg0, %arg1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
-          }
-        } {mapping = [#gpu.block<y>, #gpu.block<x>]}
-        flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [8, 8], strides = [1, 1] : tensor<8x8xi32> -> !flow.dispatch.tensor<writeonly:tensor<8x8xi32>>
-        return
-      }
-    }
-  }
+  } {mapping = [#gpu.block<y>, #gpu.block<x>]}
+  return %6 : tensor<8x8xi32>
 }
 //      TILE-LEVEL-2: @matmul_static
 //      TILE-LEVEL-2:   scf.forall
@@ -95,39 +61,27 @@ hal.executable private @matmul_tensors {
 
 // -----
 
-hal.executable private @matmul_tensors {
-  hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd"}>) {
-    hal.executable.export public @matmul_bias_add ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {translation_info = #iree_codegen.translation_info<TransformDialectCodegen codegen_spec = @__transform_main>} {
-    ^bb0(%arg0: !hal.device):
-      %x, %y, %z = flow.dispatch.workgroup_count_from_slice
-      hal.return %x, %y, %z : index, index, index
-    }
-
-    builtin.module {
-      func.func @matmul_bias_add(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %arg2 : tensor<?xf32>) -> tensor<?x?xf32> {
-        %cst = arith.constant 0.0 : f32
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
-        %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf32>
-        %init = tensor.empty(%d0, %d1) : tensor<?x?xf32>
-        %0 = linalg.fill ins(%cst : f32) outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
-        %1 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[10, 20, 30]]>}
-            ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
-            outs(%0 : tensor<?x?xf32>) -> tensor<?x?xf32>
-        %2 = linalg.generic {
-          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1)-> (d0, d1)>],
-          iterator_types = ["parallel", "parallel"]}
-          ins(%1, %arg2 : tensor<?x?xf32>, tensor<?xf32>)
-          outs(%init : tensor<?x?xf32>) {
-            ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
-              %3 = arith.addf %arg3, %arg4 : f32
-              linalg.yield %3 : f32
-          } -> tensor<?x?xf32>
-        return %2 : tensor<?x?xf32>
-      }
-    }
-  }
+func.func @matmul_bias_add(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %arg2 : tensor<?xf32>) -> tensor<?x?xf32> {
+  %cst = arith.constant 0.0 : f32
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf32>
+  %init = tensor.empty(%d0, %d1) : tensor<?x?xf32>
+  %0 = linalg.fill ins(%cst : f32) outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %1 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[10, 20, 30]]>}
+      ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
+      outs(%0 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1)-> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%1, %arg2 : tensor<?x?xf32>, tensor<?xf32>)
+    outs(%init : tensor<?x?xf32>) {
+      ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
+        %3 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %3 : f32
+    } -> tensor<?x?xf32>
+  return %2 : tensor<?x?xf32>
 }
 //      TILE-LEVEL-1: @matmul_bias_add
 //      TILE-LEVEL-1:   scf.forall


### PR DESCRIPTION
Most of the passes added recently dont need to run on the
`hal.executable.variant`. They could be run on `func.func`. This
removes a lot of boiler plate from the tests. As a consequence the
workgroup count region handling needs to be moved out of the tile and
fuse pass since it has to be run in a pass rooted on a
`hal.executable.variant`. Move just the workgroup count handling to a
separate pass.

Also organize passes better in header and tablegen files (make them
alphabetical).