### PR TITLE
Fix XRT runtime driver

### DIFF
--- a/runtime/src/iree-amd-aie/driver/xrt/CMakeLists.txt
+++ b/runtime/src/iree-amd-aie/driver/xrt/CMakeLists.txt
@@ -52,6 +52,7 @@ iree_cc_library(
     iree::base::internal::arena
     iree::base::internal::flatcc::building
     iree::base::internal::flatcc::parsing
+    iree::hal::utils::deferred_command_buffer
     iree::hal::utils::file_transfer
     iree::hal
     iree-amd-aie::schemas::xrt_executable_def_c_fbs


### PR DESCRIPTION
The XRT runtime driver was missing a cmake library dependency after the IREE update.