### PR TITLE
[AMD-AIE] Create and use AMDAIEMemSpace EnumAttr to mark memorySpace

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
@@ -15,6 +15,8 @@ iree_tablegen_library(
     "Passes.td"
   OUTS
     --gen-pass-decls Passes.h.inc
+    --gen-enum-decls AMDAIEEnums.h.inc
+    --gen-enum-defs AMDAIEEnums.cpp.inc
 )
 
 iree_cc_library(

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -12,6 +12,10 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "mlir/Pass/Pass.h"
 
+// clang-format off: must be included after all LLVM/MLIR headers.
+#include "iree-amd-aie/Transforms/AMDAIEEnums.h.inc"  // IWYU pragma: export
+// clang-format on
+
 namespace mlir::iree_compiler::AMDAIE {
 
 /// Add passes to lower from MLIR-AIR through AIE. This is

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -7,7 +7,19 @@
 #ifndef IREE_AMD_AIE_TRANSFORMS_PASSES
 #define IREE_AMD_AIE_TRANSFORMS_PASSES
 
+include "mlir/IR/EnumAttr.td"
 include "mlir/Pass/PassBase.td"
+
+def AMDAIE_MemSpace_L1 : I32EnumAttrCase<"L1", 1, "l1">;
+def AMDAIE_MemSpace_L2 : I32EnumAttrCase<"L2", 2, "l2">;
+def AMDAIE_MemSpaceAttr: I32EnumAttr<"AMDAIEMemSpace", "AIE Memory Space",
+  [
+    AMDAIE_MemSpace_L1,
+    AMDAIE_MemSpace_L2,
+  ]> {
+
+  let cppNamespace = "mlir::iree_compiler::AMDAIE";
+}
 
 def AMDAIEBridgeToAIR : Pass<"iree-amdaie-bridge-to-air", ""> {
   let summary = "Perform transformations that allow hooking into AIR/AIE lowering";

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/bufferize_to_allocation_pack.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/bufferize_to_allocation_pack.mlir
@@ -10,17 +10,17 @@ func.func @matmul_static(%arg0 : tensor<16x256xi8>, %arg1 : tensor<256x256xi8>) 
   %5 = tensor.empty() : tensor<16x256xi32>
   %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<16x256xi32>) -> tensor<16x256xi32>
   %7 = tensor.empty() : tensor<1x4x16x64xi8>
-  // CHECK-1: memref.alloc() : memref<1x4x16x64xi8, 1>
-  // CHECK-1: bufferization.to_tensor %{{.*}} restrict writable : memref<1x4x16x64xi8, 1>
+  // CHECK-1: memref.alloc() : memref<1x4x16x64xi8, 1 : i32>
+  // CHECK-1: bufferization.to_tensor %{{.*}} restrict writable : memref<1x4x16x64xi8, 1 : i32>
   %pack = tensor.pack %arg0 inner_dims_pos = [0, 1] inner_tiles = [16, 64] into %7 : tensor<16x256xi8> -> tensor<1x4x16x64xi8>
   %8 = tensor.empty() : tensor<4x4x64x64xi8>
   %9 = tensor.empty() : tensor<4x4x64x64xi8>
-  // CHECK-1: memref.alloc() : memref<4x4x64x64xi8, 1>
-  // CHECK-1: bufferization.to_tensor %{{.*}} restrict writable : memref<4x4x64x64xi8, 1>
+  // CHECK-1: memref.alloc() : memref<4x4x64x64xi8, 1 : i32>
+  // CHECK-1: bufferization.to_tensor %{{.*}} restrict writable : memref<4x4x64x64xi8, 1 : i32>
   %pack_0 = tensor.pack %arg1 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [64, 64] into %9 : tensor<256x256xi8> -> tensor<4x4x64x64xi8>
   %10 = tensor.empty() : tensor<1x4x16x64xi32>
-  // CHECK-1: memref.alloc() : memref<1x4x16x64xi32, 1>
-  // CHECK-1: bufferization.to_tensor %{{.*}} restrict writable : memref<1x4x16x64xi32, 1>
+  // CHECK-1: memref.alloc() : memref<1x4x16x64xi32, 1 : i32>
+  // CHECK-1: bufferization.to_tensor %{{.*}} restrict writable : memref<1x4x16x64xi32, 1 : i32>
   %pack_1 = tensor.pack %6 inner_dims_pos = [0, 1] inner_tiles = [16, 64] into %10 : tensor<16x256xi32> -> tensor<1x4x16x64xi32>
   %11 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%pack, %pack_0 : tensor<1x4x16x64xi8>, tensor<4x4x64x64xi8>) outs(%pack_1 : tensor<1x4x16x64xi32>) {
   ^bb0(%in: i8, %in_2: i8, %out: i32):
@@ -63,18 +63,18 @@ func.func @matmul_static(%arg0 : tensor<16x256xi8>, %arg1 : tensor<256x256xi8>) 
       %13 = linalg.fill ins(%c0_i32 : i32) outs(%extracted_slice_5 : tensor<1x1x16x64xi32>) -> tensor<1x1x16x64xi32>
       %14 = tensor.empty() : tensor<1x4x4x8x4x8xi8>
       %15 = tensor.empty() : tensor<1x4x8x4x4x8xi8>
-      // CHECK-2: memref.alloc() : memref<1x4x8x4x4x8xi8, 2>
-      // CHECK-2: bufferization.to_tensor %{{.*}} restrict writable : memref<1x4x8x4x4x8xi8, 2>
+      // CHECK-2: memref.alloc() : memref<1x4x8x4x4x8xi8, 2 : i32>
+      // CHECK-2: bufferization.to_tensor %{{.*}} restrict writable : memref<1x4x8x4x4x8xi8, 2 : i32>
       %pack_6 = tensor.pack %extracted_slice_3 outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [4, 8] into %15 : tensor<1x4x16x64xi8> -> tensor<1x4x8x4x4x8xi8>
       %16 = tensor.empty() : tensor<4x1x8x8x8x8xi8>
       %17 = tensor.empty() : tensor<4x1x8x8x8x8xi8>
-      // CHECK-2: memref.alloc() : memref<4x1x8x8x8x8xi8, 2>
-      // CHECK-2: bufferization.to_tensor %{{.*}} restrict writable : memref<4x1x8x8x8x8xi8, 2>
+      // CHECK-2: memref.alloc() : memref<4x1x8x8x8x8xi8, 2 : i32>
+      // CHECK-2: bufferization.to_tensor %{{.*}} restrict writable : memref<4x1x8x8x8x8xi8, 2 : i32>
       %pack_7 = tensor.pack %extracted_slice_4 outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [8, 8] into %17 : tensor<4x1x64x64xi8> -> tensor<4x1x8x8x8x8xi8>
       %18 = tensor.empty() : tensor<1x1x4x8x4x8xi32>
       %19 = tensor.empty() : tensor<1x1x8x4x4x8xi32>
-      // CHECK-2: memref.alloc() : memref<1x1x8x4x4x8xi32, 2>
-      // CHECK-2: bufferization.to_tensor %{{.*}} restrict writable : memref<1x1x8x4x4x8xi32, 2>
+      // CHECK-2: memref.alloc() : memref<1x1x8x4x4x8xi32, 2 : i32>
+      // CHECK-2: bufferization.to_tensor %{{.*}} restrict writable : memref<1x1x8x4x4x8xi32, 2 : i32>
       %pack_8 = tensor.pack %13 outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [4, 8] into %19 : tensor<1x1x16x64xi32> -> tensor<1x1x8x4x4x8xi32>
       %20 = linalg.generic {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%pack_6, %pack_7 : tensor<1x4x8x4x4x8xi8>, tensor<4x1x8x8x8x8xi8>) outs(%pack_8 : tensor<1x1x8x4x4x8xi32>) {
       ^bb0(%in: i8, %in_10: i8, %out: i32):

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/bufferize_to_allocation_pad.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/bufferize_to_allocation_pad.mlir
@@ -35,13 +35,13 @@ func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> 
 //      BUFFERIZE-LEVEL-0:   scf.forall
 // BUFFERIZE-LEVEL-0-SAME:   {
 //      BUFFERIZE-LEVEL-0:       linalg.fill
-//      BUFFERIZE-LEVEL-0:       memref.alloc() : memref<8x16xi32, 1>
+//      BUFFERIZE-LEVEL-0:       memref.alloc() : memref<8x16xi32, 1 : i32>
 //      BUFFERIZE-LEVEL-0:       bufferization.to_tensor %{{.*}} restrict writable
 //      BUFFERIZE-LEVEL-0:       linalg.copy
-//      BUFFERIZE-LEVEL-0:       memref.alloc() : memref<16x8xi32, 1>
+//      BUFFERIZE-LEVEL-0:       memref.alloc() : memref<16x8xi32, 1 : i32>
 //      BUFFERIZE-LEVEL-0:       bufferization.to_tensor %{{.*}} restrict writable
 //      BUFFERIZE-LEVEL-0:       linalg.copy
-//      BUFFERIZE-LEVEL-0:       memref.alloc() : memref<8x8xi32, 1>
+//      BUFFERIZE-LEVEL-0:       memref.alloc() : memref<8x8xi32, 1 : i32>
 //      BUFFERIZE-LEVEL-0:       bufferization.to_tensor %{{.*}} restrict writable
 //      BUFFERIZE-LEVEL-0:       linalg.copy
 //      BUFFERIZE-LEVEL-0:       linalg.matmul
@@ -62,20 +62,20 @@ func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> 
     %extracted_slice_0 = tensor.extract_slice %arg1[0, %iv1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
     %extracted_slice_1 = tensor.extract_slice %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
     %7 = bufferization.alloc_tensor() : tensor<8x16xi32>
-    %alloc = memref.alloc() : memref<8x16xi32, 1>
-    %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1>
+    %alloc = memref.alloc() : memref<8x16xi32, 1 : i32>
+    %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1 : i32>
     %9 = linalg.copy ins(%extracted_slice : tensor<8x16xi32>) outs(%8 : tensor<8x16xi32>) -> tensor<8x16xi32>
     %10 = bufferization.alloc_tensor() : tensor<16x8xi32>
-    %alloc_2 = memref.alloc() : memref<16x8xi32, 1>
-    %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1>
+    %alloc_2 = memref.alloc() : memref<16x8xi32, 1 : i32>
+    %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1 : i32>
     %12 = linalg.copy ins(%extracted_slice_0 : tensor<16x8xi32>) outs(%11 : tensor<16x8xi32>) -> tensor<16x8xi32>
     %13 = bufferization.alloc_tensor() : tensor<8x8xi32>
-    %alloc_3 = memref.alloc() : memref<8x8xi32, 1>
-    %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
+    %alloc_3 = memref.alloc() : memref<8x8xi32, 1 : i32>
+    %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1 : i32>
     %15 = scf.forall (%iv3, %iv4) = (0, 0) to (8, 8) step (4, 4) shared_outs(%arg5 = %14) -> (tensor<8x8xi32>) {
       %extracted_slice_4 = tensor.extract_slice %9[%iv3, 0] [4, 16] [1, 1] : tensor<8x16xi32> to tensor<4x16xi32>
       %extracted_slice_5 = tensor.extract_slice %12[0, %iv4] [16, 4] [1, 1] : tensor<16x8xi32> to tensor<16x4xi32>
-      %17 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
+      %17 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1 : i32>
       %extracted_slice_6 = tensor.extract_slice %17[%iv3, %iv4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
       %extracted_slice_7 = tensor.extract_slice %arg5[%iv3, %iv4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
       %18 = linalg.fill ins(%c0_i32 : i32) outs(%extracted_slice_7 : tensor<4x4xi32>) -> tensor<4x4xi32>
@@ -91,9 +91,9 @@ func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> 
       }
     } {mapping = [#gpu.block<y>, #gpu.block<x>]}
     %16 = linalg.copy ins(%15 : tensor<8x8xi32>) outs(%extracted_slice_1 : tensor<8x8xi32>) -> tensor<8x8xi32>
-    memref.dealloc %alloc : memref<8x16xi32, 1>
-    memref.dealloc %alloc_2 : memref<16x8xi32, 1>
-    memref.dealloc %alloc_3 : memref<8x8xi32, 1>
+    memref.dealloc %alloc : memref<8x16xi32, 1 : i32>
+    memref.dealloc %alloc_2 : memref<16x8xi32, 1 : i32>
+    memref.dealloc %alloc_3 : memref<8x8xi32, 1 : i32>
     scf.forall.in_parallel {
       tensor.parallel_insert_slice %16 into %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
     }
@@ -103,18 +103,18 @@ func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> 
 //      BUFFERIZE-LEVEL-1: @matmul_static
 //      BUFFERIZE-LEVEL-1:   scf.forall
 // BUFFERIZE-LEVEL-1-SAME:   {
-//      BUFFERIZE-LEVEL-1:       memref.alloc() : memref<8x16xi32, 1>
+//      BUFFERIZE-LEVEL-1:       memref.alloc() : memref<8x16xi32, 1 : i32>
 //      BUFFERIZE-LEVEL-1:       bufferization.to_tensor %{{.*}} restrict writable
 //      BUFFERIZE-LEVEL-1:       linalg.copy
-//      BUFFERIZE-LEVEL-1:       memref.alloc() : memref<16x8xi32, 1>
+//      BUFFERIZE-LEVEL-1:       memref.alloc() : memref<16x8xi32, 1 : i32>
 //      BUFFERIZE-LEVEL-1:       bufferization.to_tensor %{{.*}} restrict writable
 //      BUFFERIZE-LEVEL-1:       linalg.copy
-//      BUFFERIZE-LEVEL-1:       memref.alloc() : memref<8x8xi32, 1>
+//      BUFFERIZE-LEVEL-1:       memref.alloc() : memref<8x8xi32, 1 : i32>
 //      BUFFERIZE-LEVEL-1:       bufferization.to_tensor %{{.*}} restrict writable
 //      BUFFERIZE-LEVEL-1:       scf.forall
 // BUFFERIZE-LEVEL-1-SAME:       {
 //      BUFFERIZE-LEVEL-1:            linalg.fill
-//      BUFFERIZE-LEVEL-1:            memref.alloc() : memref<4x4xi32, 2>
+//      BUFFERIZE-LEVEL-1:            memref.alloc() : memref<4x4xi32, 2 : i32>
 //      BUFFERIZE-LEVEL-1:            bufferization.to_tensor %{{.*}} restrict writable
 //      BUFFERIZE-LEVEL-1:            linalg.copy
 //      BUFFERIZE-LEVEL-1:            linalg.matmul

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/bufferize_to_allocation_pad_last.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/bufferize_to_allocation_pad_last.mlir
@@ -11,23 +11,23 @@ func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> 
     %extracted_slice_0 = tensor.extract_slice %arg1[0, %iv1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
     %extracted_slice_1 = tensor.extract_slice %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
     %7 = bufferization.alloc_tensor() : tensor<8x16xi32>
-    %alloc = memref.alloc() : memref<8x16xi32, 1>
-    %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1>
+    %alloc = memref.alloc() : memref<8x16xi32, 1 : i32>
+    %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1 : i32>
     %9 = linalg.copy ins(%extracted_slice : tensor<8x16xi32>) outs(%8 : tensor<8x16xi32>) -> tensor<8x16xi32>
     %10 = bufferization.alloc_tensor() : tensor<16x8xi32>
-    %alloc_2 = memref.alloc() : memref<16x8xi32, 1>
-    %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1>
+    %alloc_2 = memref.alloc() : memref<16x8xi32, 1 : i32>
+    %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1 : i32>
     %12 = linalg.copy ins(%extracted_slice_0 : tensor<16x8xi32>) outs(%11 : tensor<16x8xi32>) -> tensor<16x8xi32>
     %13 = bufferization.alloc_tensor() : tensor<8x8xi32>
-    %alloc_3 = memref.alloc() : memref<8x8xi32, 1>
-    %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
+    %alloc_3 = memref.alloc() : memref<8x8xi32, 1 : i32>
+    %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1 : i32>
     %15 = scf.forall (%iv3, %iv4) = (0, 0) to (8, 8) step (4, 4) shared_outs(%arg5 = %14) -> (tensor<8x8xi32>) {
       %extracted_slice_4 = tensor.extract_slice %9[%iv3, 0] [4, 16] [1, 1] : tensor<8x16xi32> to tensor<4x16xi32>
       %extracted_slice_5 = tensor.extract_slice %12[0, %iv4] [16, 4] [1, 1] : tensor<16x8xi32> to tensor<16x4xi32>
       %extracted_slice_6 = tensor.extract_slice %arg5[%iv3, %iv4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
       %17 = bufferization.alloc_tensor() : tensor<4x4xi32>
-      %alloc_7 = memref.alloc() : memref<4x4xi32, 2>
-      %18 = bufferization.to_tensor %alloc_7 restrict writable : memref<4x4xi32, 2>
+      %alloc_7 = memref.alloc() : memref<4x4xi32, 2 : i32>
+      %18 = bufferization.to_tensor %alloc_7 restrict writable : memref<4x4xi32, 2 : i32>
       %19 = linalg.fill ins(%c0_i32 : i32) outs(%18 : tensor<4x4xi32>) -> tensor<4x4xi32>
       %20 = scf.for %arg6 = %c0 to %c16 step %c4 iter_args(%arg7 = %19) -> (tensor<4x4xi32>) {
         %extracted_slice_8 = tensor.extract_slice %extracted_slice_4[0, %arg6] [4, 4] [1, 1] : tensor<4x16xi32> to tensor<4x4xi32>
@@ -44,15 +44,15 @@ func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> 
         scf.yield %27 : tensor<4x4xi32>
       }
       %21 = linalg.copy ins(%20 : tensor<4x4xi32>) outs(%extracted_slice_6 : tensor<4x4xi32>) -> tensor<4x4xi32>
-      memref.dealloc %alloc_7 : memref<4x4xi32, 2>
+      memref.dealloc %alloc_7 : memref<4x4xi32, 2 : i32>
       scf.forall.in_parallel {
         tensor.parallel_insert_slice %21 into %arg5[%iv3, %iv4] [4, 4] [1, 1] : tensor<4x4xi32> into tensor<8x8xi32>
       }
     } {mapping = [#gpu.block<y>, #gpu.block<x>]}
     %16 = linalg.copy ins(%15 : tensor<8x8xi32>) outs(%extracted_slice_1 : tensor<8x8xi32>) -> tensor<8x8xi32>
-    memref.dealloc %alloc : memref<8x16xi32, 1>
-    memref.dealloc %alloc_2 : memref<16x8xi32, 1>
-    memref.dealloc %alloc_3 : memref<8x8xi32, 1>
+    memref.dealloc %alloc : memref<8x16xi32, 1 : i32>
+    memref.dealloc %alloc_2 : memref<16x8xi32, 1 : i32>
+    memref.dealloc %alloc_3 : memref<8x8xi32, 1 : i32>
     scf.forall.in_parallel {
       tensor.parallel_insert_slice %16 into %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
     }
@@ -62,25 +62,25 @@ func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> 
 //      BUFFERIZE-LEVEL-2: @matmul_static
 //      BUFFERIZE-LEVEL-2:   scf.forall
 // BUFFERIZE-LEVEL-2-SAME:   {
-//      BUFFERIZE-LEVEL-2:       memref.alloc() : memref<8x16xi32, 1>
+//      BUFFERIZE-LEVEL-2:       memref.alloc() : memref<8x16xi32, 1 : i32>
 //      BUFFERIZE-LEVEL-2:       bufferization.to_tensor %{{.*}} restrict writable
 //      BUFFERIZE-LEVEL-2:       linalg.copy
-//      BUFFERIZE-LEVEL-2:       memref.alloc() : memref<16x8xi32, 1>
+//      BUFFERIZE-LEVEL-2:       memref.alloc() : memref<16x8xi32, 1 : i32>
 //      BUFFERIZE-LEVEL-2:       bufferization.to_tensor %{{.*}} restrict writable
 //      BUFFERIZE-LEVEL-2:       linalg.copy
-//      BUFFERIZE-LEVEL-2:       memref.alloc() : memref<8x8xi32, 1>
+//      BUFFERIZE-LEVEL-2:       memref.alloc() : memref<8x8xi32, 1 : i32>
 //      BUFFERIZE-LEVEL-2:       bufferization.to_tensor %{{.*}} restrict writable
 //      BUFFERIZE-LEVEL-2:       scf.forall
 // BUFFERIZE-LEVEL-2-SAME:       {
-//      BUFFERIZE-LEVEL-2:            memref.alloc() : memref<4x4xi32, 2>
+//      BUFFERIZE-LEVEL-2:            memref.alloc() : memref<4x4xi32, 2 : i32>
 //      BUFFERIZE-LEVEL-2:            bufferization.to_tensor %{{.*}} restrict writable
 //      BUFFERIZE-LEVEL-2:            linalg.fill
 //      BUFFERIZE-LEVEL-2:            scf.for
 // BUFFERIZE-LEVEL-2-SAME:            {
-//      BUFFERIZE-LEVEL-2:                memref.alloc() : memref<4x4xi32, 2>
+//      BUFFERIZE-LEVEL-2:                memref.alloc() : memref<4x4xi32, 2 : i32>
 //      BUFFERIZE-LEVEL-2:                bufferization.to_tensor %{{.*}} restrict writable
 //      BUFFERIZE-LEVEL-2:                linalg.copy
-//      BUFFERIZE-LEVEL-2:                memref.alloc() : memref<4x4xi32, 2>
+//      BUFFERIZE-LEVEL-2:                memref.alloc() : memref<4x4xi32, 2 : i32>
 //      BUFFERIZE-LEVEL-2:                bufferization.to_tensor %{{.*}} restrict writable
 //      BUFFERIZE-LEVEL-2:                linalg.copy
 //      BUFFERIZE-LEVEL-2:                linalg.matmul

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pad.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pad.mlir
@@ -50,20 +50,20 @@ func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> t
     %extracted_slice_0 = tensor.extract_slice %arg1[0, %iv1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
     %extracted_slice_1 = tensor.extract_slice %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
     %7 = bufferization.alloc_tensor() : tensor<8x16xi32>
-    %alloc = memref.alloc() : memref<8x16xi32, 1>
-    %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1>
+    %alloc = memref.alloc() : memref<8x16xi32, 1 : i32>
+    %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1 : i32>
     %9 = linalg.copy ins(%extracted_slice : tensor<8x16xi32>) outs(%8 : tensor<8x16xi32>) -> tensor<8x16xi32>
     %10 = bufferization.alloc_tensor() : tensor<16x8xi32>
-    %alloc_2 = memref.alloc() : memref<16x8xi32, 1>
-    %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1>
+    %alloc_2 = memref.alloc() : memref<16x8xi32, 1 : i32>
+    %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1 : i32>
     %12 = linalg.copy ins(%extracted_slice_0 : tensor<16x8xi32>) outs(%11 : tensor<16x8xi32>) -> tensor<16x8xi32>
     %13 = bufferization.alloc_tensor() : tensor<8x8xi32>
-    %alloc_3 = memref.alloc() : memref<8x8xi32, 1>
-    %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
+    %alloc_3 = memref.alloc() : memref<8x8xi32, 1 : i32>
+    %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1 : i32>
     %17 = scf.forall (%arg3, %arg4) = (0, 0) to (8, 8) step (4, 4) shared_outs(%arg5 = %14) -> (tensor<8x8xi32>) {
       %extracted_slice_4 = tensor.extract_slice %9[%arg3, 0] [4, 16] [1, 1] : tensor<8x16xi32> to tensor<4x16xi32>
       %extracted_slice_5 = tensor.extract_slice %12[0, %arg4] [16, 4] [1, 1] : tensor<16x8xi32> to tensor<16x4xi32>
-      %19 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
+      %19 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1 : i32>
       %extracted_slice_6 = tensor.extract_slice %19[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
       %extracted_slice_7 = tensor.extract_slice %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
       %20 = linalg.fill ins(%c0_i32 : i32) outs(%extracted_slice_7 : tensor<4x4xi32>) -> tensor<4x4xi32>
@@ -74,9 +74,9 @@ func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> t
       }
     } {mapping = [#gpu.block<y>, #gpu.block<x>]}
     %18 = linalg.copy ins(%17 : tensor<8x8xi32>) outs(%extracted_slice_1 : tensor<8x8xi32>) -> tensor<8x8xi32>
-    memref.dealloc %alloc : memref<8x16xi32, 1>
-    memref.dealloc %alloc_2 : memref<16x8xi32, 1>
-    memref.dealloc %alloc_3 : memref<8x8xi32, 1>
+    memref.dealloc %alloc : memref<8x16xi32, 1 : i32>
+    memref.dealloc %alloc_2 : memref<16x8xi32, 1 : i32>
+    memref.dealloc %alloc_3 : memref<8x8xi32, 1 : i32>
     scf.forall.in_parallel {
       tensor.parallel_insert_slice %18 into %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
     }
@@ -86,13 +86,13 @@ func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> t
 //      PAD-LEVEL-1:   scf.forall
 // PAD-LEVEL-1-SAME:   {
 //      PAD-LEVEL-1:       linalg.fill
-//      PAD-LEVEL-1:       memref.alloc() : memref<8x16xi32, 1>
+//      PAD-LEVEL-1:       memref.alloc() : memref<8x16xi32, 1 : i32>
 //      PAD-LEVEL-1:       bufferization.to_tensor %{{.*}} restrict writable
 //      PAD-LEVEL-1:       linalg.copy
-//      PAD-LEVEL-1:       memref.alloc() : memref<16x8xi32, 1>
+//      PAD-LEVEL-1:       memref.alloc() : memref<16x8xi32, 1 : i32>
 //      PAD-LEVEL-1:       bufferization.to_tensor %{{.*}} restrict writable
 //      PAD-LEVEL-1:       linalg.copy
-//      PAD-LEVEL-1:       memref.alloc() : memref<8x8xi32, 1>
+//      PAD-LEVEL-1:       memref.alloc() : memref<8x8xi32, 1 : i32>
 //      PAD-LEVEL-1:       bufferization.to_tensor %{{.*}} restrict writable
 //      PAD-LEVEL-1:       scf.forall
 // PAD-LEVEL-1-SAME:       {
@@ -120,23 +120,23 @@ func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> 
       %extracted_slice_0 = tensor.extract_slice %arg1[0, %iv1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
       %extracted_slice_1 = tensor.extract_slice %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
       %7 = bufferization.alloc_tensor() : tensor<8x16xi32>
-      %alloc = memref.alloc() : memref<8x16xi32, 1>
-      %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1>
+      %alloc = memref.alloc() : memref<8x16xi32, 1 : i32>
+      %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1 : i32>
       %9 = linalg.copy ins(%extracted_slice : tensor<8x16xi32>) outs(%8 : tensor<8x16xi32>) -> tensor<8x16xi32>
       %10 = bufferization.alloc_tensor() : tensor<16x8xi32>
-      %alloc_2 = memref.alloc() : memref<16x8xi32, 1>
-      %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1>
+      %alloc_2 = memref.alloc() : memref<16x8xi32, 1 : i32>
+      %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1 : i32>
       %12 = linalg.copy ins(%extracted_slice_0 : tensor<16x8xi32>) outs(%11 : tensor<16x8xi32>) -> tensor<16x8xi32>
       %13 = bufferization.alloc_tensor() : tensor<8x8xi32>
-      %alloc_3 = memref.alloc() : memref<8x8xi32, 1>
-      %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
+      %alloc_3 = memref.alloc() : memref<8x8xi32, 1 : i32>
+      %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1 : i32>
       %15 = scf.forall (%arg3, %arg4) = (0, 0) to (8, 8) step (4, 4) shared_outs(%arg5 = %14) -> (tensor<8x8xi32>) {
         %extracted_slice_4 = tensor.extract_slice %9[%arg3, 0] [4, 16] [1, 1] : tensor<8x16xi32> to tensor<4x16xi32>
         %extracted_slice_5 = tensor.extract_slice %12[0, %arg4] [16, 4] [1, 1] : tensor<16x8xi32> to tensor<16x4xi32>
         %extracted_slice_6 = tensor.extract_slice %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
         %17 = bufferization.alloc_tensor() : tensor<4x4xi32>
-        %alloc_7 = memref.alloc() : memref<4x4xi32, 2>
-        %18 = bufferization.to_tensor %alloc_7 restrict writable : memref<4x4xi32, 2>
+        %alloc_7 = memref.alloc() : memref<4x4xi32, 2 : i32>
+        %18 = bufferization.to_tensor %alloc_7 restrict writable : memref<4x4xi32, 2 : i32>
         %19 = linalg.fill ins(%c0_i32 : i32) outs(%18 : tensor<4x4xi32>) -> tensor<4x4xi32>
         %20 = scf.for %arg6 = %c0 to %c16 step %c4 iter_args(%arg7 = %19) -> (tensor<4x4xi32>) {
           %extracted_slice_8 = tensor.extract_slice %extracted_slice_4[0, %arg6] [4, 4] [1, 1] : tensor<4x16xi32> to tensor<4x4xi32>
@@ -145,15 +145,15 @@ func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> 
           scf.yield %22 : tensor<4x4xi32>
         }
         %21 = linalg.copy ins(%20 : tensor<4x4xi32>) outs(%extracted_slice_6 : tensor<4x4xi32>) -> tensor<4x4xi32>
-        memref.dealloc %alloc_7 : memref<4x4xi32, 2>
+        memref.dealloc %alloc_7 : memref<4x4xi32, 2 : i32>
         scf.forall.in_parallel {
           tensor.parallel_insert_slice %21 into %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<4x4xi32> into tensor<8x8xi32>
         }
     } {mapping = [#gpu.block<y>, #gpu.block<x>]}
     %16 = linalg.copy ins(%15 : tensor<8x8xi32>) outs(%extracted_slice_1 : tensor<8x8xi32>) -> tensor<8x8xi32>
-    memref.dealloc %alloc : memref<8x16xi32, 1>
-    memref.dealloc %alloc_2 : memref<16x8xi32, 1>
-    memref.dealloc %alloc_3 : memref<8x8xi32, 1>
+    memref.dealloc %alloc : memref<8x16xi32, 1 : i32>
+    memref.dealloc %alloc_2 : memref<16x8xi32, 1 : i32>
+    memref.dealloc %alloc_3 : memref<8x8xi32, 1 : i32>
     scf.forall.in_parallel {
       tensor.parallel_insert_slice %16 into %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
     }
@@ -162,17 +162,17 @@ func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> 
 }
 //      PAD-LEVEL-2:   scf.forall
 // PAD-LEVEL-2-SAME:   {
-//      PAD-LEVEL-2:       memref.alloc() : memref<8x16xi32, 1>
+//      PAD-LEVEL-2:       memref.alloc() : memref<8x16xi32, 1 : i32>
 //      PAD-LEVEL-2:       bufferization.to_tensor %{{.*}} restrict writable
 //      PAD-LEVEL-2:       linalg.copy
-//      PAD-LEVEL-2:       memref.alloc() : memref<16x8xi32, 1>
+//      PAD-LEVEL-2:       memref.alloc() : memref<16x8xi32, 1 : i32>
 //      PAD-LEVEL-2:       bufferization.to_tensor %{{.*}} restrict writable
 //      PAD-LEVEL-2:       linalg.copy
-//      PAD-LEVEL-2:       memref.alloc() : memref<8x8xi32, 1>
+//      PAD-LEVEL-2:       memref.alloc() : memref<8x8xi32, 1 : i32>
 //      PAD-LEVEL-2:       bufferization.to_tensor %{{.*}} restrict writable
 //      PAD-LEVEL-2:       scf.forall
 // PAD-LEVEL-2-SAME:       {
-//      PAD-LEVEL-2:            memref.alloc() : memref<4x4xi32, 2>
+//      PAD-LEVEL-2:            memref.alloc() : memref<4x4xi32, 2 : i32>
 //      PAD-LEVEL-2:            bufferization.to_tensor %{{.*}} restrict writable
 //      PAD-LEVEL-2:            scf.for
 // PAD-LEVEL-2-SAME:            {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_using_scf_for.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_using_scf_for.mlir
@@ -10,35 +10,35 @@ func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> t
     %extracted_slice_0 = tensor.extract_slice %arg1[0, %iv1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
     %extracted_slice_1 = tensor.extract_slice %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
     %7 = bufferization.alloc_tensor() : tensor<8x16xi32>
-    %alloc = memref.alloc() : memref<8x16xi32, 1>
-    %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1>
+    %alloc = memref.alloc() : memref<8x16xi32, 1 : i32>
+    %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1 : i32>
     %9 = linalg.copy ins(%extracted_slice : tensor<8x16xi32>) outs(%8 : tensor<8x16xi32>) -> tensor<8x16xi32>
     %10 = bufferization.alloc_tensor() : tensor<16x8xi32>
-    %alloc_2 = memref.alloc() : memref<16x8xi32, 1>
-    %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1>
+    %alloc_2 = memref.alloc() : memref<16x8xi32, 1 : i32>
+    %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1 : i32>
     %12 = linalg.copy ins(%extracted_slice_0 : tensor<16x8xi32>) outs(%11 : tensor<16x8xi32>) -> tensor<16x8xi32>
     %13 = bufferization.alloc_tensor() : tensor<8x8xi32>
-    %alloc_3 = memref.alloc() : memref<8x8xi32, 1>
-    %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
+    %alloc_3 = memref.alloc() : memref<8x8xi32, 1 : i32>
+    %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1 : i32>
     %15 = scf.forall (%arg3, %arg4) = (0, 0) to (8, 8) step (4, 4) shared_outs(%arg5 = %14) -> (tensor<8x8xi32>) {
       %extracted_slice_4 = tensor.extract_slice %9[%arg3, 0] [4, 16] [1, 1] : tensor<8x16xi32> to tensor<4x16xi32>
       %extracted_slice_5 = tensor.extract_slice %12[0, %arg4] [16, 4] [1, 1] : tensor<16x8xi32> to tensor<16x4xi32>
       %extracted_slice_6 = tensor.extract_slice %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
       %17 = bufferization.alloc_tensor() : tensor<4x4xi32>
-      %alloc_7 = memref.alloc() : memref<4x4xi32, 2>
-      %18 = bufferization.to_tensor %alloc_7 restrict writable : memref<4x4xi32, 2>
+      %alloc_7 = memref.alloc() : memref<4x4xi32, 2 : i32>
+      %18 = bufferization.to_tensor %alloc_7 restrict writable : memref<4x4xi32, 2 : i32>
       %19 = linalg.fill ins(%c0_i32 : i32) outs(%18 : tensor<4x4xi32>) -> tensor<4x4xi32>
       %20 = linalg.matmul {lowering_config = #config} ins(%extracted_slice_4, %extracted_slice_5 : tensor<4x16xi32>, tensor<16x4xi32>) outs(%19 : tensor<4x4xi32>) -> tensor<4x4xi32>
       %21 = linalg.copy ins(%20 : tensor<4x4xi32>) outs(%extracted_slice_6 : tensor<4x4xi32>) -> tensor<4x4xi32>
-      memref.dealloc %alloc_7 : memref<4x4xi32, 2>
+      memref.dealloc %alloc_7 : memref<4x4xi32, 2 : i32>
       scf.forall.in_parallel {
         tensor.parallel_insert_slice %21 into %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<4x4xi32> into tensor<8x8xi32>
       }
     } {mapping = [#gpu.block<y>, #gpu.block<x>]}
     %16 = linalg.copy ins(%15 : tensor<8x8xi32>) outs(%extracted_slice_1 : tensor<8x8xi32>) -> tensor<8x8xi32>
-    memref.dealloc %alloc : memref<8x16xi32, 1>
-    memref.dealloc %alloc_2 : memref<16x8xi32, 1>
-    memref.dealloc %alloc_3 : memref<8x8xi32, 1>
+    memref.dealloc %alloc : memref<8x16xi32, 1 : i32>
+    memref.dealloc %alloc_2 : memref<16x8xi32, 1 : i32>
+    memref.dealloc %alloc_3 : memref<8x8xi32, 1 : i32>
     scf.forall.in_parallel {
       tensor.parallel_insert_slice %16 into %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_using_scf_forall.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_using_scf_forall.mlir
@@ -27,22 +27,22 @@ func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> t
     %extracted_slice_0 = tensor.extract_slice %arg1[0, %iv1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
     %extracted_slice_1 = tensor.extract_slice %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
     %7 = bufferization.alloc_tensor() : tensor<8x16xi32>
-    %alloc = memref.alloc() : memref<8x16xi32, 1>
-    %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1>
+    %alloc = memref.alloc() : memref<8x16xi32, 1 : i32>
+    %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1 : i32>
     %9 = linalg.copy ins(%extracted_slice : tensor<8x16xi32>) outs(%8 : tensor<8x16xi32>) -> tensor<8x16xi32>
     %10 = bufferization.alloc_tensor() : tensor<16x8xi32>
-    %alloc_2 = memref.alloc() : memref<16x8xi32, 1>
-    %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1>
+    %alloc_2 = memref.alloc() : memref<16x8xi32, 1 : i32>
+    %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1 : i32>
     %12 = linalg.copy ins(%extracted_slice_0 : tensor<16x8xi32>) outs(%11 : tensor<16x8xi32>) -> tensor<16x8xi32>
     %13 = bufferization.alloc_tensor() : tensor<8x8xi32>
-    %alloc_3 = memref.alloc() : memref<8x8xi32, 1>
-    %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1>
+    %alloc_3 = memref.alloc() : memref<8x8xi32, 1 : i32>
+    %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1 : i32>
     %15 = linalg.fill ins(%c0_i32 : i32) outs(%14 : tensor<8x8xi32>) -> tensor<8x8xi32>
     %16 = linalg.matmul ins(%9, %12 : tensor<8x16xi32>, tensor<16x8xi32>) outs(%15 : tensor<8x8xi32>) -> tensor<8x8xi32>
     %17 = linalg.copy ins(%16 : tensor<8x8xi32>) outs(%extracted_slice_1 : tensor<8x8xi32>) -> tensor<8x8xi32>
-    memref.dealloc %alloc : memref<8x16xi32, 1>
-    memref.dealloc %alloc_2 : memref<16x8xi32, 1>
-    memref.dealloc %alloc_3 : memref<8x8xi32, 1>
+    memref.dealloc %alloc : memref<8x16xi32, 1 : i32>
+    memref.dealloc %alloc_2 : memref<16x8xi32, 1 : i32>
+    memref.dealloc %alloc_3 : memref<8x8xi32, 1 : i32>
     scf.forall.in_parallel {
       tensor.parallel_insert_slice %17 into %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
     }


### PR DESCRIPTION
-- This commit adds AMDAIEMemSpace EnumAttr to mark memorySpace
   during `--iree-amdaie-bufferize-to-alloc`.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>