### PR TITLE
Update mlir-aie

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aie/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/aie/CMakeLists.txt
@@ -274,21 +274,3 @@ iree_cc_library(
     ::AIEXDialectIR
     ::AIEXTransformPassHeaders
 )
-
-###############################################################################
-# AIE Translation passes.
-###############################################################################
-
-iree_cc_library(
-  NAME
-    AIETranslationPasses
-  SRCS
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Targets/AIETargetIPU.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Targets/AIETargetLdScript.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Targets/AIETargetShared.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Targets/AIETargetXAIEV2.cpp"
-  DEPS
-    ::AIEDialectIR
-    ::AIEXDialectIR
-    ::AIEVecDialectIR
-)

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/CMakeLists.txt
@@ -18,7 +18,6 @@ iree_cc_library(
     iree::target::amd-aie::Target
     iree::target::amd-aie::Transforms
     iree::target::amd-aie::aie::AIEDialectIR
-    iree::target::amd-aie::aie::AIETransformPasses
     iree::target::amd-aie::aie::AIEXDialectIR
     iree::target::amd-aie::aie::AIEXTransformPasses
     iree::target::amd-aie::air::AIRDialectIR

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -194,7 +194,12 @@ LogicalResult AIETargetBackend::serializeExecutable(
                                  "--xclbin-kernel-name",
                                  entryPointNames[0],
                                  "--tmpdir",
-                                 workDir};
+                                 workDir,
+                                 "--install-dir",
+                                 options.mlirAieInstallDir};
+  if (options.showInvokedCommands) {
+    cmdArgs.push_back("-v");
+  }
   // Update the linker search path to find libcdo_driver.so
   SmallString<128> libPath(options.vitisInstallDir);
   llvm::sys::path::append(libPath, "aietools", "lib", "lnx64.o");
@@ -219,6 +224,11 @@ LogicalResult AIETargetBackend::serializeExecutable(
 #endif
     newPath = "PATH=" + newPath;
     cmdEnv.push_back(newPath);
+  }
+  if (options.showInvokedCommands) {
+    for (auto s : cmdEnv) llvm::dbgs() << s << " ";
+    for (auto s : cmdArgs) llvm::dbgs() << s << " ";
+    llvm::dbgs() << "\n";
   }
   int result = llvm::sys::ExecuteAndWait(cmdArgs[0], cmdArgs, cmdEnv);
   if (result != 0) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
@@ -14,7 +14,6 @@ iree_cc_library(
   DEPS
     iree::compiler::Dialect::HAL::Target
     iree::target::amd-aie::Transforms
-    iree::target::amd-aie::aie::AIETranslationPasses
     iree::target::amd-aie::aie::AIEXTransformPasses
     iree::target::amd-aie::air::AIRDialectIR
   PUBLIC


### PR DESCRIPTION
Transfers the mlir-aie install dir to aie2xclbin, respects the show commands option.
If you have a wheel made from the updated mlir-aie, it should work as the mlir-aie install dir.