### PR TITLE
Fix build dependencies & unused variable warning

### DIFF
--- a/compiler/plugins/target/AMD-AIE/air/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/air/CMakeLists.txt
@@ -69,6 +69,7 @@ iree_cc_library(
     ::defs
     ::AIRDialectIR
     ::AIRTransformOpsGen
+    ::AIRTransformPasses
     iree::target::amd-aie::aie::AIEDialectIR
     MLIRIR
     MLIRLinalgTransformOps
@@ -250,13 +251,11 @@ iree_cc_library(
     iree::target::amd-aie::aie::AIEDialectIR
     ::AIRDialectIR
     ::AIRTransform
-    ::AIRTransformOps
     ::AIRTransformPassHeaders
     ::AIRUtil
     MLIRIR
     MLIRLinalgDialect
     MLIRLinalgTransforms
-    MLIRLinalgTransformOps
     MLIRLinalgUtils
     MLIRSupport
 )

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
@@ -26,6 +26,7 @@
 
 #define DEBUG_TYPE "iree-amdaie-tile-and-fuse"
 
+
 namespace mlir::iree_compiler::AMDAIE {
 
 namespace {
@@ -162,8 +163,7 @@ void AMDAIETileAndFusePass::runOnOperation() {
   // We switch off fusion if any of the reduction dimension is being tiled. We
   // resort to the default fusion control function that eliminates certain ops
   // otherwise.
-  if (bool tilingReductionDimension =
-          isTilingReductionDimension(consumerOp, tileSizesVal)) {
+  if (isTilingReductionDimension(consumerOp, tileSizesVal)) {
     tileAndFuseOptions.setFusionControlFn(
         [&](tensor::ExtractSliceOp sliceOp, OpResult originalProducer,
             bool isDestinationOperand) -> std::tuple<bool, bool> {


### PR DESCRIPTION
Target AIRTransformOps uses symbols in AIRTransformPasses, there would be a circular dependency but AIRTransformPasses doesn't actually need AIRTransformOps.