### PR TITLE
Add multicore flag

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAddLoweringStrategy.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAddLoweringStrategy.cpp
@@ -47,7 +47,7 @@ void AMDAIELoweringStrategyPass::runOnOperation() {
         "Expected a variantOp root with an inner ModuleOp");
     return signalPassFailure();
   }
-  if (failed(initAIELaunchConfig(moduleOp, usePassPipeline, useMulticore))) {
+  if (failed(initAIELaunchConfig(moduleOp, usePassPipeline, numCores))) {
     return signalPassFailure();
   }
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAddLoweringStrategy.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAddLoweringStrategy.cpp
@@ -47,7 +47,10 @@ void AMDAIELoweringStrategyPass::runOnOperation() {
         "Expected a variantOp root with an inner ModuleOp");
     return signalPassFailure();
   }
-  if (failed(initAIELaunchConfig(moduleOp, usePassPipeline, numCores))) {
+  // To simplify development, the number of cores can be passed as a flag during
+  // compilation. In the future these parameters could be read from file.
+  struct AIEConfig cfg = {numCores};
+  if (failed(initAIELaunchConfig(moduleOp, usePassPipeline, cfg))) {
     return signalPassFailure();
   }
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAddLoweringStrategy.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAddLoweringStrategy.cpp
@@ -47,7 +47,7 @@ void AMDAIELoweringStrategyPass::runOnOperation() {
         "Expected a variantOp root with an inner ModuleOp");
     return signalPassFailure();
   }
-  if (failed(initAIELaunchConfig(moduleOp, usePassPipeline))) {
+  if (failed(initAIELaunchConfig(moduleOp, usePassPipeline, useMulticore))) {
     return signalPassFailure();
   }
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -79,7 +79,7 @@ static LogicalResult setRootConfigImpl(func::FuncOp entryPointFn, Operation *op,
         // let it first crash for all the other ops and then consiously
         // add support for them, this way we can verify our work.
         .Case<linalg::MatmulOp>([&](auto op) {
-          return setRootConfig(entryPointFn, op, usePassPipeline, int64_t useMulticore);
+          return setRootConfig(entryPointFn, op, usePassPipeline, useMulticore);
         })
         .Default([&](Operation *op) { return success(); });
   };

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
@@ -30,7 +30,7 @@ struct AIEConfig {
 
 LogicalResult initAIELaunchConfig(ModuleOp moduleOp,
                                   AIEPassPipeline usePassPipeline,
-                                  int32_t numCores);
+                                  AIEConfig cfg);
 }  // namespace mlir::iree_compiler::AMDAIE
 
 #endif  // IREE_AMD_AIE_TRANSFORMS_KERNELDISPATCH_H_

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
@@ -22,9 +22,15 @@ enum class AIEPassPipeline : int32_t {
   None = 3
 };
 
+/// Struct specifying the number of cores to use. This will be replaced
+/// by a more versatile handling in the future.
+struct AIEConfig {
+  int32_t num_cores;
+};
+
 LogicalResult initAIELaunchConfig(ModuleOp moduleOp,
                                   AIEPassPipeline usePassPipeline,
-                                  int64_t useMulticore);
+                                  int32_t numCores);
 }  // namespace mlir::iree_compiler::AMDAIE
 
 #endif  // IREE_AMD_AIE_TRANSFORMS_KERNELDISPATCH_H_

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
@@ -23,8 +23,8 @@ enum class AIEPassPipeline : int32_t {
 };
 
 LogicalResult initAIELaunchConfig(ModuleOp moduleOp,
-                                  AIEPassPipeline usePassPipeline);
-
+                                  AIEPassPipeline usePassPipeline,
+                                  int64_t useMulticore);
 }  // namespace mlir::iree_compiler::AMDAIE
 
 #endif  // IREE_AMD_AIE_TRANSFORMS_KERNELDISPATCH_H_

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -37,6 +37,11 @@ static llvm::cl::opt<AIEPassPipeline> clUsePipeline(
                    "pack operation")),
     llvm::cl::init(AIEPassPipeline::SimplePackPipeline));
 
+static llvm::cl::opt<int64_t> clUseMulticore(
+    "iree-amdaie-use-multicore",
+    llvm::cl::desc("Choose the number of cores to use"),
+    llvm::cl::init(1));
+
 //===---------------------------------------------------------------------===//
 // Default allocation functions for AIE backend
 //===---------------------------------------------------------------------===//
@@ -271,6 +276,7 @@ void buildAMDAIETransformPassPipeline(OpPassManager &pm) {
   {
     AMDAIELoweringStrategyOptions options;
     options.usePassPipeline = clUsePipeline;
+    options.useMulticore = clUseMulticore;
     pm.addPass(createAMDAIELoweringStrategyPass(options));
   }
   {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -37,8 +37,8 @@ static llvm::cl::opt<AIEPassPipeline> clUsePipeline(
                    "pack operation")),
     llvm::cl::init(AIEPassPipeline::SimplePackPipeline));
 
-static llvm::cl::opt<int64_t> clUseMulticore(
-    "iree-amdaie-use-multicore",
+static llvm::cl::opt<int64_t> clNumCores(
+    "iree-amdaie-num-cores",
     llvm::cl::desc("Choose the number of cores to use"),
     llvm::cl::init(1));
 
@@ -276,7 +276,7 @@ void buildAMDAIETransformPassPipeline(OpPassManager &pm) {
   {
     AMDAIELoweringStrategyOptions options;
     options.usePassPipeline = clUsePipeline;
-    options.useMulticore = clUseMulticore;
+    options.numCores = clNumCores;
     pm.addPass(createAMDAIELoweringStrategyPass(options));
   }
   {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -37,10 +37,9 @@ static llvm::cl::opt<AIEPassPipeline> clUsePipeline(
                    "pack operation")),
     llvm::cl::init(AIEPassPipeline::SimplePackPipeline));
 
-static llvm::cl::opt<int64_t> clNumCores(
+static llvm::cl::opt<int32_t> clNumCores(
     "iree-amdaie-num-cores",
-    llvm::cl::desc("Choose the number of cores to use"),
-    llvm::cl::init(1));
+    llvm::cl::desc("Choose the number of cores to use"), llvm::cl::init(1));
 
 //===---------------------------------------------------------------------===//
 // Default allocation functions for AIE backend

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -95,7 +95,7 @@ def AMDAIELoweringStrategy :
         clEnumValN(mlir::iree_compiler::AMDAIE::AIEPassPipeline::SimplePackPipeline, "simple-pack",
                    "Use the simple-pack based lowering strategy.")
       )}]>,
-    Option<"numCores", "num-cores", "int64_t", /*default=*/"1",
+    Option<"numCores", "num-cores", "int32_t", /*default=*/"1",
       "Choose the number of cores to use">
   ];
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -94,7 +94,9 @@ def AMDAIELoweringStrategy :
                    "Use the more advanced pack-based lowering strategy, including peeling and double-buffering."),
         clEnumValN(mlir::iree_compiler::AMDAIE::AIEPassPipeline::SimplePackPipeline, "simple-pack",
                    "Use the simple-pack based lowering strategy.")
-      )}]>  
+      )}]>,
+    Option<"useMulticore", "use-multicore", "int64_t", /*default=*/"1",
+      "Choose the number of cores to use">
   ];
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -95,7 +95,7 @@ def AMDAIELoweringStrategy :
         clEnumValN(mlir::iree_compiler::AMDAIE::AIEPassPipeline::SimplePackPipeline, "simple-pack",
                    "Use the simple-pack based lowering strategy.")
       )}]>,
-    Option<"useMulticore", "use-multicore", "int64_t", /*default=*/"1",
+    Option<"numCores", "num-cores", "int64_t", /*default=*/"1",
       "Choose the number of cores to use">
   ];
 }

--- a/tests/samples/CMakeLists.txt
+++ b/tests/samples/CMakeLists.txt
@@ -9,6 +9,8 @@ iree_lit_test_suite(
     lit
   SRCS
     "pack_pipeline_funcIR.mlir"
+    "pack_pipeline_funcIR_2core.mlir"
+    "pack_pipeline_funcIR_4core.mlir"
     "pad_pipeline_e2e.mlir"
     "simple_pack_pipeline_e2e.mlir"
   TOOLS

--- a/tests/samples/pack_pipeline_funcIR_2core.mlir
+++ b/tests/samples/pack_pipeline_funcIR_2core.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources --mlir-print-ir-after=fold-memref-alias-ops %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pack --iree-amdaie-use-multicore=2 | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources --mlir-print-ir-after=fold-memref-alias-ops %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pack --iree-amdaie-num-cores=2 | FileCheck %s
 
 func.func @matmul_example(%lhs: tensor<16x256xi8>, %rhs: tensor<256x256xi8>) -> tensor<16x256xi32>
 {

--- a/tests/samples/pack_pipeline_funcIR_2core.mlir
+++ b/tests/samples/pack_pipeline_funcIR_2core.mlir
@@ -1,0 +1,48 @@
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources --mlir-print-ir-after=fold-memref-alias-ops %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pack --iree-amdaie-use-multicore=2 | FileCheck %s
+
+func.func @matmul_example(%lhs: tensor<16x256xi8>, %rhs: tensor<256x256xi8>) -> tensor<16x256xi32>
+{
+  %empty = tensor.empty() : tensor<16x256xi32>
+  %cst = arith.constant 0 : i32
+  %fill = linalg.fill ins(%cst : i32) outs(%empty : tensor<16x256xi32>) -> tensor<16x256xi32>
+  %res = linalg.matmul ins(%lhs, %rhs: tensor<16x256xi8>, tensor<256x256xi8>)
+                    outs(%fill: tensor<16x256xi32>) -> tensor<16x256xi32>
+  return %res : tensor<16x256xi32>
+}
+
+// CHECK-LABEL: @matmul_example_dispatch_0_matmul_16x256x256_i8xi8xi32
+//       CHECK: memref.alloc() : memref<1x1x8x4x4x8xi32, 2 : i32>
+//       CHECK: memref.alloc() : memref<1x1x8x8x8x8xi8, 2 : i32>
+//       CHECK: memref.alloc() : memref<1x1x8x4x4x8xi8, 2 : i32>
+//       CHECK: memref.alloc() : memref<1x2x16x64xi32, 1 : i32>
+//       CHECK: memref.alloc() : memref<1x2x64x64xi8, 1 : i32>
+//       CHECK: memref.alloc() : memref<1x1x16x64xi8, 1 : i32>
+//       CHECK: scf.forall
+//       CHECK:   iree_linalg_ext.pack %{{.*}} : (memref<16x64xi8, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x1x16x64xi8, 1 : i32>)
+//       CHECK:   iree_linalg_ext.pack %{{.*}} : (memref<64x128xi8, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x2x64x64xi8, 1 : i32>)
+//       CHECK:   scf.forall
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<1x1x16x64xi8, strided<[1024, 1024, 64, 1], offset: ?>, 1 : i32> memref<1x1x8x4x4x8xi8, 2 : i32>)
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<1x1x64x64xi8, strided<[8192, 4096, 64, 1], offset: ?>, 1 : i32> memref<1x1x8x8x8x8xi8, 2 : i32>)
+//       CHECK:     linalg.fill
+//       CHECK:     linalg.generic
+//       CHECK:     iree_linalg_ext.unpack %{{.*}} : (memref<1x1x8x4x4x8xi32, 2 : i32> memref<1x1x16x64xi32, strided<[2048, 1024, 64, 1], offset: ?>, 1 : i32>)
+//       CHECK:   iree_linalg_ext.unpack %{{.*}} : (memref<1x2x16x64xi32, 1 : i32> memref<16x128xi32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>)
+//       CHECK:   scf.for
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<16x64xi8, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x1x16x64xi8, 1 : i32>)
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<64x128xi8, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x2x64x64xi8, 1 : i32>)
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<16x128xi32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x2x16x64xi32, 1 : i32>)
+//       CHECK:     scf.forall
+//       CHECK:       iree_linalg_ext.pack %{{.*}} : (memref<1x1x16x64xi8, strided<[1024, 1024, 64, 1], offset: ?>, 1 : i32> memref<1x1x8x4x4x8xi8, 2 : i32>)
+//       CHECK:       iree_linalg_ext.pack %{{.*}} : (memref<1x1x64x64xi8, strided<[8192, 4096, 64, 1], offset: ?>, 1 : i32> memref<1x1x8x8x8x8xi8, 2 : i32>)
+//       CHECK:       iree_linalg_ext.pack %{{.*}} : (memref<1x1x16x64xi32, strided<[2048, 1024, 64, 1], offset: ?>, 1 : i32> memref<1x1x8x4x4x8xi32, 2 : i32>)
+//       CHECK:       linalg.generic
+//       CHECK:       iree_linalg_ext.unpack %{{.*}} : (memref<1x1x8x4x4x8xi32, 2 : i32> memref<1x1x16x64xi32, strided<[2048, 1024, 64, 1], offset: ?>, 1 : i32>)
+//       CHECK:     iree_linalg_ext.unpack %{{.*}} : (memref<1x2x16x64xi32, 1 : i32> memref<16x128xi32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>)
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x16x64xi8, 1 : i32>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x2x64x64xi8, 1 : i32>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x2x16x64xi32, 1 : i32>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x8x4x4x8xi8, 2 : i32>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x8x8x8x8xi8, 2 : i32>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x8x4x4x8xi32, 2 : i32>
+
+

--- a/tests/samples/pack_pipeline_funcIR_4core.mlir
+++ b/tests/samples/pack_pipeline_funcIR_4core.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources --mlir-print-ir-after=fold-memref-alias-ops %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pack --iree-amdaie-use-multicore=4 | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources --mlir-print-ir-after=fold-memref-alias-ops %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pack --iree-amdaie-num-cores=4 | FileCheck %s
 
 func.func @matmul_example(%lhs: tensor<16x256xi8>, %rhs: tensor<256x256xi8>) -> tensor<16x256xi32>
 {

--- a/tests/samples/pack_pipeline_funcIR_4core.mlir
+++ b/tests/samples/pack_pipeline_funcIR_4core.mlir
@@ -1,0 +1,48 @@
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources --mlir-print-ir-after=fold-memref-alias-ops %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pack --iree-amdaie-use-multicore=4 | FileCheck %s
+
+func.func @matmul_example(%lhs: tensor<16x256xi8>, %rhs: tensor<256x256xi8>) -> tensor<16x256xi32>
+{
+  %empty = tensor.empty() : tensor<16x256xi32>
+  %cst = arith.constant 0 : i32
+  %fill = linalg.fill ins(%cst : i32) outs(%empty : tensor<16x256xi32>) -> tensor<16x256xi32>
+  %res = linalg.matmul ins(%lhs, %rhs: tensor<16x256xi8>, tensor<256x256xi8>)
+                    outs(%fill: tensor<16x256xi32>) -> tensor<16x256xi32>
+  return %res : tensor<16x256xi32>
+}
+
+// CHECK-LABEL: @matmul_example_dispatch_0_matmul_16x256x256_i8xi8xi32
+//       CHECK: memref.alloc() : memref<1x1x8x4x4x8xi32, 2 : i32>
+//       CHECK: memref.alloc() : memref<1x1x8x8x8x8xi8, 2 : i32>
+//       CHECK: memref.alloc() : memref<1x1x8x4x4x8xi8, 2 : i32>
+//       CHECK: memref.alloc() : memref<1x4x16x64xi32, 1 : i32>
+//       CHECK: memref.alloc() : memref<1x4x64x64xi8, 1 : i32>
+//       CHECK: memref.alloc() : memref<1x1x16x64xi8, 1 : i32>
+//       CHECK: scf.forall
+//       CHECK:   iree_linalg_ext.pack %{{.*}} : (memref<16x64xi8, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x1x16x64xi8, 1 : i32>)
+//       CHECK:   iree_linalg_ext.pack %{{.*}} : (memref<64x256xi8, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x4x64x64xi8, 1 : i32>)
+//       CHECK:   scf.forall
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<1x1x16x64xi8, strided<[1024, 1024, 64, 1], offset: ?>, 1 : i32> memref<1x1x8x4x4x8xi8, 2 : i32>)
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<1x1x64x64xi8, strided<[16384, 4096, 64, 1], offset: ?>, 1 : i32> memref<1x1x8x8x8x8xi8, 2 : i32>)
+//       CHECK:     linalg.fill
+//       CHECK:     linalg.generic
+//       CHECK:     iree_linalg_ext.unpack %{{.*}} : (memref<1x1x8x4x4x8xi32, 2 : i32> memref<1x1x16x64xi32, strided<[4096, 1024, 64, 1], offset: ?>, 1 : i32>)
+//       CHECK:   iree_linalg_ext.unpack %{{.*}} : (memref<1x4x16x64xi32, 1 : i32> memref<16x256xi32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>)
+//       CHECK:   scf.for
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<16x64xi8, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x1x16x64xi8, 1 : i32>)
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<64x256xi8, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x4x64x64xi8, 1 : i32>)
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<16x256xi32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x4x16x64xi32, 1 : i32>)
+//       CHECK:     scf.forall
+//       CHECK:       iree_linalg_ext.pack %{{.*}} : (memref<1x1x16x64xi8, strided<[1024, 1024, 64, 1], offset: ?>, 1 : i32> memref<1x1x8x4x4x8xi8, 2 : i32>)
+//       CHECK:       iree_linalg_ext.pack %{{.*}} : (memref<1x1x64x64xi8, strided<[16384, 4096, 64, 1], offset: ?>, 1 : i32> memref<1x1x8x8x8x8xi8, 2 : i32>)
+//       CHECK:       iree_linalg_ext.pack %{{.*}} : (memref<1x1x16x64xi32, strided<[4096, 1024, 64, 1], offset: ?>, 1 : i32> memref<1x1x8x4x4x8xi32, 2 : i32>)
+//       CHECK:       linalg.generic
+//       CHECK:       iree_linalg_ext.unpack %{{.*}} : (memref<1x1x8x4x4x8xi32, 2 : i32> memref<1x1x16x64xi32, strided<[4096, 1024, 64, 1], offset: ?>, 1 : i32>)
+//       CHECK:     iree_linalg_ext.unpack %{{.*}} : (memref<1x4x16x64xi32, 1 : i32> memref<16x256xi32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>)
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x16x64xi8, 1 : i32>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x4x64x64xi8, 1 : i32>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x4x16x64xi32, 1 : i32>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x8x4x4x8xi8, 2 : i32>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x8x8x8x8xi8, 2 : i32>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x8x4x4x8xi32, 2 : i32>
+
+


### PR DESCRIPTION
The PackPipeline makes only use of one AIE tile so far, by tiling to `(16,64)` at the first tiling operation.

With the new flag `iree-amdaie-num-cores` this behaviour can be adapted, namely
- `iree-amdaie-num-cores=2`: tile to `(16,128)` and use two AIE tiles
- `iree-amdaie-num-cores=4`: tile to `(16,256)` and use four AIE tiles.

By default, a single tile is used. Values different than 1, 2 or 4 result in an error.
Note that this PR is built on top of https://github.com/nod-ai/iree-amd-aie/pull/127, assuming that this will soon be merged.

This flag is ignored within the PadPipeline and SimplePackPipeline.