### PR TITLE
[WIP] Enable `linalg.batch_matmul`

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
@@ -154,7 +154,8 @@ void AMDAIETileAndFusePass::runOnOperation() {
   if (!useSCFFor) {
     options.setMapping(
         {gpu::GPUBlockMappingAttr::get(context, gpu::MappingId::DimY),
-         gpu::GPUBlockMappingAttr::get(context, gpu::MappingId::DimX)});
+         gpu::GPUBlockMappingAttr::get(context, gpu::MappingId::DimX),
+         gpu::GPUBlockMappingAttr::get(context, gpu::MappingId::DimZ)});
   }
 
   if (!useSCFFor) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -32,6 +32,7 @@ static LogicalResult setRootConfig(func::FuncOp entryPointFn,
           "dim");
     }
   }
+
   // TODO (nmeshram) : This needs to be moved in a separate more generalized
   // logic. Also, need a flag to experiment between pad based and pack based
   // approach which will have different tile sizes and pass pipelines
@@ -45,7 +46,13 @@ static LogicalResult setRootConfig(func::FuncOp entryPointFn,
         entryPointFn, matmulOp, tileSizes,
         IREE::Codegen::DispatchLoweringPassPipeline::None);
   } else if (usePassPipeline == AIEPassPipeline::SimplePackPipeline) {
-    SmallVector<int64_t> TileSizeLevel0 = {8, 16};
+    // Make sure the tile size is not larger than the input size.
+    auto initType = matmulOp.getDpsInitOperand(0)->get().getType();
+    auto initShape = llvm::cast<ShapedType>(initType).getShape();
+    auto tileM = std::min(initShape[0], (int64_t)64);
+    auto tileN = std::min(initShape[1], (int64_t)64);s
+
+    SmallVector<int64_t> TileSizeLevel0 = {tileM, tileN};
     SmallVector<int64_t> TileSizeLevel1 = {1, 1};
     SmallVector<int64_t> TileSizeLevel2 = {0, 0, 1};
     TileSizesListType tileSizes = {TileSizeLevel0, TileSizeLevel1,


### PR DESCRIPTION
This is a WIP PR.

As of now it contains 3 commits - (we should just be reviewing the 2nd one) :-
Commit 1 - @yzhang93 's fix patch for enabling lower sized `linalg.matmul`.

Commit 2 - The initial infra for `linalg.batch_matmul` <---- this changes the current matmul packing config too, so this will be addressed as part of this WIP PR + some comment cleaning up.

Commit 3 - @erwei-xilinx 's fix patch for `--iree-amdaie-decompose-pack-unpack-to-air` 3D -> 2D.