### PR TITLE
[AMD-AIE] Add initial effort for enabling matmul transpose

### DIFF
--- a/tests/samples/simple_pack_pipeline_e2e.mlir
+++ b/tests/samples/simple_pack_pipeline_e2e.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --split-input-file | FileCheck %s --check-prefix=CPP
 
-// This test demonstrates Pack pipeline based e2e lowering.
+// This test demonstrates Pack pipeline based e2e lowering for matmul.
 
 // To check the cpp path equivalent to the transform dialect script.
 // CPP-LABEL: hal.executable.export public @matmul_small_dispatch_0_matmul_8x32x16_i32
@@ -43,4 +43,33 @@ func.func @matmul_large(%lhs: tensor<2048x512xi32>, %rhs: tensor<512x2048xi32>) 
   %res = linalg.matmul ins(%lhs, %rhs: tensor<2048x512xi32>, tensor<512x2048xi32>)
                     outs(%fill: tensor<2048x2048xi32>) -> tensor<2048x2048xi32>
   return %res : tensor<2048x2048xi32>
+}
+
+// -----
+
+// This test demonstrates Pack pipeline based e2e lowering for a linalg.generic implementing
+// a linalg.matmul_transpose_b.
+
+// CPP-LABEL: hal.executable.export public @generic_matmul_transpose_static_dispatch_0_generic_8x32x16_i32
+//       CPP:    aie.device(ipu)
+//       CPP:    aie.shim_dma_allocation
+//       CPP:    aie.shim_dma_allocation
+//       CPP:    aie.shim_dma_allocation
+//       CPP:    func.func @generic_matmul_transpose_static_dispatch_0_generic_8x32x16_i32(%arg0: memref<8x16xi32>, %arg1: memref<32x16xi32>, %arg2: memref<8x32xi32>)
+//       CPP:      aiex.ipu.dma_memcpy_nd
+//       CPP:      aiex.ipu.dma_memcpy_nd
+//       CPP:      aiex.ipu.dma_memcpy_nd
+//       CPP:      aiex.ipu.sync
+func.func @generic_matmul_transpose_static(%lhs : tensor<8x16xi32>,
+    %rhs : tensor<32x16xi32>) -> tensor<8x32xi32> {
+  %cst = arith.constant 0 : i32
+  %empty = tensor.empty() : tensor<8x32xi32>
+  %fill = linalg.fill ins(%cst : i32) outs(%empty : tensor<8x32xi32>) -> tensor<8x32xi32>
+  %matmul_transpose = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%lhs, %rhs : tensor<8x16xi32>, tensor<32x16xi32>) outs(%fill : tensor<8x32xi32>) {
+  ^bb0(%in: i32, %in_0: i32, %out: i32):
+    %19 = arith.muli %in, %in_0 : i32
+    %20 = arith.addi %out, %19 : i32
+    linalg.yield %20 : i32
+  } -> tensor<8x32xi32>
+  return %matmul_transpose : tensor<8x32xi32>
 }


### PR DESCRIPTION
-- This commit adds initial effort for enabling matmul transpose.
-- Matmul transpose is represented via a linalg.generic op with the
   transpose materializing as the interchange of the dimension. This
   commit therefore adds the initial infra for dealing with linalg.generic
   and caters specifically to the transpose case.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>

NOTE: The `--split-input-file` doesn't seem to work for some reason - should be a trivial fix - I'll look into it, but rest of the infra is going to be as it is.