### PR TITLE
[AMD-AIE] Add AMDAIEDialect/Attributes + PackingConfig + Update KernelDispatch/pack-and-transpose

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_cc_library(
   DEPS
     iree::compiler::Dialect::HAL::Target
     iree::compiler::PluginAPI
+    iree::target::amd-aie::IR::AMDAIEDialect
     iree::target::amd-aie::Target
     iree::target::amd-aie::Transforms
     iree::target::amd-aie::aie::AIEDialectIR
@@ -34,5 +35,6 @@ iree_compiler_register_plugin(
     ::registration
 )
 
+add_subdirectory(IR)
 add_subdirectory(Target)
 add_subdirectory(Transforms)

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEAttrs.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEAttrs.cpp
@@ -1,0 +1,126 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-amd-aie/IR/AMDAIEAttrs.h"
+
+#include "iree-amd-aie/IR/AMDAIEDialect.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Transform/IR/TransformOps.h"
+#include "mlir/IR/DialectImplementation.h"
+
+#define GET_ATTRDEF_CLASSES
+#include "iree-amd-aie/IR/AMDAIEAttrs.cpp.inc"
+#include "iree-amd-aie/IR/AMDAIEEnums.cpp.inc"
+
+static const char kPackingConfigAttrName[] = "packing_config";
+
+namespace mlir::iree_compiler {
+
+/// Returns an `ArrayAttr` where each element is an `IntegerAttr` of 64-bit
+/// integer type whose values is obtained from `values`.
+static ArrayAttr getIndexArrayAttr(MLIRContext *context,
+                                   ArrayRef<int64_t> values) {
+  return ArrayAttr::get(
+      context, llvm::map_to_vector(values, [&](int64_t value) -> Attribute {
+        return IntegerAttr::get(IndexType::get(context), APInt(64, value));
+      }));
+}
+
+}  // namespace mlir::iree_compiler
+
+namespace mlir::iree_compiler::AMDAIE {
+
+//===----------------------------------------------------------------------===//
+// amdaie.packing_config_level
+//===----------------------------------------------------------------------===//
+
+SmallVector<ArrayRef<int64_t>>
+PackingConfigPackingLevelAttr::getInnerPermArr() {
+  SmallVector<ArrayRef<int64_t>> res;
+  PermLevelsAttr permLevelsAttr = getInnerPerm();
+  for (auto permLevel : permLevelsAttr) {
+    res.push_back(permLevel.getPerm());
+  }
+  return res;
+}
+
+SmallVector<ArrayRef<int64_t>>
+PackingConfigPackingLevelAttr::getOuterPermArr() {
+  SmallVector<ArrayRef<int64_t>> res;
+  PermLevelsAttr permLevelsAttr = getOuterPerm();
+  for (auto permLevel : permLevelsAttr) {
+    res.push_back(permLevel.getPerm());
+  }
+  return res;
+}
+
+//===----------------------------------------------------------------------===//
+// amdaie.packing_config
+//===----------------------------------------------------------------------===//
+
+PackingConfigPackingLevelAttr PackingConfigAttr::getPackingConfigVals(
+    unsigned level) {
+  auto levels = getPackingLevels();
+  if (level >= levels.size()) return {};
+  return levels[level];
+}
+
+void AMDAIEDialect::initializeAMDAIEAttrs() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "iree-amd-aie/IR/AMDAIEAttrs.cpp.inc"  // IWYU pragma: keeep
+      >();
+}
+
+}  // namespace mlir::iree_compiler::AMDAIE
+
+namespace mlir::iree_compiler {
+
+//===----------------------------------------------------------------------===//
+// Helpers for forming `amdaie.packing_config_level` attribute.
+// ===----------------------------------------------------------------------===//
+
+static AMDAIE::PermLevelAttr getPermLevelAttr(
+    MLIRContext *context, SmallVector<int64_t> permLevelVal) {
+  return AMDAIE::PermLevelAttr::get(context, permLevelVal);
+}
+
+static AMDAIE::PermLevelsAttr getPermLevelsAttr(
+    MLIRContext *context, SmallVector<SmallVector<int64_t>> permLevelsVal) {
+  SmallVector<AMDAIE::PermLevelAttr> permLevels;
+  for (auto permLevel : permLevelsVal) {
+    permLevels.push_back(AMDAIE::PermLevelAttr::get(context, permLevel));
+  }
+  return AMDAIE::PermLevelsAttr::get(context, permLevels);
+}
+
+AMDAIE::PackingConfigPackingLevelAttr getPackingConfigPackingLevelAttr(
+    MLIRContext *context, SmallVector<int64_t> &packedSizes,
+    SmallVector<int64_t> &transposePackIndices, SmallVector<bool> &unpackEmpty,
+    SmallVector<SmallVector<int64_t>> &innerPermVal,
+    SmallVector<SmallVector<int64_t>> &outerPermVal) {
+  auto innerPermAttr = getPermLevelsAttr(context, innerPermVal);
+  auto outerPermAttr = getPermLevelsAttr(context, outerPermVal);
+  return AMDAIE::PackingConfigPackingLevelAttr::get(
+      context, packedSizes, transposePackIndices, unpackEmpty, innerPermAttr,
+      outerPermAttr);
+}
+
+//===----------------------------------------------------------------------===//
+// Helpers for getting/setting `amdaie.packing_config` attribute.
+// ===----------------------------------------------------------------------===//
+
+AMDAIE::PackingConfigAttr getPackingConfig(Operation *op) {
+  return op->getAttrOfType<AMDAIE::PackingConfigAttr>(kPackingConfigAttrName);
+}
+
+void setPackingConfig(Operation *op, AMDAIE::PackingConfigAttr config) {
+  op->setAttr(kPackingConfigAttrName, config);
+}
+
+}  // namespace mlir::iree_compiler

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEAttrs.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEAttrs.h
@@ -1,0 +1,43 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===- IREECodegenAttrs.h - Codegen dialect attributes --------------------===//
+//===----------------------------------------------------------------------===//
+
+#ifndef IREE_COMPILER_AMDAIE_DIALECT_PACKINGCONFIG_H_
+#define IREE_COMPILER_AMDAIE_DIALECT_PACKINGCONFIG_H_
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+
+// clang-format off
+#include "iree-amd-aie/IR/AMDAIEEnums.h.inc"
+#define GET_ATTRDEF_CLASSES
+#include "iree-amd-aie/IR/AMDAIEAttrs.h.inc"
+// clang-format on
+
+namespace mlir::iree_compiler {
+
+/// Helps in forming a `PackingConfigPackingLevelAttr`.
+AMDAIE::PackingConfigPackingLevelAttr getPackingConfigPackingLevelAttr(
+    MLIRContext *context, SmallVector<int64_t> &packedSizes,
+    SmallVector<int64_t> &transposePackIndices, SmallVector<bool> &unpackEmpty,
+    SmallVector<SmallVector<int64_t>> &innerPermVal,
+    SmallVector<SmallVector<int64_t>> &outerPermVal);
+
+/// Returns the packing configuration set for an operation. Returns `nullptr`
+/// if no value is set.  It expects that the attribute is stored using the
+/// identifier `packing_config`.
+AMDAIE::PackingConfigAttr getPackingConfig(Operation *op);
+
+/// Sets the packing configuration, overwriting existing attribute values.
+void setPackingConfig(Operation *op, AMDAIE::PackingConfigAttr config);
+
+}  // namespace mlir::iree_compiler
+
+#endif  // IREE_COMPILER_AMDAIE_DIALECT_PACKINGCONFIG_H_

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEAttrs.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEAttrs.td
@@ -1,0 +1,103 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_AMDAIE_DIALECT_IREEAMDAIEATTRS
+#define IREE_COMPILER_AMDAIE_DIALECT_IREEAMDAIEATTRS
+
+include "iree-amd-aie/IR/AMDAIEDialect.td"
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/EnumAttr.td"
+
+def AMDAIE_MemSpace_Global : I32EnumAttrCase<"Global", 0>;
+def AMDAIE_MemSpace_Shared : I32EnumAttrCase<"Shared", 1>;
+def AMDAIE_MemSpace_Local : I32EnumAttrCase<"Local", 2>;
+def AMDAIE_MemSpaceAttr: I32EnumAttr<"AMDAIEMemSpace", "AIE Memory Space",
+  [
+    AMDAIE_MemSpace_Global,
+    AMDAIE_MemSpace_Shared,
+    AMDAIE_MemSpace_Local,
+  ]> {
+
+  let cppNamespace = "mlir::iree_compiler::AMDAIE";
+}
+
+def AMDAIE_PermLevelAttr :
+  AttrDef<AMDAIE_Dialect, "PermLevel", []>
+{
+  let mnemonic = "perm_level";
+  let parameters = (ins
+    ArrayRefParameter<"int64_t","">:$perm
+  );
+  
+  let assemblyFormat = [{
+    `[` $perm `]`
+  }];
+}
+
+def AMDAIE_PermLevelsAttr :
+  ArrayOfAttr<AMDAIE_Dialect, "PermLevels",
+    "perm_levels", "PermLevelAttr", []>
+{
+}
+
+def AMDAIE_PackingConfigPackingLevelAttr :
+  AttrDef<AMDAIE_Dialect, "PackingConfigPackingLevel", []>
+{
+  let mnemonic = "packing_config_level";
+  let parameters = (ins
+    ArrayRefParameter<"int64_t",
+        "Expected packed sizes for specified iterator dimensions">:$packedSizes,
+    ArrayRefParameter<"int64_t",
+        "Indices of pack operations need to be transposed">:$transposePackIndices,
+    ArrayRefParameter<"bool",
+        "Indicator of if there is a unpack op corresponding to a pack op">:$unpackEmpty,
+    AttrParameter<"PermLevelsAttr",
+        "Attributes for inner dimension permutation">:$innerPerm,
+    AttrParameter<"PermLevelsAttr",
+        "Attributes for outer dimension permutation">:$outerPerm
+  );
+  
+  let assemblyFormat = [{
+    `{` `packedSizes` `=` `[` $packedSizes `]` `,` `transposePackIndices` `=` `[` $transposePackIndices `]` `,` `unpackEmpty` `=` `[` $unpackEmpty `]` `,` `innerPerm` `=` $innerPerm `,` `outerPerm` `=` $outerPerm `}`
+  }];
+
+  let extraClassDeclaration = [{
+    SmallVector<ArrayRef<int64_t>> getInnerPermArr();
+    SmallVector<ArrayRef<int64_t>> getOuterPermArr();
+  }];
+}
+
+def AMDAIE_PackingConfigPackingLevelsAttr :
+  ArrayOfAttr<AMDAIE_Dialect, "PackingConfigPackingLevels",
+    "packing_config_levels", "PackingConfigPackingLevelAttr", []>
+{
+}
+
+def AMDAIE_PackingConfigAttr :
+    AttrDef<AMDAIE_Dialect, "PackingConfig", []> {
+  let mnemonic = "packing_config";
+  let summary = [{drive lowering of an operation within dispatch region via a given packing config}];
+  let description = [{
+    Specifies the information that is used by the iree-pack-and-transpose
+    pass to help in the lowering of an operation within a dispatch region.
+  }];
+
+  let assemblyFormat = [{
+    `<` `packing_config` `=` $packingLevels `>`
+  }];
+
+  let parameters = (ins
+    AttrParameter<"PackingConfigPackingLevelsAttr",
+        "The packing config at different levels">:$packingLevels
+  );
+  
+  let extraClassDeclaration = [{
+    // Returns the packing config for a level set for the op.
+    PackingConfigPackingLevelAttr getPackingConfigVals(unsigned level);
+  }];
+}
+
+#endif // IREE_COMPILER_AMDAIE_DIALECT_IREEAMDAIEATTRS

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDialect.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDialect.cpp
@@ -1,0 +1,31 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-amd-aie/IR/AMDAIEDialect.h"
+
+#include "iree-amd-aie/IR/AMDAIEAttrs.h"
+#include "iree-amd-aie/IR/AMDAIEDialect.cpp.inc"
+#include "mlir/IR/DialectImplementation.h"
+
+namespace mlir::iree_compiler::AMDAIE {
+
+struct AMDAIEDialectOpAsmInterface : public OpAsmDialectInterface {
+  using OpAsmDialectInterface::OpAsmDialectInterface;
+  AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
+    if (llvm::isa<PackingConfigAttr>(attr)) {
+      os << "packingConfig";
+      return AliasResult::OverridableAlias;
+    }
+    return AliasResult::NoAlias;
+  }
+};
+
+void AMDAIEDialect::initialize() {
+  initializeAMDAIEAttrs();
+  addInterfaces<AMDAIEDialectOpAsmInterface>();
+}
+
+}  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDialect.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDialect.h
@@ -1,0 +1,22 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_AMDAIE_DIALECT_IREEAMDAIE_DIALECT_H_
+#define IREE_COMPILER_AMDAIE_DIALECT_IREEAMDAIE_DIALECT_H_
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringMap.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/TypeID.h"
+
+// clang-format off: must be included after all LLVM/MLIR eaders
+#include "iree-amd-aie/IR/AMDAIEDialect.h.inc"  // IWYU pragma: keep
+// clang-format on
+
+#endif  // IREE_COMPILER_AMDAIE_DIALECT_IREEAMDAIE_DIALECT_H_

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDialect.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDialect.td
@@ -1,0 +1,34 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_AMDAIE_DIALECT_IREEAMDAIE_DIALECT
+#define IREE_AMDAIE_DIALECT_IREEAMDAIE_DIALECT
+
+include "mlir/IR/OpBase.td"
+
+//===----------------------------------------------------------------------===//
+// IREE Codegen dialect
+//===----------------------------------------------------------------------===//
+
+def AMDAIE_Dialect : Dialect {
+  let name = "amdaie";
+  let cppNamespace = "::mlir::iree_compiler::AMDAIE";
+
+  let summary = [{
+    A dialect representing attributes used by the IREE AMDAIE generation.
+  }];
+  let description = [{
+    This dialect is primarily meant to hold attributes that carry the
+    state of the compilation when lowered to scalar code for an
+    architecture.
+  }];
+  let extraClassDeclaration = [{
+    void initializeAMDAIEAttrs();
+  }];
+  let useDefaultAttributePrinterParser = 1;
+}
+
+#endif // IREE_AMD_AIE_DIALECT_IREEAMDAIE_DIALECT

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/CMakeLists.txt
@@ -1,0 +1,57 @@
+# Copyright 2024 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set(IREE_PACKAGE_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
+set(IREE_PACKAGE_ROOT_PREFIX "iree::target::amd-aie::IR")
+iree_add_all_subdirs()
+
+iree_cc_library(
+  NAME
+    AMDAIEDialect
+  HDRS
+    "AMDAIEAttrs.h"
+    "AMDAIEDialect.h"
+  TEXTUAL_HDRS
+    "AMDAIEAttrs.cpp.inc"
+    "AMDAIEAttrs.h.inc"
+    "AMDAIEDialect.cpp.inc"
+    "AMDAIEDialect.h.inc"
+    "AMDAIEEnums.cpp.inc"
+    "AMDAIEEnums.h.inc"
+  SRCS
+    "AMDAIEAttrs.cpp"
+    "AMDAIEDialect.cpp"
+  DEPS
+    ::AMDAIEDialectGen
+    ::PackingConfigGen
+    LLVMSupport
+    MLIRIR
+    MLIRParser
+    MLIRSupport
+  PUBLIC
+)
+
+iree_tablegen_library(
+  NAME
+    AMDAIEDialectGen
+  TD_FILE
+    "AMDAIEDialect.td"
+  OUTS
+    --gen-dialect-decls AMDAIEDialect.h.inc
+    --gen-dialect-defs AMDAIEDialect.cpp.inc
+)
+
+iree_tablegen_library(
+  NAME
+    PackingConfigGen
+  TD_FILE
+    "AMDAIEAttrs.td"
+  OUTS
+    --gen-attrdef-decls AMDAIEAttrs.h.inc
+    --gen-attrdef-defs AMDAIEAttrs.cpp.inc
+    --gen-enum-decls AMDAIEEnums.h.inc
+    --gen-enum-defs AMDAIEEnums.cpp.inc
+)

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/PluginRegistration.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/PluginRegistration.cpp
@@ -8,6 +8,7 @@
 #include "aie/Passes.h"
 #include "air/Dialect/AIR/AIRDialect.h"
 #include "air/Passes.h"
+#include "iree-amd-aie/IR/AMDAIEDialect.h"
 #include "iree-amd-aie/Target/AIETarget.h"
 #include "iree-amd-aie/Transforms/Passes.h"
 #include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
@@ -26,7 +27,8 @@ struct AMDAIESession
   }
 
   void onRegisterDialects(DialectRegistry &registry) override {
-    registry.insert<xilinx::AIE::AIEDialect, xilinx::air::airDialect>();
+    registry.insert<AMDAIE::AMDAIEDialect, xilinx::AIE::AIEDialect,
+                    xilinx::air::airDialect>();
   }
 
   void populateHALTargetBackends(

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -12,6 +12,7 @@
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
 #include "air/Dialect/AIR/AIRDialect.h"
 #include "air/Dialect/AIRRt/AIRRtDialect.h"
+#include "iree-amd-aie/IR/AMDAIEDialect.h"
 #include "iree-amd-aie/Transforms/Passes.h"
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
@@ -54,7 +55,8 @@ class AIETargetBackend final : public IREE::HAL::TargetBackend {
   std::string name() const override { return "amd-aie"; }
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<mlir::iree_compiler::IREE::Codegen::IREECodegenDialect,
+    registry.insert<mlir::iree_compiler::AMDAIE::AMDAIEDialect,
+                    mlir::iree_compiler::IREE::Codegen::IREECodegenDialect,
                     IREE::LinalgExt::IREELinalgExtDialect,
                     transform::TransformDialect, xilinx::AIE::AIEDialect,
                     xilinx::AIEX::AIEXDialect, xilinx::air::airDialect,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
@@ -13,6 +13,7 @@ iree_cc_library(
     "AIETarget.cpp"
   DEPS
     iree::compiler::Dialect::HAL::Target
+    iree::target::amd-aie::IR::AMDAIEDialect
     iree::target::amd-aie::Transforms
     iree::target::amd-aie::air::AIRDialectIR
   PUBLIC

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp
@@ -10,10 +10,6 @@
 #include "mlir/IR/Iterators.h"
 #include "mlir/Pass/Pass.h"
 
-// clang-format off: must be included after all LLVM/MLIR headers.
-#include "iree-amd-aie/Transforms/AMDAIEEnums.cpp.inc"  // IWYU pragma: export
-// clang-format on
-
 #define DEBUG_TYPE "iree-amdaie-bufferize-to-allocation"
 
 namespace mlir::iree_compiler::AMDAIE {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp
@@ -68,10 +68,10 @@ static AMDAIEMemSpaceAttr getMemorySpaceAttr(RewriterBase &rewriter,
   AMDAIEMemSpace memSpace;
   switch (memorySpace) {
     case 1:
-      memSpace = AMDAIEMemSpace::L1;
+      memSpace = AMDAIEMemSpace::Shared;
       break;
     case 2:
-      memSpace = AMDAIEMemSpace::L2;
+      memSpace = AMDAIEMemSpace::Local;
       break;
     default:
       assert(false && "incorrect memory space");

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
@@ -15,8 +15,6 @@ iree_tablegen_library(
     "Passes.td"
   OUTS
     --gen-pass-decls Passes.h.inc
-    --gen-enum-decls AMDAIEEnums.h.inc
-    --gen-enum-defs AMDAIEEnums.cpp.inc
 )
 
 iree_cc_library(
@@ -28,6 +26,7 @@ iree_cc_library(
     "Passes.h.inc"
   DEPS
     ::PassesIncGen
+    iree::target::amd-aie::IR::AMDAIEDialect
     MLIRPass
   PUBLIC
 )
@@ -36,6 +35,7 @@ iree_cc_library(
   NAME
     Transforms
   HDRS
+    "KernelDispatch.h"
     "Passes.h"
   SRCS
     "Passes.cpp"
@@ -57,6 +57,7 @@ iree_cc_library(
   DEPS
     ::PassHeaders
     ::PassesIncGen
+    iree::target::amd-aie::IR::AMDAIEDialect
     MLIRSupport
     iree::compiler::Codegen::Common::TransformDialectInterpreterPass
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
@@ -7,6 +7,7 @@
 #ifndef IREE_AMD_AIE_TRANSFORMS_KERNELDISPATCH_H_
 #define IREE_AMD_AIE_TRANSFORMS_KERNELDISPATCH_H_
 
+#include "iree-amd-aie/IR/AMDAIEAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "mlir/IR/BuiltinOps.h"
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -12,10 +12,6 @@
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "mlir/Pass/Pass.h"
 
-// clang-format off: must be included after all LLVM/MLIR headers.
-#include "iree-amd-aie/Transforms/AMDAIEEnums.h.inc"  // IWYU pragma: export
-// clang-format on
-
 namespace mlir::iree_compiler::AMDAIE {
 
 /// Add passes to lower from MLIR-AIR through AIE. This is

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -7,19 +7,8 @@
 #ifndef IREE_AMD_AIE_TRANSFORMS_PASSES
 #define IREE_AMD_AIE_TRANSFORMS_PASSES
 
-include "mlir/IR/EnumAttr.td"
+include "iree-amd-aie/IR/AMDAIEDialect.td"
 include "mlir/Pass/PassBase.td"
-
-def AMDAIE_MemSpace_L1 : I32EnumAttrCase<"L1", 1, "l1">;
-def AMDAIE_MemSpace_L2 : I32EnumAttrCase<"L2", 2, "l2">;
-def AMDAIE_MemSpaceAttr: I32EnumAttr<"AMDAIEMemSpace", "AIE Memory Space",
-  [
-    AMDAIE_MemSpace_L1,
-    AMDAIE_MemSpace_L2,
-  ]> {
-
-  let cppNamespace = "mlir::iree_compiler::AMDAIE";
-}
 
 def AMDAIEBridgeToAIR : Pass<"iree-amdaie-bridge-to-air", ""> {
   let summary = "Perform transformations that allow hooking into AIR/AIE lowering";

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pack_and_transpose_level1.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pack_and_transpose_level1.mlir
@@ -2,6 +2,8 @@
 
 // CHECK: #config
 #config = #iree_codegen.lowering_config<tile_sizes = [[8, 8], [4, 4], [0, 0, 4]]>
+// CHECK: #packingConfig
+#packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [8, 8, 256], transposePackIndices = [1], unpackEmpty = [0], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 8, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [0, 0, 1], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 // CHECK: @matmul_example_dispatch_0_matmul_16x256x256_i8xi8xi32
 func.func @matmul_example_dispatch_0_matmul_16x256x256_i8xi8xi32(%arg0 : tensor<16x256xi8>, %arg1 : tensor<256x256xi8>) -> tensor<16x256xi32> {
   %c0 = arith.constant 0 : index
@@ -12,7 +14,7 @@ func.func @matmul_example_dispatch_0_matmul_16x256x256_i8xi8xi32(%arg0 : tensor<
   // CHECK:       tensor.pack %{{.*}} outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [256, 8] into %{{.*}} : tensor<256x256xi8> -> tensor<1x32x256x8xi8>
   // CHECK:       tensor.pack %{{.*}} inner_dims_pos = [0, 1] inner_tiles = [8, 8] into %{{.*}} : tensor<16x256xi32> -> tensor<2x32x8x8xi32>
   // CHECK:       linalg.generic
-  // CHECK-SAME:  attrs =  {lowering_config = #config}
-  %7 = linalg.matmul {lowering_config = #config} ins(%arg0, %arg1 : tensor<16x256xi8>, tensor<256x256xi8>) outs(%6 : tensor<16x256xi32>) -> tensor<16x256xi32>
+  // CHECK-SAME:  attrs =  {lowering_config = #config, packing_config = #packingConfig}
+  %7 = linalg.matmul {lowering_config = #config, packing_config = #packingConfig} ins(%arg0, %arg1 : tensor<16x256xi8>, tensor<256x256xi8>) outs(%6 : tensor<16x256xi32>) -> tensor<16x256xi32>
   return %7 : tensor<16x256xi32>
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pack_and_transpose_level2.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pack_and_transpose_level2.mlir
@@ -2,6 +2,8 @@
 
 // CHECK: #config
 #config = #iree_codegen.lowering_config<tile_sizes = [[8, 8], [4, 4], [0, 0, 4]]>
+// CHECK: #packingConfig
+#packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [8, 8, 256], transposePackIndices = [1], unpackEmpty = [0], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 8, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [0, 0, 1], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #map = affine_map<(d0) -> (d0 * 16)>
 #map1 = affine_map<(d0) -> (d0 * 64)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
@@ -31,8 +33,8 @@ func.func @matmul_example_dispatch_0_matmul_16x256x256_i8xi8xi32(%arg0: tensor<1
       // CHECK: tensor.pack %{{.*}} outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [8, 8] into %{{.*}} : tensor<4x1x64x64xi8> -> tensor<4x1x8x8x8x8xi8>
       // CHECK: tensor.pack %{{.*}} outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [4, 8] into %{{.*}} : tensor<1x1x16x64xi32> -> tensor<1x1x8x4x4x8xi32>
       // CHECK:       linalg.generic
-      // CHECK-SAME:  attrs =  {lowering_config = #config}
-      %14 = linalg.generic {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%extracted_slice_3, %extracted_slice_4 : tensor<1x4x16x64xi8>, tensor<4x1x64x64xi8>) outs(%13 : tensor<1x1x16x64xi32>) attrs = {lowering_config = #config} {
+      // CHECK-SAME:  attrs =  {lowering_config = #config, packing_config = #packingConfig}
+      %14 = linalg.generic {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%extracted_slice_3, %extracted_slice_4 : tensor<1x4x16x64xi8>, tensor<4x1x64x64xi8>) outs(%13 : tensor<1x1x16x64xi32>) attrs = {lowering_config = #config, packing_config = #packingConfig} {
       ^bb0(%in: i8, %in_6: i8, %out: i32):
         %15 = arith.extsi %in : i8 to i32
         %16 = arith.extsi %in_6 : i8 to i32


### PR DESCRIPTION
This PR involves :-

1. Creating AMDAIEDialect.
2. Creating AMDAIEEnum/Attributes.
3. Creating PackingConfig Attribute infra.
4. Adapting KernelDispatch to set packing_config attribute.
5. Adapting --iree-amdaie-pack-and-transpose to work with the packing_config attribute set earlier.
5. Refactoring the directory structure to make maintaining codebase "easier" and aligns with the restructuring upstream.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>