### PR TITLE
[WIP] pass to convert linalg to vector dialect 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEVectorization.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEVectorization.cpp
@@ -1,0 +1,110 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <memory>
+
+#include "iree-amd-aie/Transforms/Passes.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Pass/Pass.h"
+
+#define DEBUG_TYPE "iree-amdaie-vectorization"
+
+namespace mlir::iree_compiler::AMDAIE {
+
+namespace {
+
+class AMDAIEVectorizationPass
+    : public impl::AMDAIEVectorizationBase<AMDAIEVectorizationPass> {
+ public:
+  void getDependentDialects(DialectRegistry &registry) const final {
+    registry.insert<scf::SCFDialect>();
+  }
+
+  AMDAIEVectorizationPass() = default;
+  AMDAIEVectorizationPass(const AMDAIEVectorizationPass &) = default;
+
+  // We only vectorize linalg.matmuls of a specific shape. The shape is chosen
+  // to target AIE instructions, and is dependent on the data type.
+  // Matmuls of the form A: 4XK, B: KX4, C: 4X4 are vectorized, where K is type
+  // specific. This function returns K based on data type. 
+  static FailureOr<uint32_t> getMatmulTargetK(mlir::linalg::MatmulOp op) {
+    auto elType =
+        op->getResult(0).getType().cast<ShapedType>().getElementType();
+    if (elType.isF16() || elType.isBF16() || elType.isInteger(16))
+      return 8;
+    else if (elType.isF32() || elType.isInteger(32))
+      return 4;
+    return op->emitOpError("Unimplemented: reduction size for type") << elType;
+  }
+
+  // Return true if 'op' is a matmul op of the correct shape. 
+  static FailureOr<bool> isMatmulCandidate(Operation *op) {
+    auto matmulOp = dyn_cast<linalg::MatmulOp>(op);
+    if (!matmulOp){
+      return false;
+    }
+    auto lhsType = op->getOperand(0).getType().cast<ShapedType>();
+    auto rhsType = op->getOperand(1).getType().cast<ShapedType>();
+    auto outType = op->getResult(0).getType().cast<ShapedType>();
+
+    // TODO: matmuls with mixed types? 
+    auto elType = outType.getElementType();
+    if (lhsType.getElementType() != elType ||
+        rhsType.getElementType() != elType) {
+      return false;
+    }
+
+    auto rhsShape = rhsType.getShape();
+    auto outShape = outType.getShape();
+
+    assert(outShape.size() == 2 && rhsShape.size() == 2 &&
+           "linalg.matmuls must be rank-2");
+
+    auto targetK = getMatmulTargetK(matmulOp);
+    if (failed(targetK)) return failure();
+
+    auto m = outShape[0];
+    if (m != 4) return false;
+    auto n = rhsShape[1];
+    if (n != 4) return false;
+    auto k = rhsShape[0];
+    if (k != targetK) return false;
+
+    return true;
+  }
+
+  void runOnOperation() final {
+    MLIRContext *context = &getContext();
+    IRRewriter rewriter(context);
+
+    auto funcOp = getOperation();
+    if (!llvm::isa<mlir::func::FuncOp>(funcOp)) {
+      funcOp->emitError("expected a function operation");
+      return signalPassFailure();
+    }
+
+    // Collect all the operations which should be vectorized.
+    SmallVector<Operation *> opsToVectorize;
+    funcOp.walk([&](Operation *op) {
+      auto candidate = isMatmulCandidate(op);
+      if (failed(candidate)) return signalPassFailure();
+      if (candidate.value()) opsToVectorize.push_back(op);
+    });
+
+    for (auto opToVectorize : opsToVectorize)
+      if (failed(linalg::vectorize(rewriter, opToVectorize))) {
+        opToVectorize->emitOpError("Unexpectedly failed to vectorize");
+        return signalPassFailure();
+      }
+  }
+};
+}  // namespace
+
+std::unique_ptr<Pass> createAMDAIEVectorizationPass() {
+  return std::make_unique<AMDAIEVectorizationPass>();
+}
+
+}  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
@@ -50,6 +50,7 @@ iree_cc_library(
     "AMDAIEPeelForLoop.cpp"
     "AMDAIEPropagateDataLayout.cpp"
     "AMDAIETileAndFuse.cpp"
+    "AMDAIEVectorization.cpp"
     "BridgeToAIRPass.cpp"
     "DecomposeLinalgExtPackUnPackToAIR.cpp"
     "Cleanup.cpp"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/PassDetail.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/PassDetail.h
@@ -33,6 +33,7 @@ namespace mlir::iree_compiler::AMDAIE {
 #define GEN_PASS_DEF_AMDAIEPROPAGATEDATALAYOUT
 #define GEN_PASS_DEF_AMDAIETILEANDFUSE
 #define GEN_PASS_DEF_AMDAIEDECOMPOSELINALGEXTPACKUNPACKTOAIR
+#define GEN_PASS_DEF_AMDAIEVECTORIZATION
 #include "iree-amd-aie/Transforms/Passes.h.inc"
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -117,7 +117,15 @@ void addPadBasedPassPipeline(OpPassManager &pm, TilingConfig &tilingConfig) {
     pm.addPass(createCanonicalizerPass());
     pm.addPass(createCSEPass());
   }
+
+  // Vectorization
+  modulePassManager.addNestedPass<func::FuncOp>(
+      createAMDAIEVectorizationPass());
+  modulePassManager.addPass(createCanonicalizerPass());
+  modulePassManager.addPass(createCSEPass());
+
   addAMDAIEBufferizePasses(modulePassManager);
+
   modulePassManager.addNestedPass<func::FuncOp>(createAMDAIECleanupPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -62,6 +62,9 @@ std::unique_ptr<Pass> createAMDAIEDecomposeLinalgExtPackUnPackToAIRPass();
 /// Create a pass to fuse the linalg.fill into the forall loops.
 std::unique_ptr<Pass> createAMDAIEFuseFillIntoForallPass();
 
+/// Create a pass to fuse vectorize ops.
+std::unique_ptr<Pass> createAMDAIEVectorizationPass();
+
 /// Create a pass to fuse the pack operations into the for loops.
 std::unique_ptr<Pass> createAMDAIEFusePackIntoForLoopPass();
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -58,6 +58,12 @@ def AMDAIEFuseFillIntoForall :
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIEFuseFillIntoForallPass()";
 }
 
+def AMDAIEVectorization :
+    Pass<"iree-amdaie-vectorization", "func::FuncOp"> {
+  let summary = "Vectorization pass. Currently this matches on matmul bfloat only.";
+  let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIEVectorizationPass()";
+}
+
 def AMDAIEFusePackIntoForLoop :
     Pass<"iree-amdaie-fuse-pack-into-for", "func::FuncOp"> {
   let summary = "Fuse the pack operations into the for loops.";

--- a/tests/samples/CMakeLists.txt
+++ b/tests/samples/CMakeLists.txt
@@ -12,6 +12,7 @@ iree_lit_test_suite(
     "pack_pipeline_funcIR_2core.mlir"
     "pack_pipeline_funcIR_4core.mlir"
     "pad_pipeline_e2e.mlir"
+    "pad_pipeline_vectorized.mlir"
     "simple_pack_pipeline_e2e.mlir"
     "pad_pipeline_conv2d.mlir"
   TOOLS

--- a/tests/samples/matmul_fill_spec_pad.mlir
+++ b/tests/samples/matmul_fill_spec_pad.mlir
@@ -122,6 +122,12 @@ module attributes { transform.with_named_sequence } {
     %padded_reduction_rhs_buffer, %padded_reduction_rhs_new = transform.structured.bufferize_to_allocation %padded_reduction_rhs
         {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
 
+    
+//     %current_matmul = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+//     // Vectorize the matmul:
+//     transform.structured.vectorize %current_matmul :  !transform.any_op
+
+
     // Clean up.
     transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()
 

--- a/tests/samples/pad_pipeline_vectorized.mlir
+++ b/tests/samples/pad_pipeline_vectorized.mlir
@@ -1,0 +1,19 @@
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pad | FileCheck %s 
+
+
+// CHECK-LABEL:   aie.device
+// CHECK-COUNT-8: vector.multi_reduction <add>{{.*}}[2] : vector<4x4x4xf32> to vector<4x4xf32>
+
+
+!lhs = tensor<8x16xf32>
+!rhs = tensor<16x8xf32>
+!out = tensor<8x8xf32>
+
+func.func @matmul_static(%lhs : !lhs, %rhs : !rhs) -> !out {
+  %empty = tensor.empty() : !out
+  %cst = arith.constant 0.0 : f32
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : !out) -> !out
+  %out = linalg.matmul ins(%lhs, %rhs : !lhs, !rhs) outs(%fill : !out) -> !out
+  return %out : !out
+}
+

--- a/tests/samples/pad_pipeline_vectorized.mlir
+++ b/tests/samples/pad_pipeline_vectorized.mlir
@@ -2,7 +2,9 @@
 
 
 // CHECK-LABEL:   aie.device
+// Matmul appears 8 times ... 4 tiles with ping-pong? 
 // CHECK-COUNT-8: vector.multi_reduction <add>{{.*}}[2] : vector<4x4x4xf32> to vector<4x4xf32>
+// CHECK-NOT vector.multi_reduction
 
 
 !lhs = tensor<8x16xf32>


### PR DESCRIPTION
Currently, this pass only converts linalg.matmul to the vector dialect, where the reduction size of the matmul is 4 (8) for 32-bit (16-bit) types. It only adds this pass to the "pad" based pipeline.

Should we rather use  `--iree-codegen-generic-vectorization` or were imagining an AIE specific pass along these lines @MaheshRavishankar ? 

I need to figure out why the linalg.matmul is converted to vector.multi_reduction and not vector.contract. I assume we must emit vector.contract @jsetoain ?

If I test with bfloat16, I hit that error which I think others have seen, not sure what the status is (@nirvedhmeshram ?) :  

```
1185: <stdin>:20:16: error: 'aiex.ipu.dma_memcpy_nd' op must be used with memref type with element width 32.
1185:           %7 = linalg.matmul ins(%3, %4 : tensor<8x16xbf16>, tensor<16x8xbf16>) outs(%6 : tensor<8x8xbf16>) -> tensor<8x8xbf16>
```  