### PR TITLE
[WIP] Use iree's generic vectorization pass

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp
@@ -27,7 +27,7 @@ static LogicalResult applyBufferizeToAllocation(RewriterBase &rewriter,
   options.memcpyOp =
       linalg::BufferizeToAllocationOptions::MemcpyOp::MaterializeInDestination;
   options.allocOp = linalg::BufferizeToAllocationOptions::AllocOp::MemrefAlloc;
-  options.bufferizeDestinationOnly = true;
+  options.bufferizeDestinationOnly = false;
   options.emitDealloc = true;
 
   // Bufferize ops.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -76,6 +76,13 @@ static void addAMDAIEBufferizePasses(OpPassManager &pm) {
   addIREEComprehensiveBufferizePasses(pm, allocationFn, memCpyFn);
 }
 
+static void addAMDAIEVectorizePasses(OpPassManager &pm) {
+  mlir::iree_compiler::GenericVectorizationPassOptions opts{};
+  opts.generateContract = true;
+  pm.addNestedPass<func::FuncOp>(
+      mlir::iree_compiler::createGenericVectorizationPass(opts));
+}
+
 void addPadBasedPassPipeline(OpPassManager &pm, TilingConfig &tilingConfig) {
   auto &modulePassManager = pm.nest<ModuleOp>();
   modulePassManager.addNestedPass<func::FuncOp>(createAMDAIECleanupPass());
@@ -117,6 +124,7 @@ void addPadBasedPassPipeline(OpPassManager &pm, TilingConfig &tilingConfig) {
     pm.addPass(createCanonicalizerPass());
     pm.addPass(createCSEPass());
   }
+  addAMDAIEVectorizePasses(modulePassManager);
   addAMDAIEBufferizePasses(modulePassManager);
   modulePassManager.addNestedPass<func::FuncOp>(createAMDAIECleanupPass());
   pm.addPass(createCanonicalizerPass());

--- a/tests/samples/CMakeLists.txt
+++ b/tests/samples/CMakeLists.txt
@@ -12,6 +12,7 @@ iree_lit_test_suite(
     "pack_pipeline_funcIR_2core.mlir"
     "pack_pipeline_funcIR_4core.mlir"
     "pad_pipeline_e2e.mlir"
+    "pad_pipeline_vectorized.mlir"
     "simple_pack_pipeline_e2e.mlir"
     "pad_pipeline_conv2d.mlir"
   TOOLS

--- a/tests/samples/pad_pipeline_vectorized.mlir
+++ b/tests/samples/pad_pipeline_vectorized.mlir
@@ -1,0 +1,18 @@
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pad | FileCheck %s 
+
+// Why 8? I guess there is ping-pong on 4 tiles.
+// CHECK-LABEL:   aie.device
+// CHECK-COUNT-8: vector.contract{{.*}}vector<4x4x4xf32>, vector<4x4x4xf32> into vector<4x4xf32>
+// CHECK-NOT:     vector.contract
+
+!lhs = tensor<8x16xf32>
+!rhs = tensor<16x8xf32>
+!out = tensor<8x8xf32>
+
+func.func @matmul_static(%lhs : !lhs, %rhs : !rhs) -> !out {
+  %empty = tensor.empty() : !out
+  %cst = arith.constant 0.0 : f32
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : !out) -> !out
+  %out = linalg.matmul ins(%lhs, %rhs : !lhs, !rhs) outs(%fill : !out) -> !out
+  return %out : !out
+}


### PR DESCRIPTION
Alternative to https://github.com/nod-ai/iree-amd-aie/pull/162 

Rather than manually convert on an op-by-op basis, use IREE's vectorization pass. 

vector.contract appears as expected, but lowering fails in an air pass -- An MLIR assertion failure in air-collapse-herd:

```
mlir::IRObjectWithUseList<mlir::OpOperand>::~IRObjectWithUseList() [OperandType = mlir::OpOperand]: Assertion `use_empty() && "Cannot destroy a value that still has uses!"' failed.
```