### PR TITLE
Ensure cleanup and avoid conflict between jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - name: "Checking out repository" # for test scripts
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
-          submodules: false
+          submodules: false # not required for testbench
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -99,4 +99,9 @@ jobs:
 
       - name: Pad matmul test
         run: |
-          bash build_tools/ci/pad_test.sh test1 iree-install
+          bash build_tools/ci/pad_test.sh test1 iree-install mlir_aie-0.0.1.2024021415+7ee44b7
+
+      - name: Clean up
+        if: ${{ always() }}
+        run: |
+          for kern in /lib/firmware/amdipu/1502/github.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}.*; do sudo /opt/xilinx/xrt/amdxdna/rm_xclbin.sh "$kern"; done

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -177,9 +177,7 @@ LogicalResult AIETargetBackend::serializeExecutable(
                                  "--xclbin-kernel-name",
                                  entryPointNames[0],
                                  "--tmpdir",
-                                 workDir,
-                                 "--install-dir",
-                                 options.mlirAieInstallDir};
+                                 workDir};
   if (options.useChess) {
     cmdArgs.push_back("--use-chess");
   }


### PR DESCRIPTION
This gives the deployed xclbins a unique name based on the current workflow run. This avoids a potential collision where parallel jobs could overwrite the deployed kernel of another job, thereby un-deploying it. Then, a cleanup step that runs even if the job is cancelled erases any kernels that were deployed using the unique name scheme.