### PR TITLE
Add initial E2E correctness tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Create venv and install dependencies
         run: |
           python3 -m venv .venv
-          source myenv/bin/activate
+          source .venv/bin/activate
           pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024021415+7ee44b7-py3-none-manylinux_2_35_x86_64.whl
           pip install -r tests/matmul/requirements.txt
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,13 +97,22 @@ jobs:
           mkdir iree-install
           tar -xf iree-dist.tar -C iree-install
 
+      - name: Create venv and install dependencies
+        run: |
+          python3 -m venv .venv
+          source myenv/bin/activate
+          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024021415+7ee44b7-py3-none-manylinux_2_35_x86_64.whl
+          pip install -r tests/matmul/requirements.txt
+
       - name: Pad matmul test
         run: |
-          bash build_tools/ci/pad_test.sh test1 iree-install mlir_aie-0.0.1.2024021415+7ee44b7
+          source .venv/bin/activate
+          bash build_tools/ci/pad_test.sh test1 iree-install
 
       - name: E2E correctness matmul test
         run: |
-          bash build_tools/ci/run_matmul_test.sh test2 iree-install mlir_aie-0.0.1.2024021415+7ee44b7
+          source .venv/bin/activate
+          bash build_tools/ci/run_matmul_test.sh test2 iree-install
 
       - name: Clean up
         if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           # installs.
           rm -f iree-install/bin/clang*
           rm -f iree-install/bin/llvm-link*
-          tar cf iree-dist.tar -C iree-install .
+          tar cf iree-dist.tar -C iree-install . -C ../iree-build tools/iree-e2e-matmul-test
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -103,7 +103,7 @@ jobs:
 
       - name: E2E correctness matmul test
         run: |
-          bash build_tools/ci/run_matmul_test.sh test2 iree-install iree-build mlir_aie-0.0.1.2024021415+7ee44b7
+          bash build_tools/ci/run_matmul_test.sh test2 iree-install mlir_aie-0.0.1.2024021415+7ee44b7
 
       - name: Clean up
         if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: E2E correctness matmul test
         run: |
-          bash build_tools/ci/run_matmul_test.sh test2 iree-install mlir_aie-0.0.1.2024021415+7ee44b7
+          bash build_tools/ci/run_matmul_test.sh test2 iree-install iree-build mlir_aie-0.0.1.2024021415+7ee44b7
 
       - name: Clean up
         if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,10 @@ jobs:
         run: |
           bash build_tools/ci/pad_test.sh test1 iree-install mlir_aie-0.0.1.2024021415+7ee44b7
 
+      - name: E2E correctness matmul test
+        run: |
+          bash build_tools/ci/run_matmul_test.sh test2 iree-install mlir_aie-0.0.1.2024021415+7ee44b7
+
       - name: Clean up
         if: ${{ always() }}
         run: |

--- a/build_tools/ci/pad_test.sh
+++ b/build_tools/ci/pad_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -xe
-
+MLIR_AIE_INSTALL=.venv/lib/python3.10/site-packages/mlir_aie
 TESTDIR="$1"
 
 BASE_DIR=`realpath "$(dirname $0)/../.."`

--- a/build_tools/ci/pad_test.sh
+++ b/build_tools/ci/pad_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -xe
-MLIR_AIE_INSTALL=.venv/lib/python3.10/site-packages/mlir_aie
+MLIR_AIE_INSTALL= `realpath .venv/lib/python3.10/site-packages/mlir_aie`
 TESTDIR="$1"
 
 BASE_DIR=`realpath "$(dirname $0)/../.."`

--- a/build_tools/ci/pad_test.sh
+++ b/build_tools/ci/pad_test.sh
@@ -17,8 +17,6 @@ MLIRFILE="${BASE_DIR}/tests/samples/pad_pipeline_e2e.mlir"
 mkdir -p "$TESTDIR"
 cd "$TESTDIR"
 
-MLIR_AIE_INSTALL=.venv/lib/python3.10/site-packages/mlir_aie
-
 OUTPUT=output.vmfb
 XRT_DIR=/opt/xilinx/xrt
 PEANO=/opt/llvm-aie

--- a/build_tools/ci/pad_test.sh
+++ b/build_tools/ci/pad_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -xe
-MLIR_AIE_INSTALL= `realpath .venv/lib/python3.10/site-packages/mlir_aie`
+MLIR_AIE_INSTALL=`realpath .venv/lib/python3.10/site-packages/mlir_aie`
 TESTDIR="$1"
 
 BASE_DIR=`realpath "$(dirname $0)/../.."`

--- a/build_tools/ci/pad_test.sh
+++ b/build_tools/ci/pad_test.sh
@@ -6,7 +6,6 @@ TESTDIR="$1"
 
 BASE_DIR=`realpath "$(dirname $0)/../.."`
 IREE_DIR="$2"
-MLIR_AIE_VERSION="$3"
 if [ -e "${IREE_DIR}/tools/iree-compile" ]; then
     IREE_BIN=`realpath "${IREE_DIR}/tools"`
 else
@@ -18,9 +17,6 @@ MLIRFILE="${BASE_DIR}/tests/samples/pad_pipeline_e2e.mlir"
 mkdir -p "$TESTDIR"
 cd "$TESTDIR"
 
-python3 -m venv .venv
-source .venv/bin/activate
-pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/${MLIR_AIE_VERSION}-py3-none-manylinux_2_35_x86_64.whl
 MLIR_AIE_INSTALL=.venv/lib/python3.10/site-packages/mlir_aie
 
 OUTPUT=output.vmfb

--- a/build_tools/ci/pad_test.sh
+++ b/build_tools/ci/pad_test.sh
@@ -18,10 +18,10 @@ MLIRFILE="${BASE_DIR}/tests/samples/pad_pipeline_e2e.mlir"
 mkdir -p "$TESTDIR"
 cd "$TESTDIR"
 
-python3 -m venv sandbox
-source sandbox/bin/activate
+python3 -m venv .venv
+source .venv/bin/activate
 pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/${MLIR_AIE_VERSION}-py3-none-manylinux_2_35_x86_64.whl
-MLIR_AIE_INSTALL=sandbox/lib/python3.10/site-packages/mlir_aie
+MLIR_AIE_INSTALL=.venv/lib/python3.10/site-packages/mlir_aie
 
 OUTPUT=output.vmfb
 XRT_DIR=/opt/xilinx/xrt
@@ -39,7 +39,6 @@ source $XRT_DIR/setup.sh
     --iree-amd-aie-mlir-aie-install-dir "${MLIR_AIE_INSTALL}" \
     --iree-amd-aie-vitis-install-dir "${VITIS}" \
     --iree-hal-dump-executable-files-to=$PWD \
-    --iree-hal-dump-executable-intermediates-to=$PWD \
     --iree-amd-aie-show-invoked-commands \
     --iree-amdaie-use-pipeline=pad -o "${OUTPUT}"
 

--- a/build_tools/ci/pad_test.sh
+++ b/build_tools/ci/pad_test.sh
@@ -7,7 +7,7 @@ TESTDIR="$1"
 BASE_DIR=`realpath "$(dirname $0)/../.."`
 IREE_DIR="$2"
 MLIR_AIE_VERSION="$3"
-if [ -d "${IREE_DIR}/tools" ]; then
+if [ -e "${IREE_DIR}/tools/iree-compile" ]; then
     IREE_BIN=`realpath "${IREE_DIR}/tools"`
 else
     IREE_BIN=`realpath "${IREE_DIR}/bin"`

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -21,6 +21,7 @@
 
 set -euox pipefail
 
+MLIR_AIE_INSTALL=.venv/lib/python3.10/site-packages/mlir_aie
 THIS_DIR="$(cd $(dirname $0) && pwd)"
 ROOT_DIR="$(cd $THIS_DIR/../.. && pwd)"
 
@@ -56,8 +57,6 @@ echo "Python version: $("${IREE_PYTHON3_EXECUTABLE}" --version)"
 echo "iree-compile version: $("${IREE_COMPILE_EXE}" --version)"
 mkdir -p ${OUTPUT_DIR}
 cd ${OUTPUT_DIR}
-
-MLIR_AIE_INSTALL=.venv/lib/python3.10/site-packages/mlir_aie
 
 ###############################################################################
 # Define helper function                                                      #

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -17,7 +17,7 @@
 #      `iree-e2e-matmul-test` to include support for the runtime HAL
 #      driver/device you wish to test.
 #   2. Update the paths in this script or specify them via environment variables
-#   3. Run: `./run_matmul_tests.sh <output_dir_path> <iree_install_path> <mlir_wheel_version>`
+#   3. Run: `./run_matmul_tests.sh <output_dir_path> <iree_install_path>`
 
 set -euox pipefail
 
@@ -33,7 +33,6 @@ if [ -d "${IREE_INSTALL_DIR}/bin" ]; then
     IREE_INSTALL_BIN=`realpath "${IREE_INSTALL_DIR}/bin"`
 fi
 
-MLIR_AIE_VERSION="$3"
 GENERATOR="${ROOT_DIR}/tests/matmul/generate_e2e_matmul_tests.py"
 IREE_PYTHON3_EXECUTABLE="${IREE_PYTHON3_EXECUTABLE:-python3}"
 
@@ -58,10 +57,6 @@ echo "iree-compile version: $("${IREE_COMPILE_EXE}" --version)"
 mkdir -p ${OUTPUT_DIR}
 cd ${OUTPUT_DIR}
 
-python3 -m venv .venv
-source .venv/bin/activate
-pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/${MLIR_AIE_VERSION}-py3-none-manylinux_2_35_x86_64.whl
-pip install -r ${ROOT_DIR}/tests/matmul/requirements.txt
 MLIR_AIE_INSTALL=.venv/lib/python3.10/site-packages/mlir_aie
 
 ###############################################################################

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -58,11 +58,11 @@ echo "iree-compile version: $("${IREE_COMPILE_EXE}" --version)"
 mkdir -p ${OUTPUT_DIR}
 cd ${OUTPUT_DIR}
 
-python3 -m venv sandbox
-source sandbox/bin/activate
+python3 -m venv .venv
+source .venv/bin/activate
 pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/${MLIR_AIE_VERSION}-py3-none-manylinux_2_35_x86_64.whl
 pip install -r ${ROOT_DIR}/tests/matmul/requirements.txt
-MLIR_AIE_INSTALL=sandbox/lib/python3.10/site-packages/mlir_aie
+MLIR_AIE_INSTALL=.venv/lib/python3.10/site-packages/mlir_aie
 
 ###############################################################################
 # Define helper function                                                      #
@@ -145,7 +145,6 @@ function run_matmul_test() {
       --iree-amd-aie-mlir-aie-install-dir=${mlir_aie_install_path} \
       --iree-amd-aie-vitis-install-dir=${vitis_path} \
       --iree-hal-dump-executable-files-to=$PWD \
-      --iree-hal-dump-executable-intermediates-to=$PWD \
       -o "${OUTPUT_DIR}/${name}_matmuls.vmfb"
   ${IREE_COMPILE_EXE} \
       "${OUTPUT_DIR}/${name}_calls.mlir" \

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -55,6 +55,7 @@ echo "Python version: $("${IREE_PYTHON3_EXECUTABLE}" --version)"
 echo "iree-compile version: $("${IREE_COMPILE_EXE}" --version)"
 mkdir -p ${OUTPUT_DIR}
 cd ${OUTPUT_DIR}
+OUTPUT_DIR=$(pwd)
 
 python3 -m venv sandbox
 source sandbox/bin/activate

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -21,7 +21,7 @@
 
 set -euox pipefail
 
-MLIR_AIE_INSTALL=.venv/lib/python3.10/site-packages/mlir_aie
+MLIR_AIE_INSTALL=`realpath .venv/lib/python3.10/site-packages/mlir_aie`
 THIS_DIR="$(cd $(dirname $0) && pwd)"
 ROOT_DIR="$(cd $THIS_DIR/../.. && pwd)"
 

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -17,26 +17,34 @@
 #      `iree-e2e-matmul-test` to include support for the runtime HAL
 #      driver/device you wish to test.
 #   2. Update the paths in this script or specify them via environment variables
-#   3. Run: `./run_matmul_tests.sh <output_dir_path> <iree_install_path> <mlir_wheel_version>`
+#   3. Run: `./run_matmul_tests.sh <output_dir_path> <iree_install_path> <iree_build_path> <mlir_wheel_version>`
 
 set -euox pipefail
 
 THIS_DIR="$(cd $(dirname $0) && pwd)"
 ROOT_DIR="$(cd $THIS_DIR/../.. && pwd)"
 
-OUTPUT_DIR="$1"
-IREE_DIR="$2"
-MLIR_AIE_VERSION="$3"
-if [ -d "${IREE_DIR}/tools" ]; then
-    IREE_INSTALL_BIN=`realpath "${IREE_DIR}/tools"`
+OUTPUT_DIR=`realpath "$1"`
+IREE_INSTALL_DIR="$2"
+if [ -d "${IREE_INSTALL_DIR}/tools" ]; then
+    IREE_INSTALL_BIN=`realpath "${IREE_INSTALL_DIR}/tools"`
 else
-    IREE_INSTALL_BIN=`realpath "${IREE_DIR}/bin"`
+    IREE_INSTALL_BIN=`realpath "${IREE_INSTALL_DIR}/bin"`
 fi
+
+IREE_BUILD_DIR="$3"
+if [ -d "${IREE_BUILD_DIR}/tools" ]; then
+    IREE_BUILD_BIN=`realpath "${IREE_BUILD_DIR}/tools"`
+else
+    IREE_BUILD_BIN=`realpath "${IREE_BUILD_DIR}/bin"`
+fi
+
+MLIR_AIE_VERSION="$4"
 GENERATOR="${ROOT_DIR}/tests/matmul/generate_e2e_matmul_tests.py"
 IREE_PYTHON3_EXECUTABLE="${IREE_PYTHON3_EXECUTABLE:-python3}"
 
 IREE_COMPILE_EXE="${IREE_INSTALL_BIN}/iree-compile"
-TEST_RUNNER="${IREE_INSTALL_BIN}/iree-e2e-matmul-test"
+TEST_RUNNER="${IREE_BUILD_BIN}/iree-e2e-matmul-test"
 
 XRT_DIR=/opt/xilinx/xrt
 PEANO=/opt/llvm-aie
@@ -55,7 +63,6 @@ echo "Python version: $("${IREE_PYTHON3_EXECUTABLE}" --version)"
 echo "iree-compile version: $("${IREE_COMPILE_EXE}" --version)"
 mkdir -p ${OUTPUT_DIR}
 cd ${OUTPUT_DIR}
-OUTPUT_DIR=$(pwd)
 
 python3 -m venv sandbox
 source sandbox/bin/activate

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -59,6 +59,7 @@ cd ${OUTPUT_DIR}
 python3 -m venv sandbox
 source sandbox/bin/activate
 pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/${MLIR_AIE_VERSION}-py3-none-manylinux_2_35_x86_64.whl
+pip install -r ${ROOT_DIR}/tests/matmul/requirements.txt
 MLIR_AIE_INSTALL=sandbox/lib/python3.10/site-packages/mlir_aie
 
 ###############################################################################

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -17,7 +17,7 @@
 #      `iree-e2e-matmul-test` to include support for the runtime HAL
 #      driver/device you wish to test.
 #   2. Update the paths in this script or specify them via environment variables
-#   3. Run: `./run_matmul_tests.sh <output_dir_path> <iree_install_path> <iree_build_path> <mlir_wheel_version>`
+#   3. Run: `./run_matmul_tests.sh <output_dir_path> <iree_install_path> <mlir_wheel_version>`
 
 set -euox pipefail
 
@@ -27,24 +27,18 @@ ROOT_DIR="$(cd $THIS_DIR/../.. && pwd)"
 OUTPUT_DIR=`realpath "$1"`
 IREE_INSTALL_DIR="$2"
 if [ -d "${IREE_INSTALL_DIR}/tools" ]; then
-    IREE_INSTALL_BIN=`realpath "${IREE_INSTALL_DIR}/tools"`
-else
+    IREE_INSTALL_TOOLS=`realpath "${IREE_INSTALL_DIR}/tools"`
+fi
+if [ -d "${IREE_INSTALL_DIR}/bin" ]; then
     IREE_INSTALL_BIN=`realpath "${IREE_INSTALL_DIR}/bin"`
 fi
 
-IREE_BUILD_DIR="$3"
-if [ -d "${IREE_BUILD_DIR}/tools" ]; then
-    IREE_BUILD_BIN=`realpath "${IREE_BUILD_DIR}/tools"`
-else
-    IREE_BUILD_BIN=`realpath "${IREE_BUILD_DIR}/bin"`
-fi
-
-MLIR_AIE_VERSION="$4"
+MLIR_AIE_VERSION="$3"
 GENERATOR="${ROOT_DIR}/tests/matmul/generate_e2e_matmul_tests.py"
 IREE_PYTHON3_EXECUTABLE="${IREE_PYTHON3_EXECUTABLE:-python3}"
 
 IREE_COMPILE_EXE="${IREE_INSTALL_BIN}/iree-compile"
-TEST_RUNNER="${IREE_BUILD_BIN}/iree-e2e-matmul-test"
+TEST_RUNNER="${IREE_INSTALL_TOOLS}/iree-e2e-matmul-test"
 
 XRT_DIR=/opt/xilinx/xrt
 PEANO=/opt/llvm-aie

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -56,6 +56,11 @@ echo "iree-compile version: $("${IREE_COMPILE_EXE}" --version)"
 mkdir -p ${OUTPUT_DIR}
 cd ${OUTPUT_DIR}
 
+python3 -m venv sandbox
+source sandbox/bin/activate
+pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/${MLIR_AIE_VERSION}-py3-none-manylinux_2_35_x86_64.whl
+MLIR_AIE_INSTALL=sandbox/lib/python3.10/site-packages/mlir_aie
+
 ###############################################################################
 # Define helper function                                                      #
 ###############################################################################

--- a/tests/matmul/generate_e2e_matmul_tests.py
+++ b/tests/matmul/generate_e2e_matmul_tests.py
@@ -111,10 +111,10 @@ def get_test_shapes(shapes_id: ShapesId):
         ]
     if shapes_id == ShapesId.LARGE:
         return [
-            TestShape(m=256, k=128, n=256, accumulate=True),
-            TestShape(m=256, k=128, n=256, accumulate=False),
-            TestShape(m=512, k=256, n=512, accumulate=True),
-            TestShape(m=512, k=256, n=512, accumulate=False),
+            TestShape(m=64, k=16, n=64, accumulate=False),
+            #TestShape(m=256, k=128, n=256, accumulate=False),
+            #TestShape(m=512, k=256, n=512, accumulate=True),
+            #TestShape(m=512, k=256, n=512, accumulate=False),
         ]
 
     raise ValueError(shapes_id)

--- a/tests/matmul/requirements.txt
+++ b/tests/matmul/requirements.txt
@@ -1,0 +1,3 @@
+PyYAML>=5.4.1
+requests>=2.28.0
+enum_tools==0.6.4


### PR DESCRIPTION
These tests are compared against a reference matmul implementation with pseudo random initialization. The test sizes are currently limited. In upstream IREE similar tests are build using cmake and run using ctest, however that is currently not possible for a plugin so the script added here is an alternate way of doing it. 