### PR TITLE
added subdirs for executables, fixed use after free

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -156,13 +156,15 @@ function run_matmul_test() {
 
   # Iterate over each function name and sign the corresponding XCLBIN
   for func_name in $function_names; do
+    # Location of XCLBIN files
+    XCLBIN_DIR="module_${func_name}_dispatch_0_amdaie_xclbin_fb"
     # Define the XCLBIN variable
     XCLBIN="module_${func_name}_dispatch_0_amdaie_xclbin_fb.xclbin"
     # Ensure unique file name
     XCLBIN_UNIQ="github.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}.${XCLBIN}"
-    cp "${XCLBIN}" "${XCLBIN_UNIQ}"
+    cp "${XCLBIN_DIR}/${XCLBIN}" "${XCLBIN_DIR}/${XCLBIN_UNIQ}"
     # Deploy firmware
-    sudo $XRT_DIR/amdxdna/setup_xclbin_firmware.sh -dev Phoenix -xclbin "${XCLBIN_UNIQ}"
+    sudo $XRT_DIR/amdxdna/setup_xclbin_firmware.sh -dev Phoenix -xclbin "${XCLBIN_DIR}/${XCLBIN_UNIQ}"
   done
 
   echo "**** Running '${name}' matmul tests ****"


### PR DESCRIPTION
Fix for https://github.com/nod-ai/iree-amd-aie/issues/177

1. Added subdirs for each parallel executable, so that their commonly named files don't step on each other
2. Fixed a use-after-free bug that caused the aie2xclbin command line to have garbage in it