### PR TITLE
Flags to print IR in mlir-aie passes (i.e. in aie2xclbin)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,18 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024021415+7ee44b7-py3-none-manylinux_2_35_x86_64.whl
+          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024030421+0899ece-py3-none-manylinux_2_35_x86_64.whl
           pip install -r tests/matmul/requirements.txt
 
       - name: E2E correctness matmul test
         run: |
           source .venv/bin/activate
           bash build_tools/ci/run_matmul_test.sh test1 iree-install
+
+      - name: Printing IR from aie2xclbin
+        run: |
+          source .venv/bin/activate
+          bash build_tools/ci/print_ir_aie2xclbin/print_ir_aie2xclbin.sh iree-install/bin print_ir_aie2xclbin_results
 
       - name: Clean up
         if: ${{ always() }}

--- a/build_tools/ci/print_ir_aie2xclbin/linalg_matmul_f32.mlir
+++ b/build_tools/ci/print_ir_aie2xclbin/linalg_matmul_f32.mlir
@@ -1,0 +1,10 @@
+!t = tensor<64x64xf32>
+
+func.func @matmul(%lhs : !t, %rhs : !t) -> !t {
+  %init_acc = tensor.empty() : !t
+  %c0_acc_t = arith.constant 0.0 : f32
+  %acc = linalg.fill ins(%c0_acc_t : f32) outs(%init_acc : !t) -> !t
+  %result = linalg.matmul ins(%lhs, %rhs: !t, !t) outs(%acc: !t) -> !t
+  return %result: !t
+}
+

--- a/build_tools/ci/print_ir_aie2xclbin/linalg_matmul_f32.mlir
+++ b/build_tools/ci/print_ir_aie2xclbin/linalg_matmul_f32.mlir
@@ -1,5 +1,5 @@
+// Input to printing test:
 !t = tensor<64x64xf32>
-
 func.func @matmul(%lhs : !t, %rhs : !t) -> !t {
   %init_acc = tensor.empty() : !t
   %c0_acc_t = arith.constant 0.0 : f32

--- a/build_tools/ci/print_ir_aie2xclbin/print_ir_aie2xclbin.sh
+++ b/build_tools/ci/print_ir_aie2xclbin/print_ir_aie2xclbin.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+#
+#Copyright 2024 The LLVM Project
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set -euox pipefail
+
+# Check for the number of provided arguments
+if [ "$#" -ne 2 ] && [ "$#" -ne 6 ]; then
+    echo -e "Illegal number of parameters: $#." \
+            "\n For 2 parameters:" \
+            "\n     1) <iree-compile-dir>" \
+            "\n     2) <output-dir>" \
+            "\n For 6 parameters:" \
+            "\n     1) <iree-compile-dir>" \
+            "\n     2) <output-dir>" \
+            "\n     3) <peano-install-dir>" \
+            "\n     4) <xrt-dir>" \
+            "\n     5) <vitis-install-dir>" \
+            "\n     6) <mlir-aie-install-dir>"\
+            "\n Example (dependent on environment variables):" \
+            "\n     ./print_ir_aie2xclbin.sh " \
+            "\$IREE_BUILD_DIR/tools " \
+            "results_dir_tmp "\
+            "\$PEANO_INSTALL_DIR "\
+            "/opt/xilinx/xrt "\
+            "\$VITIS_INSTALL_PATH "\
+            "\$MLIR_AIE_INSTALL_DIR"
+    exit 1
+fi
+
+
+OUTPUT=`realpath "${2}"`
+mkdir -p ${OUTPUT}
+
+if [ "$#" -eq 2 ]; then
+  PEANO=/opt/llvm-aie
+  XRT=/opt/xilinx/xrt
+  VITIS=/opt/Xilinx/Vitis/2023.2
+  MLIR_AIE=`realpath .venv/lib/python3.10/site-packages/mlir_aie`
+fi
+
+if [ "$#" -eq 6 ]; then
+  PEANO="$3"
+  XRT="$4"
+  VITIS="$5"
+  MLIR_AIE="$6"
+fi
+
+IREE_COMPILE="$1"
+if [ -d "${IREE_COMPILE}" ]; then
+   IREE_COMPILE=`realpath "${IREE_COMPILE}"`
+else
+  echo "IREE_COMPILE does not exist: ${IREE_COMPILE}."
+  exit 1
+fi
+
+IREE_COMPILE_EXE="${IREE_COMPILE}/iree-compile"
+if [ ! -x "${IREE_COMPILE_EXE}" ]; then
+  echo "IREE_COMPILE_EXE does not exist or isn't executable: ${IREE_COMPILE_EXE}."
+  exit 1
+fi
+
+if [ ! -d "${OUTPUT}" ]; then
+  echo "OUTPUT does not exist: ${OUTPUT}"
+  exit 1
+fi
+
+if [ -d "${PEANO}" ]; then
+  PEANO=`realpath "${PEANO}"`
+else
+  echo "PEANO does not exist: ${PEANO}"
+  exit 1
+fi
+
+if [ -d "${XRT}" ]; then
+  XRT=`realpath "${XRT}"`
+else
+  echo "XRT does not exist: ${XRT}"
+  exit 1
+fi
+
+if [ -d "${VITIS}" ]; then
+  VITIS=${VITIS} # `realpath "${VITIS}"`
+else
+  echo "VITIS does not exist: ${VITIS}"
+  exit 1
+fi
+
+if [ -d "${MLIR_AIE}" ]; then
+  MLIR_AIE=`realpath "${MLIR_AIE}"`
+else
+  echo "MLIR_AIE does not exist: ${MLIR_AIE}"
+  exit 1
+fi
+
+# There might be a FileCheck program in the IREE_COMPILE. Check. 
+# Do not fail if it not there, we can also check if it already on PATH (backup). 
+if [ -x "${IREE_COMPILE}/FileCheck" ]; then
+  FILECHECK_EXE="${IREE_COMPILE}/FileCheck"
+elif [ -x "$(command -v FileCheck)" ]; then
+  FILECHECK_EXE="$(command -v FileCheck)"
+else
+  echo "FileCheck does not exist or isn't executable in IREE_COMPILE or on PATH."
+  exit 1
+fi
+
+
+
+
+source $XRT/setup.sh
+
+
+THIS="$(cd $(dirname $0) && pwd)"
+SOURCE_MLIR_FILE="${THIS}/linalg_matmul_f32.mlir"
+
+# Construct the iree-compile command. Use all the aie2xclbin printing options, 
+# and then test that the output is printed to stdout and stderr as expected.
+IREE_COMPILE_COMMAND="${IREE_COMPILE_EXE} \
+${SOURCE_MLIR_FILE} \
+--iree-hal-target-backends=amd-aie \
+--iree-amd-aie-peano-install-dir=${PEANO} \
+--iree-amd-aie-mlir-aie-install-dir=${MLIR_AIE} \
+--iree-amd-aie-vitis-install-dir=${VITIS} \
+--iree-hal-dump-executable-files-to=${OUTPUT} \
+--aie2xclbin-print-ir-after-all \
+--aie2xclbin-print-ir-before-all \
+--aie2xclbin-print-ir-module-scope \
+--aie2xclbin-disable-threading \
+--mlir-print-ir-after-all \
+--mlir-print-ir-module-scope \
+--mlir-disable-threading \
+--iree-amdaie-use-pipeline=simple-pack \
+-o ${OUTPUT}/test_artefact.vmfb \
+--iree-amd-aie-show-invoked-commands"
+
+# set the files for stdout and stdin as variables:
+STDOUT_FULLPATH="${OUTPUT}/stdout.txt"
+STDERR_FULLPATH="${OUTPUT}/stderr.txt"
+
+# Execute the command, piping all stdout to a file named stdout.txt and all
+# stderr to a file named stderr.txt:
+echo "Executing command: $IREE_COMPILE_COMMAND"
+eval $IREE_COMPILE_COMMAND 1> ${STDOUT_FULLPATH} 2> ${STDERR_FULLPATH}
+
+if [ ! -f "${STDOUT_FULLPATH}" ]; then
+  echo "stdout file was not created: ${STDOUT_FULLPATH}"
+  exit 1
+fi
+
+if [ ! -f "${STDERR_FULLPATH}" ]; then
+  echo "stderr file was not created: ${STDERR_FULLPATH}"
+  exit 1
+fi
+
+if [ ! -f "${OUTPUT}/test_artefact.vmfb" ]; then
+  echo "test_artefact.vmfb was not created: ${OUTPUT}/test_artefact.vmfb"
+  exit 1
+fi
+
+
+# Checks for some stdout from before aie2xclbin:
+# CHECK-STDERR: linalg.matmul
+#
+# Checks for some stderr from during aie2xclbin:
+# CHECK-STDERR-DAG: aie.wire
+# CHECK-STDERR-DAG: llvm.load
+${FILECHECK_EXE} --input-file ${STDERR_FULLPATH} ${0} --check-prefix=CHECK-STDERR
+
+# CHECK-STDOUT-DAG: Bootgen
+# CHECK-STDOUT-DAG: MEM_TOPOLOGY
+${FILECHECK_EXE} --input-file ${STDOUT_FULLPATH} ${0} --check-prefix=CHECK-STDOUT
+

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -247,23 +247,16 @@ LogicalResult AIETargetBackend::serializeExecutable(
     cmdEnv.push_back(newHome);
   }
   if (options.showInvokedCommands) {
-    for (auto s : cmdEnv) llvm::outs() << s << " ";
-    for (auto s : cmdArgs) llvm::outs() << s << " ";
-    llvm::outs() << "\n";
+    for (auto s : cmdEnv) llvm::dbgs() << s << " ";
+    for (auto s : cmdArgs) llvm::dbgs() << s << " ";
+    llvm::dbgs() << "\n";
   }
 
-  int result = llvm::sys::ExecuteAndWait(cmdArgs[0], cmdArgs, cmdEnv);
-
-  if (result != 0) {
-    if (options.showInvokedCommands) {
-      llvm::outs() << "Failed in ExucuteAndWait" << result << "\n";
-    }
-    return moduleOp.emitOpError(
-        "Failed to produce an XCLBin with external tool.");
-  }
-
-  if (options.showInvokedCommands) {
-    llvm::outs() << "Succeeded in ExucuteAndWait" << result << "\n";
+  {
+    int result = llvm::sys::ExecuteAndWait(cmdArgs[0], cmdArgs, cmdEnv);
+    if (result != 0)
+      return moduleOp.emitOpError(
+          "Failed to produce an XCLBin with external tool.");
   }
 
   std::vector<uint32_t> ipuInstrs;

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
@@ -7,8 +7,10 @@
 #ifndef IREE_AMD_AIE_TARGET_AIETARGET_H_
 #define IREE_AMD_AIE_TARGET_AIETARGET_H_
 
-#include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
-#include "iree/compiler/PluginAPI/Client.h"
+#include <string>
+
+#include "iree/compiler/Dialect/HAL/Target/TargetBackend.h"
+#include "iree/compiler/Utils/OptionUtils.h"
 
 namespace mlir::iree_compiler::AMDAIE {
 
@@ -23,12 +25,25 @@ struct AMDAIEOptions {
   // Path to Vitis installation directory.
   std::string vitisInstallDir;
 
-  // Dump to stdout system commands used during compilation
-  bool showInvokedCommands;
+  // Dump system commands used during compilation
+  bool showInvokedCommands{false};
 
   // Use the legacy chess compiler.
-  bool useChess;
+  bool useChess{false};
 
+  // Print IR after all MLIR passes run in aie2xclbin (to stderr).
+  bool aie2xclbinPrintIrAfterAll{false};
+
+  // Print IR before all MLIR passes run in aie2xclbin (to stderr).
+  bool aie2xclbinPrintIrBeforeAll{false};
+
+  // Disable theading in MLIR passes in aie2xclbin.
+  bool aie2xclbinDisableTheading{false};
+
+  // Print IR at module scope in MLIR passes in aie2xclbin.
+  bool aie2xclbinPrintIrModuleScope{false};
+
+ public:
   void bindOptions(OptionsBinder &binder) {
     static llvm::cl::OptionCategory category("AMD AIE Options");
 
@@ -41,6 +56,29 @@ struct AMDAIEOptions {
         "iree-amd-aie-peano-install-dir", peanoInstallDir,
         llvm::cl::cat(category),
         llvm::cl::desc("Path to Peano installation directory"));
+
+    binder.opt<bool>(
+        "aie2xclbin-print-ir-after-all", aie2xclbinPrintIrAfterAll,
+        llvm::cl::cat(category),
+        llvm::cl::desc(
+            "If true, print the IR after all MLIR passes run in aie2xclbin"));
+
+    binder.opt<bool>(
+        "aie2xclbin-print-ir-before-all", aie2xclbinPrintIrBeforeAll,
+        llvm::cl::cat(category),
+        llvm::cl::desc(
+            "If true, print the IR before all MLIR passes run in aie2xclbin"));
+
+    binder.opt<bool>(
+        "aie2xclbin-disable-threading", aie2xclbinDisableTheading,
+        llvm::cl::cat(category),
+        llvm::cl::desc("Disable theading in MLIR passes in aie2xclbin"));
+
+    binder.opt<bool>(
+        "aie2xclbin-print-ir-module-scope", aie2xclbinPrintIrModuleScope,
+        llvm::cl::cat(category),
+        llvm::cl::desc(
+            "If true, when printing the IR do so at the module scope"));
 
     binder.opt<bool>(
         "iree-amd-aie-show-invoked-commands", showInvokedCommands,


### PR DESCRIPTION
Can now use 

`iree-compile --aie2xclbin-print-ir-after-all ...`

etc. to print mlir-aie pass information (pipes to stderr or stdout, whichever mlir pipes to by default). 

I should add a test for this. 

4 flags:  
print ir before/after all
print ir module scope
disable threading. 