### PR TITLE
[AMD-AIE] Update lower-to-ukernel pass

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -117,7 +117,9 @@ def AMDAIELowerToUKernels :
                    "Use the more advanced pack-based lowering strategy, including peeling and double-buffering."),
         clEnumValN(mlir::iree_compiler::AMDAIE::AIEPassPipeline::SimplePackPipeline, "simple-pack",
                    "Use the simple-pack based lowering strategy.")
-      )}]>
+      )}]>,
+    Option<"pathToUkernels", "path-to-ukernels", "std::string", /*default=*/"",
+      "Path to microkernels' directory">
   ];
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_ukernel.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_ukernel.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-amdaie-lower-to-ukernels,cse,canonicalize))" %s | FileCheck %s
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-amdaie-lower-to-ukernels{pass-pipeline=pack},cse,canonicalize))" %s | FileCheck %s --check-prefix=PACK
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-amdaie-lower-to-ukernels{pass-pipeline=simple-pack path-to-ukernels="/custom/path/to/ukernels"},cse,canonicalize))" %s | FileCheck %s --check-prefix=PACK_AND_UK_PATH
 
 // This first case demonstrates no lowering to ukernel when the corresponding
 // config is set to "none".
@@ -57,20 +57,9 @@ func.func @generic_matmul_bf16bf16bf16(%arg0 : tensor<?x?xbf16>, %arg1 : tensor<
 //      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "matmul_scalar_bf16_bf16"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
+// CHECK-SAME:       fn_def_attrs {link_with = "mm.o"}
 // CHECK-SAME:       strided_outer_dims(0)
 //      CHECK:   return %[[MICRO_KERNEL]]
-
-
-//      PACK: func @generic_matmul_bf16bf16bf16(
-// PACK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xbf16>
-// PACK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xbf16>
-// PACK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?xbf16>)
-//  PACK-NOT:   linalg.generic
-//      PACK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "matmul_bf16_bf16"
-// PACK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
-// PACK-SAME:       outs(%[[ARG2]] :
-// PACK-SAME:       strided_outer_dims(0)
-//      PACK:   return %[[MICRO_KERNEL]]
 
 // -----
 
@@ -101,6 +90,7 @@ func.func @generic_matmul_i32i32i32(%arg0 : tensor<?x?xi32>, %arg1 : tensor<?x?x
 //      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "matmul_scalar_i32_i32"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
+// CHECK-SAME:       fn_def_attrs {link_with = "mm.o"}
 // CHECK-SAME:       strided_outer_dims(0)
 //      CHECK:   return %[[MICRO_KERNEL]]
 
@@ -136,6 +126,7 @@ func.func @generic_matmul_fill(%arg0 : tensor<?x?xbf16>, %arg1 : tensor<?x?xbf16
 //      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "matmul_scalar_bf16_bf16"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
+// CHECK-SAME:       fn_def_attrs {link_with = "mm.o"}
 // CHECK-SAME:       strided_outer_dims(0)
 //      CHECK:   return %[[MICRO_KERNEL]]
 
@@ -201,5 +192,40 @@ func.func @matmul_bf16bf16bf16(%arg0 : tensor<?x?xbf16>, %arg1 : tensor<?x?xbf16
 //      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "matmul_scalar_bf16_bf16"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
+// CHECK-SAME:       fn_def_attrs {link_with = "mm.o"}
 // CHECK-SAME:       strided_outer_dims(0)
 //      CHECK:   return %[[MICRO_KERNEL]]
+
+// -----
+
+func.func @generic_matmul_i32i32i32_simple_pack(%arg0 : tensor<?x?x?x?x?x?xi32>, %arg1 : tensor<?x?x?x?x?x?xi32>,
+    %arg2 : tensor<?x?x?x?x?x?xi32>) -> tensor<?x?x?x?x?x?xi32> attributes {
+  hal.executable.target = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd", ukernels = "all"}>
+} {
+  %0 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d2, d5, d3, d6, d8)>,
+                     affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d2, d1, d4, d5, d8, d7)>,
+                     affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d4, d3, d6, d7)>],
+    iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]
+    } ins(%arg0, %arg1 : tensor<?x?x?x?x?x?xi32>, tensor<?x?x?x?x?x?xi32>)
+      outs(%arg2 : tensor<?x?x?x?x?x?xi32>)
+    {
+      ^bb0(%in: i32, %in_12: i32, %out: i32):
+        %16 = arith.muli %in, %in_12 : i32
+        %17 = arith.addi %out, %16 : i32
+        linalg.yield %17 : i32
+  } -> tensor<?x?x?x?x?x?xi32>
+
+  return %0 : tensor<?x?x?x?x?x?xi32>
+}
+//      PACK_AND_UK_PATH: func @generic_matmul_i32i32i32_simple_pack(
+// PACK_AND_UK_PATH-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?x?x?xi32>
+// PACK_AND_UK_PATH-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?x?x?xi32>
+// PACK_AND_UK_PATH-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?x?x?xi32>)
+//  PACK_AND_UK_PATH-NOT:   linalg.generic
+//      PACK_AND_UK_PATH:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "matmul_i32_i32"
+// PACK_AND_UK_PATH-SAME:       ins(%[[ARG0]], %[[ARG1]] :
+// PACK_AND_UK_PATH-SAME:       outs(%[[ARG2]] :
+// PACK_AND_UK_PATH-SAME:       fn_def_attrs {link_with = "/custom/path/to/ukernels/mm.o"}
+// PACK_AND_UK_PATH-SAME:       strided_outer_dims(0)
+//      PACK_AND_UK_PATH:   return %[[MICRO_KERNEL]]


### PR DESCRIPTION
-- This commit adds various updates to `--iree-amdaie-lower-to-ukernel`
   pass.
-- The updates made are as follows :-
   a. Target Simple-Pack pipeline.
   b. Add fn_def to the generated iree_codegen.ukernel op.
   c. Add a pass option `path-to-ukernels` to help add the same to the fn_def as mentioned in point b.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>