### PR TITLE
Make pad-pack as the default pipeline and decouple its lowering from other pipelines

### DIFF
--- a/tests/samples/simple_pack_pipeline_e2e.mlir
+++ b/tests/samples/simple_pack_pipeline_e2e.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --split-input-file | FileCheck %s --check-prefix=CPP
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=simple-pack --split-input-file | FileCheck %s --check-prefix=CPP
 
 // This test demonstrates Pack pipeline based e2e lowering for matmul.
 


### PR DESCRIPTION
This is in preparation for changing the lowering flow without the maintenance burden of supporting it for non-default pipelines.