### PR TITLE
Update mlir-air submodule

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -512,8 +512,12 @@ void addMLIRAIRAIELoweringPasses(OpPassManager &passManager) {
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
 
-  passManager.addNestedPass<func::FuncOp>(
-      xilinx::air::createAIRCollapseHerdPass());
+  {
+    xilinx::air::AIRCollapseHerdPassOptions options;
+    options.clMaxColSize = 4;
+    passManager.addNestedPass<func::FuncOp>(
+        xilinx::air::createAIRCollapseHerdPass(options));
+  }
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
 
@@ -612,8 +616,12 @@ void addMLIRAIRAIELegacyLoweringPasses(OpPassManager &passManager) {
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
 
-  passManager.addNestedPass<func::FuncOp>(
-      xilinx::air::createAIRCollapseHerdPass());
+  {
+    xilinx::air::AIRCollapseHerdPassOptions options;
+    options.clMaxColSize = 4;
+    passManager.addNestedPass<func::FuncOp>(
+        xilinx::air::createAIRCollapseHerdPass(options));
+  }
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createCSEPass());
 


### PR DESCRIPTION
New features in MLIR-AIR:
- Updates in `air-collapse-herd` to unblock development for the new multi-memtile buffer allocator.