### PR TITLE
Fix windows build

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -252,6 +252,7 @@ function run_matmul_test() {
       --iree-amd-aie-mlir-aie-install-dir=${mlir_aie_install_path} \
       --iree-amd-aie-vitis-install-dir=${vitis_path} \
       --iree-hal-dump-executable-files-to=$PWD \
+      --iree-amd-aie-show-invoked-commands \
       -o "${OUTPUT_DIR}/${name}_matmuls.vmfb"
   ${IREE_COMPILE_EXE} \
       "${OUTPUT_DIR}/${name}_calls.mlir" \

--- a/experimental/delegate/CMakeLists.txt
+++ b/experimental/delegate/CMakeLists.txt
@@ -42,6 +42,14 @@ set_target_properties(mlp_bf16_aie_delegate
     # OUTPUT_NAME "mlp_bf16_aie_delegate"
 )
 
+target_link_libraries(
+  mlp_bf16_aie_delegate
+  PRIVATE
+  XRT::xrt_coreutil
+  Boost::boost
+)
+set_property(TARGET mlp_bf16_aie_delegate PROPERTY CXX_STANDARD 20)
+
 add_dependencies(mlp_bf16_aie_delegate
   aie_delegate_kernels
 )

--- a/iree_runtime_plugin.cmake
+++ b/iree_runtime_plugin.cmake
@@ -16,6 +16,7 @@ endif()
 
 if(IREE_AMD_AIE_ENABLE_XRT_DRIVER)
   find_package(XRT REQUIRED)
+  find_package(Boost REQUIRED)
 endif()
 
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/runtime/src AMD-AIE)

--- a/runtime/src/iree-amd-aie/driver/xrt/CMakeLists.txt
+++ b/runtime/src/iree-amd-aie/driver/xrt/CMakeLists.txt
@@ -55,6 +55,7 @@ iree_cc_library(
     iree::hal
     iree-amd-aie::schemas::xrt_executable_def_c_fbs
     XRT::xrt_coreutil
+    Boost::boost
   COPTS
   # currenly this is needed, it can be removed after this issue is resolved
   # https://github.com/Xilinx/XRT/issues/7810

--- a/runtime/src/iree-amd-aie/driver/xrt/native_executable.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/native_executable.cc
@@ -156,7 +156,13 @@ iree_status_t iree_hal_xrt_native_executable_create(
 
   iree_hal_resource_initialize(&iree_hal_xrt_native_executable_vtable,
                                &executable->resource);
-  xrt::xclbin xclbin = xrt::xclbin(xclbinVector);
+  xrt::xclbin xclbin;
+  try {
+    xclbin = xrt::xclbin(xclbinVector);
+  } catch (std::runtime_error& e) {
+    return iree_make_status(IREE_STATUS_INTERNAL, "XCLBIN load error: %s",
+                            e.what());
+  }
   device.register_xclbin(xclbin);
   xrt::hw_context context(device, xclbin.get_uuid());
   executable->host_allocator = host_allocator;


### PR DESCRIPTION
Removed the code to amend the library search path, since libcdo_driver is now bundled with mlir-aie. Vitis path is only configured when using chess. Fixed some CMake issues finding the boost headers on Windows. Propogate C++ exceptions as IREE status when loading the xclbin file.