### PR TITLE
Fix for g++ not liking plain text in an #if 0

### DIFF
--- a/experimental/delegate/mlp_aie_bf16_plugin.cpp
+++ b/experimental/delegate/mlp_aie_bf16_plugin.cpp
@@ -44,7 +44,7 @@ const std::string kernelFileName = "matmul/matmul-bf16-256x256x256-v1";
 
 std::string getLibraryPath() {
 #if 0
-    TODO: Let's revisit the Windows implementation if we ever need it to run there
+    // TODO: Let's revisit the Windows implementation if we ever need it to run there
     char path[MAX_PATH];
     HMODULE hm = NULL;
 


### PR DESCRIPTION
I had left a plain text comment with no leading comment token in an #if 0 section.  It appears that g++ parses the section regardless!  The fix is to add the comment token.