### PR TITLE
[AMD-AIE] Generalize tiling/packing based on a given element type

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAddLoweringStrategy.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAddLoweringStrategy.cpp
@@ -4,8 +4,10 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree-amd-aie/IR/AMDAIEDialect.h"
 #include "iree-amd-aie/Transforms/KernelDispatch.h"
 #include "iree-amd-aie/Transforms/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -23,6 +25,7 @@ class AMDAIELoweringStrategyPass
  public:
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<
+        AMDAIE::AMDAIEDialect, IREE::Codegen::IREECodegenDialect,
         IREE::HAL::HALDialect, IREE::LinalgExt::IREELinalgExtDialect,
         bufferization::BufferizationDialect, linalg::LinalgDialect,
         LLVM::LLVMDialect, pdl::PDLDialect, pdl_interp::PDLInterpDialect,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
@@ -100,4 +100,10 @@ FailureOr<std::array<uint32_t, 3>> getAIEMatmulInstructionSize(Type elTypeLhs,
   return getAIEIntegerMatmulInstructionSize(nBitsLhs, nBitsRhs, nBitsAcc);
 }
 
+FailureOr<unsigned> getTilingScaleFactor(Type elemType) {
+  unsigned bitWidth = elemType.getIntOrFloatBitWidth();
+  if ((bitWidth % 16 == 0) && (bitWidth <= 64)) return (64 / bitWidth);
+  return failure();
+}
+
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
@@ -48,6 +48,22 @@ FailureOr<std::array<uint32_t, 3>> getAIEMatmulInstructionSize(
 FailureOr<std::array<uint32_t, 3>> getAIEIntegerMatmulInstructionSize(
     uint32_t nBitsLhs, uint32_t nBitsRhs, uint32_t nBitsAcc);
 
+/// Utility function that, given an element type, computes tiling scaling factor
+/// as : 64/bitWidth.
+/// Therefore, for example, if the element type has :-
+///     a. 64 bit width -> scaling factor will be 1.
+///     b. 32 bit width -> scaling factor will be 2.
+///     c. 16 bit width -> scaling factor will be 4.
+/// This can easily be scaled to other element data types by just changing the
+/// check in the `if` in the function body.
+/// The rationale/need for this is - higher bit width element types can be
+/// accomodated using small tile sizes, whereas lower bit width element types
+/// can make use of larger tile sizes as they can be easily accomodated within
+/// the same. Therefore this tiling scale factor helps dynamically
+/// increase/decrease the tiling window depending on the element type's bit
+/// width.
+FailureOr<unsigned> getTilingScaleFactor(Type elemType);
+
 }  // namespace mlir::iree_compiler::AMDAIE
 
 #endif

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     "insert_loops_for_vectorization.mlir"
     "lower_to_ukernel.mlir"
     "lower_workgroup_count.mlir"
+    "lowering_strategy.mlir"
     "map_forall_to_cores.mlir"
     "pack_and_transpose_level1.mlir"
     "pack_and_transpose_level2.mlir"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy.mlir
@@ -1,0 +1,185 @@
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-amdaie-lowering-strategy{use-pass-pipeline=pad-pack})))' %s | FileCheck %s
+
+// CHECK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[32, 32], [0, 0, 256], [16, 16], [0, 0, 2]]>
+// CHECK{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[1, 0], [1, 0], [1, 0]]}]>
+hal.executable private @matmul_pad_pack_large_i64 {
+  hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd", ukernels = "none"}>) {
+    hal.executable.export public @matmul_large_dispatch_0_matmul_2048x2048x2048_i64 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]} {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice 
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_large_dispatch_0_matmul_2048x2048x2048_i64() {
+        %c0_i64 = arith.constant 0 : i64
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x2048xi64>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x2048xi64>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2048x2048xi64>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x2048xi64>> -> tensor<2048x2048xi64>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x2048xi64>> -> tensor<2048x2048xi64>
+        %5 = tensor.empty() : tensor<2048x2048xi64>
+        %6 = linalg.fill ins(%c0_i64 : i64) outs(%5 : tensor<2048x2048xi64>) -> tensor<2048x2048xi64>
+        // CHECK:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig} 
+        %7 = linalg.matmul ins(%3, %4 : tensor<2048x2048xi64>, tensor<2048x2048xi64>) outs(%6 : tensor<2048x2048xi64>) -> tensor<2048x2048xi64>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : tensor<2048x2048xi64> -> !flow.dispatch.tensor<writeonly:tensor<2048x2048xi64>>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+// CHECK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [0, 0, 256], [32, 32], [0, 0, 4]]>
+// CHECK{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[1, 0], [1, 0], [1, 0]]}]>
+hal.executable private @matmul_pad_pack_large_i32 {
+  hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd", ukernels = "none"}>) {
+    hal.executable.export public @matmul_large_dispatch_0_matmul_2048x2048x2048_i32 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]} {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice 
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_large_dispatch_0_matmul_2048x2048x2048_i32() {
+        %c0_i32 = arith.constant 0 : i32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x2048xi32>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x2048xi32>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2048x2048xi32>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x2048xi32>> -> tensor<2048x2048xi32>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x2048xi32>> -> tensor<2048x2048xi32>
+        %5 = tensor.empty() : tensor<2048x2048xi32>
+        %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<2048x2048xi32>) -> tensor<2048x2048xi32>
+        // CHECK:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig} 
+        %7 = linalg.matmul ins(%3, %4 : tensor<2048x2048xi32>, tensor<2048x2048xi32>) outs(%6 : tensor<2048x2048xi32>) -> tensor<2048x2048xi32>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : tensor<2048x2048xi32> -> !flow.dispatch.tensor<writeonly:tensor<2048x2048xi32>>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+// CHECK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128], [0, 0, 256], [64, 64], [0, 0, 8]]>
+// CHECK{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[1, 0], [1, 0], [1, 0]]}]>
+hal.executable private @matmul_pad_pack_large_bf16 {
+  hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd", ukernels = "none"}>) {
+    hal.executable.export public @matmul_large_dispatch_0_matmul_2048x2048x2048_bf16 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]} {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice 
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_large_dispatch_0_matmul_2048x2048x2048_bf16() {
+        %c0_bf16 = arith.constant 0.0 : bf16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x2048xbf16>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x2048xbf16>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2048x2048xbf16>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x2048xbf16>> -> tensor<2048x2048xbf16>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x2048xbf16>> -> tensor<2048x2048xbf16>
+        %5 = tensor.empty() : tensor<2048x2048xbf16>
+        %6 = linalg.fill ins(%c0_bf16 : bf16) outs(%5 : tensor<2048x2048xbf16>) -> tensor<2048x2048xbf16>
+        // CHECK:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig} 
+        %7 = linalg.matmul ins(%3, %4 : tensor<2048x2048xbf16>, tensor<2048x2048xbf16>) outs(%6 : tensor<2048x2048xbf16>) -> tensor<2048x2048xbf16>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : tensor<2048x2048xbf16> -> !flow.dispatch.tensor<writeonly:tensor<2048x2048xbf16>>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+// CHECK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[8, 32], [0, 0, 16], [8, 16], [0, 0, 2]]>
+// CHECK{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[1, 0], [1, 0], [1, 0]]}]>
+hal.executable private @matmul_pad_pack_small_i64 {
+  hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd", ukernels = "none"}>) {
+    hal.executable.export public @matmul_small_dispatch_0_matmul_8x32x16_i64 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]} {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice 
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_small_dispatch_0_matmul_8x32x16_i64() {
+        %c0_i64 = arith.constant 0 : i64
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<8x16xi64>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x32xi64>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x32xi64>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x16xi64>> -> tensor<8x16xi64>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [16, 32], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x32xi64>> -> tensor<16x32xi64>
+        %5 = tensor.empty() : tensor<8x32xi64>
+        %6 = linalg.fill ins(%c0_i64 : i64) outs(%5 : tensor<8x32xi64>) -> tensor<8x32xi64>
+        // CHECK:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig} 
+        %7 = linalg.matmul ins(%3, %4 : tensor<8x16xi64>, tensor<16x32xi64>) outs(%6 : tensor<8x32xi64>) -> tensor<8x32xi64>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [8, 32], strides = [1, 1] : tensor<8x32xi64> -> !flow.dispatch.tensor<writeonly:tensor<8x32xi64>>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+// CHECK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[8, 32], [0, 0, 16], [8, 32], [0, 0, 2]]>
+// CHECK{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[1, 0], [1, 0], [1, 0]]}]>
+hal.executable private @matmul_pad_pack_small_i32 {
+  hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd", ukernels = "none"}>) {
+    hal.executable.export public @matmul_small_dispatch_0_matmul_8x32x16_i32 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]} {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice 
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_small_dispatch_0_matmul_8x32x16_i32() {
+        %c0_i32 = arith.constant 0 : i32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<8x16xi32>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x32xi32>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x32xi32>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x16xi32>> -> tensor<8x16xi32>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [16, 32], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x32xi32>> -> tensor<16x32xi32>
+        %5 = tensor.empty() : tensor<8x32xi32>
+        %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<8x32xi32>) -> tensor<8x32xi32>
+        // CHECK:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig} 
+        %7 = linalg.matmul ins(%3, %4 : tensor<8x16xi32>, tensor<16x32xi32>) outs(%6 : tensor<8x32xi32>) -> tensor<8x32xi32>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [8, 32], strides = [1, 1] : tensor<8x32xi32> -> !flow.dispatch.tensor<writeonly:tensor<8x32xi32>>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
+// CHECK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[8, 32], [0, 0, 16], [8, 32], [0, 0, 2]]>
+// CHECK{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[1, 0], [1, 0], [1, 0]]}]>
+hal.executable private @matmul_pad_pack_small_bf16 {
+  hal.executable.variant public @amdaie_xclbin_fb target(<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd", ukernels = "none"}>) {
+    hal.executable.export public @matmul_small_dispatch_0_matmul_8x32x16_bf16 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) attributes {hal.interface.bindings = [#hal.interface.binding<0, 0>, #hal.interface.binding<0, 1>, #hal.interface.binding<0, 2>]} {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_slice 
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_small_dispatch_0_matmul_8x32x16_bf16() {
+        %c0_bf16 = arith.constant 0.0 : bf16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<8x16xbf16>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x32xbf16>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<8x32xbf16>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 16], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x16xbf16>> -> tensor<8x16xbf16>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [16, 32], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x32xbf16>> -> tensor<16x32xbf16>
+        %5 = tensor.empty() : tensor<8x32xbf16>
+        %6 = linalg.fill ins(%c0_bf16 : bf16) outs(%5 : tensor<8x32xbf16>) -> tensor<8x32xbf16>
+        // CHECK:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig} 
+        %7 = linalg.matmul ins(%3, %4 : tensor<8x16xbf16>, tensor<16x32xbf16>) outs(%6 : tensor<8x32xbf16>) -> tensor<8x32xbf16>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [8, 32], strides = [1, 1] : tensor<8x32xbf16> -> !flow.dispatch.tensor<writeonly:tensor<8x32xbf16>>
+        return
+      }
+    }
+  }
+}


### PR DESCRIPTION
-- This commit generalizes tiling/packing config based on a given
   element type.
-- The rationale behind this is that element type with lesser memory
   footprint can exploit higher tiling/packing sizes and vice versa.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>