### PR TITLE
[AMD-AIE] Lower zero filling linalg.fill to ukernel

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_ukernel.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_ukernel.mlir
@@ -59,3 +59,74 @@ func.func @generic_matmul_i32i32i32_pad_pack(%arg0 : tensor<?x?x?x?xi32>, %arg1 
 // CHECK-SAME:       fn_def_attrs {link_with = "/custom/path/to/ukernels/mm.o"}
 // CHECK-SAME:       strided_outer_dims(0)
 //      CHECK:   return %[[MICRO_KERNEL]]
+
+// -----
+
+func.func @zero_fill(%arg0 : tensor<?x?x?x?xbf16>) -> tensor<?x?x?x?xbf16> attributes {
+  hal.executable.target = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd", ukernels = "all"}>
+} {
+  %cst = arith.constant 0.0 : bf16
+  %fill = linalg.fill ins(%cst : bf16) outs(%arg0 : tensor<?x?x?x?xbf16>) -> tensor<?x?x?x?xbf16>
+  return %fill : tensor<?x?x?x?xbf16>
+}
+//      CHECK: func @zero_fill(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>)
+//  CHECK-NOT:   linalg.fill
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "zero_bf16"
+// CHECK-SAME:       outs(%[[ARG0]] :
+// CHECK-SAME:       fn_def_attrs {link_with = "/custom/path/to/ukernels/mm.o"}
+// CHECK-SAME:       strided_outer_dims(0)
+//      CHECK:   return %[[MICRO_KERNEL]]
+
+// -----
+
+func.func @non_zero_fill(%arg0 : tensor<?x?x?x?xbf16>) -> tensor<?x?x?x?xbf16> attributes {
+  hal.executable.target = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd", ukernels = "all"}>
+} {
+  %cst = arith.constant 7.0 : bf16
+  %fill = linalg.fill ins(%cst : bf16) outs(%arg0 : tensor<?x?x?x?xbf16>) -> tensor<?x?x?x?xbf16>
+  return %fill : tensor<?x?x?x?xbf16>
+}
+//      CHECK: func @non_zero_fill
+//      CHECK:   linalg.fill
+//  CHECK-NOT:   iree_codegen.ukernel.generic
+
+// -----
+
+func.func @zero_fill_with_matmul(%arg0 : tensor<?x?x?x?xbf16>, %arg1 : tensor<?x?x?x?xbf16>,
+    %arg2 : tensor<?x?x?x?xbf16>) -> tensor<?x?x?x?xbf16> attributes {
+  hal.executable.target = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd", ukernels = "all"}>
+} {
+  %cst = arith.constant 0.0 : bf16
+  %fill = linalg.fill ins(%cst : bf16) outs(%arg2 : tensor<?x?x?x?xbf16>) -> tensor<?x?x?x?xbf16>
+  %matmul = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d0, d3, d5)>,
+                                        affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>,
+                                        affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d3, d4)>],
+                       iterator_types = ["parallel", "parallel", "reduction",
+                                         "parallel", "parallel", "reduction"]
+                      } ins(%arg0, %arg1 : tensor<?x?x?x?xbf16>, tensor<?x?x?x?xbf16>)
+                        outs(%fill : tensor<?x?x?x?xbf16>)
+      {
+        ^bb0(%in: bf16, %in_9: bf16, %out: bf16):
+          %22 = arith.mulf %in, %in_9 : bf16
+          %23 = arith.addf %out, %22 : bf16
+          linalg.yield %23 : bf16
+      } -> tensor<?x?x?x?xbf16>
+  return %matmul : tensor<?x?x?x?xbf16>
+}
+//      CHECK: func @zero_fill_with_matmul(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>)
+//  CHECK-NOT:   linalg.fill
+//      CHECK:   %[[ZERO_FILL_MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "zero_bf16"
+// CHECK-SAME:       outs(%[[ARG2]] :
+// CHECK-SAME:       fn_def_attrs {link_with = "/custom/path/to/ukernels/mm.o"}
+// CHECK-SAME:       strided_outer_dims(0)
+//  CHECK-NOT:   linalg.generic
+//      CHECK:   %[[MATMUL_MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "matmul_bf16_bf16"
+// CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
+// CHECK-SAME:       outs(%[[ZERO_FILL_MICRO_KERNEL]] :
+// CHECK-SAME:       fn_def_attrs {link_with = "/custom/path/to/ukernels/mm.o"}
+// CHECK-SAME:       strided_outer_dims(0)
+//      CHECK:   return %[[MATMUL_MICRO_KERNEL]]


### PR DESCRIPTION
-- This commit updates `--iree-amdaie-lower-to-ukernel` pass by
   letting a zero-filling linalg.fill to get lowered to a ukernel.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>


NOTE: The e2e requires [MLIR-AIR PR fix](https://github.com/Xilinx/mlir-air/pull/511) as well as addition of [zero ukernel in MLIR-AIE PR](https://github.com/Xilinx/mlir-aie/pull/1136) - I haven't updated the latter because of the following reason :-

1. Without "offset" argument added to the ukernel - the IR lowers e2e successfully and yields correct results.
2. With "offset" argument - the IR lowers e2e successfully but gets stuck at runtime.

Raising this PR nonetheless for review/comments/discussion.