### PR TITLE
Add support to peel the last iteration of the for loop

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPeelForLoop.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPeelForLoop.cpp
@@ -14,6 +14,45 @@ namespace mlir::iree_compiler::AMDAIE {
 
 namespace {
 
+LogicalResult peelForLoopLastIteration(RewriterBase &b, scf::ForOp forOp,
+                                       scf::ForOp &lastIteration) {
+  RewriterBase::InsertionGuard guard(b);
+  auto lbInt = getConstantIntValue(forOp.getLowerBound());
+  auto ubInt = getConstantIntValue(forOp.getUpperBound());
+  auto stepInt = getConstantIntValue(forOp.getStep());
+
+  // Check again when the first iteration is already peeled off.
+  // Peeling is not needed if there is one or less iteration.
+  if (lbInt && ubInt && stepInt && ceil(float(*ubInt - *lbInt) / *stepInt) <= 1)
+    return failure();
+
+  AffineExpr lbSymbol, ubSymbol, stepSymbol;
+  bindSymbols(b.getContext(), lbSymbol, ubSymbol, stepSymbol);
+
+  // New upper bound: %ub - (%ub - %lb) mod %step
+  auto modMap =
+      AffineMap::get(0, 3, {ubSymbol - ((ubSymbol - lbSymbol) % stepSymbol)});
+  b.setInsertionPoint(forOp);
+  auto loc = forOp.getLoc();
+  Value splitBound = b.createOrFold<affine::AffineApplyOp>(
+      loc, modMap,
+      ValueRange{forOp.getLowerBound(), forOp.getUpperBound(),
+                 forOp.getStep()});
+
+  // Create ForOp for partial iteration.
+  b.setInsertionPointAfter(forOp);
+  lastIteration = cast<scf::ForOp>(b.clone(*forOp.getOperation()));
+  lastIteration.getLowerBoundMutable().assign(splitBound);
+  b.replaceAllUsesWith(forOp.getResults(), lastIteration->getResults());
+  lastIteration.getInitArgsMutable().assign(forOp->getResults());
+
+  // Set new upper loop bound.
+  b.modifyOpInPlace(forOp,
+                    [&]() { forOp.getUpperBoundMutable().assign(splitBound); });
+
+  return success();
+}
+
 class AMDAIEPeelForLoopPass
     : public impl::AMDAIEPeelForLoopBase<AMDAIEPeelForLoopPass> {
  public:
@@ -23,6 +62,8 @@ class AMDAIEPeelForLoopPass
 
   AMDAIEPeelForLoopPass() = default;
   AMDAIEPeelForLoopPass(const AMDAIEPeelForLoopPass &pass){};
+  AMDAIEPeelForLoopPass(const AMDAIEPeelForLoopOptions &options)
+      : AMDAIEPeelForLoopBase(options) {}
   void runOnOperation() override;
 };
 
@@ -42,17 +83,39 @@ void AMDAIEPeelForLoopPass::runOnOperation() {
       return;
 
     scf::ForOp result;
-    LogicalResult status =
-        scf::peelForLoopFirstIteration(rewriter, forOp, result);
-    if (failed(status)) {
-      return signalPassFailure();
+    switch (peelLoopType) {
+      case PeelLoopType::First:
+        if (failed(scf::peelForLoopFirstIteration(rewriter, forOp, result))) {
+          forOp->emitOpError("failed to peel the first iteration.");
+          return signalPassFailure();
+        }
+        break;
+      case PeelLoopType::Last:
+        if (failed(peelForLoopLastIteration(rewriter, forOp, result))) {
+          forOp->emitOpError("failed to peel the last iteration.");
+          return signalPassFailure();
+        }
+        break;
+      case PeelLoopType::FirstLast:
+        if (failed(scf::peelForLoopFirstIteration(rewriter, forOp, result))) {
+          forOp->emitOpError("failed to peel the first iteration.");
+          return signalPassFailure();
+        }
+        if (failed(peelForLoopLastIteration(rewriter, forOp, result))) {
+          LLVM_DEBUG(llvm::dbgs() << "Skip peeling for the last iteration.\n");
+        }
+        break;
+      default:
+        forOp->emitOpError("failed to specify the type of loop peeling.");
+        return signalPassFailure();
     }
   });
 }
 
 }  // namespace
 
-std::unique_ptr<Pass> createAMDAIEPeelForLoopPass() {
-  return std::make_unique<AMDAIEPeelForLoopPass>();
+std::unique_ptr<Pass> createAMDAIEPeelForLoopPass(
+    AMDAIEPeelForLoopOptions options) {
+  return std::make_unique<AMDAIEPeelForLoopPass>(options);
 }
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
@@ -23,7 +23,7 @@ enum class AIEPassPipeline : int32_t {
 };
 
 /// Enum for target tiling op.
-enum class PeelLoopType : int32_t { First = 0, Last = 1, FirstLast = 2 };
+enum class PeelingType : int32_t { First = 0, Last = 1, FirstLast = 2 };
 
 /// Struct specifying the number of cores to use. This will be replaced
 /// by a more versatile handling in the future.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
@@ -23,7 +23,7 @@ enum class AIEPassPipeline : int32_t {
 };
 
 /// Enum for target tiling op.
-enum class TilingOp : int32_t { Matmul = 0, RhsCopy = 1, LhsCopy = 2 };
+enum class PeelLoopType : int32_t { First = 0, Last = 1, FirstLast = 2 };
 
 /// Struct specifying the number of cores to use. This will be replaced
 /// by a more versatile handling in the future.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -102,7 +102,8 @@ std::unique_ptr<Pass> createAMDAIEPackToDmaPass();
 std::unique_ptr<Pass> createAMDAIEPadPass(AMDAIEPadOptions options = {});
 
 /// Create a pass to peel the first iteration out of the scf.for loop.
-std::unique_ptr<Pass> createAMDAIEPeelForLoopPass();
+std::unique_ptr<Pass> createAMDAIEPeelForLoopPass(
+    AMDAIEPeelForLoopOptions options = {});
 
 /// Create pass to tile TilingInterface operations.
 std::unique_ptr<Pass> createAMDAIETilePass(AMDAIETileOptions options = {});

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -212,16 +212,16 @@ def AMDAIEPeelForLoop :
   let constructor =
       "mlir::iree_compiler::AMDAIE::createAMDAIEPeelForLoopPass()";
   let options = [
-    Option<"peelLoopType", "peel-loop-type",
-      "mlir::iree_compiler::AMDAIE::PeelLoopType",
-      /*default=*/"mlir::iree_compiler::AMDAIE::PeelLoopType::First",
+    Option<"peelingType", "peeling-type",
+      "mlir::iree_compiler::AMDAIE::PeelingType",
+      /*default=*/"mlir::iree_compiler::AMDAIE::PeelingType::First",
       "Choose which type of loop peeling to perform",
       [{::llvm::cl::values(
-        clEnumValN(mlir::iree_compiler::AMDAIE::PeelLoopType::First, "first",
+        clEnumValN(mlir::iree_compiler::AMDAIE::PeelingType::First, "first",
                    "Peel the first iteration."),
-        clEnumValN(mlir::iree_compiler::AMDAIE::PeelLoopType::Last, "last",
+        clEnumValN(mlir::iree_compiler::AMDAIE::PeelingType::Last, "last",
                    "Peel the last iteration."),
-        clEnumValN(mlir::iree_compiler::AMDAIE::PeelLoopType::FirstLast, "firstLast",
+        clEnumValN(mlir::iree_compiler::AMDAIE::PeelingType::FirstLast, "first-last",
                    "Peel the first and the last iterations.")
       )}]>
   ];

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -208,9 +208,23 @@ def AMDAIEPad :
 
 def AMDAIEPeelForLoop :
     Pass<"iree-amdaie-peel-for-loop", "func::FuncOp"> {
-  let summary = "Pass to peel the first iteration out of the scf.for loop.";
+  let summary = "Pass to peel the first or/and the last iteration out of the scf.for loop.";
   let constructor =
       "mlir::iree_compiler::AMDAIE::createAMDAIEPeelForLoopPass()";
+  let options = [
+    Option<"peelLoopType", "peel-loop-type",
+      "mlir::iree_compiler::AMDAIE::PeelLoopType",
+      /*default=*/"mlir::iree_compiler::AMDAIE::PeelLoopType::First",
+      "Choose which type of loop peeling to perform",
+      [{::llvm::cl::values(
+        clEnumValN(mlir::iree_compiler::AMDAIE::PeelLoopType::First, "first",
+                   "Peel the first iteration."),
+        clEnumValN(mlir::iree_compiler::AMDAIE::PeelLoopType::Last, "last",
+                   "Peel the last iteration."),
+        clEnumValN(mlir::iree_compiler::AMDAIE::PeelLoopType::FirstLast, "firstLast",
+                   "Peel the first and the last iterations.")
+      )}]>
+  ];
 }
 
 def AMDAIETile :

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/peel_for_loop.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/peel_for_loop.mlir
@@ -1,6 +1,6 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peel-loop-type=first}))"  --split-input-file %s | FileCheck %s --check-prefix=PEEL-FIRST
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peel-loop-type=last}))"  --split-input-file %s | FileCheck %s --check-prefix=PEEL-LAST
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peel-loop-type=firstLast}))"  --split-input-file %s | FileCheck %s --check-prefix=FIRST-LAST
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peeling-type=first}))"  --split-input-file %s | FileCheck %s --check-prefix=PEEL-FIRST
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peeling-type=last}))"  --split-input-file %s | FileCheck %s --check-prefix=PEEL-LAST
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peeling-type=first-last}))"  --split-input-file %s | FileCheck %s --check-prefix=FIRST-LAST
 
 #map = affine_map<(d0, d1)[s0] -> (s0, d0 - d1)>
 func.func @peel_example() -> i32 {
@@ -100,9 +100,9 @@ func.func @no_peeling_example() -> i32 {
 #map = affine_map<(d0, d1)[s0] -> (s0, d0 - d1)>
 func.func @two_iteration_example() -> i32 {
   %c0_i32 = arith.constant 0 : i32
-  %lb = arith.constant 0 : index
+  %lb = arith.constant 2 : index
   %step = arith.constant 4 : index
-  %ub = arith.constant 8 : index
+  %ub = arith.constant 10 : index
   %r = scf.for %iv = %lb to %ub step %step iter_args(%arg = %c0_i32) -> i32 {
     %s = affine.min #map(%ub, %iv)[%step]
     %casted = arith.index_cast %s : index to i32
@@ -114,14 +114,14 @@ func.func @two_iteration_example() -> i32 {
 
 // FIRST-LAST-LABEL: func.func @two_iteration_example()
 //       FIRST-LAST:   %[[C0_I32:.*]] = arith.constant 0 : i32
-//       FIRST-LAST:   %[[C0:.*]] = arith.constant 0 : index
+//       FIRST-LAST:   %[[C2:.*]] = arith.constant 2 : index
 //       FIRST-LAST:   %[[C4:.*]] = arith.constant 4 : index
-//       FIRST-LAST:   %[[C8:.*]] = arith.constant 8 : index
-//       FIRST-LAST:   %[[C4_0:.*]] = arith.constant 4 : index
-//       FIRST-LAST:   %[[FIRST:.*]] = scf.for %[[IV:.*]] = %[[C0]] to %[[C4_0]]
+//       FIRST-LAST:   %[[C10:.*]] = arith.constant 10 : index
+//       FIRST-LAST:   %[[C6:.*]] = arith.constant 6 : index
+//       FIRST-LAST:   %[[FIRST:.*]] = scf.for %[[IV:.*]] = %[[C2]] to %[[C6]]
 //  FIRST-LAST-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[C0_I32]]) -> (i32) {
 //       FIRST-LAST:   }
-//       FIRST-LAST:   %[[LAST:.*]] = scf.for %[[IV1:.*]] = %[[C4_0]] to %[[C8]]
+//       FIRST-LAST:   %[[LAST:.*]] = scf.for %[[IV1:.*]] = %[[C6]] to %[[C10]]
 //  FIRST-LAST-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[FIRST]]) -> (i32) {
 //       FIRST-LAST:   }
 //       FIRST-LAST:   return %[[LAST]]

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/peel_for_loop.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/peel_for_loop.mlir
@@ -1,4 +1,6 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop))"  --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peel-loop-type=first}))"  --split-input-file %s | FileCheck %s --check-prefix=PEEL-FIRST
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peel-loop-type=last}))"  --split-input-file %s | FileCheck %s --check-prefix=PEEL-LAST
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peel-loop-type=firstLast}))"  --split-input-file %s | FileCheck %s --check-prefix=FIRST-LAST
 
 #map = affine_map<(d0, d1)[s0] -> (s0, d0 - d1)>
 func.func @peel_example() -> i32 {
@@ -15,19 +17,51 @@ func.func @peel_example() -> i32 {
   return %r : i32
 }
 
-//      CHECK: func.func @peel_example()
-//      CHECK:   %[[C0_I32:.*]] = arith.constant 0 : i32
-//      CHECK:   %[[C0:.*]] = arith.constant 0 : index
-//      CHECK:   %[[C4:.*]] = arith.constant 4 : index
-//      CHECK:   %[[C17:.*]] = arith.constant 17 : index
-//      CHECK:   %[[C4_0:.*]] = arith.constant 4 : index
-//      CHECK:   %[[FIRST:.*]] = scf.for %[[IV:.*]] = %[[C0]] to %[[C4_0]]
-// CHECK-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[C0_I32]]) -> (i32) {
-//      CHECK:   }
-//      CHECK:   %[[RESULT:.*]] = scf.for %[[IV:.*]] = %[[C4_0]] to %[[C17]]
-// CHECK-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[FIRST]]) -> (i32) {
-//      CHECK:   }
-//      CHECK:   return %[[RESULT]]
+// PEEL-FIRST-LABEL: func.func @peel_example()
+//       PEEL-FIRST:   %[[C0_I32:.*]] = arith.constant 0 : i32
+//       PEEL-FIRST:   %[[C0:.*]] = arith.constant 0 : index
+//       PEEL-FIRST:   %[[C4:.*]] = arith.constant 4 : index
+//       PEEL-FIRST:   %[[C17:.*]] = arith.constant 17 : index
+//       PEEL-FIRST:   %[[C4_0:.*]] = arith.constant 4 : index
+//       PEEL-FIRST:   %[[FIRST:.*]] = scf.for %[[IV:.*]] = %[[C0]] to %[[C4_0]]
+//  PEEL-FIRST-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[C0_I32]]) -> (i32) {
+//       PEEL-FIRST:   }
+//       PEEL-FIRST:   %[[RESULT:.*]] = scf.for %[[IV1:.*]] = %[[C4_0]] to %[[C17]]
+//  PEEL-FIRST-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[FIRST]]) -> (i32) {
+//       PEEL-FIRST:   }
+//       PEEL-FIRST:   return %[[RESULT]]
+
+// PEEL-LAST-LABEL: func.func @peel_example()
+//       PEEL-LAST:   %[[C0_I32:.*]] = arith.constant 0 : i32
+//       PEEL-LAST:   %[[C0:.*]] = arith.constant 0 : index
+//       PEEL-LAST:   %[[C4:.*]] = arith.constant 4 : index
+//       PEEL-LAST:   %[[C17:.*]] = arith.constant 17 : index
+//       PEEL-LAST:   %[[C16:.*]] = arith.constant 16 : index
+//       PEEL-LAST:   %[[MAIN:.*]] = scf.for %[[IV:.*]] = %[[C0]] to %[[C16]]
+//  PEEL-LAST-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[C0_I32]]) -> (i32) {
+//       PEEL-LAST:   }
+//       PEEL-LAST:   %[[LAST:.*]] = scf.for %[[IV1:.*]] = %[[C16]] to %[[C17]]
+//  PEEL-LAST-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[MAIN]]) -> (i32) {
+//       PEEL-LAST:   }
+//       PEEL-LAST:   return %[[LAST]]
+
+// FIRST-LAST-LABEL: func.func @peel_example()
+//       FIRST-LAST:   %[[C0_I32:.*]] = arith.constant 0 : i32
+//       FIRST-LAST:   %[[C0:.*]] = arith.constant 0 : index
+//       FIRST-LAST:   %[[C4:.*]] = arith.constant 4 : index
+//       FIRST-LAST:   %[[C17:.*]] = arith.constant 17 : index
+//       FIRST-LAST:   %[[C4_0:.*]] = arith.constant 4 : index
+//       FIRST-LAST:   %[[FIRST:.*]] = scf.for %[[IV:.*]] = %[[C0]] to %[[C4_0]]
+//  FIRST-LAST-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[C0_I32]]) -> (i32) {
+//       FIRST-LAST:   }
+//       FIRST-LAST:   %[[C16:.*]] = arith.constant 16 : index
+//       FIRST-LAST:   %[[MAIN:.*]] = scf.for %[[IV1:.*]] = %[[C4_0]] to %[[C16]]
+//  FIRST-LAST-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[FIRST]]) -> (i32) {
+//       FIRST-LAST:   }
+//       FIRST-LAST:   %[[LAST:.*]] = scf.for %[[IV2:.*]] = %[[C16]] to %[[C17]]
+//  FIRST-LAST-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[MAIN]]) -> (i32) {
+//       FIRST-LAST:   }
+//       FIRST-LAST:   return %[[LAST]]
 
 // -----
 
@@ -46,17 +80,48 @@ func.func @no_peeling_example() -> i32 {
   return %r : i32
 }
 
-//      CHECK: #[[MAP:.*]] = affine_map<(d0, d1)[s0] -> (s0, d0 - d1)>
-//      CHECK: func @no_peeling_example(
-//      CHECK:   %[[C0_I32:.*]] = arith.constant 0 : i32
-//      CHECK:   %[[C0:.*]] = arith.constant 0 : index
-//      CHECK:   %[[C4:.*]] = arith.constant 4 : index
-//      CHECK:   %[[C4_0:.*]] = arith.constant 4 : index
-//      CHECK:   %[[RESULT:.*]] = scf.for %[[IV:.*]] = %[[C0]] to %[[C4_0]]
-// CHECK-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[C0_I32]]) -> (i32) {
-//      CHECK:     %[[MIN:.*]] = affine.min #[[MAP]](%[[C4_0]], %[[IV]])[%[[C4]]]
-//      CHECK:     %[[CAST:.*]] = arith.index_cast %[[MIN]] : index to i32
-//      CHECK:     %[[ADD:.*]] = arith.addi %[[ACC]], %[[CAST]] : i32
-//      CHECK:     scf.yield %[[ADD]]
-//      CHECK:   }
-//      CHECK:   return %[[RESULT]]
+//      PEEL-FIRST: #[[MAP:.*]] = affine_map<(d0, d1)[s0] -> (s0, d0 - d1)>
+//      PEEL-FIRST: func @no_peeling_example(
+//      PEEL-FIRST:   %[[C0_I32:.*]] = arith.constant 0 : i32
+//      PEEL-FIRST:   %[[C0:.*]] = arith.constant 0 : index
+//      PEEL-FIRST:   %[[C4:.*]] = arith.constant 4 : index
+//      PEEL-FIRST:   %[[C4_0:.*]] = arith.constant 4 : index
+//      PEEL-FIRST:   %[[RESULT:.*]] = scf.for %[[IV:.*]] = %[[C0]] to %[[C4_0]]
+// PEEL-FIRST-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[C0_I32]]) -> (i32) {
+//      PEEL-FIRST:     %[[MIN:.*]] = affine.min #[[MAP]](%[[C4_0]], %[[IV]])[%[[C4]]]
+//      PEEL-FIRST:     %[[CAST:.*]] = arith.index_cast %[[MIN]] : index to i32
+//      PEEL-FIRST:     %[[ADD:.*]] = arith.addi %[[ACC]], %[[CAST]] : i32
+//      PEEL-FIRST:     scf.yield %[[ADD]]
+//      PEEL-FIRST:   }
+//      PEEL-FIRST:   return %[[RESULT]]
+
+// -----
+
+#map = affine_map<(d0, d1)[s0] -> (s0, d0 - d1)>
+func.func @two_iteration_example() -> i32 {
+  %c0_i32 = arith.constant 0 : i32
+  %lb = arith.constant 0 : index
+  %step = arith.constant 4 : index
+  %ub = arith.constant 8 : index
+  %r = scf.for %iv = %lb to %ub step %step iter_args(%arg = %c0_i32) -> i32 {
+    %s = affine.min #map(%ub, %iv)[%step]
+    %casted = arith.index_cast %s : index to i32
+    %0 = arith.addi %arg, %casted : i32
+    scf.yield %0 : i32
+  }
+  return %r : i32
+}
+
+// FIRST-LAST-LABEL: func.func @two_iteration_example()
+//       FIRST-LAST:   %[[C0_I32:.*]] = arith.constant 0 : i32
+//       FIRST-LAST:   %[[C0:.*]] = arith.constant 0 : index
+//       FIRST-LAST:   %[[C4:.*]] = arith.constant 4 : index
+//       FIRST-LAST:   %[[C8:.*]] = arith.constant 8 : index
+//       FIRST-LAST:   %[[C4_0:.*]] = arith.constant 4 : index
+//       FIRST-LAST:   %[[FIRST:.*]] = scf.for %[[IV:.*]] = %[[C0]] to %[[C4_0]]
+//  FIRST-LAST-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[C0_I32]]) -> (i32) {
+//       FIRST-LAST:   }
+//       FIRST-LAST:   %[[LAST:.*]] = scf.for %[[IV1:.*]] = %[[C4_0]] to %[[C8]]
+//  FIRST-LAST-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[FIRST]]) -> (i32) {
+//       FIRST-LAST:   }
+//       FIRST-LAST:   return %[[LAST]]


### PR DESCRIPTION
This PR adds support to peel the last iteration out of the scf.for loop. This functionality is a special case of [peelForLoop](https://github.com/llvm/llvm-project/blob/556fe5f290ea88dcbb7ced16b0f057dcebce1fd0/mlir/lib/Dialect/SCF/Transforms/LoopSpecialization.cpp#L119) in llvm-project. However, there is a hard constraint in the upstream function that peeling only works if the step size doesn't divide the upper bound evenly. In our application, we'll need a function to peel the last iteration off in all situations. To not break the upstream patterns for loop peeling, a special function is added in this repository. 