### PR TITLE
Changes to get matmul with i8 operands (and i32 result) e2e working

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
@@ -102,8 +102,9 @@ FailureOr<std::array<uint32_t, 3>> getAIEMatmulInstructionSize(Type elTypeLhs,
 
 FailureOr<unsigned> getTilingScaleFactor(Type elemType) {
   unsigned bitWidth = elemType.getIntOrFloatBitWidth();
-  if ((bitWidth % 16 == 0) && (bitWidth <= 64)) return (64 / bitWidth);
-  return failure();
+  if (bitWidth %8 != 0) return failure();
+  if (bitWidth > 64) return failure();
+  return 64 / bitWidth;
 }
 
 // Find the largest factor of 'num' which is not larger than 'max'.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -160,7 +160,7 @@ static LogicalResult setRootConfigForPadPackPipeline(func::FuncOp entryPointFn,
   FailureOr<unsigned> maybeTilingScaleFactor =
       getTilingScaleFactor(lhsType.getElementType());
   if (failed(maybeTilingScaleFactor)) {
-    return linalgOp.emitOpError("expected bitwidth 64/32/16");
+    return linalgOp.emitOpError("expected bitwidth 64/32/16/8");
   }
   unsigned tilingScaleFactor = maybeTilingScaleFactor.value();
   // TODO (nmeshram) : We should be able to use fixed tiling config after we

--- a/tests/matmul/generate_e2e_matmul_tests.py
+++ b/tests/matmul/generate_e2e_matmul_tests.py
@@ -565,14 +565,14 @@ def parse_arguments():
     parser.add_argument(
         "--lhs_rhs_type",
         type=str,
-        choices=["i32", "f32", "f16", "bf16"],
+        choices=["i32", "f32", "f16", "bf16", "i8"],
         help="Numeric type of input matrices",
         required=True,
     )
     parser.add_argument(
         "--acc_type",
         type=str,
-        choices=["i32", "f32", "f16", "bf16"],
+        choices=["i32", "f32", "f16", "bf16", "i8"],
         help="Numeric type of input matrices",
         default="",
         required=False,


### PR DESCRIPTION
Will also require this small change in aie: https://github.com/Xilinx/mlir-aie/pull/1149

I've verified that with these changes, I can add a test to our matmul script. 

Is there anywhere else we assume element types are >= 16 bits? Please let me know if so. 