### PR TITLE
Add latest transform dialect for pack-peel based method

### DIFF
--- a/tests/transform_dialect/CMakeLists.txt
+++ b/tests/transform_dialect/CMakeLists.txt
@@ -9,6 +9,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "conv_fill_spec_pad.mlir"
+    "matmul_fill_spec_pack_funcIR.mlir"
     "matmul_fill_spec_pack_peel.mlir"
     "matmul_fill_spec_pad.mlir"
     "matmul_fill_spec_pad_pack.mlir"

--- a/tests/transform_dialect/matmul_fill_spec_pack_funcIR.mlir
+++ b/tests/transform_dialect/matmul_fill_spec_pack_funcIR.mlir
@@ -1,0 +1,191 @@
+// RUN: iree-opt --iree-transform-dialect-interpreter %s | FileCheck %s
+
+// This script shows an example lowering matmul through pack based pipeline for AIE device.
+// This script is a prototype for funcIR proposal.
+// In this strategy, we use pack operations for data movement from L3 to L2, and L2 to L1.
+// In order to keep initialization in L1, the first iteration of scf.for loop is peeled.
+
+func.func @matmul_example() {
+  %c0_i32 = arith.constant 0: i32
+  %c0 = arith.constant 0 : index
+  %arg0_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x256xi8>>
+  %arg0 = flow.dispatch.tensor.load %arg0_binding, offsets = [0, 0], sizes = [16, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x256xi8>> -> tensor<16x256xi8>
+  %arg1_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<256x256xi8>>
+  %arg1 = flow.dispatch.tensor.load %arg1_binding, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
+  %arg2_binding = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) flags(None) : !flow.dispatch.tensor<writeonly:tensor<16x256xi32>>
+  %empty = tensor.empty() : tensor<16x256xi32>
+  %0 = linalg.fill ins(%c0_i32 : i32) outs(%empty : tensor<16x256xi32>) -> tensor<16x256xi32>
+  %1 = linalg.matmul ins(%arg0, %arg1 : tensor<16x256xi8>, tensor<256x256xi8>)
+      outs(%0 : tensor<16x256xi32>) -> tensor<16x256xi32>
+  flow.dispatch.tensor.store %1, %arg2_binding, offsets = [0, 0], sizes = [16, 256], strides = [1, 1] : tensor<16x256xi32> -> !flow.dispatch.tensor<writeonly:tensor<16x256xi32>>
+  return
+}
+
+module attributes { transform.with_named_sequence } {
+  transform.named_sequence @cleanup(%variant_op: !transform.any_op {transform.readonly}) {
+    %func = transform.structured.match ops{["func.func"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+      transform.apply_patterns to %func {
+      transform.apply_patterns.linalg.tiling_canonicalization
+      transform.apply_patterns.iree.fold_fill_into_pad
+      transform.apply_patterns.scf.for_loop_canonicalization
+      transform.apply_patterns.canonicalization
+    } : !transform.any_op
+    transform.iree.apply_licm %func : !transform.any_op
+    transform.apply_cse to %func : !transform.any_op
+    transform.yield
+  }
+
+  transform.named_sequence @__transform_main(%variant_op: !transform.any_op {transform.read_only}) {
+    %ops = transform.structured.match ops{["linalg.fill", "linalg.matmul"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    %fill, %matmul = transform.split_handle %ops : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+    // First level tile to forall with tile_sizes [16, 256] to target 4 cores. Adjust to [16, 64] for 1 core.
+    %tiled_matmul, %forall =
+      transform.structured.tile_using_forall %matmul tile_sizes [16, 256]
+        ( mapping = [#gpu.block<y>, #gpu.block<x>] ) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+    // Fuse fill operation into the forall loop.
+    %fused_fill, %_ = transform.structured.fuse_into_containing_op %fill into %forall : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+    // Tile reduction dimension.
+    %tiled_reduction, %loop =
+      transform.structured.tile_using_for %tiled_matmul [0, 0, 64]
+      : (!transform.any_op) -> (!transform.any_op, !transform.op<"scf.for">)
+
+    // Pack by applying data tiling, and the linalg.matmul becomes linalg.generic.
+    %packed = transform.structured.pack %tiled_reduction packed_sizes = [16, 64, 64]
+      : (!transform.any_op) -> (!transform.any_op)
+
+    // Transpose B matrix from [K N n k] to [K N k n]
+    %pack_producer_b0 = transform.get_producer_of_operand %packed[1]
+      : (!transform.any_op) -> (!transform.any_op)
+    %packed_b0, %pack_b0, %empty_unpack_b0 =
+      transform.structured.pack_transpose %pack_producer_b0 with_compute_op(%packed)
+      inner_perm = [1, 0] : (!transform.any_op, !transform.any_op)
+      -> (!transform.any_op, !transform.any_op, !transform.any_op)
+
+    // Bufferize to shared memory allocation
+    %pack_producer_a0 = transform.get_producer_of_operand %packed_b0[0]
+      : (!transform.any_op) -> (!transform.any_op)
+    %pack_producer_c0 = transform.get_producer_of_operand %packed_b0[2]
+      : (!transform.any_op) -> (!transform.any_op)
+    %buffer_a0, %new_a0 = transform.structured.bufferize_to_allocation %pack_b0
+      {memory_space = 1, bufferize_destination_only, emit_dealloc} : !transform.any_op
+    %buffer_b0, %new_b0 = transform.structured.bufferize_to_allocation %pack_producer_a0
+      {memory_space = 1, bufferize_destination_only, emit_dealloc} : !transform.any_op
+    %buffer_c0, %new_c0 = transform.structured.bufferize_to_allocation %pack_producer_c0
+      {memory_space = 1, bufferize_destination_only, emit_dealloc} : !transform.any_op
+
+    // Second level tile to forall with tile_sizes [1, 1].
+    %tiled_matmul_1, %forall_1 =
+      transform.structured.tile_using_forall %packed_b0 tile_sizes [1, 1]
+        ( mapping = [#gpu.thread<y>, #gpu.thread<x>] ) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+    // Pack by applying data tiling, and the linalg.matmul becomes linalg.generic.
+    %packed_2 = transform.structured.pack %tiled_matmul_1 packed_sizes = [0, 0, 0, 4, 8, 8]
+      : (!transform.any_op) -> (!transform.any_op)
+
+    // Transpose A matrix from [M K m k m0 k0] to [M K k m m0 k0]
+    %pack_producer_a = transform.get_producer_of_operand %packed_2[0]
+      : (!transform.any_op) -> (!transform.any_op)
+    %packed_a, %pack_a, %empty_unpack_a =
+      transform.structured.pack_transpose %pack_producer_a with_compute_op(%packed_2)
+      outer_perm = [0, 1, 3, 2] : (!transform.any_op, !transform.any_op)
+      -> (!transform.any_op, !transform.any_op, !transform.any_op)
+
+    // Transpose B matrix from [K N k n n0 k0] to [K N n k k0 n0]
+    %pack_producer_b = transform.get_producer_of_operand %packed_a[1]
+      : (!transform.any_op) -> (!transform.any_op)
+    %packed_b, %pack_b, %empty_unpack_b =
+      transform.structured.pack_transpose %pack_producer_b with_compute_op(%packed_a)
+      outer_perm = [0, 1, 3, 2] inner_perm = [1, 0] : (!transform.any_op, !transform.any_op)
+      -> (!transform.any_op, !transform.any_op, !transform.any_op)
+
+    // Transpose C matrix from [M N m n m0 n0] to [M N n m m0 n0]
+    %unpack = transform.get_consumers_of_result %packed_b[0]
+      : (!transform.any_op) -> (!transform.any_op)
+    %packed_c, %pack_c, %unpack_c =
+      transform.structured.pack_transpose %unpack with_compute_op(%packed_b)
+      outer_perm = [0, 1, 3, 2] : (!transform.any_op, !transform.any_op)
+      -> (!transform.any_op, !transform.any_op, !transform.any_op)
+
+    // Bufferize to local memory allocation
+    %buffer_a, %new_a = transform.structured.bufferize_to_allocation %pack_a
+      {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
+    %buffer_b, %new_b = transform.structured.bufferize_to_allocation %pack_b
+      {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
+    %buffer_c, %new_c = transform.structured.bufferize_to_allocation %pack_c
+      {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
+
+    // Hoist static alloc out of the loops
+    %memref_func = transform.structured.match ops{["func.func"]} in %variant_op
+      : (!transform.any_op) -> !transform.any_op
+    transform.iree.hoist_static_alloc %memref_func : (!transform.any_op) -> ()
+
+    // Peel the first iteration out of the for loop.
+    // This only works when the for loop has more than one iteration.
+    %1 = transform.get_parent_op %packed_c {op_name = "scf.for"} : (!transform.any_op) -> !transform.op<"scf.for">
+    %main_loop, %remainder = transform.loop.peel %1 {peel_front = true}
+      : (!transform.op<"scf.for">) -> (!transform.any_op, !transform.any_op)
+    transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()
+
+    // Find the fill and the second forall operations.
+    %fused_fill_1 = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    %fill_consumer = transform.get_consumers_of_result %fused_fill_1[0] : (!transform.any_op) -> (!transform.any_op)
+
+    // Fuse fill operation into the forall loop
+    %fused_fill_2, %__ = transform.structured.fuse_into_containing_op %fused_fill_1 into %fill_consumer
+      : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+    // Clean up.
+    transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()
+    transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+
+    // Bufferize and drop HAL decriptor from memref ops.
+    %variant_op_3 = transform.iree.bufferize %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.yield
+  }
+}
+
+// CHECK-LABEL: @matmul_example
+//       CHECK: memref.alloc() : memref<1x1x8x4x4x8xi32, 2>
+//       CHECK: memref.alloc() : memref<1x1x8x8x8x8xi8, 2>
+//       CHECK: memref.alloc() : memref<1x1x8x4x4x8xi8, 2>
+//       CHECK: memref.alloc() : memref<1x4x16x64xi32, 1>
+//       CHECK: memref.alloc() : memref<1x4x64x64xi8, 1>
+//       CHECK: memref.alloc() : memref<1x1x16x64xi8, 1>
+//       CHECK: scf.forall
+//       CHECK: {
+//       CHECK:   iree_linalg_ext.pack %{{.*}} : (memref<16x64xi8, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x1x16x64xi8, 1>)
+//       CHECK:   iree_linalg_ext.pack %{{.*}} : (memref<64x256xi8, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x4x64x64xi8, 1>)
+//       CHECK:   scf.forall
+//       CHECK:   {
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<1x1x16x64xi8, strided<[1024, 1024, 64, 1], offset: ?>, 1> memref<1x1x8x4x4x8xi8, 2>)
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<1x1x64x64xi8, strided<[16384, 4096, 64, 1], offset: ?>, 1> memref<1x1x8x8x8x8xi8, 2>)
+//       CHECK:     linalg.fill ins(%{{.*}}) outs(%{{.*}} : memref<1x1x8x4x4x8xi32, 2>)
+//       CHECK:     linalg.generic
+//       CHECK:     iree_linalg_ext.unpack %{{.*}} : (memref<1x1x8x4x4x8xi32, 2> memref<1x1x16x64xi32, strided<[4096, 1024, 64, 1], offset: ?>, 1>)
+//       CHECK:   }
+//       CHECK:   iree_linalg_ext.unpack %{{.*}} : (memref<1x4x16x64xi32, 1> memref<16x256xi32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>)
+//       CHECK:   scf.for
+//       CHECK:   {
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<16x64xi8, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x1x16x64xi8, 1>)
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<64x256xi8, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x4x64x64xi8, 1>)
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<16x256xi32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x4x16x64xi32, 1>)
+//       CHECK:     scf.forall
+//       CHECK:     {
+//       CHECK:       iree_linalg_ext.pack %{{.*}} : (memref<1x1x16x64xi8, strided<[1024, 1024, 64, 1], offset: ?>, 1> memref<1x1x8x4x4x8xi8, 2>)
+//       CHECK:       iree_linalg_ext.pack %{{.*}} : (memref<1x1x64x64xi8, strided<[16384, 4096, 64, 1], offset: ?>, 1> memref<1x1x8x8x8x8xi8, 2>)
+//       CHECK:       iree_linalg_ext.pack %{{.*}} : (memref<1x1x16x64xi32, strided<[4096, 1024, 64, 1], offset: ?>, 1> memref<1x1x8x4x4x8xi32, 2>)
+//       CHECK:       linalg.generic
+//       CHECK:       iree_linalg_ext.unpack %{{.*}} : (memref<1x1x8x4x4x8xi32, 2> memref<1x1x16x64xi32, strided<[4096, 1024, 64, 1], offset: ?>, 1>)
+//       CHECK:     }
+//       CHECK:     iree_linalg_ext.unpack %{{.*}} : (memref<1x4x16x64xi32, 1> memref<16x256xi32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>)
+//       CHECK:   }
+//       CHECK: }
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x16x64xi8, 1>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x4x64x64xi8, 1>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x4x16x64xi32, 1>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x8x4x4x8xi8, 2>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x8x8x8x8xi8, 2>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x8x4x4x8xi32, 2>

--- a/tests/transform_dialect/matmul_fill_spec_pack_peel.mlir
+++ b/tests/transform_dialect/matmul_fill_spec_pack_peel.mlir
@@ -1,23 +1,22 @@
 // RUN: iree-opt --iree-transform-dialect-interpreter %s | FileCheck %s
 
-// This script shows an example lowering matmul through pack based pipeline for AIE device.
-// This script is a prototype for funcIR proposal.
+// This script shows an example lowering matmul for AIE device.
 // In this strategy, we use pack operations for data movement from L3 to L2, and L2 to L1.
 // In order to keep initialization in L1, the first iteration of scf.for loop is peeled.
 
-func.func @matmul_example() {
+func.func @matmul_i32() {
   %c0_i32 = arith.constant 0: i32
   %c0 = arith.constant 0 : index
-  %arg0_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<16x256xi8>>
-  %arg0 = flow.dispatch.tensor.load %arg0_binding, offsets = [0, 0], sizes = [16, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<16x256xi8>> -> tensor<16x256xi8>
-  %arg1_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<256x256xi8>>
-  %arg1 = flow.dispatch.tensor.load %arg1_binding, offsets = [0, 0], sizes = [256, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<256x256xi8>> -> tensor<256x256xi8>
-  %arg2_binding = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) flags(None) : !flow.dispatch.tensor<writeonly:tensor<16x256xi32>>
-  %empty = tensor.empty() : tensor<16x256xi32>
-  %0 = linalg.fill ins(%c0_i32 : i32) outs(%empty : tensor<16x256xi32>) -> tensor<16x256xi32>
-  %1 = linalg.matmul ins(%arg0, %arg1 : tensor<16x256xi8>, tensor<256x256xi8>)
-      outs(%0 : tensor<16x256xi32>) -> tensor<16x256xi32>
-  flow.dispatch.tensor.store %1, %arg2_binding, offsets = [0, 0], sizes = [16, 256], strides = [1, 1] : tensor<16x256xi32> -> !flow.dispatch.tensor<writeonly:tensor<16x256xi32>>
+  %arg0_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<1024x2048xi32>>
+  %arg0 = flow.dispatch.tensor.load %arg0_binding, offsets = [0, 0], sizes = [1024, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<1024x2048xi32>> -> tensor<1024x2048xi32>
+  %arg1_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2048x512xi32>>
+  %arg1 = flow.dispatch.tensor.load %arg1_binding, offsets = [0, 0], sizes = [2048, 512], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<2048x512xi32>> -> tensor<2048x512xi32>
+  %arg2_binding = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) flags(None) : !flow.dispatch.tensor<writeonly:tensor<1024x512xi32>>
+  %empty = tensor.empty() : tensor<1024x512xi32>
+  %0 = linalg.fill ins(%c0_i32 : i32) outs(%empty : tensor<1024x512xi32>) -> tensor<1024x512xi32>
+  %1 = linalg.matmul ins(%arg0, %arg1 : tensor<1024x2048xi32>, tensor<2048x512xi32>)
+      outs(%0 : tensor<1024x512xi32>) -> tensor<1024x512xi32>
+  flow.dispatch.tensor.store %1, %arg2_binding, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1] : tensor<1024x512xi32> -> !flow.dispatch.tensor<writeonly:tensor<1024x512xi32>>
   return
 }
 
@@ -39,153 +38,196 @@ module attributes { transform.with_named_sequence } {
     %ops = transform.structured.match ops{["linalg.fill", "linalg.matmul"]} in %variant_op : (!transform.any_op) -> !transform.any_op
     %fill, %matmul = transform.split_handle %ops : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
-    // First level tile to forall with tile_sizes [16, 256] to target 4 cores. Adjust to [16, 64] for 1 core.
-    %tiled_matmul, %forall =
-      transform.structured.tile_using_forall %matmul tile_sizes [16, 256]
+    // First level tile to forall.
+    %first_level_tiled_matmul, %outer_forall =
+      transform.structured.tile_using_forall %matmul tile_sizes [64, 64]
         ( mapping = [#gpu.block<y>, #gpu.block<x>] ) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
     // Fuse fill operation into the forall loop.
-    %fused_fill, %_ = transform.structured.fuse_into_containing_op %fill into %forall : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+    %fused_fill, %1 = transform.structured.fuse_into_containing_op %fill into %outer_forall : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
 
-    // Tile reduction dimension.
-    %tiled_reduction, %loop =
-      transform.structured.tile_using_for %tiled_matmul [0, 0, 64]
-      : (!transform.any_op) -> (!transform.any_op, !transform.op<"scf.for">)
-
-    // Pack by applying data tiling, and the linalg.matmul becomes linalg.generic.
-    %packed = transform.structured.pack %tiled_reduction packed_sizes = [16, 64, 64]
+    // First level pack the matmul.
+    %first_level_tiled_transposed_l2_packed_matmul = transform.structured.pack %first_level_tiled_matmul packed_sizes = [64, 64, 256]
       : (!transform.any_op) -> (!transform.any_op)
 
-    // Transpose B matrix from [K N n k] to [K N k n]
-    %pack_producer_b0 = transform.get_producer_of_operand %packed[1]
-      : (!transform.any_op) -> (!transform.any_op)
-    %packed_b0, %pack_b0, %empty_unpack_b0 =
-      transform.structured.pack_transpose %pack_producer_b0 with_compute_op(%packed)
-      inner_perm = [1, 0] : (!transform.any_op, !transform.any_op)
+    %lhs_l2_pack = transform.get_producer_of_operand %first_level_tiled_transposed_l2_packed_matmul[0] : (!transform.any_op) -> (!transform.any_op)
+
+    %rhs_transposed_l2_pack_op = transform.get_producer_of_operand %first_level_tiled_transposed_l2_packed_matmul[1] : (!transform.any_op) -> (!transform.any_op)
+    %first_level_tiled_l2_packed_matmul, %rhs_l2_pack, %rhs_unpack =
+      transform.structured.pack_transpose %rhs_transposed_l2_pack_op with_compute_op(%first_level_tiled_transposed_l2_packed_matmul)
+      outer_perm = [0, 1] inner_perm = [1, 0] : (!transform.any_op, !transform.any_op)
       -> (!transform.any_op, !transform.any_op, !transform.any_op)
 
-    // Bufferize to shared memory allocation
-    %pack_producer_a0 = transform.get_producer_of_operand %packed_b0[0]
-      : (!transform.any_op) -> (!transform.any_op)
-    %pack_producer_c0 = transform.get_producer_of_operand %packed_b0[2]
-      : (!transform.any_op) -> (!transform.any_op)
-    %buffer_a0, %new_a0 = transform.structured.bufferize_to_allocation %pack_b0
-      {memory_space = 1, bufferize_destination_only, emit_dealloc} : !transform.any_op
-    %buffer_b0, %new_b0 = transform.structured.bufferize_to_allocation %pack_producer_a0
-      {memory_space = 1, bufferize_destination_only, emit_dealloc} : !transform.any_op
-    %buffer_c0, %new_c0 = transform.structured.bufferize_to_allocation %pack_producer_c0
-      {memory_space = 1, bufferize_destination_only, emit_dealloc} : !transform.any_op
+    // Clean up.
+    transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()
 
-    // Second level tile to forall with tile_sizes [1, 1].
-    %tiled_matmul_1, %forall_1 =
-      transform.structured.tile_using_forall %packed_b0 tile_sizes [1, 1]
-        ( mapping = [#gpu.thread<y>, #gpu.thread<x>] ) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    // Promote the fused fill to shared memory
+    %result_l2 = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    %result_l2_buffer, %result_t2_new = transform.structured.bufferize_to_allocation %result_l2
+        {memory_space = 1, bufferize_destination_only, mempcy = "linalg.copy", emit_dealloc} : !transform.any_op
 
-    // Pack by applying data tiling, and the linalg.matmul becomes linalg.generic.
-    %packed_2 = transform.structured.pack %tiled_matmul_1 packed_sizes = [0, 0, 0, 4, 8, 8]
+    // Second level pack the matmul.
+    %generic_op = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    %l1_packed = transform.structured.pack %generic_op packed_sizes = [0, 0, 0, 4, 8, 8]
       : (!transform.any_op) -> (!transform.any_op)
 
     // Transpose A matrix from [M K m k m0 k0] to [M K k m m0 k0]
-    %pack_producer_a = transform.get_producer_of_operand %packed_2[0]
+    %l1_packed_lhs = transform.get_producer_of_operand %l1_packed[0]
       : (!transform.any_op) -> (!transform.any_op)
-    %packed_a, %pack_a, %empty_unpack_a =
-      transform.structured.pack_transpose %pack_producer_a with_compute_op(%packed_2)
+    %lhs_l1_packed_matmul, %lhs_l1_pack_op, %lhs_l1_unpack_op =
+      transform.structured.pack_transpose %l1_packed_lhs with_compute_op(%l1_packed)
       outer_perm = [0, 1, 3, 2] : (!transform.any_op, !transform.any_op)
       -> (!transform.any_op, !transform.any_op, !transform.any_op)
 
     // Transpose B matrix from [K N k n n0 k0] to [K N n k k0 n0]
-    %pack_producer_b = transform.get_producer_of_operand %packed_a[1]
+    %l1_packed_rhs = transform.get_producer_of_operand %lhs_l1_packed_matmul[1]
       : (!transform.any_op) -> (!transform.any_op)
-    %packed_b, %pack_b, %empty_unpack_b =
-      transform.structured.pack_transpose %pack_producer_b with_compute_op(%packed_a)
+    %operands_l1_packed_matmul, %rhs_l1_pack_op, %rhs_l1_unpack_op =
+      transform.structured.pack_transpose %l1_packed_rhs with_compute_op(%lhs_l1_packed_matmul)
       outer_perm = [0, 1, 3, 2] inner_perm = [1, 0] : (!transform.any_op, !transform.any_op)
       -> (!transform.any_op, !transform.any_op, !transform.any_op)
 
     // Transpose C matrix from [M N m n m0 n0] to [M N n m m0 n0]
-    %unpack = transform.get_consumers_of_result %packed_b[0]
+    %l1_packed_output = transform.get_consumers_of_result %operands_l1_packed_matmul[0]
       : (!transform.any_op) -> (!transform.any_op)
-    %packed_c, %pack_c, %unpack_c =
-      transform.structured.pack_transpose %unpack with_compute_op(%packed_b)
+    %l1_packed_matmul, %output_l1_pack_op, %output_l1_unpack_op =
+      transform.structured.pack_transpose %l1_packed_output with_compute_op(%operands_l1_packed_matmul)
       outer_perm = [0, 1, 3, 2] : (!transform.any_op, !transform.any_op)
       -> (!transform.any_op, !transform.any_op, !transform.any_op)
 
-    // Bufferize to local memory allocation
-    %buffer_a, %new_a = transform.structured.bufferize_to_allocation %pack_a
-      {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
-    %buffer_b, %new_b = transform.structured.bufferize_to_allocation %pack_b
-      {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
-    %buffer_c, %new_c = transform.structured.bufferize_to_allocation %pack_c
-      {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
+    // Promote the result to local memory
+    %output_l1_pack_op_source_buffer, %output_l1_pack_op_new = transform.structured.bufferize_to_allocation %output_l1_pack_op
+        {memory_space = 2, bufferize_destination_only, memcpy_op = "linalg.copy", emit_dealloc} : !transform.any_op
 
-    // Hoist static alloc out of the loops
-    %memref_func = transform.structured.match ops{["func.func"]} in %variant_op
-      : (!transform.any_op) -> !transform.any_op
-    transform.iree.hoist_static_alloc %memref_func : (!transform.any_op) -> ()
+    // First level for loop.
+    %first_level_tiled_reduction_matmul, %outer_for_loop =
+      transform.structured.tile_using_for %l1_packed_matmul [0, 0, 1]
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
-    // Peel the first iteration out of the for loop.
-    // This only works when the for loop has more than one iteration.
-    %1 = transform.get_parent_op %packed_c {op_name = "scf.for"} : (!transform.any_op) -> !transform.op<"scf.for">
-    %main_loop, %remainder = transform.loop.peel %1 {peel_front = true}
-      : (!transform.op<"scf.for">) -> (!transform.any_op, !transform.any_op)
+    // Fuse the pack operations in the outer for loop.
+    %fused_lhs_l1_pack, %2 = transform.structured.fuse_into_containing_op %lhs_l1_pack_op into %outer_for_loop : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+    %fused_rhs_l1_pack, %3 = transform.structured.fuse_into_containing_op %rhs_l1_pack_op into %outer_for_loop : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+    %fused_lhs_l2_pack, %4 = transform.structured.fuse_into_containing_op %lhs_l2_pack into %outer_for_loop : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+    %fused_rhs_l2_pack, %5 = transform.structured.fuse_into_containing_op %rhs_l2_pack into %outer_for_loop : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+    // Promote the lhs to shared memory
+    %lhs_l2_pack_buffer, %lhs_l2_pack_new = transform.structured.bufferize_to_allocation %fused_lhs_l2_pack
+       {memory_space = 1, bufferize_destination_only, memcpy_op = "linalg.copy", emit_dealloc} : !transform.any_op
+
+    // Promote the rhs to shared memory
+    %rhs_l2_pack_buffer, %rhs_l2_pack_new = transform.structured.bufferize_to_allocation %fused_rhs_l2_pack
+       {memory_space = 1, bufferize_destination_only, memcpy_op = "linalg.copy", emit_dealloc} : !transform.any_op
+
     transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()
 
-    // Find the fill and the second forall operations.
-    %fused_fill_1 = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!transform.any_op) -> !transform.any_op
-    %fill_consumer = transform.get_consumers_of_result %fused_fill_1[0] : (!transform.any_op) -> (!transform.any_op)
+    // Second level tile to forall with tile_sizes.
+    %second_level_tiled_matmul, %inner_forall =
+      transform.structured.tile_using_forall %first_level_tiled_reduction_matmul tile_sizes [0, 0, 0, 8, 4, 0]
+        ( mapping = [#gpu.thread<y>, #gpu.thread<x>] ) : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
 
-    // Fuse fill operation into the forall loop
-    %fused_fill_2, %__ = transform.structured.fuse_into_containing_op %fused_fill_1 into %fill_consumer
-      : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+    // Fuse the pack operations in inner forall loop.
+    %fused_lhs_l1_pack2, %6 = transform.structured.fuse_into_containing_op %fused_lhs_l1_pack into %inner_forall : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+    %fused_rhs_l1_pack2, %7 = transform.structured.fuse_into_containing_op %fused_rhs_l1_pack into %inner_forall : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
 
     // Clean up.
     transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()
-    transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+
+    // Second level for loop.
+    %generic_op1 = transform.structured.match ops{["linalg.generic"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    %second_level_tiled_reduction_matmul, %inner_for_loop =
+      transform.structured.tile_using_for %generic_op1 [0, 0, 0, 0, 0, 4]
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+    // Fuse the pack operations in inner for loop.
+    %fused_lhs_l1_pack3, %8 = transform.structured.fuse_into_containing_op %fused_lhs_l1_pack2 into %inner_for_loop : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+    %fused_rhs_l1_pack3, %9 = transform.structured.fuse_into_containing_op %fused_rhs_l1_pack2 into %inner_for_loop : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
+
+    // Promote the LHS to local memory.
+    %lhs_l1_pack_buffer, %lhs_l1_pack_new = transform.structured.bufferize_to_allocation %fused_lhs_l1_pack3
+      {memory_space = 2, bufferize_destination_only, emit_dealloc} : !transform.any_op
+
+    // Promote the RHS to local memory.
+    %rhs_l1_pack_buffer, %rhs_l1_pack_new = transform.structured.bufferize_to_allocation %fused_rhs_l1_pack3
+      {memory_space = 2, bufferize_destination_only, memcpy_op = "linalg.copy", emit_dealloc} : !transform.any_op
+
+    // Clean up.
+    transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()
+
+    // Hoist static alloc out of the loops
+    %func = transform.structured.match ops{["func.func"]} in %variant_op
+      : (!transform.any_op) -> !transform.any_op
+    transform.iree.hoist_static_alloc %func : (!transform.any_op) -> ()
+
+    // Peel the for loop
+    %for_ops = transform.structured.match ops{["scf.for"]} in %variant_op : (!transform.any_op) -> !transform.op<"scf.for">
+    %inner_for, %outer_for = transform.split_handle %for_ops : (!transform.op<"scf.for">) -> (!transform.op<"scf.for">, !transform.op<"scf.for">)
+    %peeled_outer_loop, %remainder = transform.loop.peel %outer_for {peel_front = true}
+      : (!transform.op<"scf.for">) -> (!transform.any_op, !transform.any_op)
+
+    // Clean up.
+    transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()
+
+    // Find the fill operation to fuse
+    %fill_op = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!transform.any_op) -> !transform.any_op
+    // Get the consumers of the fill. It has to be a scf.forall op.
+    %peeled_loop = transform.get_consumers_of_result %fill_op[0] : (!transform.any_op) -> (!transform.op<"scf.forall">)
+
+    // Fuse the fill within the loop.
+    %peel_fused, %13 = transform.structured.fuse_into_containing_op %fill_op into %peeled_loop : (!transform.any_op, !transform.op<"scf.forall">) -> (!transform.any_op, !transform.any_op)
+
+    // Clean up.
+    transform.include @cleanup failures(propagate) (%variant_op) : (!transform.any_op) -> ()
 
     // Bufferize and drop HAL decriptor from memref ops.
-    %variant_op_3 = transform.iree.bufferize %variant_op : (!transform.any_op) -> !transform.any_op
+    transform.iree.eliminate_empty_tensors %variant_op : (!transform.any_op) -> ()
+    %14 = transform.iree.bufferize %variant_op : (!transform.any_op) -> !transform.any_op
+
     transform.yield
   }
 }
 
-// CHECK-LABEL: @matmul_example
-//       CHECK: memref.alloc() : memref<1x1x8x4x4x8xi32, 2>
-//       CHECK: memref.alloc() : memref<1x1x8x8x8x8xi8, 2>
-//       CHECK: memref.alloc() : memref<1x1x8x4x4x8xi8, 2>
-//       CHECK: memref.alloc() : memref<1x4x16x64xi32, 1>
-//       CHECK: memref.alloc() : memref<1x4x64x64xi8, 1>
-//       CHECK: memref.alloc() : memref<1x1x16x64xi8, 1>
+// CHECK-LABEL: @matmul_i32
+//       CHECK: memref.alloc() : memref<1x1x4x4x8x8xi32, 2>
+//       CHECK: memref.alloc() : memref<1x1x4x8x4x8xi32, 2>
+//       CHECK: memref.alloc() : memref<1x1x256x64xi32, 1>
+//       CHECK: memref.alloc() : memref<1x1x64x256xi32, 1>
+//       CHECK: memref.alloc() : memref<1x1x8x16x4x8xi32, 2>
+//       CHECK: memref.alloc() : memref<1x1x64x64xi32, 1>
 //       CHECK: scf.forall
 //       CHECK: {
-//       CHECK:   iree_linalg_ext.pack %{{.*}} : (memref<16x64xi8, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x1x16x64xi8, 1>)
-//       CHECK:   iree_linalg_ext.pack %{{.*}} : (memref<64x256xi8, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x4x64x64xi8, 1>)
+//       CHECK:   iree_linalg_ext.pack %{{.*}} : (memref<64x256xi32, strided<[2048, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x1x64x256xi32, 1>)
+//       CHECK:   iree_linalg_ext.pack %{{.*}} : (memref<256x64xi32, strided<[512, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x1x256x64xi32, 1>)
 //       CHECK:   scf.forall
 //       CHECK:   {
-//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<1x1x16x64xi8, strided<[1024, 1024, 64, 1], offset: ?>, 1> memref<1x1x8x4x4x8xi8, 2>)
-//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<1x1x64x64xi8, strided<[16384, 4096, 64, 1], offset: ?>, 1> memref<1x1x8x8x8x8xi8, 2>)
-//       CHECK:     linalg.fill ins(%{{.*}}) outs(%{{.*}} : memref<1x1x8x4x4x8xi32, 2>)
-//       CHECK:     linalg.generic
-//       CHECK:     iree_linalg_ext.unpack %{{.*}} : (memref<1x1x8x4x4x8xi32, 2> memref<1x1x16x64xi32, strided<[4096, 1024, 64, 1], offset: ?>, 1>)
+//       CHECK:     memref.subview %{{.*}} : memref<1x1x8x16x4x8xi32, 2> to memref<1x1x4x8x4x8xi32, strided<[4096, 4096, 512, 32, 8, 1], offset: ?>, 2>
+//       CHECK:     linalg.fill ins(%{{.*}}) outs(%{{.*}} : memref<1x1x4x8x4x8xi32, strided<[4096, 4096, 512, 32, 8, 1], offset: ?>, 2>)
+//       CHECK:     scf.for
+//       CHECK:     {
+//       CHECK:       iree_linalg_ext.pack %{{.*}} : (memref<1x1x32x32xi32, strided<[16384, 16384, 256, 1], offset: ?>, 1> memref<1x1x4x8x4x8xi32, 2>)
+//       CHECK:       iree_linalg_ext.pack %{{.*}} : (memref<1x1x32x32xi32, strided<[16384, 16384, 64, 1], offset: ?>, 1> memref<1x1x4x4x8x8xi32, 2>)
+//       CHECK:       linalg.generic
+//       CHECK:     }
 //       CHECK:   }
-//       CHECK:   iree_linalg_ext.unpack %{{.*}} : (memref<1x4x16x64xi32, 1> memref<16x256xi32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>)
 //       CHECK:   scf.for
 //       CHECK:   {
-//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<16x64xi8, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x1x16x64xi8, 1>)
-//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<64x256xi8, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x4x64x64xi8, 1>)
-//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<16x256xi32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x4x16x64xi32, 1>)
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<64x256xi32, strided<[2048, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x1x64x256xi32, 1>)
+//       CHECK:     iree_linalg_ext.pack %{{.*}} : (memref<256x64xi32, strided<[512, 1], offset: ?>, #hal.descriptor_type<storage_buffer>> memref<1x1x256x64xi32, 1>)
 //       CHECK:     scf.forall
 //       CHECK:     {
-//       CHECK:       iree_linalg_ext.pack %{{.*}} : (memref<1x1x16x64xi8, strided<[1024, 1024, 64, 1], offset: ?>, 1> memref<1x1x8x4x4x8xi8, 2>)
-//       CHECK:       iree_linalg_ext.pack %{{.*}} : (memref<1x1x64x64xi8, strided<[16384, 4096, 64, 1], offset: ?>, 1> memref<1x1x8x8x8x8xi8, 2>)
-//       CHECK:       iree_linalg_ext.pack %{{.*}} : (memref<1x1x16x64xi32, strided<[4096, 1024, 64, 1], offset: ?>, 1> memref<1x1x8x4x4x8xi32, 2>)
-//       CHECK:       linalg.generic
-//       CHECK:       iree_linalg_ext.unpack %{{.*}} : (memref<1x1x8x4x4x8xi32, 2> memref<1x1x16x64xi32, strided<[4096, 1024, 64, 1], offset: ?>, 1>)
+//       CHECK:       scf.for
+//       CHECK:       {
+//       CHECK:         iree_linalg_ext.pack %{{.*}} : (memref<1x1x32x32xi32, strided<[16384, 16384, 256, 1], offset: ?>, 1> memref<1x1x4x8x4x8xi32, 2>)
+//       CHECK:         iree_linalg_ext.pack %{{.*}} : (memref<1x1x32x32xi32, strided<[16384, 16384, 64, 1], offset: ?>, 1> memref<1x1x4x4x8x8xi32, 2>)
+//       CHECK:         linalg.generic
+//       CHECK:       }
 //       CHECK:     }
-//       CHECK:     iree_linalg_ext.unpack %{{.*}} : (memref<1x4x16x64xi32, 1> memref<16x256xi32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>)
 //       CHECK:   }
+//       CHECK:   iree_linalg_ext.unpack %{{.*}} : (memref<1x1x8x16x4x8xi32, 2> memref<1x1x64x64xi32, 1>)
+//       CHECK:   iree_linalg_ext.unpack %{{.*}} : (memref<1x1x64x64xi32, 1> memref<64x64xi32, strided<[512, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>)
 //       CHECK: }
-//       CHECK: memref.dealloc %{{.*}} : memref<1x1x16x64xi8, 1>
-//       CHECK: memref.dealloc %{{.*}} : memref<1x4x64x64xi8, 1>
-//       CHECK: memref.dealloc %{{.*}} : memref<1x4x16x64xi32, 1>
-//       CHECK: memref.dealloc %{{.*}} : memref<1x1x8x4x4x8xi8, 2>
-//       CHECK: memref.dealloc %{{.*}} : memref<1x1x8x8x8x8xi8, 2>
-//       CHECK: memref.dealloc %{{.*}} : memref<1x1x8x4x4x8xi32, 2>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x64x64xi32, 1>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x8x16x4x8xi32, 2>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x64x256xi32, 1>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x256x64xi32, 1>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x4x8x4x8xi32, 2>
+//       CHECK: memref.dealloc %{{.*}} : memref<1x1x4x4x8x8xi32, 2>


### PR DESCRIPTION
- Rename previous script `matmul_fill_spec_pack_peel.mlir` for funcIR prototype to `matmul_fill_spec_pack_funcIR.mlir`. 
- The latest `matmul_fill_spec_pack_peel.mlir` implements `forall-for-forall-for` structure with peel operation for the first iteration. Both levels of packing happen under the outer forall op, and are gradually fused into the inner loops.
- With this method, it avoids data movement across memory hierarchy between the peeled and the remaining loops. However, it results in a larger memory allocation for the results in L1. 
- Tested with input sizes not multiple of tile sizes, and it works with [upstream hack](https://github.com/llvm/llvm-project/commit/88ae64dcd4c49542133303a007ff01ec6ae2f548). The generated IR can be found [here](https://gist.github.com/yzhang93/1ff2169ac8d8bb2fc1f1e517fc269aa5?permalink_comment_id=5003206#gistcomment-5003206).