### PR TITLE
Make matmul tests take m,n,k directly 

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -175,24 +175,42 @@ cd ${OUTPUT_DIR}
 function run_matmul_test() {
 
 
-  # Options without defaults:
+  # Options without defaults
+  # ========================
   local lhs_rhs_type=""
   local acc_type=""
   local m=""
   local n=""
   local k=""
 
-  # Options with defaults:
+  # Options with defaults
+  # =====================
+  # name_prefix: A prefix for the name of the test. The full test name will be
+  # extended with m,n,k if they are unique.
   local name_prefix="noprefix"
+
   local target_backend="amd-aie"
+
   local device="xrt"
+
   local peano_install_path="${PEANO}"
+
   local mlir_aie_install_path="${MLIR_AIE_INSTALL}"
+
   local vitis_path="${VITIS}"
+
   local pipeline="pad-pack"
+
+  # By default, the m,n,k provided are used, and there are no dynamic tensor
+  # dimensions.
   local dynamicity="static"
+
   local accumulate="false"
+
+  # By default we do not expect a compilation failure.
   local expect_compile_failure="0"
+
+  # By default we want to compile and run the numerical test.
   local compile_only="0"
 
   while [ "$#" -gt 0 ]; do
@@ -263,19 +281,22 @@ function run_matmul_test() {
         ;;
       *)
         echo "Unknown option: $1"
-        return 1
+        exit 1
         ;;
     esac
   done
 
   set -x
 
-  # Generate a name for the test based on the m,n,k parameters, but only 
+  # Generate a name for the test based on the m,n,k parameters, but only
   # if this test only has 1 set of m,n,k parameters. If there are multiple
   # sets of m,n,k parameters, then just use name_prefix provided
   # This is to prevent very long names when the number of m,n,k parameters
   # is large.
+  # Generate a name, assuming m, n, k are just single integers:
   name="mm_${name_prefix}_${lhs_rhs_type}_${acc_type}_m${m}_n${n}_k${k}"
+  # If m, n, or k was not just an integer but a sequence of integers, then
+  # just just use the name_prefix.
   if [ $(echo $name | grep -q ',') ] || [ $(echo $name | grep -q ' ') ]; then
     name="mm_${name_prefix}"
   fi
@@ -300,7 +321,7 @@ function run_matmul_test() {
       --n=${n} \
       --k=${k} \
       --dynamicity=${dynamicity} \
-      --accumulate=${accumulate} 
+      --accumulate=${accumulate}
 
 
   ## Disable exit on failure:
@@ -319,10 +340,10 @@ function run_matmul_test() {
 
   compileResult=$?
 
-  # If you expect a failure, and got a failure, exit with 0
-  # If you expect a failure, and got a success, exit with 1
-  # If you expect a success, and got a failure, exit with 1
-  # If you expect a success, and got a success, continue.
+  # If expect a failure, and get a failure, exit with 0
+  # If expect a failure, and got a success, exit with 1
+  # If expect a success, and got a failure, exit with 1
+  # If expect a success, and got a success, continue.
   if [ $expect_compile_failure -ne 0 ]; then
     if [ $compileResult -ne 0 ]; then
       echo "Expected compile failure, got compile failure."
@@ -436,8 +457,8 @@ run_matmul_test \
     --expect-compile-failure "0" \
     --compile-only "0"
 
-# An example of a matmul which we don't currently support, and which fails in 
-# compilation. We should support this (and all!) matmul. 
+# An example of a matmul which we don't currently support, and which fails in
+# compilation. We should support this (and all!) matmul.
 run_matmul_test \
    --name_prefix "failure_0" \
    --lhs_rhs_type "i32" \
@@ -446,10 +467,10 @@ run_matmul_test \
    --expect-compile-failure "1"
 
 
-# Example of a run with a group of 2+ matmuls. Currently this test is passed 
-# the flag '--compile-only' as there is currently an issue with the runtime if 
-# multiple matmuls are run in the same test. TODO(newling/nmeshram): Document 
-# this issue. 
+# Example of a run with a group of 2+ matmuls. Currently this test is passed
+# the flag '--compile-only' as there is currently an issue with the runtime if
+# multiple matmuls are run in the same test. TODO(newling/nmeshram): Document
+# this issue.
 run_matmul_test \
     --name_prefix "small" \
     --lhs_rhs_type "i32" \

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -173,21 +173,40 @@ cd ${OUTPUT_DIR}
 # Reference for named args: https://tecadmin.net/create-bash-functions-with-arguments/
 
 function run_matmul_test() {
-  local name=""
+
+
+  # Options without defaults:
   local lhs_rhs_type=""
   local acc_type=""
-  local shapes=""
-  local target_backend=""
-  local device=""
-  local peano_install_path=""
-  local mlir_aie_install_path=""
-  local vitis_path=""
-  local pipeline=""
+  local m=""
+  local n=""
+  local k=""
+
+  # Options with defaults:
+  local name_prefix="noprefix"
+  local target_backend="amd-aie"
+  local device="xrt"
+  local peano_install_path="${PEANO}"
+  local mlir_aie_install_path="${MLIR_AIE_INSTALL}"
+  local vitis_path="${VITIS}"
+  local pipeline="pad-pack"
+  local dynamicity="static"
+  local accumulate="false"
+  local expect_compile_failure="0"
+  local compile_only="0"
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --name)
-        name="$2"
+      --compile-only)
+        compile_only="$2"
+        shift 2
+        ;;
+      --expect-compile-failure)
+        expect_compile_failure="$2"
+        shift 2
+        ;;
+      --name_prefix)
+        name_prefix="$2"
         shift 2
         ;;
       --lhs_rhs_type)
@@ -196,10 +215,6 @@ function run_matmul_test() {
         ;;
       --acc_type)
         acc_type="$2"
-        shift 2
-        ;;
-      --shapes)
-        shapes="$2"
         shift 2
         ;;
       --target_backend)
@@ -226,6 +241,26 @@ function run_matmul_test() {
         pipeline="$2"
         shift 2
         ;;
+      --dynamicity)
+        dynamicity="$2"
+        shift 2
+        ;;
+      --accumulate)
+        accumulate="$2"
+        shift 2
+        ;;
+      --m)
+        m="$2"
+        shift 2
+        ;;
+      --n)
+        n="$2"
+        shift 2
+        ;;
+      --k)
+        k="$2"
+        shift 2
+        ;;
       *)
         echo "Unknown option: $1"
         return 1
@@ -235,17 +270,44 @@ function run_matmul_test() {
 
   set -x
 
+  # Generate a name for the test based on the m,n,k parameters, but only 
+  # if this test only has 1 set of m,n,k parameters. If there are multiple
+  # sets of m,n,k parameters, then just use name_prefix provided
+  # This is to prevent very long names when the number of m,n,k parameters
+  # is large.
+  name="mm_${name_prefix}_${lhs_rhs_type}_${acc_type}_m${m}_n${n}_k${k}"
+  if [ $(echo $name | grep -q ',') ] || [ $(echo $name | grep -q ' ') ]; then
+    name="mm_${name_prefix}"
+  fi
+  # Confirm that the name does not contain any commas or spaces.
+  if [ $(echo $name | grep -q ',') ] || [ $(echo $name | grep -q ' ') ]; then
+    echo "Name contains a comma or space: '$name'"
+    exit 1
+  fi
+
+  matmul_ir="${OUTPUT_DIR}/${name}_ir.mlir"
+  calls_ir="${OUTPUT_DIR}/${name}_calls.mlir"
+  matmul_vmfb="${OUTPUT_DIR}/${name}.vmfb"
+  calls_vmfb="${OUTPUT_DIR}/${name}_calls.vmfb"
+
   echo "**** Generating .mlir files ****"
   ${IREE_PYTHON3_EXECUTABLE} ${GENERATOR} \
-      --output_matmuls_mlir="${OUTPUT_DIR}/${name}_matmuls.mlir" \
-      --output_calls_mlir="${OUTPUT_DIR}/${name}_calls.mlir" \
+      --output_matmuls_mlir="${matmul_ir}" \
+      --output_calls_mlir="${calls_ir}" \
       --lhs_rhs_type=${lhs_rhs_type} \
       --acc_type=${acc_type} \
-      --shapes=${shapes}
+      --m=${m} \
+      --n=${n} \
+      --k=${k} \
+      --dynamicity=${dynamicity} \
+      --accumulate=${accumulate} 
 
-  echo "**** Generating .vmfb files for $pipeline pipeline ****"
-  ${IREE_COMPILE_EXE} \
-      "${OUTPUT_DIR}/${name}_matmuls.mlir" \
+
+  ## Disable exit on failure:
+  set +e
+
+  echo "**** Generating matmul .vmfb file for ${name} ****"
+  ${IREE_COMPILE_EXE} "${matmul_ir}"  \
       --iree-hal-target-backends=${target_backend} \
       --iree-amdaie-use-pipeline=${pipeline} \
       --iree-amd-aie-peano-install-dir=${peano_install_path} \
@@ -253,14 +315,40 @@ function run_matmul_test() {
       --iree-amd-aie-vitis-install-dir=${vitis_path} \
       --iree-hal-dump-executable-files-to=$PWD \
       --iree-amd-aie-show-invoked-commands \
-      -o "${OUTPUT_DIR}/${name}_matmuls.vmfb"
-  ${IREE_COMPILE_EXE} \
-      "${OUTPUT_DIR}/${name}_calls.mlir" \
+      -o "${matmul_vmfb}"
+
+  compileResult=$?
+
+  # If you expect a failure, and got a failure, exit with 0
+  # If you expect a failure, and got a success, exit with 1
+  # If you expect a success, and got a failure, exit with 1
+  # If you expect a success, and got a success, continue.
+  if [ $expect_compile_failure -ne 0 ]; then
+    if [ $compileResult -ne 0 ]; then
+      echo "Expected compile failure, got compile failure."
+      return 0
+    else
+      echo "Expected compile failure, got compile success."
+      exit 1
+    fi
+  else
+    if [ $compileResult -ne 0 ]; then
+      echo "Expected compile success, got compile failure."
+      exit 1
+    fi
+  fi
+
+  # Renable exit on failure:
+  set -e
+
+
+  echo "**** Generating calls .vmfb file for ${name} ****"
+  ${IREE_COMPILE_EXE} "${calls_ir}" \
       --iree-hal-target-backends=${target_backend} \
-      -o "${OUTPUT_DIR}/${name}_calls.vmfb"
+      -o "${calls_vmfb}"
 
   # Extract function names from the mlir file
-  function_names=$(grep -oP '@\K\S+(?=\()' ${OUTPUT_DIR}/${name}_matmuls.mlir)
+  function_names=$(grep -oP '@\K\S+(?=\()' ${matmul_ir})
 
   # Behavior of <do-signing> depends on if the script for
   # signing xclbins is found:
@@ -271,7 +359,6 @@ function run_matmul_test() {
   # 1              | no                              | Error
   # 0              | no/yes                          | Skip signing
   # -------------- | ------------------------------- | -------------
-
 
   if [ $DO_SIGNING -eq 0 ]; then
     echo "**** Skipping XCLBIN signing: DO_SIGNING set to 0 ****"
@@ -300,9 +387,15 @@ function run_matmul_test() {
   echo "**** Running '${name}' matmul tests ****"
 
   COMMAND="${TEST_RUNNER} \
-      --module=${OUTPUT_DIR}/${name}_matmuls.vmfb \
-      --module=${OUTPUT_DIR}/${name}_calls.vmfb \
+      --module=${matmul_vmfb} \
+      --module=${calls_vmfb} \
       --device=${device}"
+
+  # If compile only, exit with success:
+  if [ $compile_only -ne "0" ]; then
+    echo "Compile only flag is ${compile_only} which is not 0, skipping execution"
+    return 0
+  fi
 
   echo "Running command: ${COMMAND}"
 
@@ -317,38 +410,88 @@ function run_matmul_test() {
 # Run a few tests                                                             #
 ###############################################################################
 
+# Notes:
+# 1. Be conservative in adding more shapes, as that can increase both the
+#    build and execution latency of tests. The build latency is nearly the
+#    same for all shapes, while execution latency grows cubicly i.e.
+#    linearly with m*k*n.
+#
+
+# Example of a run without any defaults arguments.
 run_matmul_test \
-    --name "matmul_bf16_bf16_large_amd-aie_xrt_pad-pack" \
+    --name_prefix "test1" \
     --lhs_rhs_type "bf16" \
     --acc_type "f32" \
-    --shapes "large_legacy" \
     --target_backend "amd-aie" \
     --device "xrt" \
     --peano_install_path "${PEANO}" \
     --mlir_aie_install_path "${MLIR_AIE_INSTALL}" \
     --vitis_path  "${VITIS}" \
-    --pipeline "pad-pack"
+    --pipeline "pad-pack" \
+    --m "64" \
+    --n "64" \
+    --k "64" \
+    --dynamicity "static" \
+    --accumulate "false" \
+    --expect-compile-failure "0" \
+    --compile-only "0"
 
+# An example of a matmul which we don't currently support, and which fails in 
+# compilation. We should support this (and all!) matmul. 
 run_matmul_test \
-    --name "matmul_i32_i32_small_amd-aie_xrt_pad-pack" \
+   --name_prefix "failure_0" \
+   --lhs_rhs_type "i32" \
+   --acc_type "i32" \
+   --m "1"  --n "1" --k "1000" \
+   --expect-compile-failure "1"
+
+
+# Example of a run with a group of 2+ matmuls. Currently this test is passed 
+# the flag '--compile-only' as there is currently an issue with the runtime if 
+# multiple matmuls are run in the same test. TODO(newling/nmeshram): Document 
+# this issue. 
+run_matmul_test \
+    --name_prefix "small" \
     --lhs_rhs_type "i32" \
     --acc_type "i32" \
-    --shapes "small" \
-    --target_backend "amd-aie" \
-    --device "xrt" \
-    --peano_install_path "${PEANO}" \
-    --mlir_aie_install_path "${MLIR_AIE_INSTALL}" \
-    --vitis_path  "${VITIS}" \
-    --pipeline "pad-pack"
+    --m "512,8,16,52,7" \
+    --n "512,32,16,52,15" \
+    --k "256,16,8,63,9" \
+    --compile-only "1"
 
 run_matmul_test \
-    --name "matmul_i32_i32_large_amd-aie_xrt_pad-pack" \
+    --name_prefix "small_test3" \
     --lhs_rhs_type "i32" \
     --acc_type "i32" \
-    --shapes "large" \
-    --target_backend "amd-aie" \
-    --device "xrt" \
-    --peano_install_path "${PEANO}" \
-    --mlir_aie_install_path "${MLIR_AIE_INSTALL}" \
-    --vitis_path  "${VITIS}" \
-    --pipeline "pad-pack"
+    --m "16"  --n "16" --k "8"
+
+run_matmul_test \
+    --name_prefix "small_test2" \
+    --lhs_rhs_type "i32" \
+    --acc_type "i32" \
+    --m "8"  --n "32" --k "16"
+
+run_matmul_test \
+    --name_prefix "small_test4" \
+    --lhs_rhs_type "i32" \
+    --acc_type "i32" \
+    --m "52"  --n "52" --k "63"
+
+run_matmul_test \
+    --name_prefix "small_test5" \
+    --lhs_rhs_type "i32" \
+    --acc_type "i32" \
+    --m "9"  --n "7" --k "16"
+
+run_matmul_test \
+    --name_prefix "large_test6" \
+    --lhs_rhs_type "i32" \
+    --acc_type "i32" \
+    --m "64"  --n "64" --k "128"
+
+run_matmul_test \
+    --name_prefix "large_test7" \
+    --lhs_rhs_type "i32" \
+    --acc_type "i32" \
+    --m "512"  --n "512" --k "512"
+

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeDma.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeDma.cpp
@@ -6,10 +6,6 @@
 
 #include "air/Dialect/AIR/AIRDialect.h"
 #include "iree-amd-aie/Transforms/Passes.h"
-#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
-#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
-#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
-#include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPad.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPad.cpp
@@ -11,7 +11,6 @@
 #include "mlir/Dialect/MemRef/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
-#include "mlir/IR/Iterators.h"
 #include "mlir/Pass/Pass.h"
 
 #define DEBUG_TYPE "iree-amdaie-pad"

--- a/tests/matmul/generate_e2e_matmul_tests.py
+++ b/tests/matmul/generate_e2e_matmul_tests.py
@@ -516,26 +516,26 @@ def parse_arguments():
     parser.add_argument(
         "--m",
         type=str,
-        help="Number of rows in the lhs and acc matrices",
+        help="Number of rows in the lhs and acc matrices. Expected comma separated values if multiple test cases, example: 4,6,8",
         required=True,
     )
     parser.add_argument(
         "--n",
         type=str,
-        help="Number of columns in the rhs and acc matrices",
+        help="Number of columns in the rhs and acc matrices. Expected comma separated values if multiple test cases, example: 4,6,8",
         required=True,
     )
     parser.add_argument(
         "--k",
         type=str,
-        help="Number of columns in the lhs and rows in the rhs matrices",
+        help="Number of columns in the lhs and rows in the rhs matrices. Expected comma separated values if multiple test cases, example: 4,6,8",
         required=True,
     )
 
     parser.add_argument(
         "--accumulate",
         type=str,
-        help="Whether to accumulate the result",
+        help="Whether to accumulate the result. Expected comma separated values if multiple test cases, example: true,false",
         required=True,
     )
 
@@ -544,7 +544,7 @@ def parse_arguments():
         type=str,
         choices=["static", "dynamic", "mixed"],
         required=True,
-        help="Dynamicity of the input matrices",
+        help="Dynamicity of the input matrices. Expected comma separated values if multiple test cases, example: static,dynamic,mixed",
     )
 
     parser.add_argument(

--- a/tests/matmul/generate_e2e_matmul_tests.py
+++ b/tests/matmul/generate_e2e_matmul_tests.py
@@ -30,21 +30,13 @@ class MatrixElemTypeId(enum.Enum):
     BF16 = "bf16"
 
 
-# Enumerates of the collections of shapes that we can generate tests for.
-# The values are the accepted values for the --shapes= flag.
-@enum.unique
-class ShapesId(enum.Enum):
-    SMALL_LEGACY = "small_legacy"
-    LARGE_LEGACY = "large_legacy"
-    SMALL = "small"
-    LARGE = "large"
-
 # Enumerates of the collections of compilation info that we can generate tests
 # for. The values are the accepted values for the --compilation_info= flag.
 @enum.unique
 class CompilationInfoId(enum.Enum):
     NONE = ""
     AMDAIEPadBasedPassPipeline = "AMDAIEPadBasedPassPipeline"
+
 
 # Enumerates ways to construct MLIR tensor types.
 @enum.unique
@@ -65,13 +57,15 @@ class MatrixGenerator(enum.Enum):
 # the LHS is {m}x{k}, the RHS is {k}x{n}, the accumulator/result is {m}x{n}.
 # The extra `accumulate` boolean tells whether the matmul is accumulating into
 # an existing accumulator (C += A * B) or just overwriting the result
-# (C = A * B).
+# (C = A * B). The extra `dynamicity` parameter controls whether the values
+# `m`, `k`, and `n` are fixed to their set value or dynamic.
 @dataclasses.dataclass
 class TestShape:
     m: int
     k: int
     n: int
     accumulate: bool
+    dynamicity: Dynamicity
 
 
 # Describes how to construct compilation info for the testcase.
@@ -81,7 +75,7 @@ class CompilationInfo:
     tile_sizes: typing.List[typing.List[int]]
     # Translation Info
     dispatch_lowering_pass_pipeline: str
-    # The next two arguments dont make sense for 
+    # The next two arguments dont make sense for
     # AIE should they be removed?
     workload_per_wg: typing.List[int]
     software_pipeline_depth: int
@@ -91,65 +85,6 @@ class CompilationInfo:
     # Prints the workgroup size
     def workgroup_size_str(self):
         return "[" + ", ".join(map(str, self.workgroup_size)) + "]"
-
-
-# Returns the list of TestShape's to use for the collection of shapes
-# identified by shapes_id.
-def get_test_shapes(shapes_id: ShapesId):
-    # Notes:
-    # 1. Be conservative in adding more shapes, as that can increase both the
-    #    build and execution latency of tests. The build latency is nearly the
-    #    same for all shapes, while execution latency grows cubicly i.e.
-    #    linearly with m*k*n.
-    # 2. Some shapes are commented out: they used to be tested but have been
-    #    disabled to improve the trade-off between test coverage and build
-    #    latency.
-
-    if shapes_id == ShapesId.SMALL:
-        return [
-            # some "nice" multiple of 8 shapes
-            TestShape(m=8, k=16, n=32, accumulate=False),
-            TestShape(m=16, k=8, n=16, accumulate=False),
-            # some arbitrary shapes
-            TestShape(m=52, k=63, n=52, accumulate=False),
-            TestShape(m=7, k=9, n=15, accumulate=False)
-            # This size seems to fail in llvm IR
-            #TestShape(m=9, k=15, n=7, accumulate=False),
-
-        ]
-    if shapes_id == ShapesId.LARGE:
-        return [
-            TestShape(m=64, k=128, n=64, accumulate=False),
-            # This size compiles but has a correctness error
-            # TestShape(m=300, k=300, n=300, accumulate=False),
-            TestShape(m=512, k=512, n=512, accumulate=False),
-        ]
-    if shapes_id == ShapesId.SMALL_LEGACY:
-        return [
-            TestShape(m=8, k=16, n=32, accumulate=False),
-            #TestShape(m=16, k=8, n=16, accumulate=False),
-            #TestShape(m=64, k=16, n=32, accumulate=True),
-            #TestShape(m=8, k=16, n=16, accumulate=False),
-        ]
-    if shapes_id == ShapesId.LARGE_LEGACY:
-        return [
-            TestShape(m=64, k=16, n=64, accumulate=False),
-            #TestShape(m=64, k=64, n=64, accumulate=False),
-            #TestShape(m=256, k=128, n=256, accumulate=False),
-            #TestShape(m=512, k=256, n=512, accumulate=True),
-            #TestShape(m=512, k=256, n=512, accumulate=False),
-        ]
-
-    raise ValueError(shapes_id)
-
-
-# Returns the list of Dynamicity's to use for the collection of shapes
-# identified by shapes_id.
-# just do static for now
-def get_dynamicities(shapes_id: ShapesId):
-    return [
-        Dynamicity.STATIC,
-    ]
 
 
 @dataclasses.dataclass
@@ -202,7 +137,7 @@ def shape_dim(x: int, dynamicity: Dynamicity):
     elif dynamicity == Dynamicity.STATIC:
         return DimSize(x)
     else:
-        raise ValueError(dynamicity)
+        raise ValueError("Mixed dynamicity is not currently supported")
 
 
 # Stringification used for generating MLIR types, e.g. tensor<?x?xf32>.
@@ -232,19 +167,23 @@ class TestInputMatricesShapes:
 
 
 # Helper for generate_function. Generates TestInputMatricesShapes, i.e.
-# converts from the runtime shape dimensions in TestShape and given dynamicity to
+# converts from the runtime shape dimensions in TestShape to
 # the set of shapes to be used in a test function's input tensors.
-def generate_shapes(shape: TestShape, transpose_rhs: bool, dynamicity: Dynamicity):
-    lhs_rows = shape_dim(shape.m, dynamicity)
-    lhs_cols = shape_dim(shape.k, dynamicity)
-    acc_rows = shape_dim(shape.m, dynamicity)
-    acc_cols = shape_dim(shape.n, dynamicity)
+def generate_shapes(shape: TestShape, transpose_rhs: bool):
+    dynamicity = shape.dynamicity
+    m = shape.m
+    k = shape.k
+    n = shape.n
+    lhs_rows = shape_dim(m, dynamicity)
+    lhs_cols = shape_dim(k, dynamicity)
+    acc_rows = shape_dim(m, dynamicity)
+    acc_cols = shape_dim(n, dynamicity)
     if transpose_rhs:
-        rhs_rows = shape_dim(shape.n, dynamicity)
-        rhs_cols = shape_dim(shape.k, dynamicity)
+        rhs_rows = shape_dim(n, dynamicity)
+        rhs_cols = shape_dim(k, dynamicity)
     else:
-        rhs_rows = shape_dim(shape.k, dynamicity)
-        rhs_cols = shape_dim(shape.n, dynamicity)
+        rhs_rows = shape_dim(k, dynamicity)
+        rhs_cols = shape_dim(n, dynamicity)
     shapes = TestInputMatricesShapes(
         lhs_rows=lhs_rows,
         lhs_cols=lhs_cols,
@@ -305,10 +244,9 @@ def generate_function(
     acc_type: MatrixElemTypeId,
     shape: TestShape,
     transpose_rhs: bool,
-    dynamicity: Dynamicity,
     compilation_info: typing.Optional[CompilationInfo] = None,
 ):
-    shapes = generate_shapes(shape, transpose_rhs, dynamicity)
+    shapes = generate_shapes(shape, transpose_rhs)
     func_name = generate_function_name(
         lhs_rhs_type, acc_type, shapes, shape.accumulate, compilation_info
     )
@@ -450,7 +388,7 @@ def generate_call(
     lhs_rhs_type: MatrixElemTypeId,
     acc_type: MatrixElemTypeId,
     shape: TestShape,
-    transpose_rhs: bool=False,
+    transpose_rhs: bool = False,
 ):
     global call_id
     func_name = f"{function.name}_{shape.m}_{shape.k}_{shape.n}"
@@ -512,7 +450,7 @@ def generate_call(
 def generate(
     lhs_rhs_type: MatrixElemTypeId,
     acc_type: MatrixElemTypeId,
-    shapes_id: ShapesId,
+    shapes: typing.List[TestShape],
     transpose_rhs: bool,
     compilation_info_id: CompilationInfoId,
 ):
@@ -522,34 +460,31 @@ def generate(
     for compilation_info in get_test_compilation_infos(
         compilation_info_id, lhs_rhs_type
     ):
-        for shape in get_test_shapes(shapes_id):
-            for dynamicity in get_dynamicities(shapes_id):
-                function = generate_function(
-                    lhs_rhs_type,
-                    acc_type,
-                    shape,
-                    transpose_rhs,
-                    dynamicity,
-                    compilation_info,
-                )
-                # Different testcases may differ only by runtime parameters but
-                # share the same code. For example, dynamic-shapes testcases
-                # share the same code involing tensor<?x?xf32> even though the runtime
-                # value in the trace are different. That's why we append conditionally
-                # to calls, but unconditionally to function_definitions.
-                if function.name not in functions:
-                    functions[function.name] = function
-                calls.append(
-                    generate_call(
-                        function, lhs_rhs_type, acc_type, shape, transpose_rhs
-                    )
-                )
+        for shape in shapes:
+            function = generate_function(
+                lhs_rhs_type,
+                acc_type,
+                shape,
+                transpose_rhs,
+                compilation_info,
+            )
+            # Different testcases may differ only by runtime parameters but
+            # share the same code. For example, dynamic-shapes testcases
+            # share the same code involing tensor<?x?xf32> even though the runtime
+            # value in the trace are different. That's why we append conditionally
+            # to calls, but unconditionally to function_definitions.
+            if function.name not in functions:
+                functions[function.name] = function
+            calls.append(
+                generate_call(function, lhs_rhs_type, acc_type, shape, transpose_rhs)
+            )
 
     return (functions, calls)
 
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Generator of e2e matmul tests")
+
     parser.add_argument(
         "--output_matmuls_mlir",
         type=str,
@@ -569,6 +504,7 @@ def parse_arguments():
         help="Numeric type of input matrices",
         required=True,
     )
+
     parser.add_argument(
         "--acc_type",
         type=str,
@@ -578,12 +514,39 @@ def parse_arguments():
         required=False,
     )
     parser.add_argument(
-        "--shapes",
+        "--m",
         type=str,
-        choices=[s.value for s in ShapesId],
-        help="Collection of matrix shapes to test",
+        help="Number of rows in the lhs and acc matrices",
         required=True,
     )
+    parser.add_argument(
+        "--n",
+        type=str,
+        help="Number of columns in the rhs and acc matrices",
+        required=True,
+    )
+    parser.add_argument(
+        "--k",
+        type=str,
+        help="Number of columns in the lhs and rows in the rhs matrices",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--accumulate",
+        type=str,
+        help="Whether to accumulate the result",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--dynamicity",
+        type=str,
+        choices=["static", "dynamic", "mixed"],
+        required=True,
+        help="Dynamicity of the input matrices",
+    )
+
     parser.add_argument(
         "--transpose_rhs",
         action="store_true",
@@ -651,26 +614,64 @@ def write_calls_file(functions, calls, filename, requirements):
         file.write(module_definition)
 
 
-# For now, the accumulator type can always be inferred from the input LHS/RHS
-# type, so we do that. That is temporary: eventually there will be cases
-# where the same input types are used with different accumulator types, e.g.
-# f16 inputs with both f16 and f32 accumulator.
-def infer_acc_type(lhs_rhs_type: MatrixElemTypeId, acc_type: MatrixElemTypeId):
-    if acc_type != MatrixElemTypeId.NONE:
-        return acc_type
-    if lhs_rhs_type == MatrixElemTypeId.I8:
-        return MatrixElemTypeId.I32
-    return lhs_rhs_type
+def intsFromCommaSeperated(s):
+    return [int(x) for x in s.split(",")]
 
+def stringsFromCommaSeperated(s):
+    return s.split(",")
+
+def boolFromString(s):
+    return not s.lower() in ["false", "0", ""]
 
 def main(args):
     lhs_rhs_type = MatrixElemTypeId(args.lhs_rhs_type)
     acc_type = MatrixElemTypeId(args.acc_type)
-    acc_type = infer_acc_type(lhs_rhs_type, acc_type)
-    shapes_id = ShapesId(args.shapes)
+
+    m = intsFromCommaSeperated(args.m)
+    n = intsFromCommaSeperated(args.n)
+    k = intsFromCommaSeperated(args.k)
+
+    dynamicity = stringsFromCommaSeperated(args.dynamicity)
+    dynamicity = [Dynamicity(x) for x in dynamicity]
+
+    accumulate = stringsFromCommaSeperated(args.accumulate)
+    accumulate  = [boolFromString(x) for x in accumulate]
+
+    for a in accumulate:
+        if a:
+            raise ValueError(
+                "accumulate=true not yet supported in iree-amd-aie tests"
+            )
+
+    sizes = [len(m), len(n), len(k), len(dynamicity), len(accumulate)]
+    maxSize = max(sizes)
+    if not all(x == 1 or x == maxSize for x in sizes):
+        raise ValueError(
+            f"Sizes of m, n, k, dynamicity, and accumulate must match or be 1. "
+            f"Sizes are: m={len(m)}, n={len(n)}, k={len(k)}, "
+            f"dynamicity={len(dynamicity)}, accumulate={len(accumulate)}"
+        )
+
+
+
+    shapes = []
+    for i in range(maxSize):
+        m_i = m[0] if len(m) == 1 else m[i]
+        n_i = n[0] if len(n) == 1 else n[i]
+        k_i = k[0] if len(k) == 1 else k[i]
+        dynamicity_i = dynamicity[0] if len(dynamicity) == 1 else dynamicity[i]
+        accumulate_i = accumulate[0] if len(accumulate) == 1 else accumulate[i]
+        shapes.append(TestShape(m_i, k_i, n_i, accumulate_i, dynamicity_i))
+
+    print(shapes)
+
     compilation_info_id = CompilationInfoId(args.compilation_info)
     (functions, calls) = generate(
-        lhs_rhs_type, acc_type, shapes_id, args.transpose_rhs, compilation_info_id
+        lhs_rhs_type,
+        acc_type,
+        shapes,
+        args.transpose_rhs,
+        compilation_info_id,
     )
 
     write_code_file(functions, args.output_matmuls_mlir)


### PR DESCRIPTION
@nirvedhmeshram I've been wanting to try this for a while, and your comment in the standup this morning made me just do it. 

If I understood correctly (sorry I was having audio issues) when you compile 2+ matmuls together, you hit runtime issues? 

This PR does:
1) removes the groups 'large' 'small' 'legacy_*' and now a test must be specified directly with m,n,k values. 
2) some minor superficial changes. 