### PR TITLE
[DELEGATE] Add a PDL matcher to match a linalg.matmul

### DIFF
--- a/experimental/delegate/CMakeLists.txt
+++ b/experimental/delegate/CMakeLists.txt
@@ -53,9 +53,9 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-   "mlp.mlir"
+    "mlp.mlir"
   DATA
-    "lianlg.pdl.mlir"
+    "linalg.pdl.mlir"
   TOOLS
     FileCheck
     iree-compile

--- a/experimental/delegate/CMakeLists.txt
+++ b/experimental/delegate/CMakeLists.txt
@@ -49,4 +49,17 @@ add_dependencies(iree-sample-deps
   mlp_bf16_aie_delegate
 )
 
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+   "mlp.mlir"
+  DATA
+    "lianlg.pdl.mlir"
+  TOOLS
+    FileCheck
+    iree-compile
+    iree-opt
+)
+
 endif(IREE_HAL_EXECUTABLE_PLUGIN_SYSTEM_LIBRARY)

--- a/experimental/delegate/linalg.pdl.mlir
+++ b/experimental/delegate/linalg.pdl.mlir
@@ -46,30 +46,19 @@ pdl.pattern @mlp : benefit(1) {
   // ```
   %lhs = pdl.operand
   %rhs = pdl.operand
+  %empty = pdl.operand
   %lhs_type = pdl.type : tensor<?x?xf32>
   %rhs_type = pdl.type : tensor<?x?xf32>
   %matmul_type = pdl.type : tensor<?x?xf32>
 
-  %zero_val = pdl.attribute = 0 : index
-  %one_val = pdl.attribute = 1 : index
   %zero_val_f32 = pdl.attribute = 0.000000e+00 : f32
   %index_type = pdl.type : index
   %f32_type = pdl.type : f32
 
-  %zero_op = pdl.operation "arith.constant" {"value" = %zero_val} -> (%index_type : !pdl.type)
-  %zero = pdl.result 0 of %zero_op
-  %one_op = pdl.operation "arith.constant" {"value" = %one_val} -> (%index_type : !pdl.type)
-  %one = pdl.result 0 of %one_op
+
   %zero_f32_op = pdl.operation "arith.constant" {"value" = %zero_val_f32} -> (%f32_type : !pdl.type)
   %zero_f32 = pdl.result 0 of %zero_f32_op
 
-  %m_op = pdl.operation "tensor.dim"(%lhs, %zero : !pdl.value, !pdl.value) -> (%index_type : !pdl.type)
-  %m = pdl.result 0 of %m_op
-  %n_op = pdl.operation "tensor.dim"(%rhs, %one : !pdl.value, !pdl.value) -> (%index_type : !pdl.type)
-  %n = pdl.result 0 of %n_op
-
-  %empty_op = pdl.operation "tensor.empty" (%m, %n : !pdl.value, !pdl.value) -> (%matmul_type : !pdl.type)
-  %empty = pdl.result 0 of %empty_op
   
   %fill_op = pdl.operation "linalg.fill" (%zero_f32, %empty : !pdl.value, !pdl.value) -> (%matmul_type : !pdl.type)
   %fill = pdl.result 0 of %fill_op
@@ -79,7 +68,17 @@ pdl.pattern @mlp : benefit(1) {
     // The pattern above matched `%result`, `%lhs`, `%rhs` needed for the
     // external function call. The values of `%M`, `%N` and `%K` need to
     // be generated.
-    %i32_type = pdl.type : i32 
+    %i32_type = pdl.type : i32
+    %zero_val = pdl.attribute = 0 : index
+    %one_val = pdl.attribute = 1 : index
+    %zero_op = pdl.operation "arith.constant" {"value" = %zero_val} -> (%index_type : !pdl.type)
+    %zero = pdl.result 0 of %zero_op
+    %one_op = pdl.operation "arith.constant" {"value" = %one_val} -> (%index_type : !pdl.type)
+    %one = pdl.result 0 of %one_op
+    %m_op = pdl.operation "tensor.dim"(%lhs, %zero : !pdl.value, !pdl.value) -> (%index_type : !pdl.type)
+    %m = pdl.result 0 of %m_op
+    %n_op = pdl.operation "tensor.dim"(%rhs, %one : !pdl.value, !pdl.value) -> (%index_type : !pdl.type)
+    %n = pdl.result 0 of %n_op 
     %k_op = pdl.operation "tensor.dim"(%lhs, %one : !pdl.value, !pdl.value)
     %k = pdl.result 0 of %k_op
     %m_i32_op = pdl.operation "arith.index_cast"(%m : !pdl.value) -> (%i32_type : !pdl.type)
@@ -119,4 +118,3 @@ pdl.pattern @mlp : benefit(1) {
         : !pdl.operation, !pdl.attribute, !pdl.range<value>, !pdl.range<value>, !pdl.range<value>, !pdl.range<value>)
   }
 }
-

--- a/experimental/delegate/linalg.pdl.mlir
+++ b/experimental/delegate/linalg.pdl.mlir
@@ -1,0 +1,122 @@
+// PDL pattern spec to match an MLP and offload to an external function
+//
+// ```
+// void mlp_external(void *params, void *context, void *reserved)
+// ```
+//
+// which is the expected signature of an external function implemented
+// provided by a system plugin. See
+// samples/custom_dispatch/cpu/plugin/system_plugin.c for an example.
+//
+// The `params` is the following struct
+//
+// ```
+// struct mlp_params_t {
+//   const float *restrict lhs;
+//   size_t lhs_offset;
+//   const float *restrict rhs;
+//   size_t rhs_offset;
+//   int32_t M;
+//   int32_t N;
+//   int32_t K;
+//   float *restrict result;
+//   size_t result_offset;
+// };
+// ```
+//
+// In MLIR this corresponds to the function
+//
+// ```
+// func.func @mlp_external(%lhs : memref<..xf32>, %rhs : memref<..xf32>,
+//     %M: i32, %N : i32, %K : i32, %result : memref<..xf32>)
+// ```
+//
+// Note: In the above struct a `pointer, offset` pair represents a buffer
+// passed into the external function. So any access to `lhs`, `rhs` and
+// `result` is valid only if accessed as `lhs[lhs_offset + ...]`,
+// `rhs[rhs_offset + ]` and `result[result_offset + ...]`.
+pdl.pattern @mlp : benefit(1) {
+
+  // PDL matcher to match the MLP computation. This pattern is expected to
+  // match
+  //
+  // ```
+  // %result = func.call @mlp_external(%lhs : tensor<...xf32>,
+  //     %rhs : tensor<..xf32>, %M : i32, %N : i32, %K : i32) -> tensor<..xf32>
+  // ```
+  %lhs = pdl.operand
+  %rhs = pdl.operand
+  %lhs_type = pdl.type : tensor<?x?xf32>
+  %rhs_type = pdl.type : tensor<?x?xf32>
+  %matmul_type = pdl.type : tensor<?x?xf32>
+
+  %zero_val = pdl.attribute = 0 : index
+  %one_val = pdl.attribute = 1 : index
+  %zero_val_f32 = pdl.attribute = 0.000000e+00 : f32
+  %index_type = pdl.type : index
+  %f32_type = pdl.type : f32
+
+  %zero_op = pdl.operation "arith.constant" {"value" = %zero_val} -> (%index_type : !pdl.type)
+  %zero = pdl.result 0 of %zero_op
+  %one_op = pdl.operation "arith.constant" {"value" = %one_val} -> (%index_type : !pdl.type)
+  %one = pdl.result 0 of %one_op
+  %zero_f32_op = pdl.operation "arith.constant" {"value" = %zero_val_f32} -> (%f32_type : !pdl.type)
+  %zero_f32 = pdl.result 0 of %zero_f32_op
+
+  %m_op = pdl.operation "tensor.dim"(%lhs, %zero : !pdl.value, !pdl.value) -> (%index_type : !pdl.type)
+  %m = pdl.result 0 of %m_op
+  %n_op = pdl.operation "tensor.dim"(%rhs, %one : !pdl.value, !pdl.value) -> (%index_type : !pdl.type)
+  %n = pdl.result 0 of %n_op
+
+  %empty_op = pdl.operation "tensor.empty" (%m, %n : !pdl.value, !pdl.value) -> (%matmul_type : !pdl.type)
+  %empty = pdl.result 0 of %empty_op
+  
+  %fill_op = pdl.operation "linalg.fill" (%zero_f32, %empty : !pdl.value, !pdl.value) -> (%matmul_type : !pdl.type)
+  %fill = pdl.result 0 of %fill_op
+  %matmul = pdl.operation "linalg.matmul" (%lhs, %rhs, %fill : !pdl.value, !pdl.value, !pdl.value) -> (%matmul_type : !pdl.type)
+  
+  pdl.rewrite %matmul {
+    // The pattern above matched `%result`, `%lhs`, `%rhs` needed for the
+    // external function call. The values of `%M`, `%N` and `%K` need to
+    // be generated.
+    %i32_type = pdl.type : i32 
+    %k_op = pdl.operation "tensor.dim"(%lhs, %one : !pdl.value, !pdl.value)
+    %k = pdl.result 0 of %k_op
+    %m_i32_op = pdl.operation "arith.index_cast"(%m : !pdl.value) -> (%i32_type : !pdl.type)
+    %m_i32 = pdl.result 0 of %m_i32_op
+    %n_i32_op = pdl.operation "arith.index_cast"(%n : !pdl.value) -> (%i32_type : !pdl.type)
+    %n_i32 = pdl.result 0 of %n_i32_op
+    %k_i32_op = pdl.operation "arith.index_cast"(%k : !pdl.value) -> (%i32_type : !pdl.type)
+    %k_i32 = pdl.result 0 of %k_i32_op
+
+    %replaced_values_dims = pdl.range %m, %n : !pdl.value, !pdl.value
+    %input_values = pdl.range %lhs, %rhs : !pdl.value, !pdl.value
+    %replaced_value = pdl.result 0 of %matmul
+    %replaced_values = pdl.range %replaced_value : !pdl.value
+    %other_operands = pdl.range %m_i32, %n_i32, %k_i32 : !pdl.value, !pdl.value, !pdl.value
+
+    // The `rewriteAsFlowDispatch` is a rewrite function that allows
+    // converting the matched dag into a call to the external function call
+    // provided by a system plugin. The rewrite method expects the following
+    // arguments
+    // - the root of the matched DAG. This op will be erased after the call.
+    // - `fn_name` the name of the function that is provided externally
+    //   (using a plugin).
+    // - `input_values` are values that are captures as the part of the match
+    //   and are inputs to the match.
+    // - `replaced_values` are the values that are captured as part of the
+    //   match and are replaced by the `flow.dispatch`. The `flow.dispatch`
+    //   returns as many values as `replaced_values` (and of same type).
+    // - `replaced_values_dims` are the values for the dynamic dimensions of
+    //   all the `tensor` values in `replaced_values`. For matches that could
+    //   be static or dynamic, it should be assumed that the shape is dynamic
+    //   and the value needs to be passed to the rewrite function.
+    // - `other_operands` same as `input_values`, but kept separate to allow
+    //   flexibility of where the results are passed through the ABI boundary.
+    %fn_name = pdl.attribute = "mlp_external"
+    pdl.apply_native_rewrite "rewriteAsFlowDispatch"(
+        %matmul, %fn_name, %input_values, %replaced_values, %replaced_values_dims, %other_operands
+        : !pdl.operation, !pdl.attribute, !pdl.range<value>, !pdl.range<value>, !pdl.range<value>, !pdl.range<value>)
+  }
+}
+

--- a/experimental/delegate/mlp.mlir
+++ b/experimental/delegate/mlp.mlir
@@ -1,5 +1,55 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-preprocessing-apply-pdl-patterns{patterns-file=%p/linalg.pdl.mlir}, cse)" %s | FileCheck %s
 
-// The implementation of MLP is matched using a transform dialect script and is forwarded to a system plugin.
+// CHECK-LABEL:   stream.executable private @mlp_external_executable
+//       CHECK:   stream.executable.export public @mlp_external_entry_point
+//       CHECK:   builtin.module
+//       CHECK:     func.func private @mlp_external
+//  CHECK-SAME:         (memref<f32>, index, memref<f32>, index, memref<f32>, index, i32, i32, i32)
+//  CHECK-SAME:         attributes {llvm.bareptr = [true]}
+//       CHECK:     func.func @mlp_external_entry_point
+//  CHECK-SAME:         %[[ARG0:[a-zA-Z0-9]+]]: !stream.binding
+//  CHECK-SAME:         %[[ARG1:[a-zA-Z0-9]+]]: !stream.binding
+//  CHECK-SAME:         %[[ARG2:[a-zA-Z0-9]+]]: !stream.binding
+//  CHECK-SAME:         %[[ARG3:[a-zA-Z0-9]+]]: i32
+//  CHECK-SAME:         %[[ARG4:[a-zA-Z0-9]+]]: i32
+//  CHECK-SAME:         %[[ARG5:[a-zA-Z0-9]+]]: i32
+//  CHECK-SAME:         %[[ARG6:[a-zA-Z0-9]+]]: index
+//  CHECK-SAME:         %[[ARG7:[a-zA-Z0-9]+]]: index
+//  CHECK-SAME:         %[[ARG8:[a-zA-Z0-9]+]]: index
+//  CHECK-SAME:         %[[ARG9:[a-zA-Z0-9]+]]: index
+//  CHECK-SAME:         %[[ARG10:[a-zA-Z0-9]+]]: index
+//  CHECK-SAME:         %[[ARG11:[a-zA-Z0-9]+]]: index
+//       CHECK:       %[[C0:.+]] = arith.constant 0 : index
+//       CHECK:       %[[STREAM0:.+]] = stream.binding.subspan %[[ARG0]][%[[C0]]] : !stream.binding -> memref<?x?xf32>{%[[ARG6]], %[[ARG7]]}
+//  CHECK-NEXT:       %[[STREAM0_BASE:[a-zA-Z0-9_]+]],
+//  CHECK-SAME:             = memref.extract_strided_metadata %[[STREAM0]]
+//       CHECK:       %[[STREAM1:.+]] = stream.binding.subspan %[[ARG1]][%[[C0]]] : !stream.binding -> memref<?x?xf32>{%[[ARG8]], %[[ARG9]]}
+//  CHECK-NEXT:       %[[STREAM1_BASE:[a-zA-Z0-9_]+]],
+//  CHECK-SAME:             = memref.extract_strided_metadata %[[STREAM1]]
+//       CHECK:       %[[STREAM2:.+]] = stream.binding.subspan %[[ARG2]][%[[C0]]] : !stream.binding -> memref<?x?xf32>{%[[ARG10]], %[[ARG11]]}
+//  CHECK-NEXT:       %[[STREAM2_BASE:[a-zA-Z0-9_]+]],
+//  CHECK-SAME:             = memref.extract_strided_metadata %[[STREAM2]]
+//       CHECK:       call @mlp_external
+//  CHECK-SAME:           %[[STREAM0_BASE]], %[[C0]], %[[STREAM1_BASE]], %[[C0]], %[[STREAM2_BASE]], %[[C0]], %[[ARG3]], %[[ARG4]], %[[ARG5]]
+
+//       CHECK:     func.func @mlp_invocation
+//  CHECK-SAME:         (%[[LHS:[a-zA-Z0-9]+]]: tensor<?x?xf32>, %[[RHS:[a-zA-Z0-9]+]]: tensor<?x?xf32>)
+//   CHECK-DAG:       %[[C0:.+]] = arith.constant 0
+//   CHECK-DAG:       %[[C1:.+]] = arith.constant 1
+//       CHECK:       %[[M:.+]] = tensor.dim %[[LHS]], %[[C0]]
+//       CHECK:       %[[N:.+]] = tensor.dim %[[RHS]], %[[C1]]
+//       CHECK:       %[[K:.+]] = tensor.dim %[[LHS]], %[[C1]]
+//       CHECK:       %[[M_I32:.+]] = arith.index_cast %[[M]] : index to i32
+//       CHECK:       %[[N_I32:.+]] = arith.index_cast %[[N]] : index to i32
+//       CHECK:       %[[K_I32:.+]] = arith.index_cast %[[K]] : index to i32
+//       CHECK:       %[[K_0:.+]] = tensor.dim %[[RHS]], %[[C0]]
+//       CHECK:       %[[RESULT:.+]] = flow.dispatch
+//  CHECK-SAME:           @mlp_external_executable::@mlp_external_entry_point
+//  CHECK-SAME:           (%[[LHS]], %[[RHS]], %[[M_I32]], %[[N_I32]], %[[K_I32]], %[[M]], %[[K]], %[[K_0]], %[[N]], %[[M]], %[[N]])
+//       CHECK:       linalg.generic
+//  CHECK-SAME:           ins(%[[RESULT]] :
+
+// The implementation of MLP is matched using a transform dialect or pdl script and is forwarded to a system plugin.
 
 #x86_64_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",


### PR DESCRIPTION
PDL matching has compile time performance benefit over transform dialect matching for large models. Here we are doing the matching a linalg level, mostly following what happened at the torch level in the upstream IREE matcher test. I was able to run the resulting IR through iree-compile and was able to delegate the matmul to AIE device with iree-run-module.