### PR TITLE
Numerical test in loop 

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -190,6 +190,10 @@ function run_matmul_test() {
         name="$2"
         shift 2
         ;;
+      --n_runs)
+        n_runs="$2"
+        shift 2
+        ;;
       --lhs_rhs_type)
         lhs_rhs_type="$2"
         shift 2
@@ -304,12 +308,13 @@ function run_matmul_test() {
       --module=${OUTPUT_DIR}/${name}_calls.vmfb \
       --device=${device}"
 
-  echo "Running command: ${COMMAND}"
 
-  # Execute the command, and print the status:
-  eval "${COMMAND}"
-  echo "Command returned with status: $?"
-
+  # Run the command at most n_runs times. 
+  # If it fails once, return non-zero exit code immediately.
+  for i in $(seq 1 $n_runs); do
+    echo "Iteration ${i} of ${n_runs} complete."
+    eval "${COMMAND}"
+  done
   set +x
 }
 
@@ -318,37 +323,14 @@ function run_matmul_test() {
 ###############################################################################
 
 run_matmul_test \
-    --name "matmul_bf16_bf16_large_amd-aie_xrt_pad-pack" \
-    --lhs_rhs_type "bf16" \
-    --acc_type "f32" \
+    --name "matmul_run_til_failure" \
+    --lhs_rhs_type "i32" \
+    --acc_type "i32" \
     --shapes "large_legacy" \
     --target_backend "amd-aie" \
     --device "xrt" \
     --peano_install_path "${PEANO}" \
     --mlir_aie_install_path "${MLIR_AIE_INSTALL}" \
     --vitis_path  "${VITIS}" \
-    --pipeline "pad-pack"
-
-run_matmul_test \
-    --name "matmul_i32_i32_small_amd-aie_xrt_pad-pack" \
-    --lhs_rhs_type "i32" \
-    --acc_type "i32" \
-    --shapes "small" \
-    --target_backend "amd-aie" \
-    --device "xrt" \
-    --peano_install_path "${PEANO}" \
-    --mlir_aie_install_path "${MLIR_AIE_INSTALL}" \
-    --vitis_path  "${VITIS}" \
-    --pipeline "pad-pack"
-
-run_matmul_test \
-    --name "matmul_i32_i32_large_amd-aie_xrt_pad-pack" \
-    --lhs_rhs_type "i32" \
-    --acc_type "i32" \
-    --shapes "large" \
-    --target_backend "amd-aie" \
-    --device "xrt" \
-    --peano_install_path "${PEANO}" \
-    --mlir_aie_install_path "${MLIR_AIE_INSTALL}" \
-    --vitis_path  "${VITIS}" \
+    --n_runs 10000 \
     --pipeline "pad-pack"

--- a/runtime/src/iree-amd-aie/driver/xrt/direct_command_buffer.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/direct_command_buffer.cc
@@ -354,9 +354,16 @@ static iree_status_t iree_hal_xrt_direct_command_buffer_dispatch(
                   command_buffer->descriptor_sets[i].lengths[j],
                   command_buffer->descriptor_sets[i].offsets[j]);
 
-      if (j == binding_count - 1) {
-        arg_buffer.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-      }
+     // The 'band-aid' :
+     // 
+     // Running with this resulted in 10'000 successful runs in CI:
+     // see https://github.com/nod-ai/iree-amd-aie/actions/runs/8513126883/job/23316286103?pr=259
+     //
+     // I have commented it out to see what happens without the band-aid. 
+     //
+     //  if (j == binding_count - 1) {
+     //    arg_buffer.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+     //  }
 
       run.set_arg(arg_index + base_index + j, arg_buffer);
     }

--- a/runtime/src/iree-amd-aie/driver/xrt/direct_command_buffer.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/direct_command_buffer.cc
@@ -353,6 +353,11 @@ static iree_status_t iree_hal_xrt_direct_command_buffer_dispatch(
           xrt::bo(*command_buffer->descriptor_sets[i].bindings[j],
                   command_buffer->descriptor_sets[i].lengths[j],
                   command_buffer->descriptor_sets[i].offsets[j]);
+
+      if (j == binding_count - 1) {
+        arg_buffer.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+      }
+
       run.set_arg(arg_index + base_index + j, arg_buffer);
     }
   }

--- a/tests/matmul/generate_e2e_matmul_tests.py
+++ b/tests/matmul/generate_e2e_matmul_tests.py
@@ -105,39 +105,10 @@ def get_test_shapes(shapes_id: ShapesId):
     #    disabled to improve the trade-off between test coverage and build
     #    latency.
 
-    if shapes_id == ShapesId.SMALL:
-        return [
-            # some "nice" multiple of 8 shapes
-            TestShape(m=8, k=16, n=32, accumulate=False),
-            TestShape(m=16, k=8, n=16, accumulate=False),
-            # some arbitrary shapes
-            TestShape(m=52, k=63, n=52, accumulate=False),
-            TestShape(m=7, k=9, n=15, accumulate=False)
-            # This size seems to fail in llvm IR
-            #TestShape(m=9, k=15, n=7, accumulate=False),
 
-        ]
-    if shapes_id == ShapesId.LARGE:
-        return [
-            TestShape(m=64, k=128, n=64, accumulate=False),
-            # This size compiles but has a correctness error
-            # TestShape(m=300, k=300, n=300, accumulate=False),
-            TestShape(m=512, k=512, n=512, accumulate=False),
-        ]
-    if shapes_id == ShapesId.SMALL_LEGACY:
-        return [
-            TestShape(m=8, k=16, n=32, accumulate=False),
-            #TestShape(m=16, k=8, n=16, accumulate=False),
-            #TestShape(m=64, k=16, n=32, accumulate=True),
-            #TestShape(m=8, k=16, n=16, accumulate=False),
-        ]
     if shapes_id == ShapesId.LARGE_LEGACY:
         return [
-            TestShape(m=64, k=16, n=64, accumulate=False),
-            #TestShape(m=64, k=64, n=64, accumulate=False),
-            #TestShape(m=256, k=128, n=256, accumulate=False),
-            #TestShape(m=512, k=256, n=512, accumulate=True),
-            #TestShape(m=512, k=256, n=512, accumulate=False),
+            TestShape(m=64, k=16, n=64, accumulate=False)
         ]
 
     raise ValueError(shapes_id)


### PR DESCRIPTION
Running this on the old driver, these are results from a few runs:

**With band-aid:**
fails after 6 iterations 
fails after 1906 iterations
frozen machine
fails after 1934 iterations
fails after 836 iterations
frozen machine


**If I remove the band-aid:**
fails after 1 iterations
fails after 3 iterations
fails after 2 iterations
... 



Without the band-aid, I see the classic row of zeros in the incorrect result. 


With the band-aid, the pattern is not zeros: looks like random bits, and over a larger area of C. 