### PR TITLE
[AMD-AIE] Update lower-to-ukernel pass to deal with ExtFOps

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_ukernel.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_ukernel.mlir
@@ -59,3 +59,71 @@ func.func @generic_matmul_i32i32i32_pad_pack(%arg0 : tensor<?x?x?x?xi32>, %arg1 
 // CHECK-SAME:       fn_def_attrs {link_with = "/custom/path/to/ukernels/mm.o"}
 // CHECK-SAME:       strided_outer_dims(0)
 //      CHECK:   return %[[MICRO_KERNEL]]
+
+// -----
+
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd", ukernels = "all"}>
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d0, d3, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d3, d4)>
+module {
+  func.func @generic_matmul_bf16bf16f32_pad_pack(%arg0: tensor<?x?x?x?xbf16>, %arg1: tensor<?x?x?x?xbf16>, %arg2: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+    %0 = linalg.generic {indexing_maps = [#map, #map1, #map2],
+                         iterator_types = ["parallel", "parallel", "reduction",
+                         "parallel", "parallel", "reduction"]
+                        } ins(%arg0, %arg1 : tensor<?x?x?x?xbf16>, tensor<?x?x?x?xbf16>)
+                          outs(%arg2 : tensor<?x?x?x?xf32>) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: f32):
+      %1 = arith.extf %in : bf16 to f32
+      %2 = arith.extf %in_0 : bf16 to f32
+      %3 = arith.mulf %1, %2 : f32
+      %4 = arith.addf %out, %3 : f32
+      linalg.yield %4 : f32
+    } -> tensor<?x?x?x?xf32>
+    return %0 : tensor<?x?x?x?xf32>
+  }
+}
+//      CHECK: func @generic_matmul_bf16bf16f32_pad_pack(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>)
+//  CHECK-NOT:   linalg.generic
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "matmul_bf16_f32"
+// CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
+// CHECK-SAME:       outs(%[[ARG2]] :
+// CHECK-SAME:       fn_def_attrs {link_with = "/custom/path/to/ukernels/mm.o"}
+// CHECK-SAME:       strided_outer_dims(0)
+//      CHECK:   return %[[MICRO_KERNEL]]
+
+// -----
+
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd", ukernels = "all"}>
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d0, d3, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d3, d4)>
+module {
+  func.func @generic_matmul_bf16bf16bf16_pad_pack(%arg0: tensor<?x?x?x?xbf16>, %arg1: tensor<?x?x?x?xbf16>, %arg2: tensor<?x?x?x?xbf16>) -> tensor<?x?x?x?xbf16> attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+    %0 = linalg.generic {indexing_maps = [#map, #map1, #map2],
+                         iterator_types = ["parallel", "parallel", "reduction",
+                         "parallel", "parallel", "reduction"]
+                        } ins(%arg0, %arg1 : tensor<?x?x?x?xbf16>, tensor<?x?x?x?xbf16>)
+                          outs(%arg2 : tensor<?x?x?x?xbf16>) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %3 = arith.mulf %in, %in_0 : bf16
+      %4 = arith.addf %out, %3 : bf16
+      linalg.yield %4 : bf16
+    } -> tensor<?x?x?x?xbf16>
+    return %0 : tensor<?x?x?x?xbf16>
+  }
+}
+//      CHECK: func @generic_matmul_bf16bf16bf16_pad_pack(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xbf16>)
+//  CHECK-NOT:   linalg.generic
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "matmul_bf16_bf16"
+// CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
+// CHECK-SAME:       outs(%[[ARG2]] :
+// CHECK-SAME:       fn_def_attrs {link_with = "/custom/path/to/ukernels/mm.o"}
+// CHECK-SAME:       strided_outer_dims(0)
+//      CHECK:   return %[[MICRO_KERNEL]]


### PR DESCRIPTION
-- This commit updates `--iree-amdaie-lower-to-ukernel` pass to deal
   with optional ExtFOps in order to match body of a linalg.generic
   matmul.
-- Lit tests to demo the following were added :-
   a. bf16 inputs/output.
   b. bf16 inputs - f32 output.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>