### PR TITLE
Changes to pack-peel pipeline for matmul-elementwise ops fusion

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -269,7 +269,9 @@ def AMDAIETileAndFuse :
     Option<"useSCFFor", "use-scf-for", "bool", /*default=*/"false",
       "Use scf.forall by default for the corresponding tiling level">,
     Option<"tilingLevel", "tiling-level", "int64_t", /*default=*/"-1",
-      "Use default tiling level used to retrieve the configuration from lowering_config">
+      "Use default tiling level used to retrieve the configuration from lowering_config">,
+    Option<"tileElementwise", "tile-elementwise", "bool", /*default=*/"true",
+      "Option to whether tile and fuse the elementwise op">
   ];
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/propagate_data_layout.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/propagate_data_layout.mlir
@@ -5,36 +5,86 @@
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d2, d1, d4, d5, d8, d7)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d4, d3, d6, d7)>
 #map3 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-  func.func @matmul_static(%arg0: tensor<1x4x16x64xi32>, %arg1: tensor<4x1x64x64xi32>) -> tensor<1x1x16x64xi32> {
-    %c0_i32 = arith.constant 0 : i32
-    %0 = tensor.empty() : tensor<1x4x8x4x4x8xi32>
-    %pack = tensor.pack %arg0 outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [4, 8] into %0 : tensor<1x4x16x64xi32> -> tensor<1x4x8x4x4x8xi32>
-    %1 = tensor.empty() : tensor<4x1x8x8x8x8xi32>
-    %pack_0 = tensor.pack %arg1 outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [8, 8] into %1 : tensor<4x1x64x64xi32> -> tensor<4x1x8x8x8x8xi32>
-    %2 = tensor.empty() : tensor<1x1x8x4x4x8xi32>
-    %3 = linalg.fill ins(%c0_i32 : i32) outs(%2 : tensor<1x1x8x4x4x8xi32>) -> tensor<1x1x8x4x4x8xi32>
-    %4 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%pack, %pack_0 : tensor<1x4x8x4x4x8xi32>, tensor<4x1x8x8x8x8xi32>) outs(%3 : tensor<1x1x8x4x4x8xi32>) {
-    ^bb0(%in: i32, %in_1: i32, %out: i32):
-      %6 = arith.muli %in, %in_1 : i32
-      %7 = arith.addi %out, %6 : i32
-      linalg.yield %7 : i32
-    } -> tensor<1x1x8x4x4x8xi32>
-    %empty = tensor.empty() : tensor<1x1x16x64xi32>
-    %unpack = tensor.unpack %4 outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [4, 8] into %empty : tensor<1x1x8x4x4x8xi32> -> tensor<1x1x16x64xi32>
-    %empty2 = tensor.empty() : tensor<1x1x16x64xi32>
-    %fill = linalg.fill ins(%c0_i32 : i32) outs(%empty2 : tensor<1x1x16x64xi32>) -> tensor<1x1x16x64xi32>
-    %5 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%unpack: tensor<1x1x16x64xi32>) outs(%fill : tensor<1x1x16x64xi32>) {
-    ^bb0(%in: i32, %out: i32):
-      %6 = arith.muli %in, %out : i32
-      %7 = arith.addi %out, %6 : i32
-      linalg.yield %7 : i32
-    } -> tensor<1x1x16x64xi32>
-    return %5 : tensor<1x1x16x64xi32>
-  }
+func.func @matmul_static(%arg0: tensor<1x4x16x64xi32>, %arg1: tensor<4x1x64x64xi32>) -> tensor<1x1x16x64xi32> {
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tensor.empty() : tensor<1x4x8x4x4x8xi32>
+  %pack = tensor.pack %arg0 outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [4, 8] into %0 : tensor<1x4x16x64xi32> -> tensor<1x4x8x4x4x8xi32>
+  %1 = tensor.empty() : tensor<4x1x8x8x8x8xi32>
+  %pack_0 = tensor.pack %arg1 outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [8, 8] into %1 : tensor<4x1x64x64xi32> -> tensor<4x1x8x8x8x8xi32>
+  %2 = tensor.empty() : tensor<1x1x8x4x4x8xi32>
+  %3 = linalg.fill ins(%c0_i32 : i32) outs(%2 : tensor<1x1x8x4x4x8xi32>) -> tensor<1x1x8x4x4x8xi32>
+  %4 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%pack, %pack_0 : tensor<1x4x8x4x4x8xi32>, tensor<4x1x8x8x8x8xi32>) outs(%3 : tensor<1x1x8x4x4x8xi32>) {
+  ^bb0(%in: i32, %in_1: i32, %out: i32):
+    %6 = arith.muli %in, %in_1 : i32
+    %7 = arith.addi %out, %6 : i32
+    linalg.yield %7 : i32
+  } -> tensor<1x1x8x4x4x8xi32>
+  %empty = tensor.empty() : tensor<1x1x16x64xi32>
+  %unpack = tensor.unpack %4 outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [4, 8] into %empty : tensor<1x1x8x4x4x8xi32> -> tensor<1x1x16x64xi32>
+  %empty2 = tensor.empty() : tensor<1x1x16x64xi32>
+  %fill = linalg.fill ins(%c0_i32 : i32) outs(%empty2 : tensor<1x1x16x64xi32>) -> tensor<1x1x16x64xi32>
+  %5 = linalg.generic {indexing_maps = [#map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%unpack: tensor<1x1x16x64xi32>) outs(%fill : tensor<1x1x16x64xi32>) {
+  ^bb0(%in: i32, %out: i32):
+    %6 = arith.muli %in, %out : i32
+    %7 = arith.addi %out, %6 : i32
+    linalg.yield %7 : i32
+  } -> tensor<1x1x16x64xi32>
+  return %5 : tensor<1x1x16x64xi32>
+}
+
 // CHECK-LABEL: matmul_static
 // CHECK-COUNT-2: tensor.pack
 // CHECK: linalg.generic
 // CHECK-NOT: tensor.pack
 // CHECK-NOT: tensor.unpack
+// CHECK: linalg.generic
+// CHECK: tensor.unpack
+
+// -----
+
+func.func @matmul_elementwise_1024x1024x512_i8xi8xi32(%arg0: tensor<1024x512xi8>, %arg1: tensor<512x1024xi8>, %arg2: tensor<1024x1024xi32>) -> tensor<1024x1024xi32> {
+  %c0_i32 = arith.constant 0 : i32
+  %c0 = arith.constant 0 : index
+  %0 = tensor.empty() : tensor<1024x1024xi32>
+  %1 = scf.forall (%arg3, %arg4) = (0, 0) to (1024, 1024) step (64, 64) shared_outs(%arg5 = %0) -> (tensor<1024x1024xi32>) {
+    %extracted_slice = tensor.extract_slice %arg0[%arg3, 0] [64, 512] [1, 1] : tensor<1024x512xi8> to tensor<64x512xi8>
+    %extracted_slice_0 = tensor.extract_slice %arg1[0, %arg4] [512, 64] [1, 1] : tensor<512x1024xi8> to tensor<512x64xi8>
+    %extracted_slice_1 = tensor.extract_slice %0[%arg3, %arg4] [64, 64] [1, 1] : tensor<1024x1024xi32> to tensor<64x64xi32>
+    %2 = linalg.fill ins(%c0_i32 : i32) outs(%extracted_slice_1 : tensor<64x64xi32>) -> tensor<64x64xi32>
+    %3 = tensor.empty() : tensor<1x16x64x32xi8>
+    %pack = tensor.pack %extracted_slice inner_dims_pos = [0, 1] inner_tiles = [64, 32] into %3 : tensor<64x512xi8> -> tensor<1x16x64x32xi8>
+    %4 = tensor.empty() : tensor<16x1x64x32xi8>
+    %5 = tensor.empty() : tensor<16x1x32x64xi8>
+    %pack_2 = tensor.pack %extracted_slice_0 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [32, 64] into %5 : tensor<512x64xi8> -> tensor<16x1x32x64xi8>
+    %6 = tensor.empty() : tensor<1x1x64x64xi32>
+    %pack_3 = tensor.pack %2 inner_dims_pos = [0, 1] inner_tiles = [64, 64] into %6 : tensor<64x64xi32> -> tensor<1x1x64x64xi32>
+    %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d1, d5, d4)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d3, d4)>], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%pack, %pack_2 : tensor<1x16x64x32xi8>, tensor<16x1x32x64xi8>) outs(%pack_3 : tensor<1x1x64x64xi32>) {
+    ^bb0(%in: i8, %in_6: i8, %out: i32):
+      %9 = arith.extsi %in : i8 to i32
+      %10 = arith.extsi %in_6 : i8 to i32
+      %11 = arith.muli %9, %10 : i32
+      %12 = arith.addi %out, %11 : i32
+      linalg.yield %12 : i32
+    } -> tensor<1x1x64x64xi32>
+    %unpack = tensor.unpack %7 inner_dims_pos = [0, 1] inner_tiles = [64, 64] into %2 : tensor<1x1x64x64xi32> -> tensor<64x64xi32>
+    %extracted_slice_4 = tensor.extract_slice %arg2[%arg3, %arg4] [64, 64] [1, 1] : tensor<1024x1024xi32> to tensor<64x64xi32>
+    %extracted_slice_5 = tensor.extract_slice %arg5[%arg3, %arg4] [64, 64] [1, 1] : tensor<1024x1024xi32> to tensor<64x64xi32>
+    %8 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%unpack, %extracted_slice_4 : tensor<64x64xi32>, tensor<64x64xi32>) outs(%extracted_slice_5 : tensor<64x64xi32>) {
+    ^bb0(%in: i32, %in_6: i32, %out: i32):
+      %9 = arith.addi %in, %in_6 : i32
+      linalg.yield %9 : i32
+    } -> tensor<64x64xi32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %8 into %arg5[%arg3, %arg4] [64, 64] [1, 1] : tensor<64x64xi32> into tensor<1024x1024xi32>
+    }
+  } {mapping = [#gpu.block<y>, #gpu.block<x>]}
+  return %1 : tensor<1024x1024xi32>
+}
+
+// CHECK-LABEL: matmul_elementwise_1024x1024x512_i8xi8xi32
+// CHECK-COUNT-2: tensor.pack
+// CHECK: linalg.generic
+// CHECK-NOT: tensor.unpack
+// CHECK-COUNT-2: tensor.pack
 // CHECK: linalg.generic
 // CHECK: tensor.unpack

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_using_scf_for.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_using_scf_for.mlir
@@ -1,4 +1,5 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{use-scf-for tiling-level=2}))' --split-input-file %s | FileCheck %s --check-prefix=TILE-LEVEL-2
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{use-scf-for tiling-level=2 tile-elementwise=false}))' --split-input-file %s | FileCheck %s --check-prefix=TILE-LEVEL-2
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{use-scf-for tiling-level=0 tile-elementwise=false}))' --split-input-file %s | FileCheck %s --check-prefix=TILE-MATMUL-ONLY
 
 #config = #iree_codegen.lowering_config<tile_sizes = [[8, 8], [4, 4], [0, 0, 4]]>
 func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> tensor<8x8xi32> {
@@ -57,3 +58,36 @@ func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> t
 //      TILE-LEVEL-2:           }
 //      TILE-LEVEL-2:       }
 //      TILE-LEVEL-2:   }
+
+// -----
+
+func.func @matmul_bias_add(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %arg2 : tensor<?xf32>) -> tensor<?x?xf32> {
+  %cst = arith.constant 0.0 : f32
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf32>
+  %init = tensor.empty(%d0, %d1) : tensor<?x?xf32>
+  %0 = linalg.fill ins(%cst : f32) outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %1 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[8, 8], [4, 4], [0, 0, 4]]>}
+      ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
+      outs(%0 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1)-> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%1, %arg2 : tensor<?x?xf32>, tensor<?xf32>)
+    outs(%init : tensor<?x?xf32>) {
+      ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
+        %3 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %3 : f32
+    } -> tensor<?x?xf32>
+  return %2 : tensor<?x?xf32>
+}
+
+//      TILE-MATMUL-ONLY: @matmul_bias_add
+//      TILE-MATMUL-ONLY:   linalg.fill
+//      TILE-MATMUL-ONLY:   scf.for
+// TILE-MATMUL-ONLY-SAME:   {
+//      TILE-MATMUL-ONLY:       linalg.matmul
+//      TILE-MATMUL-ONLY:   }
+//      TILE-MATMUL-ONLY:   linalg.generic

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_using_scf_forall.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_using_scf_forall.mlir
@@ -1,5 +1,6 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=0}))' --split-input-file %s | FileCheck %s --check-prefix=TILE-LEVEL-0
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=1}))' --split-input-file %s | FileCheck %s --check-prefix=TILE-LEVEL-1
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=0 tile-elementwise=false}))' --split-input-file %s | FileCheck %s --check-prefix=TILE-MATMUL-ONLY
 
 func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> tensor<8x8xi32> {
   %c0 = arith.constant 0 : index
@@ -91,3 +92,11 @@ func.func @matmul_bias_add(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %ar
 //      TILE-LEVEL-0:       linalg.matmul
 //      TILE-LEVEL-0:       linalg.generic
 //      TILE-LEVEL-0:   }
+
+//      TILE-MATMUL-ONLY: @matmul_bias_add
+//      TILE-MATMUL-ONLY:   scf.forall
+// TILE-MATMUL-ONLY-SAME:   {
+//      TILE-MATMUL-ONLY:       linalg.fill
+//      TILE-MATMUL-ONLY:       linalg.matmul
+//      TILE-MATMUL-ONLY:   }
+//      TILE-MATMUL-ONLY:   linalg.generic


### PR DESCRIPTION
- Add data layout propagation in the pack-peel pipeline, so the pack ops can be propagated for elementwise ops.
- Modify the tileAndFusePass to include an option to not tile the elementwise ops.
- After these changes the generated IR before fusion is as https://gist.github.com/yzhang93/2d83d40f4cec20f58a135af73209759e
- TODOs:
1) Modify bufferizeToAllocation pass to include memory promotion for elementwise ops.
2) Add a method to automatically detect matmul-elementwise vs matmul-only dispatches, so that we can set different peel options. For matmul-only dispatch just the first iteration needs to be peeled, while for matmul-elementwise dispatch both the first and the last iterations need to be peeled.