### PR TITLE
Numerical failure in i8 matmul: m=n=32 k=64 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024040216+11822b0-py3-none-manylinux_2_35_x86_64.whl
+          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024041321+7b2d6e7-py3-none-manylinux_2_35_x86_64.whl
           pip install -r tests/matmul/requirements.txt
 
       - name: E2E correctness matmul test


### PR DESCRIPTION
This PR adds this failing test, and labels it as an expected numerical failure. By adding it like this we might be more likely to track and fix it. Issue created: https://github.com/nod-ai/iree-amd-aie/issues/273