### PR TITLE
Add support to bufferize the operands from elementwise ops

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree-amd-aie/IR/AMDAIEAttrs.h"
+#include "iree-amd-aie/Transforms/AMDAIEUtils.h"
 #include "iree-amd-aie/Transforms/Passes.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -39,6 +40,28 @@ static LogicalResult applyBufferizeToAllocation(RewriterBase &rewriter,
   return success();
 }
 
+/// Utility to fetch operands from the LinalgOp's input and output.
+static FailureOr<SmallVector<Value>> getInputOutputOperands(
+    linalg::LinalgOp &linalgOp) {
+  SmallVector<Value> operands;
+  for (auto operand : linalgOp->getOperands()) {
+    // For matmul-elementwise ops fusion, there is no need to promote the
+    // operand which is the output of its producer contraction op.
+    if (isMatmulElementwiseFusion(linalgOp)) {
+      auto defOp = operand.getDefiningOp();
+      if (!defOp) {
+        return failure();
+      }
+      auto defLinalgOp = dyn_cast_or_null<linalg::LinalgOp>(defOp);
+      if (defLinalgOp && linalg::isaContractionOpInterface(defLinalgOp)) {
+        continue;
+      }
+    }
+    operands.push_back(operand);
+  }
+  return operands;
+}
+
 /// Utility to fetch operands from the defining ops of LinalgOp's input
 /// operands. For example, we want to fetch the input operand of %pack0 and
 /// %pack1 as shown in below, and promote them to memory.
@@ -50,13 +73,28 @@ static LogicalResult applyBufferizeToAllocation(RewriterBase &rewriter,
 static FailureOr<SmallVector<Value>> getOperandsFromDefOp(
     linalg::LinalgOp &linalgOp) {
   SmallVector<Value> operands;
-  for (auto input : linalgOp.getDpsInputs()) {
-    auto defOp = input.getDefiningOp();
-    // The defining op has to be a pack op, fail otherwise.
-    if (!defOp || !isa<tensor::PackOp>(defOp)) {
+  // For matmul only dispatch, we only want to fetch the input operand of the
+  // pack ops.
+  auto candidateOperands = isMatmulElementwiseFusion(linalgOp)
+                               ? linalgOp->getOperands()
+                               : linalgOp.getDpsInputs();
+  for (auto operand : candidateOperands) {
+    auto defOp = operand.getDefiningOp();
+    if (!defOp) {
       return failure();
     }
-    // We only want to fetch the input operand of the pack op.
+    // For matmul-elementwise ops fusion, there is no need to promote the
+    // operand which is the output of its producer contraction op.
+    if (isMatmulElementwiseFusion(linalgOp)) {
+      auto defLinalgOp = dyn_cast_or_null<linalg::LinalgOp>(defOp);
+      if (defLinalgOp && linalg::isaContractionOpInterface(defLinalgOp)) {
+        continue;
+      }
+    } else {
+      if (!isa<tensor::PackOp>(defOp)) {
+        return failure();
+      }
+    }
     operands.push_back(defOp->getOperand(0));
   }
   return operands;
@@ -70,15 +108,15 @@ static FailureOr<SmallVector<Value>> getOperandsToBufferize(
   switch (bufferizeOperand) {
     /// Create new allocations for Lhs, Rhs and Out.
     case BufferizeOperand::InputOutput:
-      return SmallVector<Value>(linalgOp->getOperands());
+      return getInputOutputOperands(linalgOp);
     /// Create new allocation only for Lhs, Rhs.
     case BufferizeOperand::Input:
       return SmallVector<Value>(linalgOp.getDpsInputs());
     /// Create new allocations only for Out.
     case BufferizeOperand::Output:
       return SmallVector<Value>(linalgOp.getDpsInits());
-    /// Create new allocations for operands from the input def ops.
-    case BufferizeOperand::DefInput:
+    /// Create new allocations for operands from the def ops.
+    case BufferizeOperand::DefOp:
       return getOperandsFromDefOp(linalgOp);
     default:
       return failure();
@@ -126,6 +164,10 @@ void AMDAIEBufferizeToAllocationPass::runOnOperation() {
   func::FuncOp funcOp = getOperation();
   linalg::LinalgOp linalgOp;
   funcOp->walk<WalkOrder::PostOrder, ReverseIterator>([&](linalg::LinalgOp op) {
+    if (isElementwise(op) && bufferizeElementwise) {
+      linalgOp = op;
+      return WalkResult::interrupt();
+    }
     if (linalg::isaContractionOpInterface(op)) {
       linalgOp = op;
       return WalkResult::interrupt();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp
@@ -41,19 +41,14 @@ static LogicalResult applyBufferizeToAllocation(RewriterBase &rewriter,
 }
 
 /// Utility to fetch operands from the LinalgOp's input and output.
-static FailureOr<SmallVector<Value>> getInputOutputOperands(
-    linalg::LinalgOp &linalgOp) {
+static SmallVector<Value> getInputOutputOperands(linalg::LinalgOp &linalgOp) {
   SmallVector<Value> operands;
   for (auto operand : linalgOp->getOperands()) {
     // For matmul-elementwise ops fusion, there is no need to promote the
     // operand which is the output of its producer contraction op.
     if (isMatmulElementwiseFusion(linalgOp)) {
-      auto defOp = operand.getDefiningOp();
-      if (!defOp) {
-        return failure();
-      }
-      auto defLinalgOp = dyn_cast_or_null<linalg::LinalgOp>(defOp);
-      if (defLinalgOp && linalg::isaContractionOpInterface(defLinalgOp)) {
+      auto defOp = operand.getDefiningOp<linalg::LinalgOp>();
+      if (defOp && linalg::isaContractionOpInterface(defOp)) {
         continue;
       }
     }
@@ -86,7 +81,7 @@ static FailureOr<SmallVector<Value>> getOperandsFromDefOp(
     // For matmul-elementwise ops fusion, there is no need to promote the
     // operand which is the output of its producer contraction op.
     if (isMatmulElementwiseFusion(linalgOp)) {
-      auto defLinalgOp = dyn_cast_or_null<linalg::LinalgOp>(defOp);
+      auto defLinalgOp = dyn_cast<linalg::LinalgOp>(defOp);
       if (defLinalgOp && linalg::isaContractionOpInterface(defLinalgOp)) {
         continue;
       }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
@@ -299,7 +299,7 @@ bool isMatmul(linalg::LinalgOp linalgOp) {
 
 /// Utility to indentify whether a generic op is an elementwise op and whether
 /// its producer is a matmul-like op.
-bool isMatmulElementwiseFusion(linalg::LinalgOp linalgOp) {
+bool isMatmulProducerOfElementwise(linalg::LinalgOp linalgOp) {
   if (!isElementwise(linalgOp)) return false;
   // Check if any of the defining op is a matmul-like op. To simplify the
   // problem, currently only check if it is a contraction op.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
@@ -13,15 +13,15 @@ namespace mlir::iree_compiler::AMDAIE {
 
 namespace {
 
-// Generate a DenseMap key we can use for the element types (alternatives
-// considered: implement tombstone for std::array, or use std::map instead of
-// DenseMap).
+/// Generate a DenseMap key we can use for the element types (alternatives
+/// considered: implement tombstone for std::array, or use std::map instead of
+/// DenseMap).
 constexpr uint32_t getElementTypeKey(uint32_t a, uint32_t b, uint32_t c) {
   return a + (b << 8) + (c << 16);
 }
 
-// Map from (LHS bitwidth, RHS bitwidth, Accumulator bitwidth) to the AIE
-// instruction size (m, n, k) for the integer types with those bitwidths.
+/// Map from (LHS bitwidth, RHS bitwidth, Accumulator bitwidth) to the AIE
+/// instruction size (m, n, k) for the integer types with those bitwidths.
 const auto& getIntegerMatmulInstructionSizeMap() {
   // Sanity check.
   static_assert(getElementTypeKey(1, 2, 3) == 1 + 2 * 256 + 3 * 65536);
@@ -107,9 +107,8 @@ FailureOr<unsigned> getTilingScaleFactor(Type elemType) {
   return 64 / bitWidth;
 }
 
-// Utility to match iterator type and indexing map for a linalg.generic that
-/// is basically implementing a matmul with 2D input/output operands. Such
-/// matmul variants we get from Pad pipeline.
+/// Utility to match iterator type and indexing map for a linalg.generic that
+/// is basically implementing a matmul with 2D input/output operands.
 static bool match2DLinalgGenericMatmul(linalg::LinalgOp linalgOp) {
   // Check iterator types.
   SmallVector<utils::IteratorType> matmulIteratorTypes = {
@@ -147,8 +146,7 @@ static bool match2DLinalgGenericMatmul(linalg::LinalgOp linalgOp) {
 }
 
 /// Utility to match iterator type and indexing map for a linalg.generic that
-/// is basically implementing a matmul with 4D input/output operands. Such
-/// matmul variants we get from Pad-Pack pipeline.
+/// is basically implementing a matmul with 4D input/output operands.
 static bool match4DLinalgGenericMatmul(linalg::LinalgOp linalgOp) {
   // Check iterator types.
   SmallVector<utils::IteratorType> matmulIteratorTypes = {
@@ -319,7 +317,7 @@ bool isMatmulElementwiseFusion(linalg::LinalgOp linalgOp) {
   return false;
 }
 
-// Find the largest factor of 'num' which is not larger than 'max'.
+/// Find the largest factor of 'num' which is not larger than 'max'.
 int detail::findLargestFactor(int num, int max) {
   assert(max > 0 && "No factors less than or equal to 0 exist");
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
@@ -71,7 +71,7 @@ bool isMatmul(linalg::LinalgOp linalgOp);
 
 /// Utility to indentify whether a generic op is an elementwise op and whether
 /// its producer is a matmul-like op.
-bool isMatmulElementwiseFusion(linalg::LinalgOp linalgOp);
+bool isMatmulProducerOfElementwise(linalg::LinalgOp linalgOp);
 
 namespace detail {
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
@@ -66,8 +66,11 @@ FailureOr<std::array<uint32_t, 3>> getAIEIntegerMatmulInstructionSize(
 /// width.
 FailureOr<unsigned> getTilingScaleFactor(Type elemType);
 
-/// Utility to check if a generic op is an elementwise op and if its producer is
-/// a matmul-like op.
+/// Utility to indentify whether a linalg op is a matmul op.
+bool isMatmul(linalg::LinalgOp linalgOp);
+
+/// Utility to indentify whether a generic op is an elementwise op and whether
+/// its producer is a matmul-like op.
 bool isMatmulElementwiseFusion(linalg::LinalgOp linalgOp);
 
 namespace detail {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
@@ -9,6 +9,7 @@
 
 #include <array>
 
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/IR/Types.h"
 
 namespace mlir::iree_compiler::AMDAIE {
@@ -64,6 +65,10 @@ FailureOr<std::array<uint32_t, 3>> getAIEIntegerMatmulInstructionSize(
 /// increase/decrease the tiling window depending on the element type's bit
 /// width.
 FailureOr<unsigned> getTilingScaleFactor(Type elemType);
+
+/// Utility to check if a generic op is an elementwise op and if its producer is
+/// a matmul-like op.
+bool isMatmulElementwiseFusion(linalg::LinalgOp linalgOp);
 
 namespace detail {
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
@@ -28,7 +28,7 @@ enum class BufferizeOperand : int32_t {
   InputOutput = 0,
   Input = 1,
   Output = 2,
-  DefInput = 3
+  DefOp = 3
 };
 
 /// Struct specifying the number of cores to use. This will be replaced

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -183,7 +183,7 @@ void addPackPeelBasedPassPipeline(OpPassManager &pm,
   {
     AMDAIEBufferizeToAllocationOptions bufferizeOptions2;
     bufferizeOptions2.memorySpace = 1;
-    bufferizeOptions2.bufferizeOperand = BufferizeOperand::DefInput;
+    bufferizeOptions2.bufferizeOperand = BufferizeOperand::DefOp;
     modulePassManager.addNestedPass<func::FuncOp>(
         createAMDAIEBufferizeToAllocationPass(bufferizeOptions2));
   }
@@ -245,6 +245,24 @@ void addPackPeelBasedPassPipeline(OpPassManager &pm,
       createAMDAIEFuseFillIntoForallPass());
   modulePassManager.addPass(createCanonicalizerPass());
   modulePassManager.addPass(createCSEPass());
+
+  // Promote the operands from Elementwise op to shared and local memory
+  {
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions4;
+    bufferizeOptions4.memorySpace = 1;
+    bufferizeOptions4.bufferizeElementwise = true;
+    bufferizeOptions4.bufferizeOperand = BufferizeOperand::InputOutput;
+    modulePassManager.addNestedPass<func::FuncOp>(
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions4));
+  }
+  {
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions5;
+    bufferizeOptions5.memorySpace = 2;
+    bufferizeOptions5.bufferizeElementwise = true;
+    bufferizeOptions5.bufferizeOperand = BufferizeOperand::InputOutput;
+    modulePassManager.addNestedPass<func::FuncOp>(
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions5));
+  }
 
   // Comprehensive bufferization
   addAMDAIEBufferizePasses(modulePassManager);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -155,7 +155,7 @@ void addPackPeelBasedPassPipeline(OpPassManager &pm,
         createAMDAIEBufferizeToAllocationPass(bufferizeOptions1));
   }
 
-  // Promote the operands from Elementwise op to shared and local memory
+  // Promote the operands from elementwise op to shared and local memory
   {
     AMDAIEBufferizeToAllocationOptions bufferizeOptions2;
     bufferizeOptions2.memorySpace = 1;

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -251,7 +251,7 @@ void addPackPeelBasedPassPipeline(OpPassManager &pm,
   // last iterations.
   {
     AMDAIEPeelForLoopOptions peelOptions;
-    peelOptions.peelingType = PeelingType::FirstLast;
+    peelOptions.peelingType = PeelingType::First;
     modulePassManager.addNestedPass<func::FuncOp>(
         createAMDAIEPeelForLoopPass(peelOptions));
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -29,6 +29,8 @@ def AMDAIEBufferizeToAllocation :
   let options = [
     Option<"memorySpace", "memory-space", "int64_t", /*default=*/"1",
       "Set the memory space">,
+    Option<"bufferizeElementwise", "bufferize-elementwise", "bool", /*default=*/"false",
+      "Indicator of whether the target op for bufferization is an elementwise op">,
     Option<"bufferizeOperand", "bufferize-operand",
       "mlir::iree_compiler::AMDAIE::BufferizeOperand",
       /*default=*/"mlir::iree_compiler::AMDAIE::BufferizeOperand::InputOutput",
@@ -40,8 +42,8 @@ def AMDAIEBufferizeToAllocation :
                    "Create new allocations for lhs, rhs of a linalg op."),
         clEnumValN(mlir::iree_compiler::AMDAIE::BufferizeOperand::Output, "output",
                    "Create new allocations for output of a linalg op."),
-        clEnumValN(mlir::iree_compiler::AMDAIE::BufferizeOperand::DefInput, "def-input",
-                   "Create new allocations for operands from the input def ops of a matmul.")
+        clEnumValN(mlir::iree_compiler::AMDAIE::BufferizeOperand::DefOp, "def-op",
+                   "Create new allocations for operands from the def ops of a linalg op.")
     )}]>
   ];
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/bufferize_to_allocation.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/bufferize_to_allocation.mlir
@@ -1,7 +1,9 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=2 bufferize-operand=input-output}))' --split-input-file %s | FileCheck %s --check-prefix=INPUT-OUTPUT
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=2 bufferize-operand=input}))' --split-input-file %s | FileCheck %s --check-prefix=INPUT
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=2 bufferize-operand=output}))' --split-input-file %s | FileCheck %s --check-prefix=OUTPUT
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=1 bufferize-operand=def-input}))' --split-input-file %s | FileCheck %s --check-prefix=DEF-INPUT
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=1 bufferize-operand=def-op}))' --split-input-file %s | FileCheck %s --check-prefix=DEF-INPUT
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=1 bufferize-elementwise=true bufferize-operand=def-op}))' --split-input-file %s | FileCheck %s --check-prefix=ELEMENTWISE-CHECK1
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=2 bufferize-elementwise=true bufferize-operand=input-output}))' --split-input-file %s | FileCheck %s --check-prefix=ELEMENTWISE-CHECK2
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d2, d3, d5, d6, d8)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d2, d1, d5, d4, d7, d8)>
@@ -88,3 +90,85 @@ func.func @matmul_static(%arg0 : tensor<1024x2048xi32>, %arg1 : tensor<2048x512x
 // DEF-INPUT-NOT:  memref.alloc
 //     DEF-INPUT:  linalg.fill
 //     DEF-INPUT:  linalg.generic
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d2, d5, d3, d6, d8)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d2, d1, d4, d5, d8, d7)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d4, d3, d6, d7)>
+#map3 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4, d5)>
+func.func @matmul_elementwise(%arg0: tensor<1024x512xi8>, %arg1: tensor<512x1024xi8>, %arg2: tensor<1024x1024xi32>) -> tensor<1024x1024xi32> {
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tensor.empty() : tensor<1024x1024xi32>
+  %1 = scf.forall (%arg3, %arg4) = (0, 0) to (1024, 1024) step (64, 64) shared_outs(%arg5 = %0) -> (tensor<1024x1024xi32>) {
+    %extracted_slice = tensor.extract_slice %arg0[%arg3, 0] [64, 512] [1, 1] : tensor<1024x512xi8> to tensor<64x512xi8>
+    %extracted_slice_0 = tensor.extract_slice %arg1[0, %arg4] [512, 64] [1, 1] : tensor<512x1024xi8> to tensor<512x64xi8>
+    %extracted_slice_1 = tensor.extract_slice %0[%arg3, %arg4] [64, 64] [1, 1] : tensor<1024x1024xi32> to tensor<64x64xi32>
+    %2 = tensor.empty() : tensor<1x16x64x32xi8>
+    %pack = tensor.pack %extracted_slice inner_dims_pos = [0, 1] inner_tiles = [64, 32] into %2 : tensor<64x512xi8> -> tensor<1x16x64x32xi8>
+    %3 = tensor.empty() : tensor<16x1x32x64xi8>
+    %pack_2 = tensor.pack %extracted_slice_0 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [32, 64] into %3 : tensor<512x64xi8> -> tensor<16x1x32x64xi8>
+    %4 = tensor.empty() : tensor<1x1x64x64xi32>
+    %5 = tensor.empty() : tensor<1x16x4x16x4x8xi8>
+    %pack_3 = tensor.pack %pack outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [4, 8] into %5 : tensor<1x16x64x32xi8> -> tensor<1x16x4x16x4x8xi8>
+    %6 = tensor.empty() : tensor<16x1x8x4x8x8xi8>
+    %pack_4 = tensor.pack %pack_2 outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [8, 8] into %6 : tensor<16x1x32x64xi8> -> tensor<16x1x8x4x8x8xi8>
+    %7 = tensor.empty() : tensor<1x1x8x16x4x8xi32>
+    %8 = linalg.fill ins(%c0_i32 : i32) outs(%7 : tensor<1x1x8x16x4x8xi32>) -> tensor<1x1x8x16x4x8xi32>
+    %9 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]} ins(%pack_3, %pack_4 : tensor<1x16x4x16x4x8xi8>, tensor<16x1x8x4x8x8xi8>) outs(%8 : tensor<1x1x8x16x4x8xi32>) {
+    ^bb0(%in: i8, %in_12: i8, %out: i32):
+      %11 = arith.extsi %in : i8 to i32
+      %12 = arith.extsi %in_12 : i8 to i32
+      %13 = arith.muli %11, %12 : i32
+      %14 = arith.addi %out, %13 : i32
+      linalg.yield %14 : i32
+    } -> tensor<1x1x8x16x4x8xi32>
+    %extracted_slice_5 = tensor.extract_slice %arg2[%arg3, %arg4] [64, 64] [1, 1] : tensor<1024x1024xi32> to tensor<64x64xi32>
+    %extracted_slice_6 = tensor.extract_slice %arg5[%arg3, %arg4] [64, 64] [1, 1] : tensor<1024x1024xi32> to tensor<64x64xi32>
+    %pack_7 = tensor.pack %extracted_slice_6 inner_dims_pos = [0, 1] inner_tiles = [64, 64] into %4 : tensor<64x64xi32> -> tensor<1x1x64x64xi32>
+    %pack_8 = tensor.pack %extracted_slice_5 inner_dims_pos = [0, 1] inner_tiles = [64, 64] into %4 : tensor<64x64xi32> -> tensor<1x1x64x64xi32>
+    %pack_9 = tensor.pack %pack_7 outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [4, 8] into %7 : tensor<1x1x64x64xi32> -> tensor<1x1x8x16x4x8xi32>
+    %pack_10 = tensor.pack %pack_8 outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [4, 8] into %7 : tensor<1x1x64x64xi32> -> tensor<1x1x8x16x4x8xi32>
+    %10 = linalg.generic {indexing_maps = [#map3, #map3, #map3], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%9, %pack_10 : tensor<1x1x8x16x4x8xi32>, tensor<1x1x8x16x4x8xi32>) outs(%pack_9 : tensor<1x1x8x16x4x8xi32>) {
+    ^bb0(%in: i32, %in_12: i32, %out: i32):
+      %11 = arith.addi %in, %in_12 : i32
+      linalg.yield %11 : i32
+    } -> tensor<1x1x8x16x4x8xi32>
+    %unpack = tensor.unpack %10 outer_dims_perm = [0, 1, 3, 2] inner_dims_pos = [2, 3] inner_tiles = [4, 8] into %4 : tensor<1x1x8x16x4x8xi32> -> tensor<1x1x64x64xi32>
+    %unpack_11 = tensor.unpack %unpack inner_dims_pos = [0, 1] inner_tiles = [64, 64] into %extracted_slice_1 : tensor<1x1x64x64xi32> -> tensor<64x64xi32>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %unpack_11 into %arg5[%arg3, %arg4] [64, 64] [1, 1] : tensor<64x64xi32> into tensor<1024x1024xi32>
+    }
+  } {mapping = [#gpu.block<y>, #gpu.block<x>]}
+  return %1 : tensor<1024x1024xi32>
+}
+
+// ELEMENTWISE-CHECK1-COUNT-4:  tensor.pack
+//         ELEMENTWISE-CHECK1:  linalg.fill
+//         ELEMENTWISE-CHECK1:  linalg.generic
+//         ELEMENTWISE-CHECK1:  memref.alloc() : memref<1x1x64x64xi32, 1 : i32>
+//         ELEMENTWISE-CHECK1:  bufferization.to_tensor
+//         ELEMENTWISE-CHECK1:  tensor.pack
+//         ELEMENTWISE-CHECK1:  memref.alloc() : memref<1x1x64x64xi32, 1 : i32>
+//         ELEMENTWISE-CHECK1:  bufferization.to_tensor
+//         ELEMENTWISE-CHECK1:  tensor.pack
+//     ELEMENTWISE-CHECK1-NOT:  memref.alloc
+//         ELEMENTWISE-CHECK1:  tensor.pack
+//     ELEMENTWISE-CHECK1-NOT:  memref.alloc
+//         ELEMENTWISE-CHECK1:  tensor.pack
+//         ELEMENTWISE-CHECK1:  linalg.generic
+
+// ELEMENTWISE-CHECK2-COUNT-4:  tensor.pack
+//         ELEMENTWISE-CHECK2:  linalg.fill
+//         ELEMENTWISE-CHECK2:  linalg.generic
+//     ELEMENTWISE-CHECK2-NOT:  memref.alloc
+//         ELEMENTWISE-CHECK2:  tensor.pack
+//     ELEMENTWISE-CHECK2-NOT:  memref.alloc
+//         ELEMENTWISE-CHECK2:  tensor.pack
+//         ELEMENTWISE-CHECK2:  memref.alloc() : memref<1x1x8x16x4x8xi32, 2 : i32>
+//         ELEMENTWISE-CHECK2:  bufferization.to_tensor
+//         ELEMENTWISE-CHECK2:  tensor.pack
+//         ELEMENTWISE-CHECK2:  memref.alloc() : memref<1x1x8x16x4x8xi32, 2 : i32>
+//         ELEMENTWISE-CHECK2:  bufferization.to_tensor
+//         ELEMENTWISE-CHECK2:  tensor.pack
+//         ELEMENTWISE-CHECK2:  linalg.generic


### PR DESCRIPTION
- We will need to run this pass for elementwise ops after the elementwise op is fused into the last iteration of the matmul computation.