### PR TITLE
[WIP,experiment] matmul benchmarking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,11 @@ jobs:
           source .venv/bin/activate
           bash build_tools/ci/run_matmul_test.sh test1 iree-install
 
+      - name: E2E matmul with direct xrt calls
+        run: |
+          source .venv/bin/activate
+          bash build_tools/ci/use_xrt_directly/run_test.sh test1 iree-install
+
       - name: Printing IR from aie2xclbin
         run: |
           source .venv/bin/activate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,11 @@ jobs:
           source .venv/bin/activate
           bash build_tools/ci/use_xrt_directly/run_test.sh test1 iree-install
 
+      - name: Baremetal matmul performance benchmark
+        run: |
+          source .venv/bin/activate
+          bash build_tools/ci/matmul_without_runtime_bench/run_test.sh test1 iree-install
+
       - name: Printing IR from aie2xclbin
         run: |
           source .venv/bin/activate

--- a/build_tools/ci/matmul_without_runtime_bench/generate_linalg_matmul.py
+++ b/build_tools/ci/matmul_without_runtime_bench/generate_linalg_matmul.py
@@ -1,0 +1,60 @@
+def generate(M, N, K):
+    """
+    Create MLIR linalg matmul function with given dimensions M, N, K.
+    Initialize the output with '7.0'
+    bfloat16 operands, float32 output.
+    """
+
+    mlirStr = """
+!A = tensor<%dx%dxbf16>
+!B = tensor<%dx%dxbf16>
+!C = tensor<%dx%dxf32>"""%(M, K, K, N, M, N)
+
+    mlirStr+="""
+
+// C = 7 + A @ B (The '@' symbol denotes matrix multiplication)
+func.func @matmul(%A : !A, %B : !B) -> !C {
+
+  // Initialize output tensor with '7'
+  %init_acc = tensor.empty() : !C
+  %c0_acc_type = arith.constant 7.0 : f32
+
+  %acc = linalg.fill ins(%c0_acc_type : f32)
+                     outs(%init_acc : !C) -> !C
+
+  %C = linalg.matmul ins(%A, %B: !A, !B) outs(%acc: !C) -> !C
+
+  return %C: !C
+}
+"""
+    return mlirStr
+
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} M=int N=int K=int")
+        sys.exit(1)
+
+    M = -1
+    N = -1
+    K = -1
+
+    for arg in sys.argv[1:]:
+        if arg.startswith("M="):
+            M = int(arg[2:])
+        elif arg.startswith("N="):
+            N = int(arg[2:])
+        elif arg.startswith("K="):
+            K = int(arg[2:])
+        else:
+            print(f"Invalid argument: {arg}")
+            sys.exit(1)
+
+    if M < 0 or N < 0 or K < 0:
+        print(f"Invalid arguments: M={M} N={N} K={K}")
+        sys.exit(1)
+
+    print(generate(M, N, K))
+

--- a/build_tools/ci/matmul_without_runtime_bench/run_test.sh
+++ b/build_tools/ci/matmul_without_runtime_bench/run_test.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+#
+# Copyright 2024 The LLVM Project
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+set -euox pipefail
+
+# The usual boilerplate for getting the AIE directories setup.
+if [ "$#" -lt 2 ] || [ "$#" -gt 6 ]; then
+
+   # The expected parameters are
+   #    1) <output-dir>            (required)
+   #    2) <iree-install-dir>      (required)
+   #    3) <mlir-aie-install-dir>  (optional)
+   #    4) <peano-install-dir>     (optional)
+   #    5) <xrt-dir>               (optional)
+   #    6) <vitis-install-dir>     (optional)
+    echo -e "Illegal number of parameters: $#, expected 2,3,4,5, or 6 parameters." \
+            "\n The parameters are as follows:" \
+            "\n     1) <output-dir>               (required)" \
+            "\n     2) <iree-install-dir>         (required)" \
+            "\n     3) <mlir-aie-install-dir>     (optional)" \
+            "\n     4) <peano-install-dir>        (optional)" \
+            "\n     5) <xrt-dir>                  (optional)" \
+            "\n     6) <vitis-install-dir>        (optional)" \
+            "\n Example, dependent on environment variables:" \
+            "\n     ./run_test.sh  " \
+            "results_dir_tmp  \$IREE_BUILD_OR_INSTALL_DIR  \$MLIR_AIE_INSTALL_DIR  " \
+            "\$PEANO_INSTALL_DIR  /opt/xilinx/xrt  \$VITIS_INSTALL_PATH"
+    exit 1
+fi
+
+
+# All temporary files should end up in the output directory. 
+OUTPUT_DIR=`realpath "$1"`
+mkdir -p ${OUTPUT_DIR}
+if [ ! -d "${OUTPUT_DIR}" ]; then
+  echo "Failed to locate on construct OUTPUT_DIR '${OUTPUT_DIR}'."
+  exit 1
+fi
+
+IREE_INSTALL_DIR=`realpath "$2"`
+if [ ! -d "${IREE_INSTALL_DIR}" ]; then
+  echo "IREE_INSTALL_DIR must be a directory, '${IREE_INSTALL_DIR}' is not."
+  exit 1
+fi
+
+# Search for iree-compile in the user provide directory.
+IREE_COMPILE_EXE=""
+for dir in "${IREE_INSTALL_DIR}" "${IREE_INSTALL_DIR}/bin" "${IREE_INSTALL_DIR}/tools"; do
+  if [ -f "${dir}/iree-compile" ]; then
+    IREE_COMPILE_EXE="${dir}/iree-compile"
+  fi
+done
+
+if [ -z "${IREE_COMPILE_EXE}" ]; then
+  echo "No 'iree-compile' found in any of the following directories: " \
+       "'${IREE_INSTALL_DIR}', '${IREE_INSTALL_DIR}/bin', '${IREE_INSTALL_DIR}/tools'."
+  exit 1
+fi
+
+
+# Parameter 3) <mlir-aie-install-dir>
+if [ -z "${3-}" ]; then
+  MLIR_AIE_INSTALL=`realpath .venv/lib/python3.10/site-packages/mlir_aie`
+else
+  MLIR_AIE_INSTALL=`realpath "$3"`
+fi
+if [ ! -d "${MLIR_AIE_INSTALL}" ]; then
+  echo "No directory '${MLIR_AIE_INSTALL}' (argument 3) found."
+  exit 1
+fi
+
+# Parameter 4) <peano-install-dir>
+if [ -z "${4-}" ]; then
+  PEANO=/opt/llvm-aie
+else
+  PEANO=`realpath "$4"`
+fi
+if [ ! -d "${PEANO}" ]; then
+  echo "No directory '${PEANO}' (argument 4) found."
+  exit 1
+fi
+
+# Parameter 5) <xrt-dir>
+if [ -z "${5-}" ]; then
+  XRT_DIR=/opt/xilinx/xrt
+else
+  XRT_DIR=`realpath "$5"`
+fi
+if [ ! -d "${XRT_DIR}" ]; then
+  echo "No directory '${XRT_DIR}' (argument 5) found."
+  exit 1
+fi
+
+# Parameter 6) <vitis-install-dir>
+if [ -z "${6-}" ]; then
+  # An alternate to a full vitis install, will work
+  # here but not for a full build of mlir-aie
+  # https://riallto.ai/install-riallto.html#install-riallto
+  # VITIS=/opt/Riallto/Vitis/2023.1
+  VITIS=/opt/Xilinx/Vitis/2023.2
+else
+  VITIS=`realpath "$6"`
+fi
+if [ ! -d "${VITIS}" ]; then
+  echo "No directory '${VITIS}' (argument 6) found."
+  exit 1
+fi
+
+THIS_DIR="$(cd $(dirname $0) && pwd)"
+ROOT_DIR="$(cd $THIS_DIR/../.. && pwd)"
+
+source $XRT_DIR/setup.sh
+
+    # --m "8192" --k "2432" --n "2432"  \
+
+# M=1024
+# N=1024
+# K=1024
+
+M=8192
+K=2432
+N=2432
+
+# Create a file ${OUTPUT_DIR}/generated_linalg_matmul.mlir
+# by running 'generate_linalg_matmul.py with arguments M, K, and N. 
+GENERATE_SCRIPT="${THIS_DIR}/generate_linalg_matmul.py"
+SOURCE_MLIR_FILE="${OUTPUT_DIR}/generated_linalg_matmul.mlir"
+if [ ! -f "${GENERATE_SCRIPT}" ]; then
+  echo "generate_linalg_matmul.py not found: ${GENERATE_SCRIPT}"
+  exit 1
+fi
+GENERATE_COMMAND="python ${GENERATE_SCRIPT} M=${M} K=${K} N=${N} > ${SOURCE_MLIR_FILE}"
+echo "Executing command: $GENERATE_COMMAND"
+eval $GENERATE_COMMAND
+
+THIS="$(cd $(dirname $0) && pwd)"
+
+# Construct the iree-compile command. 
+IREE_COMPILE_COMMAND="${IREE_COMPILE_EXE} \
+${SOURCE_MLIR_FILE} \
+--iree-hal-target-backends=amd-aie \
+--iree-amd-aie-peano-install-dir=${PEANO} \
+--iree-amd-aie-mlir-aie-install-dir=${MLIR_AIE_INSTALL} \
+--iree-amd-aie-vitis-install-dir=${VITIS} \
+--iree-hal-dump-executable-files-to=${OUTPUT_DIR} \
+-o ${OUTPUT_DIR}/test_artefact.vmfb \
+--iree-amd-aie-show-invoked-commands"
+
+#--mlir-print-ir-after-all \
+
+# Execute the command to generate the .vmfb, .xclbin, .npu.txt files, etc.
+echo "Executing command: $IREE_COMPILE_COMMAND"
+eval $IREE_COMPILE_COMMAND 
+
+if [ ! -f "${OUTPUT_DIR}/test_artefact.vmfb" ]; then
+  echo "test_artefact.vmfb was not created: ${OUTPUT_DIR}/test_artefact.vmfb"
+  exit 1
+fi
+
+# Get the full path of test.cpp (which is in the same directory as this script).
+TEST_CPP="${THIS_DIR}/test.cpp"
+
+# Compile the host code (flags inspired by mlir-air tests). 
+g++ ${TEST_CPP} -o ${OUTPUT_DIR}/test.exe -Wall -I${XRT_DIR}/include -L${XRT_DIR}/lib -luuid -lxrt_coreutil -lrt -lstdc++
+
+# Verify that ${OUTPUT_DIR}/test.exe exists:
+if [ ! -f "${OUTPUT_DIR}/test.exe" ]; then
+  echo "test.exe was not created: ${OUTPUT_DIR}/test.exe"
+  exit 1
+fi
+
+# We expect to find a file with the .xclbin extension in the output directory, 
+# or in a subdirectory of the output directory. Locate it if possible. 
+XCLBIN_FILE=""
+for file in `find ${OUTPUT_DIR} -name "*.xclbin"`; do
+  XCLBIN_FILE="${file}"
+done
+if [ -z "${XCLBIN_FILE}" ]; then
+  echo "No .xclbin file found in the output directory or any of its subdirectories."
+  exit 1
+else
+  echo "Found .xclbin file: ${XCLBIN_FILE}"
+fi
+
+# Maybe sign the XCLBIN file (CI moonshot). 
+SIGNER=${XRT_DIR}/amdxdna/setup_xclbin_firmware.sh
+if [ ! -f "$SIGNER" ]; then
+  echo "**** Skipping XCLBIN signing: $SIGNER not found ****"
+else
+  sudo $SIGNER -dev Phoenix -xclbin "${XCLBIN_FILE}"
+fi
+
+# Just like above for the XCLBIN file, we expect to find a .npu.txt file in the output directory.
+IPU_TXT_FILE=""
+for file in `find ${OUTPUT_DIR} -name "*.npu.txt"`; do
+  IPU_TXT_FILE="${file}"
+done
+if [ -z "${IPU_TXT_FILE}" ]; then
+  echo "No .npu.txt file found in the output directory or any of its subdirectories."
+  exit 1
+else
+  echo "Found .npu.txt file: ${IPU_TXT_FILE}"
+fi
+
+${OUTPUT_DIR}/test.exe ${XCLBIN_FILE} ${IPU_TXT_FILE} ${M} ${K} ${N} 
+
+

--- a/build_tools/ci/matmul_without_runtime_bench/run_test.sh
+++ b/build_tools/ci/matmul_without_runtime_bench/run_test.sh
@@ -165,8 +165,24 @@ fi
 # Get the full path of test.cpp (which is in the same directory as this script).
 TEST_CPP="${THIS_DIR}/test.cpp"
 
-# Compile the host code (flags inspired by mlir-air tests). 
-g++ ${TEST_CPP} -o ${OUTPUT_DIR}/test.exe -Wall -I${XRT_DIR}/include -L${XRT_DIR}/lib -luuid -lxrt_coreutil -lrt -lstdc++
+FLAGS="-Wall -I${XRT_DIR}/include -L${XRT_DIR}/lib -luuid -lxrt_coreutil -lrt -lstdc++"
+g++ ${TEST_CPP} -o ${OUTPUT_DIR}/test.exe ${FLAGS}
+
+# =============================================
+# ==== YCM VIM SETUP =======================
+# =======================================
+YCM_EXTRA_CONF="${THIS_DIR}/.ycm_extra_conf.py"
+echo "def Settings( **kwargs ):" > ${YCM_EXTRA_CONF}
+echo "  return {" >> ${YCM_EXTRA_CONF}
+echo "    'flags': [ '-x', 'c++'," >> ${YCM_EXTRA_CONF}
+for flag in ${FLAGS}; do
+  echo "              '${flag}'," >> ${YCM_EXTRA_CONF}
+done
+echo "            ]" >> ${YCM_EXTRA_CONF}
+echo "  }" >> ${YCM_EXTRA_CONF}
+# ====================
+# =================
+# ==============
 
 # Verify that ${OUTPUT_DIR}/test.exe exists:
 if [ ! -f "${OUTPUT_DIR}/test.exe" ]; then

--- a/build_tools/ci/matmul_without_runtime_bench/test.cpp
+++ b/build_tools/ci/matmul_without_runtime_bench/test.cpp
@@ -120,7 +120,7 @@ int main(int argc, const char *argv[]) {
   double totalTime;
   double minTime = 1e9;
   double maxTime = 0;
-  int nIters = 100;
+  int nIters = 10;
   for (int i = 0; i < nIters; ++i) {
     bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
     bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);

--- a/build_tools/ci/matmul_without_runtime_bench/test.cpp
+++ b/build_tools/ci/matmul_without_runtime_bench/test.cpp
@@ -1,0 +1,165 @@
+//===- test.cpp -------------------------------------------000---*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include <bits/stdc++.h>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+int main(int argc, const char *argv[]) {
+
+  if (argc != 6) {
+    std::string errorMessage =
+        "Usage: thisProgram <pathToXclbin> <pathToInstrFile> <M> <K> <N>.";
+    std::cerr << errorMessage;
+    return 1;
+  }
+
+
+  // Get the xclbin from file:
+  std::string xclbin_path = argv[1];
+  {
+    std::ifstream xclbin_file(xclbin_path);
+    if (!xclbin_file.good()) {
+      std::cerr << "Unable to open xclbin file: " << xclbin_path << std::endl;
+      return 1;
+    }
+  }
+  auto xclbin = xrt::xclbin(xclbin_path);
+
+
+  // Get the lx6 instructions from file:
+  std::vector<uint32_t> instr_v;
+  {
+    std::string instr_path = argv[2];
+    std::ifstream instr_file(instr_path);
+    if (!instr_file.good()) {
+      std::cerr << "Unable to open lx6 instruction file: " << instr_path
+                << std::endl;
+      return 1;
+    }
+    std::string line;
+    while (std::getline(instr_file, line)) {
+      std::istringstream iss(line);
+      uint32_t a;
+      if (!(iss >> std::hex >> a)) {
+        std::cerr << "Unable to parse instruction file" << std::endl;
+        return 1;
+      }
+      instr_v.push_back(a);
+    }
+  }
+
+
+  // Get kernel from xclbin and register it with a device:
+  auto device = xrt::device(/* device_index */ 0);
+  auto xkernels = xclbin.get_kernels();
+  if (xkernels.size() != 1) {
+    std::cerr << "Kernel count: " << xkernels.size()
+              << ". Kernel count must be 1" << std::endl;
+    return 1;
+  }
+  auto xkernel = xkernels[0];
+  auto kernelName = xkernel.get_name();
+  device.register_xclbin(xclbin);
+
+  // Parse M, K, N:
+  int M, K, N;
+  std::string MStr = argv[3];
+  M = std::stoi(MStr);
+  std::string KStr = argv[4];
+  K = std::stoi(KStr);
+  std::string NStr = argv[5];
+  N = std::stoi(NStr);
+
+
+  xrt::hw_context context(device, xclbin.get_uuid());
+  auto kernel = xrt::kernel(context, kernelName);
+
+  int sizeInstructions = instr_v.size() * sizeof(int32_t);
+  int nBytesA = M * K * sizeof(int32_t);
+  int nBytesB = N * K * sizeof(int32_t);
+  int nBytesC = M * N * sizeof(int32_t);
+
+  auto bo_instr = xrt::bo(device, sizeInstructions, XCL_BO_FLAGS_CACHEABLE,
+                          kernel.group_id(0));
+  auto bo_a =
+      xrt::bo(device, nBytesA, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(2));
+  auto bo_b =
+      xrt::bo(device, nBytesB, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+  auto bo_c =
+      xrt::bo(device, nBytesC, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+
+  void *bufInstr = bo_instr.map<void *>();
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int32_t));
+
+  // Initialize A and B with 1's:
+  int32_t *bufA = bo_a.map<int32_t *>();
+  std::vector<int> AVec(M * K, 1);
+  memcpy(bufA, AVec.data(), (AVec.size() * sizeof(int32_t)));
+
+  int32_t *bufB = bo_b.map<int32_t *>();
+  std::vector<int> BVec(N * K, 1);
+  memcpy(bufB, BVec.data(), (BVec.size() * sizeof(int32_t)));
+
+  int32_t *bufC = bo_c.map<int32_t *>();
+
+  double totalTime;
+  double minTime = 1e9;
+  double maxTime = 0;
+  int nIters = 100;
+  for (int i = 0; i < nIters; ++i) {
+    bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+    bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+    bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+    bo_c.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+
+    // We will time the run, and print it.
+    auto start = std::chrono::high_resolution_clock::now();
+    auto run = kernel(bo_instr, instr_v.size(), bo_a, bo_b, bo_c);
+    run.wait();
+    auto end = std::chrono::high_resolution_clock::now();
+
+    bo_c.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+    double dt =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(end - start)
+            .count();
+
+    totalTime += dt;
+    minTime = std::min(minTime, dt);
+    maxTime = std::max(maxTime, dt);
+
+    std::cout << "Elapsed time on run " << i << ": " << dt << " [ns]\n";
+  }
+
+  double avgTime = totalTime / nIters;
+  std::cout << "Average time over runs: " << avgTime << " [ns]\n";
+  std::cout << "Min time over runs: " << minTime << " [ns]\n";
+  std::cout << "Max time over runs: " << maxTime << " [ns]\n";
+
+  double nOps = static_cast<double>(M) * static_cast<double>(N) * static_cast<double>(K) * 2;
+  std::cout << "With M=" << M << ", K=" << K << ", N=" << N
+            << ", nOps = " << nOps << std::endl;
+
+  // How many operations per second, for the fastest run? 
+  double opsPerSec = nOps / minTime * 1e9;
+  std::cout << "Operations per second (fastest run): " << opsPerSec << std::endl;
+  std::cout << "Tera operations per second (fastest run): " << opsPerSec / 1e12 << std::endl;
+
+  return 0;
+}

--- a/build_tools/ci/use_xrt_directly/.ycm_extra_conf.py
+++ b/build_tools/ci/use_xrt_directly/.ycm_extra_conf.py
@@ -1,0 +1,12 @@
+def Settings( **kwargs ):
+  return {
+    'flags': [ '-x', 'c++',
+              '-Wall',
+              '-I/opt/xilinx/xrt/include',
+              '-L/opt/xilinx/xrt/lib',
+              '-luuid',
+              '-lxrt_coreutil',
+              '-lrt',
+              '-lstdc++',
+            ]
+  }

--- a/build_tools/ci/use_xrt_directly/linalg_matmul.mlir
+++ b/build_tools/ci/use_xrt_directly/linalg_matmul.mlir
@@ -1,0 +1,19 @@
+// C = 7 + A @ B (The '@' symbol denotes matrix multiplication)
+func.func @matmul(%A : tensor<64x16xi32>, 
+                  %B : tensor<16x64xi32>) -> tensor<64x64xi32> {
+
+  // Initialize output tensor with '7'
+  %init_acc = tensor.empty() : tensor<64x64xi32>
+  %c0_acc_type = arith.constant 7 : i32
+
+  %acc = linalg.fill ins(%c0_acc_type : i32) 
+                     outs(%init_acc : tensor<64x64xi32>) -> tensor<64x64xi32>
+
+  %C = linalg.matmul ins(%A, %B: tensor<64x16xi32>, tensor<16x64xi32>) 
+                     outs(%acc: tensor<64x64xi32>) -> tensor<64x64xi32>
+
+  return %C: tensor<64x64xi32>
+}
+
+
+

--- a/build_tools/ci/use_xrt_directly/run_test.sh
+++ b/build_tools/ci/use_xrt_directly/run_test.sh
@@ -144,8 +144,24 @@ fi
 TEST_CPP="${THIS_DIR}/test.cpp"
 
 
-# Compile the host code (flags inspired by mlir-air tests). 
-g++ ${TEST_CPP} -o ${OUTPUT_DIR}/test.exe -Wall -I${XRT_DIR}/include -L${XRT_DIR}/lib -luuid -lxrt_coreutil -lrt -lstdc++
+FLAGS="-Wall -I${XRT_DIR}/include -L${XRT_DIR}/lib -luuid -lxrt_coreutil -lrt -lstdc++"
+g++ ${TEST_CPP} -o ${OUTPUT_DIR}/test.exe ${FLAGS}
+
+# =============================================
+# ==== YCM VIM SETUP =======================
+# =======================================
+YCM_EXTRA_CONF="${THIS_DIR}/.ycm_extra_conf.py"
+echo "def Settings( **kwargs ):" > ${YCM_EXTRA_CONF}
+echo "  return {" >> ${YCM_EXTRA_CONF}
+echo "    'flags': [ '-x', 'c++'," >> ${YCM_EXTRA_CONF}
+for flag in ${FLAGS}; do
+  echo "              '${flag}'," >> ${YCM_EXTRA_CONF}
+done
+echo "            ]" >> ${YCM_EXTRA_CONF}
+echo "  }" >> ${YCM_EXTRA_CONF}
+# ====================
+# =================
+# ==============
 
 # Verify that ${OUTPUT_DIR}/test.exe exists:
 if [ ! -f "${OUTPUT_DIR}/test.exe" ]; then

--- a/build_tools/ci/use_xrt_directly/run_test.sh
+++ b/build_tools/ci/use_xrt_directly/run_test.sh
@@ -127,11 +127,10 @@ ${SOURCE_MLIR_FILE} \
 --iree-amd-aie-mlir-aie-install-dir=${MLIR_AIE_INSTALL} \
 --iree-amd-aie-vitis-install-dir=${VITIS} \
 --iree-hal-dump-executable-files-to=${OUTPUT_DIR} \
---iree-amdaie-use-pipeline=simple-pack \
 -o ${OUTPUT_DIR}/test_artefact.vmfb \
 --iree-amd-aie-show-invoked-commands"
 
-# Execute the command to generate the .vmfb, .xclbin, .ipu.txt files, etc.
+# Execute the command to generate the .vmfb, .xclbin, .npu.txt files, etc.
 echo "Executing command: $IREE_COMPILE_COMMAND"
 eval $IREE_COMPILE_COMMAND 
 
@@ -175,16 +174,16 @@ else
   sudo $SIGNER -dev Phoenix -xclbin "${XCLBIN_FILE}"
 fi
 
-# Just like above for the XCLBIN file, we expect to find a .ipu.txt file in the output directory.
+# Just like above for the XCLBIN file, we expect to find a .npu.txt file in the output directory.
 IPU_TXT_FILE=""
-for file in `find ${OUTPUT_DIR} -name "*.ipu.txt"`; do
+for file in `find ${OUTPUT_DIR} -name "*.npu.txt"`; do
   IPU_TXT_FILE="${file}"
 done
 if [ -z "${IPU_TXT_FILE}" ]; then
-  echo "No .ipu.txt file found in the output directory or any of its subdirectories."
+  echo "No .npu.txt file found in the output directory or any of its subdirectories."
   exit 1
 else
-  echo "Found .ipu.txt file: ${IPU_TXT_FILE}"
+  echo "Found .npu.txt file: ${IPU_TXT_FILE}"
 fi
 
 echo "Running the test executable with writeC and syncC set to true (writeC=true and syncC=false is the failure mode)."

--- a/build_tools/ci/use_xrt_directly/run_test.sh
+++ b/build_tools/ci/use_xrt_directly/run_test.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+#
+# Copyright 2024 The LLVM Project
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+set -euox pipefail
+
+# The usual boilerplate for getting the AIE directories setup.
+if [ "$#" -lt 2 ] || [ "$#" -gt 6 ]; then
+
+   # The expected parameters are
+   #    1) <output-dir>            (required)
+   #    2) <iree-install-dir>      (required)
+   #    3) <mlir-aie-install-dir>  (optional)
+   #    4) <peano-install-dir>     (optional)
+   #    5) <xrt-dir>               (optional)
+   #    6) <vitis-install-dir>     (optional)
+    echo -e "Illegal number of parameters: $#, expected 2,3,4,5, or 6 parameters." \
+            "\n The parameters are as follows:" \
+            "\n     1) <output-dir>               (required)" \
+            "\n     2) <iree-install-dir>         (required)" \
+            "\n     3) <mlir-aie-install-dir>     (optional)" \
+            "\n     4) <peano-install-dir>        (optional)" \
+            "\n     5) <xrt-dir>                  (optional)" \
+            "\n     6) <vitis-install-dir>        (optional)" \
+            "\n Example, dependent on environment variables:" \
+            "\n     ./run_test.sh  " \
+            "results_dir_tmp  \$IREE_BUILD_OR_INSTALL_DIR  \$MLIR_AIE_INSTALL_DIR  " \
+            "\$PEANO_INSTALL_DIR  /opt/xilinx/xrt  \$VITIS_INSTALL_PATH"
+    exit 1
+fi
+
+
+# All temporary files should end up in the output directory. 
+OUTPUT_DIR=`realpath "$1"`
+mkdir -p ${OUTPUT_DIR}
+if [ ! -d "${OUTPUT_DIR}" ]; then
+  echo "Failed to locate on construct OUTPUT_DIR '${OUTPUT_DIR}'."
+  exit 1
+fi
+
+IREE_INSTALL_DIR=`realpath "$2"`
+if [ ! -d "${IREE_INSTALL_DIR}" ]; then
+  echo "IREE_INSTALL_DIR must be a directory, '${IREE_INSTALL_DIR}' is not."
+  exit 1
+fi
+
+# Search for iree-compile in the user provide
+IREE_COMPILE_EXE=""
+for dir in "${IREE_INSTALL_DIR}" "${IREE_INSTALL_DIR}/bin" "${IREE_INSTALL_DIR}/tools"; do
+  if [ -f "${dir}/iree-compile" ]; then
+    IREE_COMPILE_EXE="${dir}/iree-compile"
+  fi
+done
+
+if [ -z "${IREE_COMPILE_EXE}" ]; then
+  echo "No 'iree-compile' found in any of the following directories: " \
+       "'${IREE_INSTALL_DIR}', '${IREE_INSTALL_DIR}/bin', '${IREE_INSTALL_DIR}/tools'."
+  exit 1
+fi
+
+
+# Parameter 3) <mlir-aie-install-dir>
+if [ -z "${3-}" ]; then
+  MLIR_AIE_INSTALL=`realpath .venv/lib/python3.10/site-packages/mlir_aie`
+else
+  MLIR_AIE_INSTALL=`realpath "$3"`
+fi
+if [ ! -d "${MLIR_AIE_INSTALL}" ]; then
+  echo "No directory '${MLIR_AIE_INSTALL}' (argument 3) found."
+  exit 1
+fi
+
+# Parameter 4) <peano-install-dir>
+if [ -z "${4-}" ]; then
+  PEANO=/opt/llvm-aie
+else
+  PEANO=`realpath "$4"`
+fi
+if [ ! -d "${PEANO}" ]; then
+  echo "No directory '${PEANO}' (argument 4) found."
+  exit 1
+fi
+
+# Parameter 5) <xrt-dir>
+if [ -z "${5-}" ]; then
+  XRT_DIR=/opt/xilinx/xrt
+else
+  XRT_DIR=`realpath "$5"`
+fi
+if [ ! -d "${XRT_DIR}" ]; then
+  echo "No directory '${XRT_DIR}' (argument 5) found."
+  exit 1
+fi
+
+# Parameter 6) <vitis-install-dir>
+if [ -z "${6-}" ]; then
+  # An alternate to a full vitis install, will work
+  # here but not for a full build of mlir-aie
+  # https://riallto.ai/install-riallto.html#install-riallto
+  # VITIS=/opt/Riallto/Vitis/2023.1
+  VITIS=/opt/Xilinx/Vitis/2023.2
+else
+  VITIS=`realpath "$6"`
+fi
+if [ ! -d "${VITIS}" ]; then
+  echo "No directory '${VITIS}' (argument 6) found."
+  exit 1
+fi
+
+THIS_DIR="$(cd $(dirname $0) && pwd)"
+ROOT_DIR="$(cd $THIS_DIR/../.. && pwd)"
+
+source $XRT_DIR/setup.sh
+
+THIS="$(cd $(dirname $0) && pwd)"
+SOURCE_MLIR_FILE="${THIS_DIR}/linalg_matmul.mlir"
+
+# Construct the iree-compile command. 
+IREE_COMPILE_COMMAND="${IREE_COMPILE_EXE} \
+${SOURCE_MLIR_FILE} \
+--iree-hal-target-backends=amd-aie \
+--iree-amd-aie-peano-install-dir=${PEANO} \
+--iree-amd-aie-mlir-aie-install-dir=${MLIR_AIE_INSTALL} \
+--iree-amd-aie-vitis-install-dir=${VITIS} \
+--iree-hal-dump-executable-files-to=${OUTPUT_DIR} \
+--iree-amdaie-use-pipeline=simple-pack \
+-o ${OUTPUT_DIR}/test_artefact.vmfb \
+--iree-amd-aie-show-invoked-commands"
+
+# Execute the command to generate the .vmfb, .xclbin, .ipu.txt files, etc.
+echo "Executing command: $IREE_COMPILE_COMMAND"
+eval $IREE_COMPILE_COMMAND 
+
+if [ ! -f "${OUTPUT_DIR}/test_artefact.vmfb" ]; then
+  echo "test_artefact.vmfb was not created: ${OUTPUT_DIR}/test_artefact.vmfb"
+  exit 1
+fi
+
+
+# Get the full path of test.cpp (which is in the same directory as this script).
+TEST_CPP="${THIS_DIR}/test.cpp"
+
+
+# Compile the host code (flags inspired by mlir-air tests). 
+g++ ${TEST_CPP} -o ${OUTPUT_DIR}/test.exe -Wall -I${XRT_DIR}/include -L${XRT_DIR}/lib -luuid -lxrt_coreutil -lrt -lstdc++
+
+# Verify that ${OUTPUT_DIR}/test.exe exists:
+if [ ! -f "${OUTPUT_DIR}/test.exe" ]; then
+  echo "test.exe was not created: ${OUTPUT_DIR}/test.exe"
+  exit 1
+fi
+
+# We expect to find a file with the .xclbin extension in the output directory, 
+# or in a subdirectory of the output directory. Locate it if possible. 
+XCLBIN_FILE=""
+for file in `find ${OUTPUT_DIR} -name "*.xclbin"`; do
+  XCLBIN_FILE="${file}"
+done
+if [ -z "${XCLBIN_FILE}" ]; then
+  echo "No .xclbin file found in the output directory or any of its subdirectories."
+  exit 1
+else
+  echo "Found .xclbin file: ${XCLBIN_FILE}"
+fi
+
+# Maybe sign the XCLBIN file (CI moonshot). 
+SIGNER=${XRT_DIR}/amdxdna/setup_xclbin_firmware.sh
+if [ ! -f "$SIGNER" ]; then
+  echo "**** Skipping XCLBIN signing: $SIGNER not found ****"
+else
+  sudo $SIGNER -dev Phoenix -xclbin "${XCLBIN_FILE}"
+fi
+
+# Just like above for the XCLBIN file, we expect to find a .ipu.txt file in the output directory.
+IPU_TXT_FILE=""
+for file in `find ${OUTPUT_DIR} -name "*.ipu.txt"`; do
+  IPU_TXT_FILE="${file}"
+done
+if [ -z "${IPU_TXT_FILE}" ]; then
+  echo "No .ipu.txt file found in the output directory or any of its subdirectories."
+  exit 1
+else
+  echo "Found .ipu.txt file: ${IPU_TXT_FILE}"
+fi
+
+echo "Running the test executable with writeC and syncC set to true (writeC=true and syncC=false is the failure mode)."
+${OUTPUT_DIR}/test.exe ${XCLBIN_FILE} ${IPU_TXT_FILE} true true
+
+

--- a/build_tools/ci/use_xrt_directly/test.cpp
+++ b/build_tools/ci/use_xrt_directly/test.cpp
@@ -1,0 +1,205 @@
+//===- test.cpp -------------------------------------------000---*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include <bits/stdc++.h>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <vector>
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+int main(int argc, const char *argv[]) {
+
+  // see the mlir code for these matmul dimensions:
+  constexpr int M = 64;
+  constexpr int K = 16;
+  constexpr int N = 64;
+
+  // This program is run as 
+  // 'thisProgram pathToXclbin pathToInstrFile writeC syncC'
+  if (argc != 5) {
+
+    auto errorMessage =
+        R"(Usage: thisProgram <pathToXclbin> <pathToInstrFile> <writeC> <syncC>
+This test demonstrates the importance of syncing all buffers that are written to
+before running the kernel. If writeC is true and syncC is false, the test may
+fail with a non-zero probability.
+
+Example calls:
+    Failing:  <executable> pathToXclbin pathToInstrFile true false
+    Passing:  <executable> pathToXclbin pathToInstrFile true true
+    Passing:  <executable> pathToXclbin pathToInstrFile false false
+)";
+
+    std::cerr << errorMessage;
+    return 1;
+  }
+
+
+
+  // Get the xclbin from file:
+  std::string xclbin_path = argv[1];
+  {
+    std::ifstream xclbin_file(xclbin_path);
+    if (!xclbin_file.good()) {
+      std::cerr << "Unable to open xclbin file: " << xclbin_path << std::endl;
+      return 1;
+    }
+  }
+  auto xclbin = xrt::xclbin(xclbin_path);
+
+  // Get the lx6 instructions from file:
+  std::vector<uint32_t> instr_v;
+  {
+    std::string instr_path = argv[2];
+    std::ifstream instr_file(instr_path);
+    if (!instr_file.good()) {
+      std::cerr << "Unable to open lx6 instruction file: " << instr_path
+                << std::endl;
+      return 1;
+    }
+    std::string line;
+    while (std::getline(instr_file, line)) {
+      std::istringstream iss(line);
+      uint32_t a;
+      if (!(iss >> std::hex >> a)) {
+        std::cerr << "Unable to parse instruction file" << std::endl;
+        return 1;
+      }
+      instr_v.push_back(a);
+    }
+  }
+
+  // Get kernel from xclbin and register it with a device:
+  auto device = xrt::device(/* device_index */ 0);
+  auto xkernels = xclbin.get_kernels();
+  if (xkernels.size() != 1) {
+    std::cerr << "Kernel count: " << xkernels.size()
+              << ". Kernel count must be 1" << std::endl;
+    return 1;
+  }
+  auto xkernel = xkernels[0];
+  auto kernelName = xkernel.get_name();
+  device.register_xclbin(xclbin);
+
+  // Parse the writeC parameter provided by the user:
+  bool writeC;
+  std::string writeCStr = argv[3];
+  if (writeCStr == "true") {
+    writeC = true;
+  } else if (writeCStr == "false") {
+    writeC = false;
+  } else {
+    std::cerr << "Invalid value for writeC: " << writeCStr << std::endl;
+    return 1;
+  }
+
+  // Parse the syncC parameter provided by the user:
+  bool syncC;
+  std::string syncCStr = argv[4];
+  if (syncCStr == "true") {
+    syncC = true;
+  } else if (syncCStr == "false") {
+    syncC = false;
+  } else {
+    std::cerr << "Invalid value for syncC: " << syncCStr << std::endl;
+    return 1;
+  }
+
+  std::cerr << "Running with writeC: " << writeC << " and syncC: " << syncC
+            << std::endl;
+
+  xrt::hw_context context(device, xclbin.get_uuid());
+  auto kernel = xrt::kernel(context, kernelName);
+
+  int sizeInstructions = instr_v.size() * sizeof(int32_t);
+  int nBytesA = M * K * sizeof(int32_t);
+  int nBytesB = N * K * sizeof(int32_t);
+  int nBytesC = M * N * sizeof(int32_t);
+
+  auto bo_instr = xrt::bo(device, sizeInstructions, XCL_BO_FLAGS_CACHEABLE,
+                          kernel.group_id(0));
+  auto bo_a =
+      xrt::bo(device, nBytesA, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(2));
+  auto bo_b =
+      xrt::bo(device, nBytesB, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+  auto bo_c =
+      xrt::bo(device, nBytesC, XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+
+  void *bufInstr = bo_instr.map<void *>();
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int32_t));
+
+
+  // Initialize A and B with 1's:
+  int32_t *bufA = bo_a.map<int32_t *>();
+  std::vector<int> AVec(M * K, 1);
+  memcpy(bufA, AVec.data(), (AVec.size() * sizeof(int32_t)));
+
+  int32_t *bufB = bo_b.map<int32_t *>();
+  std::vector<int> BVec(N * K, 1);
+  memcpy(bufB, BVec.data(), (BVec.size() * sizeof(int32_t)));
+
+  // Maybe initialize C with junk (-11). Conditional on writeC.
+  int32_t *bufC = bo_c.map<int32_t *>();
+  if (writeC) {
+    std::vector<int> CVecInitializer(M * N, -11);
+    std::memcpy(bufC, CVecInitializer.data(), M * N * sizeof(int32_t));
+  }
+
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  if (syncC) {
+    bo_c.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  }
+
+  // The interesting failure case is when writeC is true and syncC is false.
+  // This is my explanantion:
+  //
+  // 1) host writes -11 to bufC, but does not ensure that the CPU values in the
+  // CPU cache for bufC are written out to DDR. So bufC in DDR might not be -11.
+  //
+  // 2) kernel runs. It writes the correct result (7 + K * 1 * 1) = 23 to bufC
+  // in DDR. At this point all the values are 23 (i.e. good).
+  //
+  // 3) We print bufC. The host/OS/CPU cache doesn't know anything about what
+  // happened in step 2, because the AIE is cache incoherent. If there is value
+  // for bufC in the CPU cache, it is printed without going to DDR. Bad. 
+  //
+
+  // Expected output where A and B are matrices of 1's (see the mlir code):
+  std::vector<int32_t> CVecRef(M * N, 7 + K * 1 * 1);
+
+  auto run = kernel(bo_instr, instr_v.size(), bo_a, bo_b, bo_c);
+  run.wait();
+
+  bo_c.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+  std::vector<int32_t> CVecOut(M * N, 0);
+  memcpy(CVecOut.data(), bufC, M * N * sizeof(int32_t));
+
+  // The number of indices where CVec and CVecRef differ:
+  auto nDifferingValues = 0;
+  for (int i = 0; i < M * N; i++) {
+    if (CVecOut[i] != CVecRef[i]) {
+      std::cout << "CVecOut[" << i << "] = " << CVecOut[i]
+                << " and CVecRef[" << i << "] = " << CVecRef[i] << std::endl;
+      nDifferingValues++;
+    }
+  }
+
+  std::cout << "The number of differing values with baseline was "
+            << nDifferingValues << " (out of " << M * N << ")." << std::endl;
+
+  return nDifferingValues;
+}


### PR DESCRIPTION
I was interested to see what kind of performance the end-to-end codegen gets for matmul. The test here does not use IREE runtime, it just extracts the compiled xclbin from the IREE compilation pipeline, and then runs it against bare metal XRT. Timing based on mlir-air's test: mlir-air/test/xrt/08_gemm_extern_vec

For 1024x1024x1024 bfloat16 operands (float32 result) I'm seeing about 0.6 tops (2MNK / time / 1e12). 

This is using the full 4x4 AIE. 
