### PR TITLE
Overwrite option to force peeling first and last iterations for matmul-elementwise fusion

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPeelForLoop.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPeelForLoop.cpp
@@ -125,8 +125,11 @@ void AMDAIEPeelForLoopPass::runOnOperation() {
         }
         break;
       default:
-        forOp->emitOpError("failed to specify the type of loop peeling.");
-        return signalPassFailure();
+        // Set peeling first iteration as default.
+        if (failed(scf::peelForLoopFirstIteration(rewriter, forOp, result))) {
+          forOp->emitOpError("failed to peel the first iteration.");
+          return signalPassFailure();
+        }
     }
   });
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPeelForLoop.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPeelForLoop.cpp
@@ -4,8 +4,10 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree-amd-aie/Transforms/AMDAIEUtils.h"
 #include "iree-amd-aie/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
+#include "mlir/IR/Iterators.h"
 #include "mlir/Pass/Pass.h"
 
 #define DEBUG_TYPE "iree-amdaie-peel-for-loop"
@@ -78,6 +80,16 @@ void AMDAIEPeelForLoopPass::runOnOperation() {
   MLIRContext *context = &getContext();
   mlir::FunctionOpInterface funcOp = getOperation();
   IRRewriter rewriter(context);
+
+  // Check if there is matmul-elementwise fusion opportunity. If so, overwrite
+  // the `peelingType` to PeelingType::FirstLast.
+  funcOp->walk<WalkOrder::PostOrder, ReverseIterator>([&](linalg::LinalgOp op) {
+    if (isMatmulProducerOfElementwise(op)) {
+      peelingType = PeelingType::FirstLast;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
 
   funcOp->walk([&](scf::ForOp forOp) {
     auto lbInt = getConstantIntValue(forOp.getLowerBound());

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
@@ -298,13 +298,12 @@ bool isMatmul(linalg::LinalgOp linalgOp) {
          match6DLinalgGenericMatmul(linalgOp);
 }
 
-/// Utility to indentify whether a generic op is an elementwise op and whether
-/// its producer is a matmul-like op.
+/// Utility to identify if `linalgOp` is an elementwise operation with a
+/// matmul-like op upstream in its computation tree.
 bool isMatmulProducerOfElementwise(linalg::LinalgOp linalgOp) {
   if (!isElementwise(linalgOp)) return false;
   if (isa<linalg::FillOp>(linalgOp)) return false;
-  // Check if any of the defining op is a matmul-like op. To simplify the
-  // problem, currently only check if it is a contraction op.
+  // Check if any of the defining op is a matmul-like op.
   for (auto operand : linalgOp->getOperands()) {
     while (Operation* defOp = operand.getDefiningOp()) {
       if (auto defLinalgOp = dyn_cast_or_null<linalg::LinalgOp>(defOp)) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
@@ -69,8 +69,8 @@ FailureOr<unsigned> getTilingScaleFactor(Type elemType);
 /// Utility to indentify whether a linalg op is a matmul op.
 bool isMatmul(linalg::LinalgOp linalgOp);
 
-/// Utility to indentify whether a generic op is an elementwise op and whether
-/// its producer is a matmul-like op.
+/// Utility to identify if `linalgOp` is an elementwise operation with a
+/// matmul-like op upstream in its computation tree.
 bool isMatmulProducerOfElementwise(linalg::LinalgOp linalgOp);
 
 namespace detail {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -135,8 +135,7 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
   {
     AMDAIEPackAndTransposeOptions packOptions;
     packOptions.packLevel = 1;
-    funcPassManager.addPass(
-        createAMDAIEPackAndTransposePass(packOptions));
+    funcPassManager.addPass(createAMDAIEPackAndTransposePass(packOptions));
   }
 
   // Propagate pack ops for the elementwise op
@@ -177,8 +176,7 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
     tileFuseOptions.tilingLevel = 1;
     tileFuseOptions.useSCFFor = true;
     tileFuseOptions.tileElementwise = false;
-    funcPassManager.addPass(
-        createAMDAIETileAndFusePass(tileFuseOptions));
+    funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions));
   }
   funcPassManager.addPass(createAMDAIECleanupPass());
   funcPassManager.addPass(createCanonicalizerPass());
@@ -189,8 +187,7 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
     AMDAIEFusePackIntoLoopOptions fusePackOptions;
     fusePackOptions.fusePackDepth = 2;
     fusePackOptions.useSCFFor = true;
-    funcPassManager.addPass(
-        createAMDAIEFusePackIntoLoopPass(fusePackOptions));
+    funcPassManager.addPass(createAMDAIEFusePackIntoLoopPass(fusePackOptions));
   }
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
@@ -210,8 +207,7 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
     tileFuseOptions.tilingLevel = 2;
     tileFuseOptions.useSCFFor = false;
     tileFuseOptions.tileElementwise = false;
-    funcPassManager.addPass(
-        createAMDAIETileAndFusePass(tileFuseOptions));
+    funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions));
   }
   funcPassManager.addPass(createAMDAIECleanupPass());
   funcPassManager.addPass(createCanonicalizerPass());
@@ -222,8 +218,7 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
     AMDAIEFusePackIntoLoopOptions fusePackOptions;
     fusePackOptions.fusePackDepth = 1;
     fusePackOptions.useSCFFor = false;
-    funcPassManager.addPass(
-        createAMDAIEFusePackIntoLoopPass(fusePackOptions));
+    funcPassManager.addPass(createAMDAIEFusePackIntoLoopPass(fusePackOptions));
   }
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
@@ -264,8 +259,7 @@ void addPadPackBasedPassPipeline(OpPassManager &funcPassManager,
     AMDAIETileAndFuseOptions tileFuseOptions;
     tileFuseOptions.tilingLevel = 0;
     tileFuseOptions.useSCFFor = false;
-    funcPassManager.addPass(
-        createAMDAIETileAndFusePass(tileFuseOptions));
+    funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions));
   }
   funcPassManager.addPass(createAMDAIECleanupPass());
   funcPassManager.addPass(createCanonicalizerPass());
@@ -291,8 +285,7 @@ void addPadPackBasedPassPipeline(OpPassManager &funcPassManager,
   {
     AMDAIETileOptions tileOptions;
     tileOptions.tilingLevel = 1;
-    funcPassManager.addPass(
-        createAMDAIETilePass(tileOptions));
+    funcPassManager.addPass(createAMDAIETilePass(tileOptions));
   }
   funcPassManager.addPass(createAMDAIECleanupPass());
   funcPassManager.addPass(createCanonicalizerPass());
@@ -303,8 +296,7 @@ void addPadPackBasedPassPipeline(OpPassManager &funcPassManager,
     AMDAIETileAndFuseOptions tileFuseOptions;
     tileFuseOptions.tilingLevel = 2;
     tileFuseOptions.useSCFFor = false;
-    funcPassManager.addPass(
-        createAMDAIETileAndFusePass(tileFuseOptions));
+    funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions));
   }
   funcPassManager.addPass(createAMDAIECleanupPass());
   funcPassManager.addPass(createCanonicalizerPass());
@@ -331,8 +323,7 @@ void addPadPackBasedPassPipeline(OpPassManager &funcPassManager,
     AMDAIETileAndFuseOptions tileFuseOptions;
     tileFuseOptions.tilingLevel = 3;
     tileFuseOptions.useSCFFor = true;
-    funcPassManager.addPass(
-        createAMDAIETileAndFusePass(tileFuseOptions));
+    funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions));
   }
   funcPassManager.addPass(createAMDAIECleanupPass());
   funcPassManager.addPass(createCanonicalizerPass());

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -101,10 +101,10 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
                                   TilingConfig &tilingConfig) {
   // First level tiling using scf.forall
   {
-    AMDAIETileAndFuseOptions tileFuseOptions0;
-    tileFuseOptions0.tilingLevel = 0;
-    tileFuseOptions0.useSCFFor = false;
-    funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions0));
+    AMDAIETileAndFuseOptions tileFuseOptions;
+    tileFuseOptions.tilingLevel = 0;
+    tileFuseOptions.useSCFFor = false;
+    funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions));
   }
   funcPassManager.addPass(createAMDAIECleanupPass());
   funcPassManager.addPass(createCanonicalizerPass());
@@ -112,9 +112,9 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
 
   // First level packing
   {
-    AMDAIEPackAndTransposeOptions packOptions0;
-    packOptions0.packLevel = 0;
-    funcPassManager.addPass(createAMDAIEPackAndTransposePass(packOptions0));
+    AMDAIEPackAndTransposeOptions packOptions;
+    packOptions.packLevel = 0;
+    funcPassManager.addPass(createAMDAIEPackAndTransposePass(packOptions));
   }
 
   // Propagate pack ops for the elementwise op
@@ -124,18 +124,19 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
 
   // Promote the output to shared memory
   {
-    AMDAIEBufferizeToAllocationOptions bufferizeOptions0;
-    bufferizeOptions0.memorySpace = 1;
-    bufferizeOptions0.bufferizeOperand = BufferizeOperand::Output;
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
+    bufferizeOptions.memorySpace = 1;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::Output;
     funcPassManager.addPass(
-        createAMDAIEBufferizeToAllocationPass(bufferizeOptions0));
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
   }
 
   // Second level packing
   {
-    AMDAIEPackAndTransposeOptions packOptions1;
-    packOptions1.packLevel = 1;
-    funcPassManager.addPass(createAMDAIEPackAndTransposePass(packOptions1));
+    AMDAIEPackAndTransposeOptions packOptions;
+    packOptions.packLevel = 1;
+    funcPassManager.addPass(
+        createAMDAIEPackAndTransposePass(packOptions));
   }
 
   // Propagate pack ops for the elementwise op
@@ -145,38 +146,39 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
 
   // Promote the output to local memory
   {
-    AMDAIEBufferizeToAllocationOptions bufferizeOptions1;
-    bufferizeOptions1.memorySpace = 2;
-    bufferizeOptions1.bufferizeOperand = BufferizeOperand::Output;
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
+    bufferizeOptions.memorySpace = 2;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::Output;
     funcPassManager.addPass(
-        createAMDAIEBufferizeToAllocationPass(bufferizeOptions1));
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
   }
 
   // Promote the operands from elementwise op to shared and local memory
   {
-    AMDAIEBufferizeToAllocationOptions bufferizeOptions2;
-    bufferizeOptions2.memorySpace = 1;
-    bufferizeOptions2.bufferizeElementwise = true;
-    bufferizeOptions2.bufferizeOperand = BufferizeOperand::DefOp;
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
+    bufferizeOptions.memorySpace = 1;
+    bufferizeOptions.bufferizeElementwise = true;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::DefOp;
     funcPassManager.addPass(
-        createAMDAIEBufferizeToAllocationPass(bufferizeOptions2));
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
   }
   {
-    AMDAIEBufferizeToAllocationOptions bufferizeOptions3;
-    bufferizeOptions3.memorySpace = 2;
-    bufferizeOptions3.bufferizeElementwise = true;
-    bufferizeOptions3.bufferizeOperand = BufferizeOperand::InputOutput;
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
+    bufferizeOptions.memorySpace = 2;
+    bufferizeOptions.bufferizeElementwise = true;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::InputOutput;
     funcPassManager.addPass(
-        createAMDAIEBufferizeToAllocationPass(bufferizeOptions3));
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
   }
 
   // Tile the reduction dimension using scf.for
   {
-    AMDAIETileAndFuseOptions tileFuseOptions1;
-    tileFuseOptions1.tilingLevel = 1;
-    tileFuseOptions1.useSCFFor = true;
-    tileFuseOptions1.tileElementwise = false;
-    funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions1));
+    AMDAIETileAndFuseOptions tileFuseOptions;
+    tileFuseOptions.tilingLevel = 1;
+    tileFuseOptions.useSCFFor = true;
+    tileFuseOptions.tileElementwise = false;
+    funcPassManager.addPass(
+        createAMDAIETileAndFusePass(tileFuseOptions));
   }
   funcPassManager.addPass(createAMDAIECleanupPass());
   funcPassManager.addPass(createCanonicalizerPass());
@@ -184,30 +186,32 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
 
   // Fuse both levels of pack ops into for loop
   {
-    AMDAIEFusePackIntoLoopOptions fusePackOptions0;
-    fusePackOptions0.fusePackDepth = 2;
-    fusePackOptions0.useSCFFor = true;
-    funcPassManager.addPass(createAMDAIEFusePackIntoLoopPass(fusePackOptions0));
+    AMDAIEFusePackIntoLoopOptions fusePackOptions;
+    fusePackOptions.fusePackDepth = 2;
+    fusePackOptions.useSCFFor = true;
+    funcPassManager.addPass(
+        createAMDAIEFusePackIntoLoopPass(fusePackOptions));
   }
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
   // Promote the inputs to shared memory
   {
-    AMDAIEBufferizeToAllocationOptions bufferizeOptions4;
-    bufferizeOptions4.memorySpace = 1;
-    bufferizeOptions4.bufferizeOperand = BufferizeOperand::DefOp;
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
+    bufferizeOptions.memorySpace = 1;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::DefOp;
     funcPassManager.addPass(
-        createAMDAIEBufferizeToAllocationPass(bufferizeOptions4));
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
   }
 
   // Second level tiling using scf.forall
   {
-    AMDAIETileAndFuseOptions tileFuseOptions2;
-    tileFuseOptions2.tilingLevel = 2;
-    tileFuseOptions2.useSCFFor = false;
-    tileFuseOptions2.tileElementwise = false;
-    funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions2));
+    AMDAIETileAndFuseOptions tileFuseOptions;
+    tileFuseOptions.tilingLevel = 2;
+    tileFuseOptions.useSCFFor = false;
+    tileFuseOptions.tileElementwise = false;
+    funcPassManager.addPass(
+        createAMDAIETileAndFusePass(tileFuseOptions));
   }
   funcPassManager.addPass(createAMDAIECleanupPass());
   funcPassManager.addPass(createCanonicalizerPass());
@@ -215,21 +219,22 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
 
   // Fuse second level pack ops into forall loop
   {
-    AMDAIEFusePackIntoLoopOptions fusePackOptions1;
-    fusePackOptions1.fusePackDepth = 1;
-    fusePackOptions1.useSCFFor = false;
-    funcPassManager.addPass(createAMDAIEFusePackIntoLoopPass(fusePackOptions1));
+    AMDAIEFusePackIntoLoopOptions fusePackOptions;
+    fusePackOptions.fusePackDepth = 1;
+    fusePackOptions.useSCFFor = false;
+    funcPassManager.addPass(
+        createAMDAIEFusePackIntoLoopPass(fusePackOptions));
   }
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
   // Promote the inputs to local memory
   {
-    AMDAIEBufferizeToAllocationOptions bufferizeOptions5;
-    bufferizeOptions5.memorySpace = 2;
-    bufferizeOptions5.bufferizeOperand = BufferizeOperand::Input;
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
+    bufferizeOptions.memorySpace = 2;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::Input;
     funcPassManager.addPass(
-        createAMDAIEBufferizeToAllocationPass(bufferizeOptions5));
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
   }
 
   // Hoist static allocations
@@ -237,15 +242,9 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
-  // Peel the first iteration out of the for loop.
-  // TODO (vivian): Find a way to automatically detect matmul + elementwise
-  // dispatches, so that we can change the peelOptions to peel both first and
-  // last iterations.
-  {
-    AMDAIEPeelForLoopOptions peelOptions;
-    peelOptions.peelingType = PeelingType::First;
-    funcPassManager.addPass(createAMDAIEPeelForLoopPass(peelOptions));
-  }
+  // Peel the for loop. For matmul dispatch, only peel the first iteration. For
+  // matmul-elementwise dispatch, peel the first and last iteration.
+  funcPassManager.addPass(createAMDAIEPeelForLoopPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
@@ -262,10 +261,11 @@ void addPadPackBasedPassPipeline(OpPassManager &funcPassManager,
                                  TilingConfig &tilingConfig) {
   // First level tiling using scf.forall
   {
-    AMDAIETileAndFuseOptions tileFuseOptions0;
-    tileFuseOptions0.tilingLevel = 0;
-    tileFuseOptions0.useSCFFor = false;
-    funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions0));
+    AMDAIETileAndFuseOptions tileFuseOptions;
+    tileFuseOptions.tilingLevel = 0;
+    tileFuseOptions.useSCFFor = false;
+    funcPassManager.addPass(
+        createAMDAIETileAndFusePass(tileFuseOptions));
   }
   funcPassManager.addPass(createAMDAIECleanupPass());
   funcPassManager.addPass(createCanonicalizerPass());
@@ -280,18 +280,19 @@ void addPadPackBasedPassPipeline(OpPassManager &funcPassManager,
 
   // Promote the input and result to shared memory
   {
-    AMDAIEBufferizeToAllocationOptions bufferizeOptions0;
-    bufferizeOptions0.memorySpace = 1;
-    bufferizeOptions0.bufferizeOperand = BufferizeOperand::InputOutput;
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
+    bufferizeOptions.memorySpace = 1;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::InputOutput;
     funcPassManager.addPass(
-        createAMDAIEBufferizeToAllocationPass(bufferizeOptions0));
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
   }
 
   // Tile linalg.copy ops using scf.for
   {
-    AMDAIETileOptions tileOptions1;
-    tileOptions1.tilingLevel = 1;
-    funcPassManager.addPass(createAMDAIETilePass(tileOptions1));
+    AMDAIETileOptions tileOptions;
+    tileOptions.tilingLevel = 1;
+    funcPassManager.addPass(
+        createAMDAIETilePass(tileOptions));
   }
   funcPassManager.addPass(createAMDAIECleanupPass());
   funcPassManager.addPass(createCanonicalizerPass());
@@ -299,10 +300,11 @@ void addPadPackBasedPassPipeline(OpPassManager &funcPassManager,
 
   // Second level tiling using scf.forall
   {
-    AMDAIETileAndFuseOptions tileFuseOptions2;
-    tileFuseOptions2.tilingLevel = 2;
-    tileFuseOptions2.useSCFFor = false;
-    funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions2));
+    AMDAIETileAndFuseOptions tileFuseOptions;
+    tileFuseOptions.tilingLevel = 2;
+    tileFuseOptions.useSCFFor = false;
+    funcPassManager.addPass(
+        createAMDAIETileAndFusePass(tileFuseOptions));
   }
   funcPassManager.addPass(createAMDAIECleanupPass());
   funcPassManager.addPass(createCanonicalizerPass());
@@ -317,19 +319,20 @@ void addPadPackBasedPassPipeline(OpPassManager &funcPassManager,
 
   // Only promote the result to local memory
   {
-    AMDAIEBufferizeToAllocationOptions bufferizeOptions1;
-    bufferizeOptions1.memorySpace = 2;
-    bufferizeOptions1.bufferizeOperand = BufferizeOperand::Output;
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
+    bufferizeOptions.memorySpace = 2;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::Output;
     funcPassManager.addPass(
-        createAMDAIEBufferizeToAllocationPass(bufferizeOptions1));
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
   }
 
   // Tile the reduction dimension using scf.for
   {
-    AMDAIETileAndFuseOptions tileFuseOptions3;
-    tileFuseOptions3.tilingLevel = 3;
-    tileFuseOptions3.useSCFFor = true;
-    funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions3));
+    AMDAIETileAndFuseOptions tileFuseOptions;
+    tileFuseOptions.tilingLevel = 3;
+    tileFuseOptions.useSCFFor = true;
+    funcPassManager.addPass(
+        createAMDAIETileAndFusePass(tileFuseOptions));
   }
   funcPassManager.addPass(createAMDAIECleanupPass());
   funcPassManager.addPass(createCanonicalizerPass());
@@ -343,11 +346,11 @@ void addPadPackBasedPassPipeline(OpPassManager &funcPassManager,
 
   // Promote the inputs to local memory
   {
-    AMDAIEBufferizeToAllocationOptions bufferizeOptions2;
-    bufferizeOptions2.memorySpace = 2;
-    bufferizeOptions2.bufferizeOperand = BufferizeOperand::Input;
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
+    bufferizeOptions.memorySpace = 2;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::Input;
     funcPassManager.addPass(
-        createAMDAIEBufferizeToAllocationPass(bufferizeOptions2));
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
   }
 
   // Lower to UKernels

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -246,7 +246,7 @@ def AMDAIEPeelForLoop :
   let options = [
     Option<"peelingType", "peeling-type",
       "mlir::iree_compiler::AMDAIE::PeelingType",
-      /*default=*/"mlir::iree_compiler::AMDAIE::PeelingType::First",
+      /*default=*/"",
       "Choose which type of loop peeling to perform",
       [{::llvm::cl::values(
         clEnumValN(mlir::iree_compiler::AMDAIE::PeelingType::First, "first",

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/peel_for_loop.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/peel_for_loop.mlir
@@ -1,6 +1,7 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peeling-type=first}))"  --split-input-file %s | FileCheck %s --check-prefix=PEEL-FIRST
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peeling-type=last}))"  --split-input-file %s | FileCheck %s --check-prefix=PEEL-LAST
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peeling-type=first-last}))"  --split-input-file %s | FileCheck %s --check-prefix=FIRST-LAST
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peeling-type=first}))"  --split-input-file %s | FileCheck %s --check-prefix=OVERWRITE-FLAG
 
 #map = affine_map<(d0, d1)[s0] -> (s0, d0 - d1)>
 func.func @peel_indivisible_example() -> i32 {
@@ -188,3 +189,45 @@ func.func @two_iteration_example() -> i32 {
 //  FIRST-LAST-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[FIRST]]) -> (i32) {
 //       FIRST-LAST:   }
 //       FIRST-LAST:   return %[[LAST]]
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func @matmul_elementwise_i32(%arg0: tensor<1024x512xi8>, %arg1: tensor<512x1024xi8>, %arg2: tensor<1024x1024xi32>) -> tensor<1024x1024xi32> {
+  %c32 = arith.constant 32 : index
+  %c512 = arith.constant 512 : index
+  %c0_i32 = arith.constant 0 : i32
+  %c0 = arith.constant 0 : index
+  %0 = tensor.empty() : tensor<1024x1024xi32>
+  %1 = linalg.fill ins(%c0_i32 : i32) outs(%0 : tensor<1024x1024xi32>) -> tensor<1024x1024xi32>
+  %2 = scf.for %arg3 = %c0 to %c512 step %c32 iter_args(%arg4 = %1) -> (tensor<1024x1024xi32>) {
+    %extracted_slice = tensor.extract_slice %arg0[0, %arg3] [1024, 32] [1, 1] : tensor<1024x512xi8> to tensor<1024x32xi8>
+    %extracted_slice_0 = tensor.extract_slice %arg1[%arg3, 0] [32, 1024] [1, 1] : tensor<512x1024xi8> to tensor<32x1024xi8>
+    %4 = linalg.matmul ins(%extracted_slice, %extracted_slice_0 : tensor<1024x32xi8>, tensor<32x1024xi8>) outs(%arg4 : tensor<1024x1024xi32>) -> tensor<1024x1024xi32>
+    scf.yield %4 : tensor<1024x1024xi32>
+  }
+  %3 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%2, %arg2 : tensor<1024x1024xi32>, tensor<1024x1024xi32>) outs(%0 : tensor<1024x1024xi32>) {
+  ^bb0(%in: i32, %in_0: i32, %out: i32):
+    %4 = arith.addi %in, %in_0 : i32
+    linalg.yield %4 : i32
+  } -> tensor<1024x1024xi32>
+  return %3 : tensor<1024x1024xi32>
+}
+
+// OVERWRITE-FLAG-LABEL: func.func @matmul_elementwise_i32
+//       OVERWRITE-FLAG:   %[[C32:.*]] = arith.constant 32 : index
+//       OVERWRITE-FLAG:   %[[C512:.*]] = arith.constant 512 : index
+//       OVERWRITE-FLAG:   %[[C0_I32:.*]] = arith.constant 0 : i32
+//       OVERWRITE-FLAG:   %[[C0:.*]] = arith.constant 0 : index
+//       OVERWRITE-FLAG:   %[[FILL:.*]] = linalg.fill
+//       OVERWRITE-FLAG:   %[[C32_0:.*]] = arith.constant 32 : index
+//       OVERWRITE-FLAG:   %[[FIRST:.*]] = scf.for %[[IV:.*]] = %[[C0]] to %[[C32_0]]
+//  OVERWRITE-FLAG-SAME:       step %[[C32]] iter_args(%[[ACC:.*]] = %[[FILL]]) -> (tensor<1024x1024xi32>) {
+//       OVERWRITE-FLAG:   }
+//       OVERWRITE-FLAG:   %[[C480:.*]] = arith.constant 480 : index
+//       OVERWRITE-FLAG:   %[[MAIN:.*]] = scf.for %[[IV1:.*]] = %[[C32_0]] to %[[C480]]
+//  OVERWRITE-FLAG-SAME:       step %[[C32]] iter_args(%[[ACC_1:.*]] = %[[FIRST]]) -> (tensor<1024x1024xi32>) {
+//       OVERWRITE-FLAG:   }
+//       OVERWRITE-FLAG:   %[[LAST:.*]] = scf.for %[[IV2:.*]] = %[[C480]] to %[[C512]]
+//  OVERWRITE-FLAG-SAME:       step %[[C32]] iter_args(%[[ACC_2:.*]] = %[[MAIN]]) -> (tensor<1024x1024xi32>) {
+//       OVERWRITE-FLAG:   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/peel_for_loop.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/peel_for_loop.mlir
@@ -1,7 +1,8 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peeling-type=first}))"  --split-input-file %s | FileCheck %s --check-prefix=PEEL-FIRST
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peeling-type=last}))"  --split-input-file %s | FileCheck %s --check-prefix=PEEL-LAST
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peeling-type=first-last}))"  --split-input-file %s | FileCheck %s --check-prefix=FIRST-LAST
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop{peeling-type=first}))"  --split-input-file %s | FileCheck %s --check-prefix=OVERWRITE-FLAG
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop))"  --split-input-file %s | FileCheck %s --check-prefix=DEFAULT-FLAG
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-peel-for-loop))"  --split-input-file %s | FileCheck %s --check-prefix=OVERWRITE-FLAG
 
 #map = affine_map<(d0, d1)[s0] -> (s0, d0 - d1)>
 func.func @peel_indivisible_example() -> i32 {
@@ -63,6 +64,20 @@ func.func @peel_indivisible_example() -> i32 {
 //  FIRST-LAST-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[MAIN]]) -> (i32) {
 //       FIRST-LAST:   }
 //       FIRST-LAST:   return %[[LAST]]
+
+// DEFAULT-FLAG-LABEL: func.func @peel_indivisible_example()
+//       DEFAULT-FLAG:   %[[C0_I32:.*]] = arith.constant 0 : i32
+//       DEFAULT-FLAG:   %[[C0:.*]] = arith.constant 0 : index
+//       DEFAULT-FLAG:   %[[C4:.*]] = arith.constant 4 : index
+//       DEFAULT-FLAG:   %[[C17:.*]] = arith.constant 17 : index
+//       DEFAULT-FLAG:   %[[C4_0:.*]] = arith.constant 4 : index
+//       DEFAULT-FLAG:   %[[FIRST:.*]] = scf.for %[[IV:.*]] = %[[C0]] to %[[C4_0]]
+//  DEFAULT-FLAG-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[C0_I32]]) -> (i32) {
+//       DEFAULT-FLAG:   }
+//       DEFAULT-FLAG:   %[[RESULT:.*]] = scf.for %[[IV1:.*]] = %[[C4_0]] to %[[C17]]
+//  DEFAULT-FLAG-SAME:       step %[[C4]] iter_args(%[[ACC:.*]] = %[[FIRST]]) -> (i32) {
+//       DEFAULT-FLAG:   }
+//       DEFAULT-FLAG:   return %[[RESULT]]
 
 // -----
 


### PR DESCRIPTION
- In pack-peel pipeline, for matmul dispatch only the first iteration is peeled from the scf.for, while for matmul-elementwise dispatch, both the first and the last iterations need to be peeled. To avoid bringing extra flags to switch between such cases, the  default option `peelingType` is overwritten as `FirstLast` when it detects the matmul-elementwise pattern. 
- Clean up the pass option names as suggested in the previous review comment https://github.com/nod-ai/iree-amd-aie/pull/275#discussion_r1569154836.