### PR TITLE
Remove legacy pipeline

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -354,8 +354,6 @@ void addPadPackBasedPassPipeline(OpPassManager &funcPassManager,
   // Vectorization passes
   appendVectorizationToPipeline(funcPassManager);
 
-  modulePassManager.addPass(createCanonicalizerPass());
-
   // Comprehensive bufferization
   addAMDAIEBufferizePasses(funcPassManager);
 }
@@ -386,7 +384,7 @@ void buildAMDAIETransformPassPipeline(OpPassManager &variantPassManager) {
     addMLIRAIRAIELoweringPasses(modulePassManager, false);
   } else if (clUsePipeline == AIEPassPipeline::PackPeelPipeline) {
     addMLIRAIRAIELoweringPasses(modulePassManager, true);
-  } 
+  }
   variantPassManager.addPass(createReconcileTranslationInfoPass());
   variantPassManager.addPass(createAMDAIELowerWorkgroupCountPass());
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -8,7 +8,6 @@
 #define IREE_AMD_AIE_TRANSFORMS_PASSES_H_
 
 #include "iree-amd-aie/Transforms/PassDetail.h"
-#include "iree/compiler/Codegen/Common/PassUtils.h"
 #include "iree/compiler/Codegen/Common/TileSizeSelection.h"
 #include "mlir/Pass/Pass.h"
 
@@ -17,11 +16,6 @@ namespace mlir::iree_compiler::AMDAIE {
 /// Add passes to lower from MLIR-AIR through AIE. This is
 /// currently the default passes used for lowering after IREEs tiling.
 void addMLIRAIRAIELoweringPasses(OpPassManager &passManager, bool packPeel);
-
-/// Add passes to lower from MLIR-AIR through AIE. This is
-/// currently the default passes used for lowering after IREEs tiling from
-/// pipelines other than the pad-pack pipelines
-void addMLIRAIRAIELegacyLoweringPasses(OpPassManager &passManager);
 
 /// Populates passes needed to lower linalg/arith/math ops to LLVM dialect via
 /// the structured ops path. The pass manager `pm` here operate on the module


### PR DESCRIPTION
This PR removes 2 things:

1)  The method `addMLIRAIRAIELegacyLoweringPasses` which is not needed it seems (pad-pack uses 
 the very similar `addMLIRAIRAIELoweringPasses` and pack-peel uses neither (is this an oversight?)). 
 
 2) ` static PassPipelineRegistration<> AIELoweringPipeline("iree-amdaie-aie-lowering-pipeline", ... ` which doesn't seem to be used anywhere. 
 
 Is it ok to just go ahead with these removals, or is a plan to use them in the future? 