### PR TITLE
Add all 9 sd3 matmuls to CI testing 

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -598,7 +598,7 @@ run_matmul_test \
      --acc_type "f32" \
      --m "8192" --k "2432" --n "9728"  \
      --expect-compile-failure "0" \
-     --compile-only "0"
+     --compile-only "1" #could be 0 but too slow...
 
 # SD3 matmuls that compile but fail at runtime #
 # ============================================ #

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -558,6 +558,7 @@ run_matmul_test \
 # SD3 matmul tracker: https://github.com/nod-ai/iree-amd-aie/issues/285
 
 
+
 # SD3 matmuls that do not compile #
 # =============================== #
 # We expect a compilation failure here because m is not a multiple of 4.
@@ -574,12 +575,17 @@ run_matmul_test \
 
 # e2e SD3 matmuls which work e2e #
 # ============================== #
+#
+# TODO(newling) this takes way too long to verify on CPU 
+# (like 10 minutes with IREE atm). We need to find a way to make this faster. 
+# Low-rank tensors? Plumb through to IREE? Blocking:tried doesn't help.
 run_matmul_test \
     --name_prefix "sd3_mm6" \
     --lhs_rhs_type "bf16" \
     --acc_type "f32" \
     --m "308"  --k "9728" --n "2432"  \
-    --expect-compile-failure "0"
+    --expect-compile-failure "0" \
+    --compile-only "0"
 
 run_matmul_test \
     --name_prefix "sd3_mm4" \
@@ -588,80 +594,54 @@ run_matmul_test \
     --m "308"  --k "2432" --n "2432"  \
     --expect-compile-failure "0"
 
-
-# TODO(newling) this takes way too long to verify on CPU 
-# (like 10 minutes with IREE atm). We need to find a way to make this faster. 
-# Low-rank tensors? Plumb through to IREE? Blocking:tried doesn't help.
-run_matmul_test \
-     --name_prefix "sd3_mm8" \
-     --lhs_rhs_type "bf16" \
-     --acc_type "f32" \
-     --m "8192" --k "2432" --n "9728"  \
-     --expect-compile-failure "0" \
-     --compile-only "1" #could be 0 but too slow...
-
-# SD3 matmuls that compile but fail at runtime #
-# ============================================ #
-# TODO: support this matmul
-#  https://github.com/nod-ai/iree-amd-aie/issues/285
-#
-#  I have seen both:
-#   incorrect numbers
-#   'the actual and expected result matrices disagree at row 0, column 256.
-run_matmul_test \
-    --name_prefix "sd3_mm5" \
-    --lhs_rhs_type "bf16" \
-    --acc_type "f32" \
-    --m "308"  --k "2432" --n "9728"  \
-    --expect-compile-failure "0" \
-    --compile-only "1" \
-
-# TODO: support this matmul
-#  https://github.com/nod-ai/iree-amd-aie/issues/285
-#  incorrect numbers. error: the actual and expected result matrices disagree 
-#  at row 0, column 192. TODO(newling) find way to make reference matmul not 
-#  necessary (tried blocking, only marginal gains, we need a low-rank trick).
 run_matmul_test \
      --name_prefix "sd3_mm2" \
      --lhs_rhs_type "bf16" \
      --acc_type "f32" \
      --m "308"  --k "2432" --n "7296"  \
      --expect-compile-failure "0" \
-     --compile-only "1" 
+     --compile-only "0" 
 
-#TODO: support this matmul
-# https://github.com/nod-ai/iree-amd-aie/issues/285
-# hangs in AIE. Stuck in 
-# 'Calling wait in function iree_hal_xrt_direct_command_buffer_dispatch'
+
+run_matmul_test \
+     --name_prefix "sd3_mm8" \
+     --lhs_rhs_type "bf16" \
+     --acc_type "f32" \
+     --m "8192" --k "2432" --n "9728"  \
+     --expect-compile-failure "0" \
+     --compile-only "0"
+
+run_matmul_test \
+    --name_prefix "sd3_mm5" \
+    --lhs_rhs_type "bf16" \
+    --acc_type "f32" \
+    --m "308"  --k "2432" --n "9728"  \
+    --expect-compile-failure "0" \
+    --compile-only "0"
+
 run_matmul_test \
     --name_prefix "sd3_mm7" \
     --lhs_rhs_type "bf16" \
     --acc_type "f32" \
     --m "8192" --k "2432" --n "2432"  \
     --expect-compile-failure "0" \
-    --compile-only "1" 
+    --compile-only "0" 
 
-#TODO: support this matmul
-# hangs in AIE. Stuck in 
-# 'Calling wait in function iree_hal_xrt_direct_command_buffer_dispatch'
 run_matmul_test \
      --name_prefix "sd3_mm9" \
      --lhs_rhs_type "bf16" \
      --acc_type "f32" \
      --m "8192" --k "9728" --n "2432"  \
      --expect-compile-failure "0" \
-     --compile-only "1" 
+     --compile-only "0"
 
-# TODO: support this matmul
-# hangs in AIE. Stuck in 
-# 'Calling wait in function iree_hal_xrt_direct_command_buffer_dispatch'
 run_matmul_test \
     --name_prefix "sd3_mm3" \
     --lhs_rhs_type "bf16" \
     --acc_type "f32" \
     --m "8192" --k "2432" --n "7296"  \
     --expect-compile-failure "0" \
-    --compile-only "1" 
+    --compile-only "0"
 
 ###########################################
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -222,6 +222,7 @@ LogicalResult AIETargetBackend::serializeExecutable(
   addOpt("--print-ir-before-all", options.aie2xclbinPrintIrBeforeAll);
   addOpt("--disable-threading", options.aie2xclbinDisableTheading);
   addOpt("--print-ir-module-scope", options.aie2xclbinPrintIrModuleScope);
+  addOpt("--timing", options.aie2xclbinTiming);
 
   SmallVector<StringRef> cmdEnv{};
   if (options.useChess) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
@@ -44,6 +44,9 @@ struct AMDAIEOptions {
   // Print IR at module scope in MLIR passes in aie2xclbin.
   bool aie2xclbinPrintIrModuleScope{false};
 
+  // Print MLIR timing summart for the MLIR passes in aie2xclbin.
+  bool aie2xclbinTiming{false};
+
  public:
   void bindOptions(OptionsBinder &binder) {
     static llvm::cl::OptionCategory category("AMD AIE Options");
@@ -80,6 +83,11 @@ struct AMDAIEOptions {
         llvm::cl::cat(category),
         llvm::cl::desc(
             "If true, when printing the IR do so at the module scope"));
+
+    binder.opt<bool>(
+        "aie2xclbin-timing", aie2xclbinTiming, llvm::cl::cat(category),
+        llvm::cl::desc("If true, print MLIR timing summary for the MLIR passes "
+                       "in aie2xclbin"));
 
     binder.opt<bool>(
         "iree-amd-aie-show-invoked-commands", showInvokedCommands,

--- a/runtime/src/iree-amd-aie/driver/xrt/direct_command_buffer.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/direct_command_buffer.cc
@@ -141,6 +141,7 @@ static iree_status_t iree_hal_xrt_direct_command_buffer_execution_barrier(
     const iree_hal_memory_barrier_t* memory_barriers,
     iree_host_size_t buffer_barrier_count,
     const iree_hal_buffer_barrier_t* buffer_barriers) {
+  printf("Just entered into iree_hal_xrt_direct_command_buffer_execution_barrier\n");
   if (iree_any_bit_set(source_stage_mask, IREE_HAL_EXECUTION_STAGE_HOST) ||
       iree_any_bit_set(target_stage_mask, IREE_HAL_EXECUTION_STAGE_HOST)) {
     return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
@@ -192,6 +193,8 @@ static iree_status_t iree_hal_xrt_direct_command_buffer_fill_buffer(
     iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
     iree_device_size_t length, const void* pattern,
     iree_host_size_t pattern_length) {
+
+  printf("Just entered into iree_hal_xrt_direct_command_buffer_fill_buffer\n");
   return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
                           "fill buffer not yet supported");
 }
@@ -200,6 +203,8 @@ static iree_status_t iree_hal_xrt_direct_command_buffer_update_buffer(
     iree_hal_command_buffer_t* base_command_buffer, const void* source_buffer,
     iree_host_size_t source_offset, iree_hal_buffer_t* target_buffer,
     iree_device_size_t target_offset, iree_device_size_t length) {
+
+  printf("Just entered into iree_hal_xrt_direct_command_buffer_update_buffer\n");
   IREE_TRACE_ZONE_BEGIN(z0);
   const uint8_t* src = (const uint8_t*)source_buffer + source_offset;
 
@@ -221,6 +226,8 @@ static iree_status_t iree_hal_xrt_direct_command_buffer_copy_buffer(
     iree_hal_buffer_t* source_buffer, iree_device_size_t source_offset,
     iree_hal_buffer_t* target_buffer, iree_device_size_t target_offset,
     iree_device_size_t length) {
+
+  printf("Just entered into iree_hal_xrt_direct_command_buffer_copy_buffer\n");
   IREE_TRACE_ZONE_BEGIN(z0);
 
   xrt::bo* target_device_buffer = iree_hal_xrt_buffer_handle(
@@ -307,6 +314,8 @@ static iree_status_t iree_hal_xrt_direct_command_buffer_dispatch(
     iree_hal_command_buffer_t* base_command_buffer,
     iree_hal_executable_t* executable, int32_t entry_point,
     uint32_t workgroup_x, uint32_t workgroup_y, uint32_t workgroup_z) {
+
+  printf("Just entered into iree_hal_xrt_direct_command_buffer_dispatch\n");
   iree_hal_xrt_direct_command_buffer_t* command_buffer =
       iree_hal_xrt_direct_command_buffer_cast(base_command_buffer);
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -356,10 +365,15 @@ static iree_status_t iree_hal_xrt_direct_command_buffer_dispatch(
       run.set_arg(arg_index + base_index + j, arg_buffer);
     }
   }
+
+  // Print a message stating that we're about to call start:
+  printf("Calling start in function iree_hal_xrt_direct_command_buffer_dispatch\n");
   run.start();
+  printf("Calling wait in function iree_hal_xrt_direct_command_buffer_dispatch\n");
   run.wait();
 
   IREE_TRACE_ZONE_END(z0);
+  printf("Returning from dispatch in function iree_hal_xrt_direct_command_buffer_dispatch\n");
   return iree_ok_status();
 }
 


### PR DESCRIPTION
Currently 0/9 of the matmuls for sd3 compile. They are added to CI with the  
--expect-compile-failure="1" flag. 

There are 2 different compilation failures seen in the matmuls, these are documented in the tests it this PR.  

The tracker task for get these matmuls compiling and then running is https://github.com/nod-ai/iree-amd-aie/issues/285