### PR TITLE
Bump mlir-air

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -533,7 +533,7 @@ run_matmul_test \
     --m "64"  --n "64" --k "64"
 
 run_matmul_test \
-    --name_prefix "large" \
+    --name_prefix "bf16_2304" \
     --lhs_rhs_type "bf16" \
     --acc_type "f32" \
     --m "2304"  --n "2304" --k "2304"

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -532,3 +532,9 @@ run_matmul_test \
     --acc_type "i32" \
     --m "64"  --n "64" --k "64"
 
+run_matmul_test \
+    --name_prefix "large" \
+    --lhs_rhs_type "bf16" \
+    --acc_type "f32" \
+    --m "2304"  --n "2304" --k "2304"
+


### PR DESCRIPTION
New bugfix:
- Improve AIRRtToIpu pass stability when any wrap size exceeds 1023.
- The pass attempts to tile the wrap dimension using one extra wrap-and-stride dimension, taking the original wrap's largest integer factor (less than 1024) as the wrap's tiling factor (previously hardcoded as 512).
- Fixes error 1 in https://github.com/nod-ai/iree-amd-aie/issues/285.