### PR TITLE
Do packing before tiling in pad-pack pipeline

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
@@ -358,4 +358,18 @@ int detail::findLargestFactor(int num, int max) {
   return largestLowFactor;
 }
 
+/// Find the largest factor of 'num' which is not larger than 'max' and is a
+/// multiple of `multiple` if possible.
+int detail::findLargestFactor(int num, int max, int multiple) {
+  int factor = 0;
+  for (int i = multiple; i <= max && i <= num; i += multiple) {
+    if (num % i == 0 && i % multiple == 0) {
+      factor = i;
+    }
+  }
+  // if we could not find the desired factor then we give up and call the code
+  // that doesnt require the multiple constrain.
+  return factor ? factor : detail::findLargestFactor(num, max);
+}
+
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
@@ -79,6 +79,9 @@ namespace detail {
 // is less than or equal to max
 int findLargestFactor(int num, int max);
 
+// A variant where we prefer factors to also be a multiple of `multiple`
+int findLargestFactor(int num, int max, int multiple);
+
 }  // namespace detail
 
 }  // namespace mlir::iree_compiler::AMDAIE


### PR DESCRIPTION
This makes sure we make a reasonable tiling/packing config for any shape that is a multiple of the minimum packing config.
The order is 
1. Set the packing config first.
2. Then the inner tile which should be a multiple of the packing.
3. Then the outer tile that should be a multiple of the inner tile.