### PR TITLE
Bump mlir-air; add initial ci test for pack-peel pipeline

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -538,3 +538,10 @@ run_matmul_test \
     --acc_type "f32" \
     --m "128"  --n "128" --k "2304"
 
+run_matmul_test \
+    --name_prefix "packPeel" \
+    --pipeline "pack-peel" \
+    --lhs_rhs_type "i32" \
+    --acc_type "i32" \
+    --m "64"  --n "64" --k "160"
+


### PR DESCRIPTION
Bugfix in MLIR-AIR:
- Fixup an issue with aie.core lock allocation, which mistakenly lowers peeled code as ping-pong buffered code, leading to numerical error.