### PR TITLE
Option to require tiles to be powers of 2

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
@@ -77,7 +77,7 @@ namespace detail {
 
 // Returns the largest number that perfectly divides `num` that
 // is less than or equal to max
-int findLargestFactor(int num, int max);
+int findLargestFactor(int num, int max, bool mustBePowerOf2 = false);
 
 }  // namespace detail
 


### PR DESCRIPTION
The good news is that this PR allows matmul of size m=n=k=2432 to compile to the end (before it was hitting a failure where pack ops failed to lower due to imperfect tiling). 

It needs tidyinng up, but feel free to comment now...  I know @nirvedhmeshram has a similar solution proposed: https://github.com/nod-ai/iree-amd-aie/pull/293

Alternative (and possibly more robust) solution is padding all inputs to be of a "sufficient" size (for this problem size, I have found that m=n=2560 works). There are still things to work out to make this solution feasible in my mind: (1) algo to find the smallest round up (2) do the actual padding in the producer of the tensors as mentioned in today's standup with @MaheshRavishankar 