### PR TITLE
Bump IREE to latest

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -193,7 +193,9 @@ def AMDAIE_LogicalObjectFifoFromMemrefOp : AMDAIE_Op<"logicalobjectfifo.from_mem
 
   let extraClassDeclaration = [{
     Attribute getMemorySpace() { return getMemrefType().getMemorySpace(); }
-    MemRefType getMemrefType() { return getOutput().getType().cast<LogicalObjectFifoType>().getElementType(); }
+    MemRefType getMemrefType() { 
+      return cast<LogicalObjectFifoType>(getOutput().getType()).getElementType();
+    }
   }];
 
   let hasVerifier = 0;

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAIRDmaToAMDAIEDma.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAIRDmaToAMDAIEDma.cpp
@@ -25,8 +25,8 @@ class AIRDmaToAMDAIEDma : public OpRewritePattern<xilinx::air::DmaMemcpyNdOp> {
 
   LogicalResult matchAndRewrite(xilinx::air::DmaMemcpyNdOp op,
                                 PatternRewriter &rewriter) const override {
-    auto srcType = op.getSrc().getType().cast<MemRefType>();
-    auto dstType = op.getDst().getType().cast<MemRefType>();
+    auto srcType = cast<MemRefType>(op.getSrc().getType());
+    auto dstType = cast<MemRefType>(op.getDst().getType());
     rewriter.setInsertionPointAfter(op.getSrc().getDefiningOp());
     auto src = rewriter.create<AMDAIE::LogicalObjectFifoFromMemrefOp>(
         rewriter.getUnknownLoc(), LogicalObjectFifoType::get(srcType),

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertLoopsForVectorization.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertLoopsForVectorization.cpp
@@ -27,7 +27,7 @@ class AMDAIEInsertLoopsForVectorizationPass
   //   (1,1,5) -> 1
   //   (1,1,1) -> 0
   static int getNumInnerDims(Value v) {
-    auto shape = v.getType().cast<ShapedType>().getShape();
+    auto shape = cast<ShapedType>(v.getType()).getShape();
     auto nDims = shape.size();
 
     // The first dimension which is not 0 or 1.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
@@ -72,13 +72,13 @@ FailureOr<std::array<uint32_t, 3>> getAIEIntegerMatmulInstructionSize(
 FailureOr<std::array<uint32_t, 3>> getAIEMatmulInstructionSize(Type elTypeLhs,
                                                                Type elTypeRhs,
                                                                Type elTypeAcc) {
-  bool allFloatingPoint = elTypeLhs.isa<FloatType>() &&
-                          elTypeRhs.isa<FloatType>() &&
-                          elTypeAcc.isa<FloatType>();
+  bool allFloatingPoint = isa<FloatType>(elTypeLhs) &&
+                          isa<FloatType>(elTypeRhs) &&
+                          isa<FloatType>(elTypeAcc);
 
-  bool allInteger = elTypeLhs.isa<IntegerType>() &&
-                    elTypeRhs.isa<IntegerType>() &&
-                    elTypeAcc.isa<IntegerType>();
+  bool allInteger = isa<IntegerType>(elTypeLhs) &&
+                    isa<IntegerType>(elTypeRhs) &&
+                    isa<IntegerType>(elTypeAcc);
 
   if (!allInteger && !allFloatingPoint) {
     return failure();
@@ -245,13 +245,13 @@ static bool match6DLinalgGenericMatmul(linalg::LinalgOp linalgOp) {
 /// ops.
 static BlockArgument checkOptionalExtOps(Value val) {
   BlockArgument blockArg;
-  if (!(blockArg = val.dyn_cast<BlockArgument>())) {
+  if (!(blockArg = dyn_cast<BlockArgument>(val))) {
     auto defOp = val.getDefiningOp();
     if (!dyn_cast<arith::ExtFOp>(defOp) && !dyn_cast<arith::ExtSIOp>(defOp) &&
         !dyn_cast<arith::ExtUIOp>(defOp)) {
       return nullptr;
     }
-    blockArg = defOp->getOperand(0).dyn_cast<BlockArgument>();
+    blockArg = dyn_cast<BlockArgument>(defOp->getOperand(0));
   }
   return blockArg;
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEVectorization.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEVectorization.cpp
@@ -44,7 +44,7 @@ class AMDAIEVectorizationPass
 
   static bool hasOperandWithSmallElementType(Operation *op) {
     for (auto operand : op->getOperands()) {
-      if (auto type = operand.getType().dyn_cast<ShapedType>()) {
+      if (auto type = dyn_cast<ShapedType>(operand.getType())) {
         auto elementType = type.getElementType();
         if (elementType.getIntOrFloatBitWidth() <= 16) {
           return true;
@@ -55,8 +55,6 @@ class AMDAIEVectorizationPass
   }
 };
 
-
-
 void AMDAIEVectorizationPass::runOnOperation() {
   MLIRContext *context = &getContext();
   auto funcOp = getOperation();
@@ -66,7 +64,6 @@ void AMDAIEVectorizationPass::runOnOperation() {
   // Collect all operations which must be vectorized.
   SmallVector<Operation *> candidates;
   funcOp.walk([&](Operation *op) {
-
     // Only vectorize linalg ops (for now)
     if (!isa<linalg::LinalgOp>(op)) return;
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/DecomposeLinalgExtPackUnPackToAIR.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/DecomposeLinalgExtPackUnPackToAIR.cpp
@@ -183,7 +183,7 @@ FailureOr<LowerPackUnPackResult> lowerUnPack(
   if (llvm::any_of(innerDimsPos, [srcShape](int64_t index) {
         return srcShape[index] != 1;
       })) {
-    MemRefType memrefType = unPackOp.getInputType().cast<MemRefType>();
+    MemRefType memrefType = cast<MemRefType>(unPackOp.getInputType());
     int64_t packedRank = memrefType.getRank();
 
     // Compute the permutation vector to move the last `numPackedDims` into
@@ -243,7 +243,7 @@ FailureOr<LowerPackUnPackResult> lowerUnPack(
     readShape.append(tileShape.begin(), tileShape.end());
     Type elemType = unPackOp.getInputType().getElementType();
     Attribute memorySpace =
-        unPackOp.getInputType().cast<MemRefType>().getMemorySpace();
+        cast<MemRefType>(unPackOp.getInputType()).getMemorySpace();
     auto readType = MemRefType::get(readShape, elemType, nullptr, memorySpace);
     tile = rewriter.create<memref::SubViewOp>(loc, readType, input, readOffsets,
                                               readSizes, readStrides);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -43,7 +43,7 @@ static SmallVector<int64_t> getPackedSize(linalg::LinalgOp linalgOp,
   }
 
   auto getElementType = [](Value v) {
-    return v.getType().cast<ShapedType>().getElementType();
+    return cast<ShapedType>(v.getType()).getElementType();
   };
 
   auto elTypeLhs = getElementType(linalgOp->getOperand(0));
@@ -245,9 +245,9 @@ static bool bodyMatcherForMatmulTranspose(Value yieldVal, Block *body) {
   if (!isa_and_nonnull<arith::MulIOp, arith::MulFOp>(mulOp)) {
     return false;
   }
-  auto lhsBlockArg = mulOp->getOperand(0).dyn_cast<BlockArgument>();
-  auto rhsBlockArg = mulOp->getOperand(1).dyn_cast<BlockArgument>();
-  auto outBlockArg = addOp->getOperand(0).dyn_cast<BlockArgument>();
+  auto lhsBlockArg = dyn_cast<BlockArgument>(mulOp->getOperand(0));
+  auto rhsBlockArg = dyn_cast<BlockArgument>(mulOp->getOperand(1));
+  auto outBlockArg = dyn_cast<BlockArgument>(addOp->getOperand(0));
   if (!lhsBlockArg || !rhsBlockArg || !outBlockArg ||
       lhsBlockArg.getOwner() != body || rhsBlockArg.getOwner() != body ||
       outBlockArg.getOwner() != body || lhsBlockArg.getArgNumber() != 0 ||

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,7 +7,7 @@
 ### Update with: shark-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "125f4200d8326349a9fc5ef9ed090872400c18d0",
+  "iree": "2976a9bda6813b1bde2580505180e6e1204d8947",
 }
 
 ORIGINS = {


### PR DESCRIPTION
Bump to latest IREE. 

Update for deprecated `mlir::Value::isa/dyn_cast/cast/` member functions: https://github.com/llvm/llvm-project/pull/89238. See also: https://discourse.llvm.org/t/preferred-casting-style-going-forward/68443.

This brings in a standalone `forallToFor` transformation which will avoid duplication in this repo: https://github.com/llvm/llvm-project/pull/89636