### PR TITLE
MLIR --timing flag to aie2xclbin passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024040122+d233485-py3-none-manylinux_2_35_x86_64.whl
+          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024042921+2a55238-py3-none-manylinux_2_35_x86_64.whl
           pip install -r tests/matmul/requirements.txt
 
       - name: E2E correctness matmul test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024042415+32127bf-py3-none-manylinux_2_35_x86_64.whl
+          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024040122+d233485-py3-none-manylinux_2_35_x86_64.whl
           pip install -r tests/matmul/requirements.txt
 
       - name: E2E correctness matmul test

--- a/build_tools/ci/print_ir_aie2xclbin/print_ir_aie2xclbin.sh
+++ b/build_tools/ci/print_ir_aie2xclbin/print_ir_aie2xclbin.sh
@@ -128,9 +128,11 @@ ${SOURCE_MLIR_FILE} \
 --aie2xclbin-print-ir-before-all \
 --aie2xclbin-print-ir-module-scope \
 --aie2xclbin-disable-threading \
+--aie2xclbin-timing \
 --mlir-print-ir-after-all \
 --mlir-print-ir-module-scope \
 --mlir-disable-threading \
+--mlir-timing \
 --iree-amdaie-use-pipeline=pad-pack \
 -o ${OUTPUT}/test_artefact.vmfb \
 --iree-amd-aie-show-invoked-commands"
@@ -170,4 +172,6 @@ ${FILECHECK_EXE} --input-file ${STDERR_FULLPATH} ${0} --check-prefix=CHECK-STDER
 # CHECK-STDOUT-DAG: Bootgen
 # CHECK-STDOUT-DAG: MEM_TOPOLOGY
 ${FILECHECK_EXE} --input-file ${STDOUT_FULLPATH} ${0} --check-prefix=CHECK-STDOUT
+
+#TODO(newling) add check of sorts for timing. 
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -222,6 +222,7 @@ LogicalResult AIETargetBackend::serializeExecutable(
   addOpt("--print-ir-before-all", options.aie2xclbinPrintIrBeforeAll);
   addOpt("--disable-threading", options.aie2xclbinDisableTheading);
   addOpt("--print-ir-module-scope", options.aie2xclbinPrintIrModuleScope);
+  addOpt("--timing", options.aie2xclbinTiming);
 
   SmallVector<StringRef> cmdEnv{};
   if (options.useChess) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
@@ -44,6 +44,9 @@ struct AMDAIEOptions {
   // Print IR at module scope in MLIR passes in aie2xclbin.
   bool aie2xclbinPrintIrModuleScope{false};
 
+  // Print MLIR timing summary for the MLIR passes in aie2xclbin.
+  bool aie2xclbinTiming{false};
+
  public:
   void bindOptions(OptionsBinder &binder) {
     static llvm::cl::OptionCategory category("AMD AIE Options");
@@ -80,6 +83,11 @@ struct AMDAIEOptions {
         llvm::cl::cat(category),
         llvm::cl::desc(
             "If true, when printing the IR do so at the module scope"));
+
+    binder.opt<bool>(
+        "aie2xclbin-timing", aie2xclbinTiming, llvm::cl::cat(category),
+        llvm::cl::desc("If true, print MLIR timing summary for the MLIR passes "
+                       "in aie2xclbin"));
 
     binder.opt<bool>(
         "iree-amd-aie-show-invoked-commands", showInvokedCommands,


### PR DESCRIPTION
- This is useful to locate slow passes in mlir-aie (I used it to find the slow pass for https://github.com/Xilinx/mlir-aie/pull/1431)
- Required bump of mlir-aie wheel used 