### PR TITLE
Integrate FuseConsumerIntoLoop to pack-peel pipeline and fix bufferization

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp
@@ -47,7 +47,7 @@ static LogicalResult applyBufferizeToAllocation(RewriterBase &rewriter,
 static SmallVector<Value> getInputOutputOperands(linalg::LinalgOp &linalgOp) {
   if (isMatmulProducerOfElementwise(linalgOp)) {
     SmallVector<Value> operands;
-    for (auto operand : linalgOp->getOperands()) {
+    for (Value operand : linalgOp->getOperands()) {
       if (isMatmulInDefChain(operand)) continue;
       operands.push_back(operand);
     }
@@ -63,7 +63,7 @@ static SmallVector<Value> getInputOutputOperands(linalg::LinalgOp &linalgOp) {
 static SmallVector<Value> getInputOperands(linalg::LinalgOp &linalgOp) {
   if (isMatmulProducerOfElementwise(linalgOp)) {
     SmallVector<Value> operands;
-    for (auto operand : linalgOp.getDpsInputs()) {
+    for (Value operand : linalgOp.getDpsInputs()) {
       if (isMatmulInDefChain(operand)) continue;
       operands.push_back(operand);
     }
@@ -83,7 +83,7 @@ static SmallVector<Value> getInputOperands(linalg::LinalgOp &linalgOp) {
 static FailureOr<SmallVector<Value>> getOperandsFromDefOp(
     linalg::LinalgOp &linalgOp) {
   SmallVector<Value> operands;
-  for (auto input : linalgOp.getDpsInputs()) {
+  for (Value input : linalgOp.getDpsInputs()) {
     auto defOp = input.getDefiningOp();
     // The defining op has to be a pack op, fail otherwise.
     if (!defOp || !isa<tensor::PackOp>(defOp)) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp
@@ -84,9 +84,9 @@ static FailureOr<SmallVector<Value>> getOperandsFromDefOp(
     linalg::LinalgOp &linalgOp) {
   SmallVector<Value> operands;
   for (Value input : linalgOp.getDpsInputs()) {
-    auto defOp = input.getDefiningOp();
+    auto defOp = input.getDefiningOp<tensor::PackOp>();
     // The defining op has to be a pack op, fail otherwise.
-    if (!defOp || !isa<tensor::PackOp>(defOp)) {
+    if (!defOp) {
       return failure();
     }
     // We only want to fetch the input operand of the pack op.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEFusePackIntoLoop.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEFusePackIntoLoop.cpp
@@ -33,7 +33,7 @@ static FailureOr<tensor::ExtractSliceOp> getTensorExtractSliceDefiningOp(
       }
       if (isa<BlockArgument>(sliceOp.getSource())) {
         auto blkArg = dyn_cast<BlockArgument>(sliceOp.getSource());
-        for (auto blkOperand :
+        for (Value blkOperand :
              blkArg.getOwner()->getParentOp()->getOperands()) {
           if (isa_and_nonnull<tensor::PackOp>(blkOperand.getDefiningOp())) {
             return sliceOp;

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEFusePackIntoLoop.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEFusePackIntoLoop.cpp
@@ -7,6 +7,7 @@
 #include "iree-amd-aie/Transforms/Passes.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 #include "mlir/IR/Iterators.h"
 #include "mlir/Pass/Pass.h"
@@ -29,6 +30,15 @@ static FailureOr<tensor::ExtractSliceOp> getTensorExtractSliceDefiningOp(
       if (isa_and_nonnull<tensor::PackOp>(
               sliceOp.getSource().getDefiningOp())) {
         return sliceOp;
+      }
+      if (isa<BlockArgument>(sliceOp.getSource())) {
+        auto blkArg = dyn_cast<BlockArgument>(sliceOp.getSource());
+        for (auto blkOperand :
+             blkArg.getOwner()->getParentOp()->getOperands()) {
+          if (isa_and_nonnull<tensor::PackOp>(blkOperand.getDefiningOp())) {
+            return sliceOp;
+          }
+        }
       }
       break;
     }
@@ -86,18 +96,17 @@ void AMDAIEFusePackIntoLoopPass::runOnOperation() {
   }
 
   LoopLikeOpInterface loops = cast<LoopLikeOpInterface>(scfLoopOp);
-  auto loopBody = useSCFFor ? cast<scf::ForOp>(loops).getBody()
-                            : cast<scf::ForallOp>(loops).getBody();
+  auto castLoop =
+      useSCFFor ? cast<scf::ForOp>(loops) : cast<scf::ForallOp>(loops);
 
   // Based on the `fusePackDepth`, we would greedily fuse the producer
   // tensor.pack ops.
   for (unsigned depth = 1; depth <= fusePackDepth; depth++) {
-    // Search the compute op and its producer slices.
+    // Search the last compute op in the loop and its producer slices.
     linalg::GenericOp genericOp;
-    loopBody->walk<WalkOrder::PostOrder, ReverseIterator>(
+    castLoop->walk<WalkOrder::PostOrder, ReverseIterator>(
         [&](linalg::LinalgOp op) {
-          if (isa<linalg::GenericOp>(op) &&
-              linalg::isaContractionOpInterface(op)) {
+          if (isa<linalg::GenericOp>(op)) {
             genericOp = cast<linalg::GenericOp>(op);
             return WalkResult::interrupt();
           }
@@ -106,6 +115,12 @@ void AMDAIEFusePackIntoLoopPass::runOnOperation() {
 
     if (!genericOp) {
       LLVM_DEBUG(llvm::dbgs() << "----- There is no compute op.-----\n");
+      return;
+    }
+
+    if (targetElementwise && !isElementwise(genericOp)) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "----- The target compute op is not elementwise.-----\n");
       return;
     }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
@@ -69,6 +69,10 @@ FailureOr<unsigned> getTilingScaleFactor(Type elemType);
 /// Utility to indentify whether a linalg op is a matmul op.
 bool isMatmul(linalg::LinalgOp linalgOp);
 
+/// Utility to identify if the input operand has matmul-like op in its
+/// def-chain.
+bool isMatmulInDefChain(Value operand);
+
 /// Utility to identify if `linalgOp` is an elementwise operation with a
 /// matmul-like op upstream in its computation tree.
 bool isMatmulProducerOfElementwise(linalg::LinalgOp linalgOp);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Cleanup.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Cleanup.cpp
@@ -54,6 +54,7 @@ static void populateCleanupPatterns(RewritePatternSet &patterns) {
   // Pulling in upstream scf.for and affine.min canonicalization patterns.
   // They work on tiled (but not distributed) loops.
   scf::populateSCFForLoopCanonicalizationPatterns(patterns);
+  tensor::populateFoldTensorEmptyPatterns(patterns);
 }
 
 class AMDAIECleanupPass : public impl::AMDAIECleanupBase<AMDAIECleanupPass> {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -122,11 +122,21 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
-  // Promote the output to shared memory
+  // Promote the matmul output to shared memory
   {
     AMDAIEBufferizeToAllocationOptions bufferizeOptions;
     bufferizeOptions.memorySpace = 1;
     bufferizeOptions.bufferizeOperand = BufferizeOperand::Output;
+    funcPassManager.addPass(
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
+  }
+
+  // Promote the elementwise input and output to shared memory
+  {
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
+    bufferizeOptions.memorySpace = 1;
+    bufferizeOptions.bufferizeElementwise = true;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::InputOutput;
     funcPassManager.addPass(
         createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
   }
@@ -143,7 +153,7 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
-  // Promote the output to local memory
+  // Promote the matmul output to local memory
   {
     AMDAIEBufferizeToAllocationOptions bufferizeOptions;
     bufferizeOptions.memorySpace = 2;
@@ -152,20 +162,12 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
         createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
   }
 
-  // Promote the operands from elementwise op to shared and local memory
-  {
-    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
-    bufferizeOptions.memorySpace = 1;
-    bufferizeOptions.bufferizeElementwise = true;
-    bufferizeOptions.bufferizeOperand = BufferizeOperand::DefOp;
-    funcPassManager.addPass(
-        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
-  }
+  // Promote the elementwise output to local memory
   {
     AMDAIEBufferizeToAllocationOptions bufferizeOptions;
     bufferizeOptions.memorySpace = 2;
     bufferizeOptions.bufferizeElementwise = true;
-    bufferizeOptions.bufferizeOperand = BufferizeOperand::InputOutput;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::Output;
     funcPassManager.addPass(
         createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
   }
@@ -192,7 +194,7 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
-  // Promote the inputs to shared memory
+  // Promote the matmul inputs to shared memory
   {
     AMDAIEBufferizeToAllocationOptions bufferizeOptions;
     bufferizeOptions.memorySpace = 1;
@@ -223,7 +225,7 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
-  // Promote the inputs to local memory
+  // Promote the matmul inputs to local memory
   {
     AMDAIEBufferizeToAllocationOptions bufferizeOptions;
     bufferizeOptions.memorySpace = 2;
@@ -237,16 +239,41 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
-  // Peel the for loop. For matmul dispatch, only peel the first iteration. For
-  // matmul-elementwise dispatch, peel the first and last iteration.
+  // Peel the for loop. For matmul dispatch, only peel the first iteration,
+  // while for matmul-elementwise dispatch, peel the first and last iteration.
+  // Note: Do not run CSE pass afterwards, because it may bring problem for
+  // bufferization.
   funcPassManager.addPass(createAMDAIEPeelForLoopPass());
   funcPassManager.addPass(createCanonicalizerPass());
-  funcPassManager.addPass(createCSEPass());
 
-  // Fuse fill into forall loop
+  // Fuse fill op into the first inner forall loop
   funcPassManager.addPass(createAMDAIEFuseFillIntoForallPass());
+
+  // Fuse elementwise op into the last inner forall loop
+  funcPassManager.addPass(createAMDAIEFuseConsumerIntoLoopPass());
   funcPassManager.addPass(createCanonicalizerPass());
-  funcPassManager.addPass(createCSEPass());
+
+  // Fuse pack ops into the last inner forall loop
+  {
+    AMDAIEFusePackIntoLoopOptions fusePackOptions;
+    fusePackOptions.fusePackDepth = 1;
+    fusePackOptions.useSCFFor = false;
+    fusePackOptions.targetElementwise = true;
+    funcPassManager.addPass(createAMDAIEFusePackIntoLoopPass(fusePackOptions));
+  }
+  funcPassManager.addPass(createCanonicalizerPass());
+
+  // Promote the elementwise inputs to local memory
+  {
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
+    bufferizeOptions.memorySpace = 2;
+    bufferizeOptions.bufferizeElementwise = true;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::Input;
+    funcPassManager.addPass(
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
+  }
+  funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
+  funcPassManager.addPass(createCanonicalizerPass());
 
   // Comprehensive bufferization
   addAMDAIEBufferizePasses(funcPassManager);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -106,7 +106,7 @@ def AMDAIEFusePackIntoLoop :
     Option<"useSCFFor", "use-scf-for", "bool", /*default=*/"true",
       "Set the innermost scf loop type to fuse tensor.pack ops into">,
     Option<"targetElementwise", "target-elementwise", "bool", /*default=*/"false",
-      "Set if the compute op within the loop is an elementwise op">
+      "Set if the target compute op within the loop is an elementwise op">
   ];
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -89,43 +89,6 @@ def AMDAIEFuseFillIntoForall :
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIEFuseFillIntoForallPass()";
 }
 
-def AMDAIEInsertLoopsForVectorization :
-    InterfacePass<"iree-amdaie-insert-loops-for-vectorization", "mlir::FunctionOpInterface"> {
-
-    let summary = "Replace outer-dimensions of matmul-like linalg.generics with scf.for loops.";
-
-    let description  = [{
-      This pass transforms all linalg.generic operations with matmul-like
-      inner-dimension semantics. It replaces all outer-dimensions with scf.for
-      loops. For example, it replaces a generic operation that describes a
-      batched matmul with an scf.for loop containing a linalg.generic that
-      describes a lower rank non-batched matmul. In other words, it replaces
-      the batch dimension in the linalg.generic with an scf.for loop.
-
-      All outer dimensions are replaced with scf.for loops. The three
-      inner-dimensions must describe a matmul: 2 parallel dimensions and 1
-      reduction dimension, at correct indices. The pass does not transform
-      transposed matmuls, or any other operation that does not have exact
-      matmul semantics.
-
-      The motivation for this pass is to enable a subsequent vectorization pass
-      to generate vector.contract operations which map easily to the AIEVec
-      dialect.
-    }];
-
-   let constructor =
-       "mlir::iree_compiler::AMDAIE::createAMDAIEInsertLoopsForVectorizationPass()";
-}
-
-
-def AMDAIEVectorization :
-    InterfacePass<"iree-amdaie-vectorization", "mlir::FunctionOpInterface"> {
-
-  let summary = "Convert operations to the vector dialect in an AIE-friendly way.";
-
-  let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIEVectorizationPass()";
-}
-
 def AMDAIEFuseLogicalObjectFifoIntoWorkgroup :
     Pass<"iree-amdaie-fuse-logicalobjectfifo-into-workgroup", "ModuleOp"> {
   let summary = "Fuse or distribute logical objectfifos into workgroups.";
@@ -141,7 +104,9 @@ def AMDAIEFusePackIntoLoop :
     Option<"fusePackDepth", "fuse-pack-depth", "int64_t", /*default=*/"1",
       "Set the depth until which we would keep fusing producer tensor.pack chain">,
     Option<"useSCFFor", "use-scf-for", "bool", /*default=*/"true",
-      "Set the innermost scf loop type to fuse tensor.pack ops into">
+      "Set the innermost scf loop type to fuse tensor.pack ops into">,
+    Option<"targetElementwise", "target-elementwise", "bool", /*default=*/"false",
+      "Set if the compute op within the loop is an elementwise op">
   ];
 }
 
@@ -154,6 +119,34 @@ def AMDAIEInsertAIEWorkgroup :
   Pass<"iree-amdaie-insert-aie-workgroup", "ModuleOp"> {
   let summary = "Insert AIE workgroups around forall loops selected for parallel execution.";
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIEInsertAIEWorkgroupPass()";
+}
+
+def AMDAIEInsertLoopsForVectorization :
+  InterfacePass<"iree-amdaie-insert-loops-for-vectorization", "mlir::FunctionOpInterface"> {
+
+  let summary = "Replace outer-dimensions of matmul-like linalg.generics with scf.for loops.";
+
+  let description  = [{
+    This pass transforms all linalg.generic operations with matmul-like
+    inner-dimension semantics. It replaces all outer-dimensions with scf.for
+    loops. For example, it replaces a generic operation that describes a
+    batched matmul with an scf.for loop containing a linalg.generic that
+    describes a lower rank non-batched matmul. In other words, it replaces
+    the batch dimension in the linalg.generic with an scf.for loop.
+
+    All outer dimensions are replaced with scf.for loops. The three
+    inner-dimensions must describe a matmul: 2 parallel dimensions and 1
+    reduction dimension, at correct indices. The pass does not transform
+    transposed matmuls, or any other operation that does not have exact
+    matmul semantics.
+
+    The motivation for this pass is to enable a subsequent vectorization pass
+    to generate vector.contract operations which map easily to the AIEVec
+    dialect.
+  }];
+
+ let constructor =
+     "mlir::iree_compiler::AMDAIE::createAMDAIEInsertLoopsForVectorizationPass()";
 }
 
 def AMDAIELowerExecutableTarget :
@@ -287,6 +280,12 @@ def AMDAIEPeelForLoop :
   ];
 }
 
+def AMDAIEPropagateDataLayout :
+    InterfacePass<"iree-amdaie-propagate-data-layout", "mlir::FunctionOpInterface"> {
+  let summary = "Pass to propagate pack/unpack ops using upstream patterns.";
+  let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIEPropagateDataLayoutPass()";
+}
+
 def AMDAIETile :
     InterfacePass<"iree-amdaie-tile", "mlir::FunctionOpInterface"> {
   let summary = "Pass to tile TilingInterface operations.";
@@ -311,10 +310,10 @@ def AMDAIETileAndFuse :
   ];
 }
 
-def AMDAIEPropagateDataLayout :
-    InterfacePass<"iree-amdaie-propagate-data-layout", "mlir::FunctionOpInterface"> {
-  let summary = "Pass to propagate pack/unpack ops using upstream patterns.";
-  let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIEPropagateDataLayoutPass()";
+def AMDAIEVectorization :
+    InterfacePass<"iree-amdaie-vectorization", "mlir::FunctionOpInterface"> {
+  let summary = "Convert operations to the vector dialect in an AIE-friendly way.";
+  let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIEVectorizationPass()";
 }
 
 def AMDAIEUnrollAndDistributeWorkgroup : 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/bufferize_to_allocation.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/bufferize_to_allocation.mlir
@@ -2,7 +2,7 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=2 bufferize-operand=input}))' --split-input-file %s | FileCheck %s --check-prefix=INPUT
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=2 bufferize-operand=output}))' --split-input-file %s | FileCheck %s --check-prefix=OUTPUT
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=1 bufferize-operand=def-op}))' --split-input-file %s | FileCheck %s --check-prefix=DEF-OP
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=1 bufferize-elementwise=true bufferize-operand=def-op}))' --split-input-file %s | FileCheck %s --check-prefix=ELEMENTWISE-DEF-OP
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=2 bufferize-elementwise=true bufferize-operand=input}))' --split-input-file %s | FileCheck %s --check-prefix=ELEMENTWISE-INPUT
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=2 bufferize-elementwise=true bufferize-operand=input-output}))' --split-input-file %s | FileCheck %s --check-prefix=ELEMENTWISE-INPUT-OUTPUT
 
 #map = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d2, d3, d5, d6, d8)>
@@ -143,20 +143,19 @@ func.func @matmul_elementwise(%arg0: tensor<1024x512xi8>, %arg1: tensor<512x1024
   return %1 : tensor<1024x1024xi32>
 }
 
-// ELEMENTWISE-DEF-OP-COUNT-4:  tensor.pack
-//         ELEMENTWISE-DEF-OP:  linalg.fill
-//         ELEMENTWISE-DEF-OP:  linalg.generic
-//         ELEMENTWISE-DEF-OP:  memref.alloc() : memref<1x1x64x64xi32, 1 : i32>
-//         ELEMENTWISE-DEF-OP:  bufferization.to_tensor
-//         ELEMENTWISE-DEF-OP:  tensor.pack
-//         ELEMENTWISE-DEF-OP:  memref.alloc() : memref<1x1x64x64xi32, 1 : i32>
-//         ELEMENTWISE-DEF-OP:  bufferization.to_tensor
-//         ELEMENTWISE-DEF-OP:  tensor.pack
-//     ELEMENTWISE-DEF-OP-NOT:  memref.alloc
-//         ELEMENTWISE-DEF-OP:  tensor.pack
-//     ELEMENTWISE-DEF-OP-NOT:  memref.alloc
-//         ELEMENTWISE-DEF-OP:  tensor.pack
-//         ELEMENTWISE-DEF-OP:  linalg.generic
+// ELEMENTWISE-INPUT-COUNT-4:  tensor.pack
+//         ELEMENTWISE-INPUT:  linalg.fill
+//         ELEMENTWISE-INPUT:  linalg.generic
+//     ELEMENTWISE-INPUT-NOT:  memref.alloc
+//         ELEMENTWISE-INPUT:  tensor.pack
+//     ELEMENTWISE-INPUT-NOT:  memref.alloc
+//         ELEMENTWISE-INPUT:  tensor.pack
+//     ELEMENTWISE-INPUT-NOT:  memref.alloc
+//         ELEMENTWISE-INPUT:  tensor.pack
+//         ELEMENTWISE-INPUT:  memref.alloc() : memref<1x1x8x16x4x8xi32, 2 : i32>
+//         ELEMENTWISE-INPUT:  bufferization.to_tensor
+//         ELEMENTWISE-INPUT:  tensor.pack
+//         ELEMENTWISE-INPUT:  linalg.generic
 
 // ELEMENTWISE-INPUT-OUTPUT-COUNT-4:  tensor.pack
 //         ELEMENTWISE-INPUT-OUTPUT:  linalg.fill

--- a/tests/samples/CMakeLists.txt
+++ b/tests/samples/CMakeLists.txt
@@ -8,7 +8,8 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "pack_peel_pipeline.mlir"
+    "pack_peel_pipeline_matmul.mlir"
+    "pack_peel_pipeline_matmul_elementwise.mlir"
     "pad_pack_pipeline_e2e.mlir"
     "xdna_oplib_plugin.mlir"
   TOOLS

--- a/tests/samples/pack_peel_pipeline.mlir
+++ b/tests/samples/pack_peel_pipeline.mlir
@@ -46,7 +46,7 @@ func.func @matmul_bf16(%lhs: tensor<512x1024xbf16>, %rhs: tensor<1024x512xbf16>)
 
 // -----
 
-func.func @matmul_elementwise(%lhs: tensor<1024x512xi32>, %rhs: tensor<512x1024xi32>, %ele: tensor<1024x1024xi32>) -> tensor<1024x1024xi32>
+func.func @matmul_elementwise_i32(%lhs: tensor<1024x512xi32>, %rhs: tensor<512x1024xi32>, %ele: tensor<1024x1024xi32>) -> tensor<1024x1024xi32>
 {
   %cst = arith.constant 0 : i32
   %0 = tensor.empty() : tensor<1024x1024xi32>
@@ -65,12 +65,84 @@ func.func @matmul_elementwise(%lhs: tensor<1024x512xi32>, %rhs: tensor<512x1024x
   return %add : tensor<1024x1024xi32>
 }
 
-// CHECK-LABEL: hal.executable.export public @matmul_elementwise_dispatch_0_matmul_1024x1024x512_i32
+// CHECK-LABEL: hal.executable.export public @matmul_elementwise_i32_dispatch_0_matmul_1024x1024x512_i32
 //       CHECK:    aie.device(npu)
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
-//       CHECK:    func.func @matmul_elementwise_dispatch_0_matmul_1024x1024x512_i32(%arg0: memref<1024x512xi32>, %arg1: memref<512x1024xi32>, %arg2: memref<1024x1024xi32>)
+//       CHECK:    func.func @matmul_elementwise_i32_dispatch_0_matmul_1024x1024x512_i32(%arg0: memref<1024x512xi32>, %arg1: memref<512x1024xi32>, %arg2: memref<1024x1024xi32>)
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.sync
+
+// -----
+
+func.func @matmul_elementwise_bf16(%arg0: tensor<1024x512xbf16>, %arg1: tensor<512x1024xbf16>, %arg2: tensor<1024xbf16>) -> tensor<1024x1024xbf16> {
+  %cst = arith.constant 0.000000e+00 : bf16
+  %0 = tensor.empty() : tensor<1024x1024xbf16>
+  %1 = linalg.fill ins(%cst : bf16) outs(%0 : tensor<1024x1024xbf16>) -> tensor<1024x1024xbf16>
+  %2 = linalg.matmul ins(%arg0, %arg1 : tensor<1024x512xbf16>, tensor<512x1024xbf16>) outs(%1 : tensor<1024x1024xbf16>) -> tensor<1024x1024xbf16>
+  %3 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%2, %arg2 : tensor<1024x1024xbf16>, tensor<1024xbf16>) outs(%0 : tensor<1024x1024xbf16>) {
+  ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+    %5 = arith.addf %in, %in_0 : bf16
+    linalg.yield %5 : bf16
+  } -> tensor<1024x1024xbf16>
+  %4 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%3 : tensor<1024x1024xbf16>) outs(%0 : tensor<1024x1024xbf16>) {
+  ^bb0(%in: bf16, %out: bf16):
+    %5 = arith.cmpf ugt, %in, %cst : bf16
+    %6 = arith.select %5, %in, %cst : bf16
+    linalg.yield %6 : bf16
+  } -> tensor<1024x1024xbf16>
+  return %4 : tensor<1024x1024xbf16>
+}
+
+// CHECK-LABEL: hal.executable.export public @matmul_elementwise_bf16_dispatch_0_matmul_1024x1024x512_bf16
+//       CHECK:    aie.device(npu)
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    func.func @matmul_elementwise_bf16_dispatch_0_matmul_1024x1024x512_bf16(%arg0: memref<262144xi32>, %arg1: memref<262144xi32>, %arg2: memref<524288xi32>)
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.sync
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d1, d0)>
+#map2 = affine_map<(d0, d1) -> (d1)>
+func.func @matmul_elementwise_transpose_b(%arg0: tensor<256x512xbf16>, %arg1: tensor<1024x512xbf16>, %arg2: tensor<1024xbf16>) -> tensor<256x1024xbf16> {
+  %cst = arith.constant 0.000000e+00 : bf16
+  %0 = tensor.empty() : tensor<512x1024xbf16>
+  %1 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg1 : tensor<1024x512xbf16>) outs(%0 : tensor<512x1024xbf16>) {
+  ^bb0(%in: bf16, %out: bf16):
+    linalg.yield %in : bf16
+  } -> tensor<512x1024xbf16>
+  %2 = tensor.empty() : tensor<256x1024xbf16>
+  %3 = linalg.fill ins(%cst : bf16) outs(%2 : tensor<256x1024xbf16>) -> tensor<256x1024xbf16>
+  %4 = linalg.matmul ins(%arg0, %1 : tensor<256x512xbf16>, tensor<512x1024xbf16>) outs(%3 : tensor<256x1024xbf16>) -> tensor<256x1024xbf16>
+  %5 = linalg.generic {indexing_maps = [#map, #map2, #map], iterator_types = ["parallel", "parallel"]} ins(%4, %arg2 : tensor<256x1024xbf16>, tensor<1024xbf16>) outs(%2 : tensor<256x1024xbf16>) {
+  ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+    %7 = arith.addf %in, %in_0 : bf16
+    linalg.yield %7 : bf16
+  } -> tensor<256x1024xbf16>
+  %6 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%5 : tensor<256x1024xbf16>) outs(%2 : tensor<256x1024xbf16>) {
+  ^bb0(%in: bf16, %out: bf16):
+    %7 = arith.cmpf ugt, %in, %cst : bf16
+    %8 = arith.select %7, %in, %cst : bf16
+    linalg.yield %8 : bf16
+  } -> tensor<256x1024xbf16>
+  return %6 : tensor<256x1024xbf16>
+}
+
+// CHECK-LABEL: hal.executable.export public @matmul_elementwise_transpose_b_dispatch_0_matmul_transpose_b_256x1024x512_bf16
+//       CHECK:    aie.device(npu)
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    func.func @matmul_elementwise_transpose_b_dispatch_0_matmul_transpose_b_256x1024x512_bf16(%arg0: memref<65536xi32>, %arg1: memref<262144xi32>, %arg2: memref<131072xi32>)
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd

--- a/tests/samples/pack_peel_pipeline.mlir
+++ b/tests/samples/pack_peel_pipeline.mlir
@@ -1,6 +1,6 @@
-// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources --mlir-print-ir-after=fold-memref-alias-ops %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pack-peel | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pack-peel --split-input-file | FileCheck %s
 
-func.func @matmul_example(%lhs: tensor<1024x512xi8>, %rhs: tensor<512x1024xi8>) -> tensor<1024x1024xi32>
+func.func @matmul_i8_i32(%lhs: tensor<1024x512xi8>, %rhs: tensor<512x1024xi8>) -> tensor<1024x1024xi32>
 {
   %cst = arith.constant 0 : i32
   %0 = tensor.empty() : tensor<1024x1024xi32>
@@ -10,16 +10,18 @@ func.func @matmul_example(%lhs: tensor<1024x512xi8>, %rhs: tensor<512x1024xi8>) 
   return %res : tensor<1024x1024xi32>
 }
 
-// CHECK-LABEL: hal.executable.export public @matmul_example_dispatch_0_matmul_1024x1024x512_i8xi8xi32
+// CHECK-LABEL: hal.executable.export public @matmul_i8_i32_dispatch_0_matmul_1024x1024x512_i8xi8xi32
 //       CHECK:    aie.device(npu)
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
-//       CHECK:    func.func @matmul_example_dispatch_0_matmul_1024x1024x512_i8xi8xi32(%arg0: memref<131072xi32>, %arg1: memref<131072xi32>, %arg2: memref<1024x1024xi32>)
+//       CHECK:    func.func @matmul_i8_i32_dispatch_0_matmul_1024x1024x512_i8xi8xi32(%arg0: memref<131072xi32>, %arg1: memref<131072xi32>, %arg2: memref<1024x1024xi32>)
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.sync
+
+// -----
 
 func.func @matmul_bf16(%lhs: tensor<512x1024xbf16>, %rhs: tensor<1024x512xbf16>) -> tensor<512x512xbf16>
 {
@@ -37,6 +39,38 @@ func.func @matmul_bf16(%lhs: tensor<512x1024xbf16>, %rhs: tensor<1024x512xbf16>)
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    func.func @matmul_bf16_dispatch_0_matmul_512x512x1024_bf16(%arg0: memref<262144xi32>, %arg1: memref<262144xi32>, %arg2: memref<131072xi32>)
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.sync
+
+// -----
+
+func.func @matmul_elementwise(%lhs: tensor<1024x512xi32>, %rhs: tensor<512x1024xi32>, %ele: tensor<1024x1024xi32>) -> tensor<1024x1024xi32>
+{
+  %cst = arith.constant 0 : i32
+  %0 = tensor.empty() : tensor<1024x1024xi32>
+  %1 = linalg.fill ins(%cst : i32) outs(%0 : tensor<1024x1024xi32>) -> tensor<1024x1024xi32>
+  %res = linalg.matmul ins(%lhs, %rhs: tensor<1024x512xi32>, tensor<512x1024xi32>)
+                    outs(%1: tensor<1024x1024xi32>) -> tensor<1024x1024xi32>
+  %add = linalg.generic
+        {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>,
+         affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]}
+         ins(%res, %ele : tensor<1024x1024xi32>, tensor<1024x1024xi32>)
+         outs(%0 : tensor<1024x1024xi32>) {
+           ^bb0(%in: i32, %in_0: i32, %out: i32):
+           %2 = arith.addi %in, %in_0 : i32
+           linalg.yield %2 : i32
+         } -> tensor<1024x1024xi32>
+  return %add : tensor<1024x1024xi32>
+}
+
+// CHECK-LABEL: hal.executable.export public @matmul_elementwise_dispatch_0_matmul_1024x1024x512_i32
+//       CHECK:    aie.device(npu)
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    func.func @matmul_elementwise_dispatch_0_matmul_1024x1024x512_i32(%arg0: memref<1024x512xi32>, %arg1: memref<512x1024xi32>, %arg2: memref<1024x1024xi32>)
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd

--- a/tests/samples/pack_peel_pipeline_matmul.mlir
+++ b/tests/samples/pack_peel_pipeline_matmul.mlir
@@ -1,0 +1,45 @@
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pack-peel --split-input-file | FileCheck %s
+
+func.func @matmul_i8_i32(%lhs: tensor<1024x512xi8>, %rhs: tensor<512x1024xi8>) -> tensor<1024x1024xi32>
+{
+  %cst = arith.constant 0 : i32
+  %0 = tensor.empty() : tensor<1024x1024xi32>
+  %1 = linalg.fill ins(%cst : i32) outs(%0 : tensor<1024x1024xi32>) -> tensor<1024x1024xi32>
+  %res = linalg.matmul ins(%lhs, %rhs: tensor<1024x512xi8>, tensor<512x1024xi8>)
+                    outs(%1: tensor<1024x1024xi32>) -> tensor<1024x1024xi32>
+  return %res : tensor<1024x1024xi32>
+}
+
+// CHECK-LABEL: hal.executable.export public @matmul_i8_i32_dispatch_0_matmul_1024x1024x512_i8xi8xi32
+//       CHECK:    aie.device(npu)
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    func.func @matmul_i8_i32_dispatch_0_matmul_1024x1024x512_i8xi8xi32(%arg0: memref<131072xi32>, %arg1: memref<131072xi32>, %arg2: memref<1024x1024xi32>)
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.sync
+
+// -----
+
+func.func @matmul_bf16(%lhs: tensor<512x1024xbf16>, %rhs: tensor<1024x512xbf16>) -> tensor<512x512xbf16>
+{
+  %cst = arith.constant 0.000000e+00 : bf16
+  %0 = tensor.empty() : tensor<512x512xbf16>
+  %1 = linalg.fill ins(%cst : bf16) outs(%0 : tensor<512x512xbf16>) -> tensor<512x512xbf16>
+  %res = linalg.matmul ins(%lhs, %rhs: tensor<512x1024xbf16>, tensor<1024x512xbf16>)
+                    outs(%1: tensor<512x512xbf16>) -> tensor<512x512xbf16>
+  return %res : tensor<512x512xbf16>
+}
+
+// CHECK-LABEL: hal.executable.export public @matmul_bf16_dispatch_0_matmul_512x512x1024_bf16
+//       CHECK:    aie.device(npu)
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    func.func @matmul_bf16_dispatch_0_matmul_512x512x1024_bf16(%arg0: memref<262144xi32>, %arg1: memref<262144xi32>, %arg2: memref<131072xi32>)
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.sync

--- a/tests/samples/pack_peel_pipeline_matmul_elementwise.mlir
+++ b/tests/samples/pack_peel_pipeline_matmul_elementwise.mlir
@@ -1,50 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pack-peel --split-input-file | FileCheck %s
-
-func.func @matmul_i8_i32(%lhs: tensor<1024x512xi8>, %rhs: tensor<512x1024xi8>) -> tensor<1024x1024xi32>
-{
-  %cst = arith.constant 0 : i32
-  %0 = tensor.empty() : tensor<1024x1024xi32>
-  %1 = linalg.fill ins(%cst : i32) outs(%0 : tensor<1024x1024xi32>) -> tensor<1024x1024xi32>
-  %res = linalg.matmul ins(%lhs, %rhs: tensor<1024x512xi8>, tensor<512x1024xi8>)
-                    outs(%1: tensor<1024x1024xi32>) -> tensor<1024x1024xi32>
-  return %res : tensor<1024x1024xi32>
-}
-
-// CHECK-LABEL: hal.executable.export public @matmul_i8_i32_dispatch_0_matmul_1024x1024x512_i8xi8xi32
-//       CHECK:    aie.device(npu)
-//       CHECK:    aie.shim_dma_allocation
-//       CHECK:    aie.shim_dma_allocation
-//       CHECK:    aie.shim_dma_allocation
-//       CHECK:    func.func @matmul_i8_i32_dispatch_0_matmul_1024x1024x512_i8xi8xi32(%arg0: memref<131072xi32>, %arg1: memref<131072xi32>, %arg2: memref<1024x1024xi32>)
-//       CHECK:      aiex.npu.dma_memcpy_nd
-//       CHECK:      aiex.npu.dma_memcpy_nd
-//       CHECK:      aiex.npu.dma_memcpy_nd
-//       CHECK:      aiex.npu.sync
-
-// -----
-
-func.func @matmul_bf16(%lhs: tensor<512x1024xbf16>, %rhs: tensor<1024x512xbf16>) -> tensor<512x512xbf16>
-{
-  %cst = arith.constant 0.000000e+00 : bf16
-  %0 = tensor.empty() : tensor<512x512xbf16>
-  %1 = linalg.fill ins(%cst : bf16) outs(%0 : tensor<512x512xbf16>) -> tensor<512x512xbf16>
-  %res = linalg.matmul ins(%lhs, %rhs: tensor<512x1024xbf16>, tensor<1024x512xbf16>)
-                    outs(%1: tensor<512x512xbf16>) -> tensor<512x512xbf16>
-  return %res : tensor<512x512xbf16>
-}
-
-// CHECK-LABEL: hal.executable.export public @matmul_bf16_dispatch_0_matmul_512x512x1024_bf16
-//       CHECK:    aie.device(npu)
-//       CHECK:    aie.shim_dma_allocation
-//       CHECK:    aie.shim_dma_allocation
-//       CHECK:    aie.shim_dma_allocation
-//       CHECK:    func.func @matmul_bf16_dispatch_0_matmul_512x512x1024_bf16(%arg0: memref<262144xi32>, %arg1: memref<262144xi32>, %arg2: memref<131072xi32>)
-//       CHECK:      aiex.npu.dma_memcpy_nd
-//       CHECK:      aiex.npu.dma_memcpy_nd
-//       CHECK:      aiex.npu.dma_memcpy_nd
-//       CHECK:      aiex.npu.sync
-
-// -----
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pack-peel --iree-amdaie-matmul-elementwise-fusion --split-input-file | FileCheck %s
 
 func.func @matmul_elementwise_i32(%lhs: tensor<1024x512xi32>, %rhs: tensor<512x1024xi32>, %ele: tensor<1024x1024xi32>) -> tensor<1024x1024xi32>
 {
@@ -70,7 +24,7 @@ func.func @matmul_elementwise_i32(%lhs: tensor<1024x512xi32>, %rhs: tensor<512x1
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
-//       CHECK:    func.func @matmul_elementwise_i32_dispatch_0_matmul_1024x1024x512_i32(%arg0: memref<1024x512xi32>, %arg1: memref<512x1024xi32>, %arg2: memref<1024x1024xi32>)
+//       CHECK:    func.func @matmul_elementwise_i32_dispatch_0_matmul_1024x1024x512_i32(%arg0: memref<1024x512xi32>, %arg1: memref<512x1024xi32>, %arg2: memref<1024x1024xi32>, %arg3: memref<1024x1024xi32>)
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd
@@ -102,7 +56,7 @@ func.func @matmul_elementwise_bf16(%arg0: tensor<1024x512xbf16>, %arg1: tensor<5
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
-//       CHECK:    func.func @matmul_elementwise_bf16_dispatch_0_matmul_1024x1024x512_bf16(%arg0: memref<262144xi32>, %arg1: memref<262144xi32>, %arg2: memref<524288xi32>)
+//       CHECK:    func.func @matmul_elementwise_bf16_dispatch_0_matmul_1024x1024x512_bf16(%arg0: memref<262144xi32>, %arg1: memref<262144xi32>, %arg2: memref<524288xi32>, %arg3: memref<512xi32>)
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd
@@ -142,7 +96,7 @@ func.func @matmul_elementwise_transpose_b(%arg0: tensor<256x512xbf16>, %arg1: te
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
-//       CHECK:    func.func @matmul_elementwise_transpose_b_dispatch_0_matmul_transpose_b_256x1024x512_bf16(%arg0: memref<65536xi32>, %arg1: memref<262144xi32>, %arg2: memref<131072xi32>)
+//       CHECK:    func.func @matmul_elementwise_transpose_b_dispatch_0_matmul_transpose_b_256x1024x512_bf16(%arg0: memref<65536xi32>, %arg1: memref<262144xi32>, %arg2: memref<131072xi32>, %arg3: memref<512xi32>)
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd


### PR DESCRIPTION
- Integrate FuseConsumerIntoLoopPass to pack-peel packline. Adjust the order of certain passes to avoid bufferization problem.
- Modified BufferizeToAllocationPass and FusePackIntoLoopPass to generate correct IR without extra alloc/copies after bufferization.
- Add an e2e matmul-elementwise example to demonstrate the lowering through AIR and generate NPU instructions.