### PR TITLE
Runtime changes to use DPU Sequence rather than run_pp mode

### DIFF
--- a/runtime/src/iree-amd-aie/driver/xrt/direct_command_buffer.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/direct_command_buffer.cc
@@ -329,11 +329,15 @@ static iree_status_t iree_hal_xrt_direct_command_buffer_dispatch(
   // Index to push arguments on the kernel.
   iree_host_size_t arg_index = 0;
 
-  // First argument is the LX6 instructions.
-  run.set_arg(arg_index++, instr);
+  // First argument is the opcode, currently using DPU sequence which has opcode
+  // 0
+  run.set_arg(arg_index++, 0x01);
 
-  // Second argument is the number of LX6 instructions.
-  run.set_arg(arg_index++, num_instr);
+  // Fifth argument is the LX6 instructions.
+  run.set_arg(5, instr);
+
+  // Sizxth argument is the number of LX6 instructions.
+  run.set_arg(6, num_instr);
 
   // Copy descriptors from all sets to the end of the current segment for later
   // access.

--- a/runtime/src/iree-amd-aie/driver/xrt/native_executable.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/native_executable.cc
@@ -180,11 +180,11 @@ iree_status_t iree_hal_xrt_native_executable_create(
       kernel = std::make_unique<xrt::kernel>(context, entry_name);
       // XCL_BO_FLAGS_CACHEABLE is used to indicate that this is an instruction
       // buffer that resides in instr_memory. This buffer is always passed as
-      // the first argument to the kernel and we can use the
-      // kernel.group_id(/*index of first argument*/=0) to get the group_id.
+      // the sixth argument to the kernel and we can use the
+      // kernel.group_id(/*index of sixth argument*/=5) to get the group_id.
       instr = std::make_unique<xrt::bo>(device, num_instr * sizeof(uint32_t),
                                         XCL_BO_FLAGS_CACHEABLE,
-                                        kernel.get()->group_id(0));
+                                        kernel.get()->group_id(5));
     } catch (...) {
       iree_hal_executable_destroy((iree_hal_executable_t*)executable);
       IREE_TRACE_ZONE_END(z0);


### PR DESCRIPTION
Currently the kernels are compiled to run in an outdated run_pp (run as a post processing kernel) mode. This PR contains the runtime changes needed to run the kernels in the DPU Sequence mode which is soon to be put on maintenance mode but still better that run_pp. The goal is to run as a transactional binary with control packets so this can be a temporary stop gap till we move to that flow. The compiler side changes for this have to happen in mlir-aie.