### PR TITLE
For the pad-pack pipeline, avoid tile size ratio of 2

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -667,12 +667,6 @@ run_matmul_test \
     --compile-only "1"
 
 ###################################################################
-<<<<<<< HEAD
-=======
-
-
-
->>>>>>> ed6d5eb (squash)
 
 run_matmul_test \
     --name_prefix "packPeelLarge" \

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -616,21 +616,39 @@ run_matmul_test \
     --acc_type "i32" \
     --m "64"  --n "64" --k "128"
 
-
-# We're seeing intermittent numerical errors in these 3 tests, 
-# needs investigation. TODO(newling/yzhang93): Add more info. 
+# We're seeing intermittent numerical errors in these 3 tests,
+# needs investigation. TODO(newling/yzhang93): Add more info.
 # Appears to be only pack-peel pipeline with bf16->f32.
 # Using 'compile-only' flag to avoid running the numerical test.
-# ################################################################
+#################################################################
 
+
+# TODO: compilation error with the below test.
+#
+# error: 'aie.dma_bd' op Cannot give more than 3 dimensions for step sizes and wraps in this  tile (got 4 dimensions).
+#
+# The config generated with the current strategy is:
+#
+# packing_config = #amdaie.packing_config<packing_config =
+#   [{packedSizes = [64, 64, 64],
+#     transposePackIndices = [1],
+#     unpackEmpty = [false],
+#     innerPerm = [[1, 0]],
+#     outerPerm = [[0, 1]]},
+#     {
+#       packedSizes = [0, 0, 0, 4, 4, 8],
+#       transposePackIndices = [0, 1, 2],
+#       unpackEmpty = [false, false, true],
+#       innerPerm = [[0, 1], [1, 0], [0, 1]],
+#       outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+#     }
 run_matmul_test \
     --name_prefix "packPeel" \
     --pipeline "pack-peel" \
     --lhs_rhs_type "bf16" \
     --acc_type "f32" \
     --m "64"  --n "64" --k "128" \
-    --compile-only "1"
-
+    --expect-compile-failure "1" \
 
 run_matmul_test \
     --name_prefix "packPeelLarge" \
@@ -649,6 +667,12 @@ run_matmul_test \
     --compile-only "1"
 
 ###################################################################
+<<<<<<< HEAD
+=======
+
+
+
+>>>>>>> ed6d5eb (squash)
 
 run_matmul_test \
     --name_prefix "packPeelLarge" \

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy.mlir
@@ -67,7 +67,7 @@ builtin.module {
 
 // -----
 
-// CHECK-PAD-PACK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[8, 32], [0, 0, 16], [8, 16], [0, 0, 2]]>
+// CHECK-PAD-PACK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[8, 32], [0, 0, 16], [8, 8], [0, 0, 2]]>
 // CHECK-PAD-PACK{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[1, 0], [1, 0], [1, 0]]}]>
 builtin.module {
   func.func @matmul_small_dispatch_0_matmul_8x32x16_i64() {
@@ -132,7 +132,7 @@ builtin.module {
 
 // -----
 
-// CHECK-PAD-PACK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128], [0, 0, 128], [32, 32], [0, 0, 4]]>
+// CHECK-PAD-PACK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128], [0, 0, 128], [32, 32], [0, 0, 8]]>
 // CHECK-PAD-PACK{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[1, 0], [1, 0], [1, 0]]}]>
 builtin.module {
   func.func @matmul_2432x2432x2432_bf16xbf16xf32() {
@@ -153,8 +153,8 @@ builtin.module {
 
 // -----
 
-// CHECK-PACK-PEEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [0, 0, 1], [0, 0, 0, 8, 4, 0]]>
-// CHECK-PACK-PEEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [64, 64, 32], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 8, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+// CHECK-PACK-PEEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [0, 0, 1], [0, 0, 0, 8, 8, 0]]>
+// CHECK-PACK-PEEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [64, 64, 32], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 builtin.module {
   func.func @matmul_large_dispatch_0_matmul_2048x2048x2048_i8_i32() {
     %c0_i32 = arith.constant 0 : i32


### PR DESCRIPTION
This is low priority as pad-pack isn't going to be our main pipeline, and this doesn't fix any hangs since https://github.com/Xilinx/mlir-air/pull/562/ landed,  but maybe a nice thing to have (we can use in peel-pack later).

The pad-pack pipeline currently targets a 4x4 AIE array, so for a fixed shared memory tiling in the M- and N- directions (M0 and N0) it is better to have 

```
M1=M0/4, N1 = N0/4
```
than 
```
M1=M0/2, N1 = N0/2
```

where M1 and N1 are the tiling sizes on the AIE core memory. 

This PR checks for M0/M1 = 2 and if possible halves M1 so that M0/M1 = 4 (ditto the N- dimension) 

Note that since https://github.com/Xilinx/mlir-air/pull/562/files has landed this change is purely for performance and not for correctness. 
