### PR TITLE
[Delegate] Enhancements in support of OPT matmul

### DIFF
--- a/experimental/delegate/.gitignore
+++ b/experimental/delegate/.gitignore
@@ -1,0 +1,2 @@
+*.vmfb
+*.sub.mlir

--- a/experimental/delegate/CMakeLists.txt
+++ b/experimental/delegate/CMakeLists.txt
@@ -62,8 +62,10 @@ iree_lit_test_suite(
     lit
   SRCS
     "mlp.mlir"
+    "opt.mlir"
   DATA
     "linalg.pdl.mlir"
+    "opt.pdl.mlir"
   TOOLS
     FileCheck
     iree-compile

--- a/experimental/delegate/CMakeLists.txt
+++ b/experimental/delegate/CMakeLists.txt
@@ -62,6 +62,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "mlp.mlir"
+    "matmul.mlir"
     "opt.mlir"
   DATA
     "linalg.pdl.mlir"

--- a/experimental/delegate/README.md
+++ b/experimental/delegate/README.md
@@ -14,10 +14,13 @@ The AIE Delegate is embedded within a model compiled down to a non-AIE target,
 such as the CPU.
 
 In this first draft, several aspects of AIE Delegates are hard-coded for the
-specific use case of a 256x256x256 matmul.  In the `experimental/delegate`
-directory the `mlp.mlir` file is a test model containing such a matmul.
-`mlp_spec.mlir` contains a Transform dialect script to replace the matmul with
-a `func.call` to an external function for the matmul.
+specific use case of a 256x256x256 or a 8x768x768 matmul, selectable by
+enabling or disabling the macro `USE_OPT_KERNEL`.  As checked in, the macro
+is enabled, meaning that the 8x768x768 matmul is being used.
+
+In the `experimental/delegate` directory the `mlp.mlir` file is a test model
+containing such a matmul. `mlp_spec.mlir` contains a Transform dialect script
+to replace the matmul with a `func.call` to an external function for the matmul.
 `mlp_aie_bf16_plugin.cpp` implements the custom dispatch plugin and the matmul
 function.  It makes calls to XRT to load and communicate with the AIE matmul
 kernel.
@@ -25,7 +28,8 @@ kernel.
 The build artifacts include `mlp_bf16_aie_delegate.so`, which is the custom
 dispatch plugin, an XCLBIN file to load into the AIE device, and a `insts.txt`
 file for the Ryzen AI controller.  These files must currently reside under the
-same directory as the `.so`.
+same directory as the `.so`.  At iree-amd-aie build time, these artifacts are
+downloaded from Azure.
 
 ## Running the Demo
 
@@ -47,7 +51,7 @@ iree-compile --iree-preprocessing-transform-spec-filename=mlp_spec.mlir mlp.mlir
 ### Run the model
 
 ```
-# Circumvent xclbin security
+# Circumvent xclbin security (no longer needed as of April 2024 XDNA driver)
 export XRT_HACK_UNSECURE_LOADING_XCLBIN=1
 
 # Set this to the location of the IREE build
@@ -57,6 +61,53 @@ iree-run-module --device=local-sync \
   --executable_plugin=${PATH_TO_IREE_BUILD}/runtime/plugins/AMD-AIE-experimental/delegate/mlp_bf16_aie_delegate.so \
   --module=mlp.vmfb \
   --function=mlp_invocation \
-  --input="256x256xf32=2" \
-  --input="256x256xf32=3"
+  --input="8x768xf32=2" \
+  --input="768x768xf32=3"
+```
+
+## OPT Demo
+
+There is a second demo containing two matmuls to demonstrate a scenario closer
+to that of a real model, such as OPT.  Its transform script, `opt.pdl.mlir`,
+which uses PDL, specifically targets matmuls of 8x768x768 and transforms only
+those, as opposed to all matmuls as with `mlp_spec.mlir`.
+
+The usage of this demo is similar to the previous one, except that for now,
+supporting IREE code is temporarily provided in a private GitHub repo:
+https://github.com/daveliddell/iree/tree/nirvedhs-patch.  The iree-amd-aie
+branch that works with this temporary fix can be found at:
+https://github.com/daveliddell/iree-amd-aie/tree/dliddell-opt-matmul.  An
+effort is underway to upstream these changes.
+
+### Compile the model
+
+First, log in to a Ryzen AI machine (aka IPU, Phoenix).
+
+```
+# Set up the shell
+cd <workspace root (containing iree-build)>
+source /opt/xilinx/xrt/setup.sh
+export PATH=$PATH:$PWD/iree-build/tools:$PWD/llvm-build/bin
+
+# Compile the model
+cd iree-amd-aie/experimental/delegate
+iree-opt --pass-pipeline="builtin.module(iree-preprocessing-apply-pdl-patterns{patterns-file=opt.pdl.mlir}, cse)" opt.mlir -o opt.sub.mlir
+iree-compile opt.sub.mlir -o opt.vmfb --iree-scheduling-optimize-bindings=false
+```
+
+### Run the model
+
+```
+# Circumvent xclbin security (no longer needed as of April 2024 XDNA driver)
+export XRT_HACK_UNSECURE_LOADING_XCLBIN=1
+
+# Set this to the location of the IREE build
+export PATH_TO_IREE_BUILD=../../../iree-build
+
+iree-run-module --device=local-sync \
+  --executable_plugin=${PATH_TO_IREE_BUILD}/runtime/plugins/AMD-AIE-experimental/delegate/mlp_bf16_aie_delegate.so \
+  --module=opt.vmfb \
+  --function=mlp_invocation \
+  --input="1x8x768xbf16=2" \
+  --input="1x768x768xbf16=3"
 ```

--- a/experimental/delegate/README.md
+++ b/experimental/delegate/README.md
@@ -2,60 +2,98 @@
 
 ## Introduction
 
+### Purpose
+
 As an early demonstration of the ability to combine executable code for
 heterogenious devices, here we partition a simple model such that most of the
 model compiles for running on CPU, except for the model's matmul, which uses
 a pre-built AIE kernel.
 
+### Operation
+
 An AIE Delegate is a C/C++ function implementing an operator (or fusion of
 operators) by dispatching to a pre-built AIE kernel.  The implementation is
-built on the dynamically-linked custom dispatch method as described [here](https://github.com/daveliddell/iree/blob/main/samples/custom_dispatch/README.md).
-The AIE Delegate is embedded within a model compiled down to a non-AIE target,
-such as the CPU.
+built on the dynamically-linked custom dispatch method as described [here](https://github.com/iree-org/iree/blob/main/samples/custom_dispatch/README.md).
+The AIE Delegate is embedded within a model by using a PDL or Transform pass
+to rewrite the operator as an external function call.  The model is then
+compiled down to target the llvm-cpu backend.
+
+The external function is implemented in C++ in the file `mlp_aie_bf16_plugin.cpp`.
+The function makes XRT calls to load the AIE kernel, transfer the operand
+tensors to the AIE device, run the kernel, and transfer the result tensor
+from the device.
 
 In this first draft, several aspects of AIE Delegates are hard-coded for the
 specific use case of a 256x256x256 or a 8x768x768 matmul, selectable by
 enabling or disabling the macro `USE_OPT_KERNEL`.  As checked in, the macro
 is enabled, meaning that the 8x768x768 matmul is being used.
 
-In the `experimental/delegate` directory the `mlp.mlir` file is a test model
-containing such a matmul. `mlp_spec.mlir` contains a Transform dialect script
-to replace the matmul with a `func.call` to an external function for the matmul.
-`mlp_aie_bf16_plugin.cpp` implements the custom dispatch plugin and the matmul
-function.  It makes calls to XRT to load and communicate with the AIE matmul
-kernel.
+### Build Artifacts
 
-The build artifacts include `mlp_bf16_aie_delegate.so`, which is the custom
-dispatch plugin, an XCLBIN file to load into the AIE device, and a `insts.txt`
-file for the Ryzen AI controller.  These files must currently reside under the
-same directory as the `.so`.  At iree-amd-aie build time, these artifacts are
-downloaded from Azure.
+The build artifacts include `mlp_bf16_aie_delegate.so`, which is the "custom
+dispatch plugin" containing the external function, and kernel files for each
+kernel.  The files for a kernel include an XCLBIN file to load into the AIE
+device, and a `insts.txt` file for the Ryzen AI controller.  These files must
+currently reside under the same directory as the `.so`.  At iree-amd-aie build
+time, these artifacts are downloaded from Azure.
 
-## Running the Demo
+### Demos
 
-### Compile the model
+In the `experimental/delegate` directory there are three demos, as described
+below.
 
-First, log in to a Ryzen AI machine (aka IPU, Phoenix).
+#### Demo 1: Dynamic shape model with one matmul, Transform script
+
+In the first demo the `mlp.mlir` file is a test model containing a matmul
+whose inputs are dynamically shaped. `mlp_spec.mlir` contains a Transform
+dialect script to replace the matmul with a `func.call` to the external
+function for the matmul.  While the model itself is shape agnostic, this demo
+has been tested with only the 256x256x256 kernel.
+
+The model uses f32 tensors, whereas the kernel uses bf16 tensors, so the
+plugin function converts between the two types.
+
+#### Demo 2: Model with one 8x768x768 batch_matmul, PDL script
+
+In the second demo the `matmul.mlir` file is an OPT-like model with a single
+batch_matmul of the most common shape found in OPT.  `opt.pdl.mlir` is the
+PDL script that replaces the batch_matmul with the external function call.
+
+The model uses bf16 tensors, whereas the kernel has bf16 inputs but a f32
+result, so the plugin converts the f32 result to bf16.
+
+#### Demo 3: Model with two 8x768x768 batch_matmuls, PDL script
+
+The third demo is like the second, except that the model, `opt.mlir`,
+contains two batch_matmuls to demonstrate the delegate getting called
+multiple times in a model.  It uses the same PDL script, `opt.pdl.mlir`.
+
+## Running the Demos
+
+### Setting up the shell
+
+First, log in to a Ryzen AI machine (aka IPU, Phoenix), then do the following:
 
 ```
-# Set up the shell
 cd <workspace root (containing iree-build)>
 source /opt/xilinx/xrt/setup.sh
 export PATH=$PATH:$PWD/iree-build/tools:$PWD/llvm-build/bin
-
-# Compile the model
 cd iree-amd-aie/experimental/delegate
-iree-compile --iree-preprocessing-transform-spec-filename=mlp_spec.mlir mlp.mlir -o mlp.vmfb
-```
 
-### Run the model
-
-```
 # Circumvent xclbin security (no longer needed as of April 2024 XDNA driver)
 export XRT_HACK_UNSECURE_LOADING_XCLBIN=1
 
 # Set this to the location of the IREE build
 export PATH_TO_IREE_BUILD=../../../iree-build
+```
+
+### Compiling and running demo 1
+
+Don't forget to disable `USE_OPT_KERNEL` in `mlp_bf16_aie_delegate.so` and
+recompile IREE!
+
+```
+iree-compile --iree-preprocessing-transform-spec-filename=mlp_spec.mlir mlp.mlir -o mlp.vmfb
 
 iree-run-module --device=local-sync \
   --executable_plugin=${PATH_TO_IREE_BUILD}/runtime/plugins/AMD-AIE-experimental/delegate/mlp_bf16_aie_delegate.so \
@@ -65,44 +103,22 @@ iree-run-module --device=local-sync \
   --input="768x768xf32=3"
 ```
 
-## OPT Demo
-
-There is a second demo containing two matmuls to demonstrate a scenario closer
-to that of a real model, such as OPT.  Its transform script, `opt.pdl.mlir`,
-which uses PDL, specifically targets matmuls of 8x768x768 and transforms only
-those, as opposed to all matmuls as with `mlp_spec.mlir`.
-
-The usage of this demo is similar to the previous one, except that for now,
-supporting IREE code is temporarily provided in a private GitHub repo:
-https://github.com/daveliddell/iree/tree/nirvedhs-patch.  The iree-amd-aie
-branch that works with this temporary fix can be found at:
-https://github.com/daveliddell/iree-amd-aie/tree/dliddell-opt-matmul.  An
-effort is underway to upstream these changes.
-
-### Compile the model
-
-First, log in to a Ryzen AI machine (aka IPU, Phoenix).
+### Compiling and running demo 2
 
 ```
-# Set up the shell
-cd <workspace root (containing iree-build)>
-source /opt/xilinx/xrt/setup.sh
-export PATH=$PATH:$PWD/iree-build/tools:$PWD/llvm-build/bin
-
-# Compile the model
-cd iree-amd-aie/experimental/delegate
-iree-opt --pass-pipeline="builtin.module(iree-preprocessing-apply-pdl-patterns{patterns-file=opt.pdl.mlir}, cse)" opt.mlir -o opt.sub.mlir
-iree-compile opt.sub.mlir -o opt.vmfb --iree-scheduling-optimize-bindings=false
+iree-compile --iree-preprocessing-pdl-spec-filename=opt.pdl.mlir matmul.mlir -o matmul.vmfb
+ 
+iree-run-module --device=local-sync \
+  --executable_plugin=${PATH_TO_IREE_BUILD}/runtime/plugins/AMD-AIE-experimental/delegate/mlp_bf16_aie_delegate.so \
+  --module=matmul.vmfb \
+  --function=mlp_invocation \
+  --input="1x8x768xbf16=2" \
+  --input="1x768x768xbf16=3"
 ```
-
-### Run the model
+### Compililng and running demo 3
 
 ```
-# Circumvent xclbin security (no longer needed as of April 2024 XDNA driver)
-export XRT_HACK_UNSECURE_LOADING_XCLBIN=1
-
-# Set this to the location of the IREE build
-export PATH_TO_IREE_BUILD=../../../iree-build
+iree-compile --iree-preprocessing-pdl-spec-filename=opt.pdl.mlir opt.mlir -o opt.vmfb
 
 iree-run-module --device=local-sync \
   --executable_plugin=${PATH_TO_IREE_BUILD}/runtime/plugins/AMD-AIE-experimental/delegate/mlp_bf16_aie_delegate.so \

--- a/experimental/delegate/kernels/CMakeLists.txt
+++ b/experimental/delegate/kernels/CMakeLists.txt
@@ -15,6 +15,8 @@ message(STATUS "Processing AIE Delegate Kernels")
 # List of all kernels stored in Azure (without file extension)
 set(AIE_DELEGATE_KERNELS
     "matmul/matmul-bf16-256x256x256-v1"
+    "matmul/matmul-bf16-8x768x768-v1"  # OPT ref vec matmul (doesn't work)
+    "matmul/matmul-bf16-f32-8x768x768-v1"  # for OPT, Erwei's 4x4 vec matmul
 )
 
 # List of all kernel file extensions

--- a/experimental/delegate/matmul.mlir
+++ b/experimental/delegate/matmul.mlir
@@ -1,7 +1,5 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(iree-preprocessing-apply-pdl-patterns{patterns-file=%p/opt.pdl.mlir}, cse)" %s | FileCheck %s
 
-// TODO: Add filecheck checks
-
 #x86_64_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 32 : index,
@@ -17,6 +15,17 @@
 ]>
 
 module @example attributes {hal.device.targets = [#cpu_target]} {
+// CHECK-LABEL: module @example
+
+// Check that the stream executable uses the proper name format
+// CHECK-DAG: stream.executable private @mlp_external_bf16_bf16_bf16_i32_i32_i32_executable
+
+// Check that the external function is declared with the right dtypes
+// CHECK-DAG: func.func private @mlp_external(memref<bf16>, index, memref<bf16>, index, memref<bf16>, index, i32, i32, i32)
+
+// Check that the call to the external function exists and is called with the right types
+// CHECK-DAG: call @mlp_external({{.+}}) : (memref<bf16>, index, memref<bf16>, index, memref<bf16>, index, i32, i32, i32) -> ()
+
 
   func.func @mlp_invocation(%lhs: tensor<1x8x768xbf16>,
                             %rhs: tensor<1x768x768xbf16>) -> (tensor<1x8x768xbf16>) {
@@ -25,6 +34,10 @@ module @example attributes {hal.device.targets = [#cpu_target]} {
     %44 = tensor.empty() : tensor<1x8x768xbf16>
     %64 = linalg.fill ins(%cst_206 : bf16) outs(%44 : tensor<1x8x768xbf16>) -> tensor<1x8x768xbf16>
     %65 = linalg.batch_matmul ins(%lhs, %rhs : tensor<1x8x768xbf16>, tensor<1x768x768xbf16>) outs(%64 : tensor<1x8x768xbf16>) -> tensor<1x8x768xbf16>
+
+// Check that the batch_matmul has been replaced with a call to the external function with the right types
+// CHECK-DAG: flow.dispatch @mlp_external_bf16_bf16_bf16_i32_i32_i32_executable::@mlp_external_entry_point({{.+}}) : (tensor<1x8x768xbf16>, tensor<1x768x768xbf16>, i32, i32, i32) -> tensor<1x8x768xbf16>
+
     return %65 : tensor<1x8x768xbf16>
   }
 }  // module

--- a/experimental/delegate/matmul.mlir
+++ b/experimental/delegate/matmul.mlir
@@ -18,13 +18,15 @@ module @example attributes {hal.device.targets = [#cpu_target]} {
 // CHECK-LABEL: module @example
 
 // Check that the stream executable uses the proper name format
-// CHECK-DAG: stream.executable private @mlp_external_bf16_bf16_bf16_i32_i32_i32_executable
+// CHECK: stream.executable private @mlp_external_bf16_bf16_bf16_i32_i32_i32_executable {
 
 // Check that the external function is declared with the right dtypes
-// CHECK-DAG: func.func private @mlp_external(memref<bf16>, index, memref<bf16>, index, memref<bf16>, index, i32, i32, i32)
+// CHECK: builtin.module {
+// CHECK: func.func private @mlp_external(memref<bf16>, index, memref<bf16>, index, memref<bf16>, index, i32, i32, i32)
 
 // Check that the call to the external function exists and is called with the right types
-// CHECK-DAG: call @mlp_external({{.+}}) : (memref<bf16>, index, memref<bf16>, index, memref<bf16>, index, i32, i32, i32) -> ()
+// CHECK: func.func @mlp_external_entry_point({{.+}}) {
+// CHECK: call @mlp_external({{.+}}) : (memref<bf16>, index, memref<bf16>, index, memref<bf16>, index, i32, i32, i32) -> ()
 
 
   func.func @mlp_invocation(%lhs: tensor<1x8x768xbf16>,
@@ -36,7 +38,8 @@ module @example attributes {hal.device.targets = [#cpu_target]} {
     %65 = linalg.batch_matmul ins(%lhs, %rhs : tensor<1x8x768xbf16>, tensor<1x768x768xbf16>) outs(%64 : tensor<1x8x768xbf16>) -> tensor<1x8x768xbf16>
 
 // Check that the batch_matmul has been replaced with a call to the external function with the right types
-// CHECK-DAG: flow.dispatch @mlp_external_bf16_bf16_bf16_i32_i32_i32_executable::@mlp_external_entry_point({{.+}}) : (tensor<1x8x768xbf16>, tensor<1x768x768xbf16>, i32, i32, i32) -> tensor<1x8x768xbf16>
+// CHECK: func.func @mlp_invocation({{.+}}) -> {{.+}} {
+// CHECK: flow.dispatch @mlp_external_bf16_bf16_bf16_i32_i32_i32_executable::@mlp_external_entry_point({{.+}}) : (tensor<1x8x768xbf16>, tensor<1x768x768xbf16>, i32, i32, i32) -> tensor<1x8x768xbf16>
 
     return %65 : tensor<1x8x768xbf16>
   }

--- a/experimental/delegate/matmul.mlir
+++ b/experimental/delegate/matmul.mlir
@@ -1,0 +1,30 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-preprocessing-apply-pdl-patterns{patterns-file=%p/opt.pdl.mlir}, cse)" %s | FileCheck %s
+
+// TODO: Add filecheck checks
+
+#x86_64_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  native_vector_size = 32 : index,
+  target_triple = "x86_64-none-elf"
+}>
+
+// The target devices that the program will run on. We can compile and run with
+// multiple targets, but this example is maintaining an implicit requirement
+// that the custom kernel being spliced in is supported by the target device,
+// hence we only support llvm-cpu here.
+#cpu_target = #hal.device.target<"llvm-cpu", [
+  #x86_64_target
+]>
+
+module @example attributes {hal.device.targets = [#cpu_target]} {
+
+  func.func @mlp_invocation(%lhs: tensor<1x8x768xbf16>,
+                            %rhs: tensor<1x768x768xbf16>) -> (tensor<1x8x768xbf16>) {
+    %cst_189 = arith.constant dense<512.0> : tensor<768xbf16>
+    %cst_206 = arith.constant 0.000000e+00 : bf16
+    %44 = tensor.empty() : tensor<1x8x768xbf16>
+    %64 = linalg.fill ins(%cst_206 : bf16) outs(%44 : tensor<1x8x768xbf16>) -> tensor<1x8x768xbf16>
+    %65 = linalg.batch_matmul ins(%lhs, %rhs : tensor<1x8x768xbf16>, tensor<1x768x768xbf16>) outs(%64 : tensor<1x8x768xbf16>) -> tensor<1x8x768xbf16>
+    return %65 : tensor<1x8x768xbf16>
+  }
+}  // module

--- a/experimental/delegate/mlp_aie_bf16_plugin.cpp
+++ b/experimental/delegate/mlp_aie_bf16_plugin.cpp
@@ -102,6 +102,10 @@ using ModelLhsDType = bfloat16_t;
 using ModelRhsDType = bfloat16_t;
 using ModelReturnDType = bfloat16_t;
 
+// Set to 1 if the kernel requires a pre-initialized buffer to be loaded
+// into the kernel before the kernel runs
+#define KERNEL_REQUIRES_RESULT_PRELOAD 0
+
 //-----------------------------------------------------------------------------
 
 #else
@@ -125,6 +129,10 @@ using C_DATATYPE = float;
 using ModelLhsDType = float;
 using ModelRhsDType = float;
 using ModelReturnDType = float;
+
+// Set to 1 if the kernel requires a pre-initialized buffer to be loaded
+// into the kernel before the kernel runs
+#define KERNEL_REQUIRES_RESULT_PRELOAD 0
 
 #endif
 
@@ -633,8 +641,10 @@ int aie_matmul(Params *params) {
     xrtState->lhsBinder->copyModelToXrt();
     xrtState->rhsBinder->copyModelToXrt();
 
-    // copy output to XRT BO and sync it (is this really necessary?)
+    // copy output to XRT BO and sync it, if the kernel requires it
+#if KERNEL_REQUIRES_RESULT_PRELOAD
     xrtState->resultBinder->copyModelToXrt();
+#endif
 
     // execute the kernel on NPU
     auto run = xrtState->kernel(xrtState->boInstr, instrSize,

--- a/experimental/delegate/opt.mlir
+++ b/experimental/delegate/opt.mlir
@@ -1,0 +1,47 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-preprocessing-apply-pdl-patterns{patterns-file=%p/opt.pdl.mlir}, cse)" %s | FileCheck %s
+
+// TODO: Add filecheck checks
+
+#x86_64_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  native_vector_size = 32 : index,
+  target_triple = "x86_64-none-elf"
+}>
+
+// The target devices that the program will run on. We can compile and run with
+// multiple targets, but this example is maintaining an implicit requirement
+// that the custom kernel being spliced in is supported by the target device,
+// hence we only support llvm-cpu here.
+#cpu_target = #hal.device.target<"llvm-cpu", [
+  #x86_64_target
+]>
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+#map10 = affine_map<(d0, d1, d2) -> (0, d1, d2)>
+#map11 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+#map14 = affine_map<(d0, d1, d2) -> (d2)>
+module @example attributes {hal.device.targets = [#cpu_target]} {
+
+  func.func @mlp_invocation(%lhs: tensor<1x8x768xbf16>,
+                            %rhs: tensor<1x768x768xbf16>) -> (tensor<1x8x768xbf16>) {
+    %cst_189 = arith.constant dense<512.0> : tensor<768xbf16>
+    %cst_206 = arith.constant 0.000000e+00 : bf16
+    %44 = tensor.empty() : tensor<1x8x768xbf16>
+    %64 = linalg.fill ins(%cst_206 : bf16) outs(%44 : tensor<1x8x768xbf16>) -> tensor<1x8x768xbf16>
+    %65 = linalg.batch_matmul ins(%lhs, %rhs : tensor<1x8x768xbf16>, tensor<1x768x768xbf16>) outs(%64 : tensor<1x8x768xbf16>) -> tensor<1x8x768xbf16>
+    %66 = linalg.generic {indexing_maps = [#map14, #map10, #map11], iterator_types = ["parallel", "parallel", "parallel"]} ins(%cst_189, %65 : tensor<768xbf16>, tensor<1x8x768xbf16>) outs(%44 : tensor<1x8x768xbf16>) {
+    ^bb0(%in: bf16, %in_372: bf16, %out: bf16):
+      %884 = arith.addf %in, %in_372 : bf16
+      linalg.yield %884 : bf16
+    } -> tensor<1x8x768xbf16>
+    
+    %cst_191 = arith.constant dense<1.31072e+05> : tensor<768xbf16>
+    %69 = linalg.batch_matmul ins(%66, %rhs : tensor<1x8x768xbf16>, tensor<1x768x768xbf16>) outs(%64 : tensor<1x8x768xbf16>) -> tensor<1x8x768xbf16>
+    %70 = linalg.generic {indexing_maps = [#map14, #map10, #map11], iterator_types = ["parallel", "parallel", "parallel"]} ins(%cst_191, %69 : tensor<768xbf16>, tensor<1x8x768xbf16>) outs(%44 : tensor<1x8x768xbf16>) {
+    ^bb0(%in: bf16, %in_372: bf16, %out: bf16):
+      %884 = arith.addf %in, %in_372 : bf16
+      linalg.yield %884 : bf16
+    } -> tensor<1x8x768xbf16>
+    return %70 : tensor<1x8x768xbf16>
+  }
+}  // module

--- a/experimental/delegate/opt.mlir
+++ b/experimental/delegate/opt.mlir
@@ -1,7 +1,5 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(iree-preprocessing-apply-pdl-patterns{patterns-file=%p/opt.pdl.mlir}, cse)" %s | FileCheck %s
 
-// TODO: Add filecheck checks
-
 #x86_64_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 32 : index,
@@ -21,6 +19,18 @@
 #map11 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 #map14 = affine_map<(d0, d1, d2) -> (d2)>
 module @example attributes {hal.device.targets = [#cpu_target]} {
+// CHECK-LABEL: module @example
+
+// Check that the stream executable uses the proper name format
+// CHECK-DAG: stream.executable private @mlp_external_bf16_bf16_bf16_i32_i32_i32_executable
+
+// Check that the external function is declared with the right dtypes
+// CHECK-DAG: func.func private @mlp_external(memref<bf16>, index, memref<bf16>, index, memref<bf16>, index, i32, i32, i32)
+
+// Check that the call to the external function exists and is called with the right types
+// CHECK-DAG: call @mlp_external({{.+}}) : (memref<bf16>, index, memref<bf16>, index, memref<bf16>, index, i32, i32, i32) -> ()
+
+
 
   func.func @mlp_invocation(%lhs: tensor<1x8x768xbf16>,
                             %rhs: tensor<1x768x768xbf16>) -> (tensor<1x8x768xbf16>) {
@@ -29,6 +39,10 @@ module @example attributes {hal.device.targets = [#cpu_target]} {
     %44 = tensor.empty() : tensor<1x8x768xbf16>
     %64 = linalg.fill ins(%cst_206 : bf16) outs(%44 : tensor<1x8x768xbf16>) -> tensor<1x8x768xbf16>
     %65 = linalg.batch_matmul ins(%lhs, %rhs : tensor<1x8x768xbf16>, tensor<1x768x768xbf16>) outs(%64 : tensor<1x8x768xbf16>) -> tensor<1x8x768xbf16>
+
+// Check that the batch_matmul has been replaced with a call to the external function with the right types
+// CHECK-DAG: flow.dispatch @mlp_external_bf16_bf16_bf16_i32_i32_i32_executable::@mlp_external_entry_point({{.+}}) : (tensor<1x8x768xbf16>, tensor<1x768x768xbf16>, i32, i32, i32) -> tensor<1x8x768xbf16>
+
     %66 = linalg.generic {indexing_maps = [#map14, #map10, #map11], iterator_types = ["parallel", "parallel", "parallel"]} ins(%cst_189, %65 : tensor<768xbf16>, tensor<1x8x768xbf16>) outs(%44 : tensor<1x8x768xbf16>) {
     ^bb0(%in: bf16, %in_372: bf16, %out: bf16):
       %884 = arith.addf %in, %in_372 : bf16
@@ -37,6 +51,10 @@ module @example attributes {hal.device.targets = [#cpu_target]} {
     
     %cst_191 = arith.constant dense<1.31072e+05> : tensor<768xbf16>
     %69 = linalg.batch_matmul ins(%66, %rhs : tensor<1x8x768xbf16>, tensor<1x768x768xbf16>) outs(%64 : tensor<1x8x768xbf16>) -> tensor<1x8x768xbf16>
+
+// Check that the second batch_matmul has been replaced with a call to the external function
+// CHECK-DAG: flow.dispatch @mlp_external_bf16_bf16_bf16_i32_i32_i32_executable::@mlp_external_entry_point({{.+}}) : (tensor<1x8x768xbf16>, tensor<1x768x768xbf16>, i32, i32, i32) -> tensor<1x8x768xbf16>
+
     %70 = linalg.generic {indexing_maps = [#map14, #map10, #map11], iterator_types = ["parallel", "parallel", "parallel"]} ins(%cst_191, %69 : tensor<768xbf16>, tensor<1x8x768xbf16>) outs(%44 : tensor<1x8x768xbf16>) {
     ^bb0(%in: bf16, %in_372: bf16, %out: bf16):
       %884 = arith.addf %in, %in_372 : bf16

--- a/experimental/delegate/opt.pdl.mlir
+++ b/experimental/delegate/opt.pdl.mlir
@@ -1,0 +1,118 @@
+// PDL pattern spec to match an MLP of shape 8x768x768 and offload to an
+// external function
+//
+// ```
+// void mlp_external(void *params, void *context, void *reserved)
+// ```
+//
+// which is the expected signature of an external function implemented
+// provided by a system plugin. See
+// samples/custom_dispatch/cpu/plugin/system_plugin.c for an example.
+//
+// The `params` is the following struct
+//
+// ```
+// using bfloat16_t = unsigned short;
+//
+// struct mlp_params_t {
+//   const bfloat16_t *restrict lhs;
+//   size_t lhs_offset;
+//   const bfloat16_t *restrict rhs;
+//   size_t rhs_offset;
+//   bfloat16_t *restrict result;
+//   size_t result_offset;
+//   int32_t M;
+//   int32_t N;
+//   int32_t K;
+// };
+// ```
+//
+// In MLIR this corresponds to the function
+//
+// ```
+// func.func private @mlp_external(%lhs : memref<bf16>, lhs_offset : index,
+//   %rhs : memref<bf16>, %rhs_offset : index, %result : memref<bf16>,
+//   %result_offset : index, %M : i32, %N : i32, %K : i32)
+// ```
+//
+// Note: In the above struct a `pointer, offset` pair represents a buffer
+// passed into the external function. So any access to `lhs`, `rhs` and
+// `result` is valid only if accessed as `lhs[lhs_offset + ...]`,
+// `rhs[rhs_offset + ]` and `result[result_offset + ...]`.
+pdl.pattern @mlp : benefit(1) {
+
+  // PDL matcher to match the MLP computation. This pattern is expected to
+  // match
+  //
+  // ```
+  // linalg.batch_matmul ins(%lhs, %rhs : tensor<1x8x768xbf16>,
+  //   tensor<1x768x768xbf16>) outs(%64 : tensor<1x8x768xbf16>) ->
+  //   tensor<1x8x768xbf16>
+  // ```
+  %lhs = pdl.operand
+  %rhs = pdl.operand
+  %empty = pdl.operand
+  
+  %lhs_type = pdl.type : tensor<1x8x768xbf16>
+  %rhs_type = pdl.type : tensor<1x768x768xbf16>
+  %matmul_type = pdl.type : tensor<1x8x768xbf16>
+  %fixed_M = pdl.attribute = 8 : i32
+  %fixed_N = pdl.attribute = 768 : i32
+  %fixed_K = pdl.attribute = 768 : i32
+  %one_attribute = pdl.attribute = 1 : i32
+
+  %index_type = pdl.type : index
+  %zero_val_bf16 = pdl.attribute = 0.0 : bf16
+  %bf16_type = pdl.type : bf16
+
+
+  %zero_bf16_op = pdl.operation "arith.constant" {"value" = %zero_val_bf16} -> (%bf16_type : !pdl.type)
+  %zero_bf16 = pdl.result 0 of %zero_bf16_op
+
+  
+  %fill_op = pdl.operation "linalg.fill" (%zero_bf16, %empty : !pdl.value, !pdl.value) -> (%matmul_type : !pdl.type)
+  %fill = pdl.result 0 of %fill_op
+  %matmul = pdl.operation "linalg.batch_matmul" (%lhs, %rhs, %fill : !pdl.value, !pdl.value, !pdl.value) -> (%matmul_type : !pdl.type)
+  
+  pdl.rewrite %matmul {
+    %i32_type = pdl.type : i32
+    %m_op = pdl.operation "arith.constant" {"value" = %fixed_M} -> (%i32_type : !pdl.type)
+    %m = pdl.result 0 of %m_op
+    %n_op = pdl.operation "arith.constant" {"value" = %fixed_N} -> (%i32_type : !pdl.type)
+    %n = pdl.result 0 of %n_op
+    %k_op = pdl.operation "arith.constant" {"value" = %fixed_K} -> (%i32_type : !pdl.type)
+    %k = pdl.result 0 of %n_op
+    %one_op = pdl.operation "arith.constant" {"value" = %one_attribute} -> (%i32_type : !pdl.type)
+    %one = pdl.result 0 of %one_op
+
+    // %replaced_values_dims = pdl.range %one, %m, %n : !pdl.value, !pdl.value, !pdl.value
+    %replaced_values_dims = pdl.range : !pdl.range<value>
+    %input_values = pdl.range %lhs, %rhs : !pdl.value, !pdl.value
+    %replaced_value = pdl.result 0 of %matmul
+    %replaced_values = pdl.range %replaced_value : !pdl.value
+    %other_operands = pdl.range %m, %n, %k : !pdl.value, !pdl.value, !pdl.value
+
+    // The `rewriteAsFlowDispatch` is a rewrite function that allows
+    // converting the matched dag into a call to the external function call
+    // provided by a system plugin. The rewrite method expects the following
+    // arguments
+    // - the root of the matched DAG. This op will be erased after the call.
+    // - `fn_name` the name of the function that is provided externally
+    //   (using a plugin).
+    // - `input_values` are values that are captures as the part of the match
+    //   and are inputs to the match.
+    // - `replaced_values` are the values that are captured as part of the
+    //   match and are replaced by the `flow.dispatch`. The `flow.dispatch`
+    //   returns as many values as `replaced_values` (and of same type).
+    // - `replaced_values_dims` are the values for the dynamic dimensions of
+    //   all the `tensor` values in `replaced_values`. For matches that could
+    //   be static or dynamic, it should be assumed that the shape is dynamic
+    //   and the value needs to be passed to the rewrite function.
+    // - `other_operands` same as `input_values`, but kept separate to allow
+    //   flexibility of where the results are passed through the ABI boundary.
+    %fn_name = pdl.attribute = "mlp_external"
+    pdl.apply_native_rewrite "rewriteAsFlowDispatch"(
+        %matmul, %fn_name, %input_values, %replaced_values, %replaced_values_dims, %other_operands
+        : !pdl.operation, !pdl.attribute, !pdl.range<value>, !pdl.range<value>, !pdl.range<value>, !pdl.range<value>)
+  }
+}


### PR DESCRIPTION
Added several enhancements to AIE delegates:

- Now using a 4x4 vector matmul of shape 8x768x768, stored in Azure
- dtypes of model and AIE kernel inputs and outputs now defined in one place
- All tensor conversion and copying code templatized to automate those functions and use minimal implementations when possible
- New PDL transform to convert 8x768x768 matmul in linalg MLIR to external func call
- prototype code for direct XRT buffer use (disabled until HAL buffers are allocated with XRT)
- copy from result buffer to kernel now switchable by macro (not needed for both kernels we're currently using)
