### PR TITLE
Add pass to create a single AIE workgroup

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEAttrs.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEAttrs.td
@@ -21,6 +21,15 @@ def AMDAIE_CopyOpOperateOn: I32EnumAttr<"CopyOpOperateOn",
 {
 }
 
+def DMAChannelDir: I32EnumAttr<"DMAChannelDir",
+  "DMA Channel direction",
+  [
+    I32EnumAttrCase<"S2MM", 0>,
+    I32EnumAttrCase<"MM2S", 1>
+  ]> {
+  let cppNamespace = "mlir::iree_compiler::AMDAIE";
+}
+
 def AMDAIE_MemSpace_Global : I32EnumAttrCase<"Global", 0>;
 def AMDAIE_MemSpace_Shared : I32EnumAttrCase<"Shared", 1>;
 def AMDAIE_MemSpace_Local : I32EnumAttrCase<"Local", 2>;

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -158,6 +158,145 @@ def AMDAIE_WorkgroupOp : AMDAIE_Op<"workgroup",
 }
 
 //===----------------------------------------------------------------------===//
+// IREE AMDAIE Npu Ops
+//===----------------------------------------------------------------------===//
+
+def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd",
+    [AttrSizedOperandSegments, DoublyStridedOpInterface]>,
+    Results<(outs Index)> {
+  let summary = "The Npu uController's dma operator";
+  let description = [{
+    The Npu DMA operation represents a strided copy operation with an unlimited
+    number of dimenions, executed by the Npu uController. This operation refers
+    to a `CircularDmaCpyNdOp`, which will contain the necessary information
+    about the source and target logical object fifos of the operation and which
+    will instantiate the DMA connection.
+
+    The representation supports a partially-static representation of both the source and
+    target `offsets`, `sizes` and `strides`. A special sentinel value ShapedType::kDynamic
+    encodes that the corresponding entry has a dynamic value.
+
+    Example:
+
+    ```mlir
+    %1 = amdaie.circular_dma_cpy_nd(%1[] [] [], %0[] [] []) : (!amdaie.logicalobjectfifo<memref<32x64xi32, 1>>, !amdaie.logicalobjectfifo<memref<32x1024xi32>>)
+    ...
+    amdaie.controlcode {
+      %2 = amdaie.npu.dma_cpy_nd %1([] [] [], [%c0, %c0] [%c32, %c64] [%c1024, %c1])
+      ...
+    }
+    ```
+  }];
+
+  let arguments = (
+    ins Index:$dma,
+        Variadic<Index>:$target_offsets,
+        Variadic<Index>:$target_sizes,
+        Variadic<Index>:$target_strides,
+        DenseI64ArrayAttr:$target_static_offsets,
+        DenseI64ArrayAttr:$target_static_sizes,
+        DenseI64ArrayAttr:$target_static_strides,
+        Variadic<Index>:$source_offsets,
+        Variadic<Index>:$source_sizes,
+        Variadic<Index>:$source_strides,
+        DenseI64ArrayAttr:$source_static_offsets,
+        DenseI64ArrayAttr:$source_static_sizes,
+        DenseI64ArrayAttr:$source_static_strides
+  );
+
+  let assemblyFormat = [{
+    $dma
+    `(`
+    custom<DynamicIndexList>($target_offsets, $target_static_offsets)
+    custom<DynamicIndexList>($target_sizes, $target_static_sizes)
+    custom<DynamicIndexList>($target_strides, $target_static_strides)
+    `,`
+    custom<DynamicIndexList>($source_offsets, $source_static_offsets)
+    custom<DynamicIndexList>($source_sizes, $source_static_sizes)
+    custom<DynamicIndexList>($source_strides, $source_static_strides)
+    `)`
+    attr-dict
+  }];
+
+  let builders = [
+    // Build a NpuDmaCpyNdOp with mixed static and dynamic entries.
+    OpBuilder<(ins "Value":$dma, "ArrayRef<OpFoldResult>":$target_offsets,
+      "ArrayRef<OpFoldResult>":$target_sizes,
+      "ArrayRef<OpFoldResult>":$target_strides,
+      "ArrayRef<OpFoldResult>":$source_offsets,
+      "ArrayRef<OpFoldResult>":$source_sizes,
+      "ArrayRef<OpFoldResult>":$source_strides)>,
+    // Build a NpuDmaCpyNdOp with static entries.
+    OpBuilder<(ins "Value":$dma, "ArrayRef<int64_t>":$target_offsets,
+      "ArrayRef<int64_t>":$target_sizes, "ArrayRef<int64_t>":$target_strides,
+      "ArrayRef<int64_t>":$source_offsets, "ArrayRef<int64_t>":$source_sizes,
+      "ArrayRef<int64_t>":$source_strides)>,
+    // Build a NpuDmaCpyNdOp with dynamic entries.
+    OpBuilder<(ins "Value":$dma, "ValueRange":$target_offsets,
+      "ValueRange":$target_sizes, "ValueRange":$target_strides,
+      "ValueRange":$source_offsets, "ValueRange":$source_sizes,
+      "ValueRange":$source_strides)>
+  ];
+
+  let extraClassDeclaration = [{
+    // Return the input circular dma copy operation.
+    CircularDmaCpyNdOp getDmaCpyNdOp() {
+      return dyn_cast<CircularDmaCpyNdOp>(getDma().getDefiningOp());
+    }
+    // Check whether this operation has addressing on the target side.
+    bool hasTargetAddressing() { 
+      return !getTargetMixedOffsets().empty() || !getTargetMixedSizes().empty()
+        || !getTargetMixedStrides().empty();
+    }
+    // Check whether this operation has addressing on the target side.
+    bool hasSourceAddressing() {
+      return !getSourceMixedOffsets().empty() || !getSourceMixedSizes().empty() 
+        || !getSourceMixedStrides().empty();
+    }
+    // Check whether this dma operation has a wait user.
+    bool hasDmaWaitOpUser();
+  }];
+}
+
+def AMDAIE_NpuDmaWaitOp: AMDAIE_Op<"npu.dma_wait", []> {
+  let summary = "Wait for the Npu DMA operation to complete.";
+  let description = [{
+    The wait operation will block on the referenced DMA operation to complete
+    execution on provided `direction`. The `S2MM` direction will block on the
+    destination side of the dma operation, ensuring complete execution. The
+    `MM2S` direction will block on the source side of the dma operation,
+    ensuring that the DMA has successfully started execution, but not
+    guaranteeing that all data has been received on the destination side.
+
+    Example:
+
+    ```mlir
+    %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [%c0, %c0] [%c32, %c64] [%c1024, %c1])
+    amdaie.npu.dma_wait(%2, MM2S)
+    ```
+
+    Here, the `dma_wait` operation will wait until the referenced Npu DMA
+    operation has started execution.
+  }];
+
+  let arguments = (
+    ins Index:$dma,
+        DMAChannelDir:$direction
+  );
+
+  let assemblyFormat = [{
+    `(` $dma `,` $direction `)`  attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    // Return the Npu DMA operation argument.
+    NpuDmaCpyNdOp getDmaOp() { 
+      return dyn_cast<NpuDmaCpyNdOp>(getDma().getDefiningOp());
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // IREE AMDAIE LogicalObjectFifo Ops
 //===----------------------------------------------------------------------===//
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/invalid.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/invalid.mlir
@@ -325,6 +325,168 @@ func.func @dma_cpy_nd_negative_source_stride(%arg0: !amdaie.logicalobjectfifo<me
 
 // -----
 
+func.func @npu_dma_cpy_nd_invalid_src_offsets() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c128 = arith.constant 128 : index
+  %alloc = memref.alloc() : memref<1x1x8x16xi32, 1>
+  %0 = amdaie.logicalobjectfifo.from_memref %alloc, {} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+  %alloc_0 = memref.alloc() : memref<8x16xi32, 1>
+  %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+  %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  // expected-error @+1 {{source sizes should have same number of dimensions as source offsets}}
+  %3 = amdaie.npu.dma_cpy_nd %2([%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16, %c1], [%c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c16, %c16, %c1])
+  return
+}
+
+// -----
+
+func.func @npu_dma_cpy_nd_invalid_src_sizes() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c128 = arith.constant 128 : index
+  %alloc = memref.alloc() : memref<1x1x8x16xi32, 1>
+  %0 = amdaie.logicalobjectfifo.from_memref %alloc, {} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+  %alloc_0 = memref.alloc() : memref<8x16xi32, 1>
+  %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+  %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  // expected-error @+1 {{source sizes should have same number of dimensions as source offsets}}
+  %3 = amdaie.npu.dma_cpy_nd %2([%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16, %c1], [%c0, %c0, %c0, %c0] [%c1, %c8, %c16] [%c128, %c16, %c16, %c1])
+  return
+}
+
+// -----
+
+func.func @npu_dma_cpy_nd_invalid_src_strides() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c128 = arith.constant 128 : index
+  %alloc = memref.alloc() : memref<1x1x8x16xi32, 1>
+  %0 = amdaie.logicalobjectfifo.from_memref %alloc, {} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+  %alloc_0 = memref.alloc() : memref<8x16xi32, 1>
+  %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+  %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  // expected-error @+1 {{source strides should have same number of dimensions as source offsets}}
+  %3 = amdaie.npu.dma_cpy_nd %2([%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16, %c1], [%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c16, %c16])
+  return
+}
+
+// -----
+
+func.func @npu_dma_cpy_nd_invalid_target_offsets() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c128 = arith.constant 128 : index
+  %alloc = memref.alloc() : memref<1x1x8x16xi32, 1>
+  %0 = amdaie.logicalobjectfifo.from_memref %alloc, {} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+  %alloc_0 = memref.alloc() : memref<8x16xi32, 1>
+  %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+  %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  // expected-error @+1 {{target sizes should have same number of dimensions as target offsets}}
+  %3 = amdaie.npu.dma_cpy_nd %2([%c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16, %c1], [%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c16, %c16, %c1])
+  return
+}
+
+// -----
+
+func.func @npu_dma_cpy_nd_invalid_target_sizes() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c128 = arith.constant 128 : index
+  %alloc = memref.alloc() : memref<1x1x8x16xi32, 1>
+  %0 = amdaie.logicalobjectfifo.from_memref %alloc, {} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+  %alloc_0 = memref.alloc() : memref<8x16xi32, 1>
+  %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+  %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  // expected-error @+1 {{target sizes should have same number of dimensions as target offsets}}
+  %3 = amdaie.npu.dma_cpy_nd %2([%c0, %c0, %c0, %c0] [%c1, %c8, %c16] [%c128, %c128, %c16, %c1], [%c0, %c0, %c0, %c0] [%c1, %c8, %c16] [%c128, %c16, %c16, %c1])
+  return
+}
+
+// -----
+
+func.func @npu_dma_cpy_nd_invalid_target_strides() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c128 = arith.constant 128 : index
+  %alloc = memref.alloc() : memref<1x1x8x16xi32, 1>
+  %0 = amdaie.logicalobjectfifo.from_memref %alloc, {} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+  %alloc_0 = memref.alloc() : memref<8x16xi32, 1>
+  %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+  %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  // expected-error @+1 {{target strides should have same number of dimensions as target offsets}}
+  %3 = amdaie.npu.dma_cpy_nd %2([%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16], [%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c16, %c16, %c1])
+  return
+}
+
+// -----
+
+func.func @npu_dma_cpy_nd_negative_target_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+  %0 = amdaie.dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  // expected-error @+1 {{expected target offsets to be non-negative, but got -1}}
+  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, -1] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
+  return
+}
+
+// -----
+
+func.func @npu_dma_cpy_nd_negative_target_size(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+  %0 = amdaie.dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  // expected-error @+1 {{expected target sizes to be non-negative, but got -16}}
+  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, -16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
+  return
+}
+
+// -----
+
+func.func @npu_dma_cpy_nd_negative_target_stride(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+  %0 = amdaie.dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  // expected-error @+1 {{expected target strides to be non-negative, but got -16}}
+  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, -16, 1], [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
+  return
+}
+
+// -----
+
+func.func @npu_dma_cpy_nd_negative_source_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+  %0 = amdaie.dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  // expected-error @+1 {{expected source offsets to be non-negative, but got -1}}
+  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, -1] [1, 1, 8, 16] [128, 16, 16, 1])
+  return
+}
+
+// -----
+
+func.func @npu_dma_cpy_nd_negative_source_size(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+  %0 = amdaie.dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  // expected-error @+1 {{expected source sizes to be non-negative, but got -8}}
+  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 1, -8, 16] [128, 16, 16, 1])
+  return
+}
+
+// -----
+
+func.func @npu_dma_cpy_nd_negative_source_stride(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+  %0 = amdaie.dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  // expected-error @+1 {{expected source strides to be non-negative, but got -16}}
+  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 1, 8, 16] [128, -16, 16, 1])
+  return
+}
+
+// -----
+
 func.func @workgroup_no_terminator() {
   // expected-note @+2 {{in custom textual format, the absence of terminator implies 'amdaie.controlcode'}}
   // expected-error @+1 {{'amdaie.workgroup' op expects regions to end with 'amdaie.controlcode', found 'amdaie.end}}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/roundtrip.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/roundtrip.mlir
@@ -138,6 +138,54 @@ func.func @logicalobjectfifo_produce(%arg0: !amdaie.logicalobjectfifo<memref<1x1
 
 // -----
 
+// CHECK-LABEL: func.func @npu_dma_cpy_nd
+// CHECK:       %[[DMA0:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK:       %{{.*}} = amdaie.npu.dma_cpy_nd
+// CHECK-SAME:  [%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16, %c1]
+// CHECK-SAME:  [%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c16, %c16, %c1]
+func.func @npu_dma_cpy_nd(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c128 = arith.constant 128 : index
+  %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  %1 = amdaie.npu.dma_cpy_nd %0([%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16, %c1], [%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c16, %c16, %c1])
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @npu_dma_cpy_nd_inline_literals
+// CHECK:       %[[DMA0:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK:       %{{.*}} = amdaie.npu.dma_cpy_nd
+// CHECK-SAME:  [0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1]
+// CHECK-SAME:  [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+func.func @npu_dma_cpy_nd_inline_literals(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+  %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @npu_dma_cpy_nd_mixed
+// CHECK:       %[[DMA0:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK:       %{{.*}} = amdaie.npu.dma_cpy_nd
+// CHECK-SAME:  [%c0, %c0, %c0, %c0] [1, 1, %c8, %c16] [%c128, %c128, %c16, 1]
+// CHECK-SAME:  [%c0, %c0, %c0, %c0] [1, 1, %c8, %c16] [%c128, %c16, %c16, 1]
+func.func @npu_dma_cpy_nd_mixed(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+  %c0 = arith.constant 0 : index
+  %c8 = arith.constant 8 : index
+  %c16 = arith.constant 16 : index
+  %c128 = arith.constant 128 : index
+  %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  %1 = amdaie.npu.dma_cpy_nd %0([%c0, %c0, %c0, %c0] [1, 1, %c8, %c16] [%c128, %c128, %c16, 1], [%c0, %c0, %c0, %c0] [1, 1, %c8, %c16] [%c128, %c16, %c16, 1])
+  return
+}
+
+// -----
+
 // CHECK-LABEL: func.func @workgroup
 // CHECK: amdaie.workgroup
 // CHECK: amdaie.core

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
@@ -1,0 +1,282 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "AMDAIECreateAIEWorkgroup.h"
+
+#include "iree-amd-aie/IR/AMDAIEDialect.h"
+#include "iree-amd-aie/IR/AMDAIEOps.h"
+#include "iree-amd-aie/Transforms/Passes.h"
+#include "iree/compiler/Codegen/TransformStrategies/GPU/Common.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
+#define DEBUG_TYPE "iree-amdaie-to-aie-workgroup"
+
+namespace mlir::iree_compiler::AMDAIE {
+
+void CoreContext::mergeCoreOps(AMDAIE::CoreOp source, AMDAIE::CoreOp dest) {
+  OpBuilder::InsertionGuard guard(rewriter);
+  Block::iterator insertIt = dest.getBody()->getTerminator()->getIterator();
+  Block::iterator sourceBegin = source.getBody()->begin();
+  Block::iterator sourceEnd = source.getBody()->getTerminator()->getIterator();
+  dest.getBody()->getOperations().splice(
+      insertIt, source.getBody()->getOperations(), sourceBegin, sourceEnd);
+  rewriter.moveOpBefore(dest, source);
+  rewriter.replaceOp(source, dest);
+}
+
+/// Recursive workgroup build function for an operation.
+LogicalResult workgroupBuild(IRRewriterAndMapper &rewriter, Operation *op,
+                             Block *target, Block *controlCode,
+                             CoreContext &coreContext,
+                             Block::iterator targetBegin,
+                             Block::iterator controlCodeBegin,
+                             Block::iterator controlCodeEnd) {
+  OpBuilder::InsertionGuard guard(rewriter);
+  if (auto coreOp = dyn_cast<AMDAIE::CoreOp>(op)) {
+    LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [CoreOp] Start\n");
+    int64_t col = getConstantIntValue(coreOp.getTileOp().getCol()).value();
+    int64_t row = getConstantIntValue(coreOp.getTileOp().getRow()).value();
+    std::tuple<int64_t, int64_t> coordinate = std::make_tuple(col, row);
+    // Create a clone CoreOp and add to or merge with coreContext.
+    auto cloneCoreOp = dyn_cast<AMDAIE::CoreOp>(rewriter.cloneAndMap(*op));
+    coreContext.mapOrMerge(coordinate, cloneCoreOp);
+    LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [CoreOp] End\n");
+  } else if (auto dmaOp = dyn_cast<AMDAIE::CircularDmaCpyNdOp>(op)) {
+    LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [CircularDmaCpyNdOp] Start\n");
+    // CircularDmaCpyNd operations are just cloned and mapped as they run
+    // indefinitely and only need to be programmed once.
+    rewriter.cloneAndMap(*op);
+    LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [CircularDmaCpyNdOp] End\n");
+  } else if (auto dmaOp = dyn_cast<AMDAIE::DmaCpyNdOp>(op)) {
+    LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [DmaCpyNdOp] Start\n");
+    // DmaCpyNd operations are converted into CircularDmaCpyNd operations by
+    // moving the strided access specifiers to an npu dma instruction, followed
+    // by a wait.
+    Attribute sourceMemSpace = dmaOp.getSourceObjectFifo().getMemorySpace();
+    Location loc = rewriter.getUnknownLoc();
+    SmallVector<OpFoldResult> empty;
+    auto newDmaOp = rewriter.createAndMap<AMDAIE::CircularDmaCpyNdOp>(
+        rewriter.getUnknownLoc(), dmaOp, dmaOp.getTarget(),
+        getValueOrCreateConstantIndexOp(rewriter, loc, empty),
+        getValueOrCreateConstantIndexOp(rewriter, loc, empty),
+        getValueOrCreateConstantIndexOp(rewriter, loc, empty),
+        dmaOp.getSource(),
+        getValueOrCreateConstantIndexOp(rewriter, loc, empty),
+        getValueOrCreateConstantIndexOp(rewriter, loc, empty),
+        getValueOrCreateConstantIndexOp(rewriter, loc, empty));
+
+    IRRewriter::InsertPoint dmaInsertionPoint = rewriter.saveInsertionPoint();
+    rewriter.setInsertionPoint(controlCode, controlCodeEnd);
+    auto ipuDmaCpy = rewriter.createAndLookup<AMDAIE::NpuDmaCpyNdOp>(
+        loc, newDmaOp.getResult(), dmaOp.getTargetMixedOffsets(),
+        dmaOp.getTargetMixedSizes(), dmaOp.getTargetMixedStrides(),
+        dmaOp.getSourceMixedOffsets(), dmaOp.getSourceMixedSizes(),
+        dmaOp.getSourceMixedStrides());
+    DMAChannelDir direction =
+        !sourceMemSpace ? DMAChannelDir::MM2S : DMAChannelDir::S2MM;
+    rewriter.createAndLookup<AMDAIE::NpuDmaWaitOp>(
+        rewriter.getUnknownLoc(), SmallVector<Type, 1>{}, ipuDmaCpy.getResult(),
+        direction);
+    rewriter.restoreInsertionPoint(dmaInsertionPoint);
+    LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [DmaCpyNdOp] End\n");
+  } else if (auto forallOp = dyn_cast<scf::ForallOp>(op)) {
+    LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [ForallOp] Start\n");
+
+    // Create forall op for control code before the recursive visit of the inner
+    // block, so induction vars are mapped correctly.
+    auto newForallOp = rewriter.createAndMap<scf::ForallOp>(
+        forallOp.getLoc(), forallOp, forallOp.getMixedLowerBound(),
+        forallOp.getMixedUpperBound(), forallOp.getMixedStep(),
+        forallOp.getOutputs(), forallOp.getMapping());
+
+    // Create a new core map and control code block for visiting the nested ops.
+    CoreContext nestedCoreContext(rewriter);
+    Block *nestedControlCode = rewriter.createBlock(controlCode->getParent());
+    if (failed(workgroupBuild(
+            rewriter, forallOp.getBody(), target, nestedControlCode,
+            nestedCoreContext, forallOp.getBody()->begin(),
+            std::prev(forallOp.getBody()->end()), target->end(),
+            nestedControlCode->begin(), nestedControlCode->end()))) {
+      return forallOp.emitOpError()
+             << "failed to add scf.forall body to workgroup";
+    }
+
+    // Create a new scf.forall for every nested core and insert into the core
+    // operations around all existing ops, except for the terminator.
+    for (auto &&[coordinate, coreOp] : nestedCoreContext.getCoreMap()) {
+      auto newForallOp = rewriter.create<scf::ForallOp>(
+          forallOp.getLoc(), forallOp.getMixedLowerBound(),
+          forallOp.getMixedUpperBound(), forallOp.getMixedStep(),
+          forallOp.getOutputs(), forallOp.getMapping());
+      Block::iterator insertIt = newForallOp.getBody()->begin();
+      Block::iterator coreBegin = coreOp.getBody()->begin();
+      Block::iterator coreEnd =
+          coreOp.getBody()->getTerminator()->getIterator();
+      newForallOp.getBody()->getOperations().splice(
+          insertIt, coreOp.getBody()->getOperations(), coreBegin, coreEnd);
+      rewriter.moveOpBefore(newForallOp, coreOp.getBody()->getTerminator());
+    }
+    coreContext.mergeContext(nestedCoreContext);
+
+    // Add forall op to control code as well.
+    rewriter.inlineBlockBefore(nestedControlCode,
+                               newForallOp.getBody()->getTerminator());
+    rewriter.moveOpBefore(newForallOp, controlCode, controlCodeEnd);
+    LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [ForallOp] Start\n");
+  } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+    LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [ForOp] Start\n");
+    Value lb = forOp.getLowerBound();
+    Value ub = forOp.getUpperBound();
+    Value step = forOp.getStep();
+    auto newControlCodeForOp = rewriter.createAndMap<scf::ForOp>(
+        forOp.getLoc(), forOp, lb, ub, step, forOp.getInits());
+
+    // Create a new core map and control code block for visiting the nested ops.
+    CoreContext nestedCoreContext(rewriter);
+    Block *nestedControlCode = rewriter.createBlock(controlCode->getParent());
+    if (failed(workgroupBuild(
+            rewriter, forOp.getBody(), target, nestedControlCode,
+            nestedCoreContext, forOp.getBody()->begin(),
+            std::prev(forOp.getBody()->end()), target->end(),
+            nestedControlCode->begin(), nestedControlCode->end()))) {
+      return forOp.emitOpError() << "failed to add scf.for body to workgroup";
+    }
+
+    // Create a new scf.for for every nested core and insert into the core
+    // op around all existing ops, except for the terminator.
+    for (auto &&[coordinate, coreOp] : nestedCoreContext.getCoreMap()) {
+      auto newforOp =
+          rewriter.createAndLookup<scf::ForOp>(forOp.getLoc(), lb, ub, step);
+      Block::iterator insertIt = newforOp.getBody()->begin();
+      Block::iterator coreBegin = coreOp.getBody()->begin();
+      Block::iterator coreEnd =
+          coreOp.getBody()->getTerminator()->getIterator();
+      newforOp.getBody()->getOperations().splice(
+          insertIt, coreOp.getBody()->getOperations(), coreBegin, coreEnd);
+      rewriter.moveOpBefore(newforOp, coreOp.getBody()->getTerminator());
+    }
+    coreContext.mergeContext(nestedCoreContext);
+
+    // Inline the nested control code within the external control code.
+    rewriter.inlineBlockBefore(nestedControlCode,
+                               newControlCodeForOp.getBody()->getTerminator());
+    rewriter.moveOpBefore(newControlCodeForOp, controlCode, controlCodeEnd);
+    LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [ForOp] End\n");
+  } else if (auto workgroupOp = dyn_cast<AMDAIE::WorkgroupOp>(op)) {
+    LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [WorkgroupOp] Start\n");
+    // Skip workgroups and just visit their bodies.
+    if (failed(
+            workgroupBuild(rewriter, workgroupOp.getBody(), target, controlCode,
+                           coreContext, workgroupOp.getBody()->begin(),
+                           std::prev(workgroupOp.getBody()->end()),
+                           target->end(), controlCodeBegin, controlCodeEnd))) {
+      return workgroupOp.emitOpError()
+             << "failed to add workgroup body to workgroup";
+    }
+    LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [WorkgroupOp] End\n");
+  } else {
+    // All other operations are cloned.
+    rewriter.cloneAndMap(*op);
+  }
+  return success();
+}
+
+/// Recursive workgroup build function for a block with a provided source and
+/// end point.
+LogicalResult workgroupBuild(
+    IRRewriterAndMapper &rewriter, Block *source, Block *target,
+    Block *controlCode, CoreContext &coreContext, Block::iterator sourceBegin,
+    Block::iterator sourceEnd, Block::iterator targetBegin,
+    Block::iterator controlCodeBegin, Block::iterator controlCodeEnd) {
+  OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(target, targetBegin);
+  for (Block::iterator it = sourceBegin; it != sourceEnd; ++it) {
+    OpBuilder::InsertionGuard guard(rewriter);
+    if (failed(workgroupBuild(rewriter, &(*it), target, controlCode,
+                              coreContext, targetBegin, controlCodeBegin,
+                              controlCodeEnd))) {
+      return failure();
+    }
+  }
+  return success();
+}
+
+namespace {
+
+/// Traverse the function operation and create a single workgroup and control
+/// code.
+LogicalResult createSingleWorkgroupAndControlCode(func::FuncOp funcOp) {
+  IRRewriterAndMapper rewriter(funcOp.getContext());
+  Block *funcBlock = &funcOp.getBody().front();
+  Block *newBlock = rewriter.createBlock(&funcOp.getRegion());
+
+  // Map function arguments.
+  // FunctionType funcType = funcOp.getFunctionType();
+  // for (unsigned i = 0, numArgs = oldType.getNumInputs(); i != numArgs; ++i) {
+
+  // }
+
+  // Create the workgroup op to be filled in with AIE DMAs, cores and the
+  // control code.
+  rewriter.setInsertionPoint(newBlock, newBlock->begin());
+  auto workgroupOp =
+      rewriter.create<AMDAIE::WorkgroupOp>(rewriter.getUnknownLoc());
+  Block *newWorkgroupBlock = rewriter.createBlock(&workgroupOp.getRegion());
+  Block *controlCodeBlock = workgroupOp.getControlCode().getBody();
+  Block::iterator controlCodeEnd =
+      controlCodeBlock->getTerminator()->getIterator();
+
+  // Recursively build the workgroup and control code.
+  CoreContext coreContext(rewriter);
+  if (failed(workgroupBuild(rewriter, funcBlock, newWorkgroupBlock,
+                            controlCodeBlock, coreContext, funcBlock->begin(),
+                            std::prev(funcBlock->end()),
+                            newWorkgroupBlock->begin(),
+                            controlCodeBlock->begin(), controlCodeEnd))) {
+    return failure();
+  }
+
+  // Inline the workgroup at the start of the FuncOp and erase the previous
+  // block's operations.
+  rewriter.inlineBlockBefore(newWorkgroupBlock, workgroupOp.getControlCode());
+  rewriter.moveOpBefore(funcBlock->getTerminator(), newBlock, newBlock->end());
+  for (auto &op : llvm::make_early_inc_range(llvm::reverse(*funcBlock))) {
+    assert(op.use_empty() && "expected 'op' to have no uses");
+    rewriter.eraseOp(&op);
+  }
+  rewriter.inlineBlockBefore(newBlock, funcBlock, funcBlock->begin());
+  // rewriter.moveBlockBefore(newBlock, funcBlock);
+  // rewriter.eraseBlock(funcBlock);
+  return success();
+}
+
+class AMDAIECreateAIEWorkgroupPass
+    : public impl::AMDAIECreateAIEWorkgroupBase<AMDAIECreateAIEWorkgroupPass> {
+ public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<AMDAIEDialect, linalg::LinalgDialect, scf::SCFDialect>();
+  }
+
+  AMDAIECreateAIEWorkgroupPass() = default;
+  AMDAIECreateAIEWorkgroupPass(const AMDAIECreateAIEWorkgroupPass &pass){};
+  void runOnOperation() override;
+};
+
+void AMDAIECreateAIEWorkgroupPass::runOnOperation() {
+  if (failed(createSingleWorkgroupAndControlCode(getOperation()))) {
+    return signalPassFailure();
+  }
+}
+
+}  // namespace
+
+std::unique_ptr<Pass> createAMDAIECreateAIEWorkgroupPass() {
+  return std::make_unique<AMDAIECreateAIEWorkgroupPass>();
+}
+
+}  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.h
@@ -1,0 +1,176 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_AMD_AIE_TRANSFORMS_AMDAIETOAIEWORKGROUP_H_
+#define IREE_AMD_AIE_TRANSFORMS_AMDAIETOAIEWORKGROUP_H_
+
+#include "iree-amd-aie/IR/AMDAIEDialect.h"
+#include "iree-amd-aie/IR/AMDAIEOps.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir::iree_compiler::AMDAIE {
+
+//===----------------------------------------------------------------------===//
+// IRRewriterAndMapper
+//===----------------------------------------------------------------------===//
+
+/// A special type of `IRRewriter` that coordinates mapping and looking up IR
+/// entities while creating new operations. The IR entities include operations,
+/// results, operands and arguments among others.
+class IRRewriterAndMapper : public IRRewriter {
+ public:
+  using IRRewriter::IRRewriter;
+
+  /// Creates a deep copy of the specified operation, remapping operands based
+  /// on the class's IR map and mapping this op to the cloned operation.
+  Operation *cloneAndMap(Operation &op) {
+    return IRRewriter::clone(op, mapper);
+  }
+
+  /// Create an operation of the specific op type at the current insertion point
+  /// and lookup and replace the operands based on IR map.
+  template <typename OpTy, typename... Args>
+  OpTy createAndLookup(Location location, Args &&... args) {
+    OpTy newOp =
+        IRRewriter::create<OpTy>(location, std::forward<Args>(args)...);
+    for (unsigned i = 0, e = newOp->getNumOperands(); i != e; ++i) {
+      newOp->setOperand(i, mapper.lookupOrDefault(newOp->getOperand(i)));
+    }
+    return newOp;
+  }
+
+  /// Create an operation of the specific op type at the current insertion point
+  /// and map it to the provided operation. When creating the new op, the
+  /// operands are looked up and replaced with values found in the IR map if
+  /// found.
+  template <typename OpTy, typename... Args>
+  OpTy createAndMap(Location location, Operation *op, Args &&... args) {
+    assert(op && "expected non-null op");
+    OpTy newOp = createAndLookup<OpTy>(location, std::forward<Args>(args)...);
+    mapOperations(op, newOp.getOperation());
+    return newOp;
+  }
+
+ protected:
+  /// Map the 'source' operation, it's results and regions to the 'target'
+  /// counterparts.
+  void mapOperations(Operation *source, Operation *target) {
+    assert(source->getNumResults() == target->getNumResults() &&
+           "expected same number of results");
+    assert(source->getNumRegions() == target->getNumRegions() &&
+           "expected same number of regions");
+    mapper.map(source, target);
+    for (unsigned i = 0, e = target->getNumResults(); i != e; ++i) {
+      mapper.map(source->getResult(i), target->getResult(i));
+    }
+    for (unsigned i = 0, e = target->getNumRegions(); i != e; ++i) {
+      mapRegions(&source->getRegion(i), &target->getRegion(i));
+    }
+  }
+
+  /// Map the 'source' regions's block arguments to the 'target' region's block
+  /// arguments.
+  void mapRegions(Region *source, Region *target) {
+    assert(source->getNumArguments() == target->getNumArguments() &&
+           "expected same number of arguments");
+    for (auto &&[sourceArg, targetArg] :
+         llvm::zip(source->getArguments(), target->getArguments())) {
+      mapper.map(sourceArg, targetArg);
+    }
+  }
+
+  /// The map to be used for mapping and looking up IR entities.
+  IRMapping mapper;
+};
+
+/// Utility class to contain and maintain the core operations' as a map from
+/// coordinates to the respective core operation on that location. The core map
+/// can be accessed through lookup functions and new entries can be added
+/// through the 'mapOrMerge' method or by merging with another CoreContext. This
+/// is useful for creating a clean context for building nested operations and
+/// then merging with the outer context.
+class CoreContext {
+ public:
+  CoreContext(IRRewriterAndMapper &rewriter) : rewriter(rewriter) {}
+  CoreContext(IRRewriterAndMapper &&rewriter) = delete;
+
+  // Check whether the coordinate exists in the map.
+  bool contains(const std::tuple<int64_t, int64_t> &coordinate) {
+    return coreMap.contains(coordinate);
+  }
+
+  /// Return the underlying core map.
+  DenseMap<std::tuple<int64_t, int64_t>, AMDAIE::CoreOp> &getCoreMap() {
+    return coreMap;
+  }
+
+  /// Lookup a coordinate in the core map. This asserts that the provided
+  /// coordinate exists.
+  AMDAIE::CoreOp lookup(const std::tuple<int64_t, int64_t> &coordinate) {
+    AMDAIE::CoreOp res = lookupOrNull(coordinate);
+    assert(res && "expected 'coordinate' to be found in the map");
+    return res;
+  }
+
+  /// Return the underlying core map.
+  AMDAIE::CoreOp lookupOrNull(const std::tuple<int64_t, int64_t> &coordinate) {
+    return contains(coordinate) ? coreMap[coordinate] : AMDAIE::CoreOp(nullptr);
+  }
+
+  // Inserts a new mapping from 'coordinate' to 'coreOp' or merges with a
+  // potentially existing entry.
+  void mapOrMerge(const std::tuple<int64_t, int64_t> &coordinate,
+                  AMDAIE::CoreOp coreOp) {
+    AMDAIE::CoreOp existingCoreOp = lookupOrNull(coordinate);
+    if (!existingCoreOp) {
+      coreMap[coordinate] = coreOp;
+    } else {
+      mergeCoreOps(coreOp, existingCoreOp);
+    }
+  }
+
+  /// Merge another context with this one.
+  void mergeContext(CoreContext &other) {
+    for (auto &&[coordinate, coreOp] : other.getCoreMap())
+      mapOrMerge(coordinate, coreOp);
+  }
+
+ private:
+  /// Merge the 'source' core operations in the end of the 'dest' core
+  /// operation.
+  void mergeCoreOps(AMDAIE::CoreOp source, AMDAIE::CoreOp dest);
+
+  /// The rewriter to be used.
+  IRRewriterAndMapper &rewriter;
+
+  /// Map from coordinates, represented as a tuple of integers, to the
+  /// respective core operation on that location.
+  DenseMap<std::tuple<int64_t, int64_t>, AMDAIE::CoreOp> coreMap;
+};
+
+/// Recursive workgroup build function for an operation.
+LogicalResult workgroupBuild(IRRewriterAndMapper &rewriter, Operation *op,
+                             Block *target, Block *controlCode,
+                             CoreContext &contextCoreMap,
+                             Block::iterator targetBegin,
+                             Block::iterator controlCodeBegin,
+                             Block::iterator controlCodeEnd);
+
+/// Recursive workgroup build function for a block with a provided source and
+/// end point.
+LogicalResult workgroupBuild(IRRewriterAndMapper &rewriter, Block *source,
+                             Block *target, Block *controlCode,
+                             CoreContext &contextCoreMap,
+                             Block::iterator sourceBegin,
+                             Block::iterator sourceEnd,
+                             Block::iterator targetBegin,
+                             Block::iterator controlCodeBegin,
+                             Block::iterator controlCodeEnd);
+
+}  // namespace mlir::iree_compiler::AMDAIE
+
+#endif

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
@@ -37,6 +37,7 @@ iree_cc_library(
   HDRS
     "KernelDispatch.h"
     "Passes.h"
+    "AMDAIECreateAIEWorkgroup.h"
     "AMDAIEOpUtils.h"
     "AMDAIEUtils.h"
     "Transforms.h"
@@ -45,6 +46,7 @@ iree_cc_library(
     "AMDAIEAIRDmaToAMDAIEDma.cpp"
     "AMDAIEBufferizeToAllocation.cpp"
     "AMDAIECanonicalizeDma.cpp"
+    "AMDAIECreateAIEWorkgroup.cpp"
     "AMDAIEDmaToCircularDma.cpp"
     "AMDAIEFuseConsumerIntoLoop.cpp"
     "AMDAIEFuseFillIntoForall.cpp"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/PassDetail.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/PassDetail.h
@@ -10,6 +10,7 @@
 #include "iree-amd-aie/Transforms/KernelDispatch.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
@@ -24,6 +25,7 @@ namespace mlir::iree_compiler::AMDAIE {
 #define GEN_PASS_DEF_AMDAIEBUFFERIZETOALLOCATION
 #define GEN_PASS_DEF_AMDAIECANONICALIZEDMA
 #define GEN_PASS_DEF_AMDAIECLEANUP
+#define GEN_PASS_DEF_AMDAIECREATEAIEWORKGROUP
 #define GEN_PASS_DEF_AMDAIEDECOMPOSELINALGEXTPACKUNPACKTOAIR
 #define GEN_PASS_DEF_AMDAIEDMATOCIRCULARDMA
 #define GEN_PASS_DEF_AMDAIEFUSECONSUMERINTOLOOP

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -46,6 +46,9 @@ std::unique_ptr<Pass> createAMDAIEBufferizeToAllocationPass(
 /// Create pass to apply caonicaliztions to air.dma_memcpy_nd op's.
 std::unique_ptr<Pass> createAMDAIECanonicalizeDmaPass();
 
+/// Pass to create a single AIE workgroup.
+std::unique_ptr<Pass> createAMDAIECreateAIEWorkgroupPass();
+
 /// Create a pass to vectorize operations.
 std::unique_ptr<Pass> createAMDAIEVectorizationPass();
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -61,6 +61,12 @@ def AMDAIECleanup :
       "mlir::iree_compiler::AMDAIE::createAMDAIECleanupPass()";
 }
 
+def AMDAIECreateAIEWorkgroup : 
+  Pass<"iree-amdaie-create-aie-workgroup", "func::FuncOp"> {
+  let summary = "Creates a single AIE workgroup.";
+  let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIECreateAIEWorkgroupPass()";
+}
+
 def AMDAIEDecomposeLinalgExtPackUnPackToAIR :
     Pass<"iree-amdaie-decompose-pack-unpack-to-air", ""> {
   let summary = "Decompose LinalgExt pack/unpack ops into patterns compatible to AIR.";

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
@@ -12,6 +12,7 @@ iree_lit_test_suite(
     "bridge_to_air.mlir"
     "bufferize_to_allocation.mlir"
     "canonicalize_dma.mlir"
+    "create_aie_workgroup.mlir"
     "disable_vectorization.mlir"
     "dma_to_circular_dma.mlir"
     "fuse_consumer_into_loop.mlir"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
@@ -1,0 +1,383 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-amdaie-create-aie-workgroup))" %s | FileCheck %s
+
+// CHECK-LABEL: @circular_dma_cpy_nd
+// CHECK:       amdaie.workgroup
+// CHECK:         amdaie.circular_dma_cpy_nd
+// CHECK-SAME:    [0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1]
+// CHECK-SAME:    [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+func.func @circular_dma_cpy_nd(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+  %0 = amdaie.circular_dma_cpy_nd(%arg0[0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @core
+// CHECK:       amdaie.workgroup
+// CHECK:         %[[TILE_0:.+]] = amdaie.tile
+// CHECK:         %[[TILE_1:.+]] = amdaie.tile
+// CHECK:         %{{.+}} = amdaie.core(%[[TILE_0]])
+// CHECK:         %{{.+}} = amdaie.core(%[[TILE_1]])
+// CHECK:         amdaie.controlcode
+func.func @core() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %tile_0_0 = amdaie.tile(%c0, %c0)
+  %tile_0_1 = amdaie.tile(%c0, %c1)
+  %core_0_0 = amdaie.core(%tile_0_0) {
+    amdaie.end
+  }
+  %core_0_1 = amdaie.core(%tile_0_1) {
+    amdaie.end
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @dma_cpy_nd
+// CHECK:       amdaie.workgroup
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
+// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+// CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK-SAME:    %[[FROMMEMREF0]][] [] []
+// CHECK-SAME:    %[[FROMMEMREF1]][] [] []
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+// CHECK:         amdaie.controlcode
+// CHECK:           %[[IPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
+// CHECK-SAME:      [] [] []
+// CHECK-SAME:      [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK:           amdaie.npu.dma_wait(%[[IPU_DMA]], S2MM)
+func.func @dma_cpy_nd(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi32, 1>) {
+  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
+  %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+  %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @for
+// CHECK:       amdaie.workgroup
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C8:.+]] = arith.constant 8 : index
+// CHECK:         amdaie.controlcode
+// CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
+func.func @for() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  scf.for %arg2 = %c0 to %c8 step %c1  {
+  }
+  return
+}
+
+// -----
+
+// Verify that scf.for is inserted in both control code and cores.
+//
+// CHECK-LABEL: @for_cores
+// CHECK:       amdaie.workgroup
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C8:.+]] = arith.constant 8 : index
+// CHECK-DAG:     %[[TILE_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
+// CHECK-DAG:     %[[TILE_1:.+]] = amdaie.tile(%[[C0]], %[[C1]])
+// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_0]])
+// CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
+// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_1]])
+// CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
+// CHECK:         amdaie.controlcode
+// CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
+func.func @for_cores() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  scf.for %arg2 = %c0 to %c8 step %c1  {
+    %tile_0_0 = amdaie.tile(%c0, %c0)
+    %tile_0_1 = amdaie.tile(%c0, %c1)
+    %core_0_0 = amdaie.core(%tile_0_0) {
+      amdaie.end
+    }
+    %core_0_1 = amdaie.core(%tile_0_1) {
+      amdaie.end
+    }
+  }
+  return
+}
+
+// -----
+
+// Verify that empty scf.for is inserted in control code with nested dmas.
+//
+// CHECK-LABEL: @for_dma
+// CHECK:       amdaie.workgroup
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C8:.+]] = arith.constant 8 : index
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
+// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+// CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK-SAME:    %[[FROMMEMREF0]][] [] []
+// CHECK-SAME:    %[[FROMMEMREF1]][] [] []
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+// CHECK:         amdaie.controlcode
+// CHECK:           scf.for %[[ARG:.+]] = %[[C0]] to %[[C8]] step %[[C1]]
+// CHECK:             %[[IPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
+// CHECK-SAME:        [] [] []
+// CHECK-SAME:        [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, %[[ARG]], 1]
+// CHECK:             amdaie.npu.dma_wait(%[[IPU_DMA]], S2MM)
+func.func @for_dma(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi32, 1>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
+  %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+  scf.for %arg2 = %c0 to %c8 step %c1  {
+    %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, %arg2, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  }
+  return
+}
+
+// -----
+
+// Verify that empty scf.forall is inserted in control code.
+//
+// CHECK-LABEL: @forall
+// CHECK:       amdaie.workgroup
+// CHECK:         amdaie.controlcode
+// CHECK:           scf.forall (%{{.*}}, %{{.*}}) in (1, 2)
+func.func @forall() {
+  scf.forall (%arg2, %arg3) in (1, 2) {
+  }
+  return
+}
+
+// -----
+
+// Verify that scf.forall is inserted in both control code and cores.
+//
+// CHECK-LABEL: @forall_cores
+// CHECK:       amdaie.workgroup
+// CHECK:         %[[TILE_0:.+]] = amdaie.tile
+// CHECK:         %[[TILE_1:.+]] = amdaie.tile
+// CHECK:         %{{.+}} = amdaie.core(%[[TILE_0]])
+// CHECK:           scf.forall (%{{.*}}, %{{.*}}) in (1, 2)
+// CHECK:         %{{.+}} = amdaie.core(%[[TILE_1]])
+// CHECK:           scf.forall (%{{.*}}, %{{.*}}) in (1, 2)
+// CHECK:         amdaie.controlcode
+// CHECK:           scf.forall (%{{.*}}, %{{.*}}) in (1, 2)
+func.func @forall_cores() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  scf.forall (%arg2, %arg3) in (1, 2) {
+    %tile_0_0 = amdaie.tile(%c0, %c0)
+    %tile_0_1 = amdaie.tile(%c0, %c1)
+    %core_0_0 = amdaie.core(%tile_0_0) {
+      amdaie.end
+    }
+    %core_0_1 = amdaie.core(%tile_0_1) {
+      amdaie.end
+    }
+  }
+  return
+}
+
+// -----
+
+// Verify that empty scf.forall is inserted in control code with nested dmas.
+//
+// CHECK-LABEL: @forall_dmas
+// CHECK:       amdaie.workgroup
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
+// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+// CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK-SAME:    %[[FROMMEMREF0]][] [] []
+// CHECK-SAME:    %[[FROMMEMREF1]][] [] []
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+// CHECK:         amdaie.controlcode
+// CHECK:           scf.forall (%[[ARG0:.*]], %[[ARG1:.*]]) in (2, 2)
+// CHECK:             %[[IPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
+// CHECK-SAME:        [] [] []
+// CHECK-SAME:        [0, 0, 0, 0] [1, 1, 8, 16] [128, %[[ARG1]], %[[ARG0]], 1]
+// CHECK:             amdaie.npu.dma_wait(%[[IPU_DMA]], S2MM)
+func.func @forall_dmas(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi32, 1>) {
+  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
+  %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+  scf.forall (%arg2, %arg3) in (2, 2) {
+    %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, %arg3, %arg2, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @func
+// CHECK:       amdaie.workgroup
+// CHECK:         amdaie.controlcode
+func.func @func() {
+  return
+}
+
+// -----
+
+// Verify that cores on the same location, but within different scope merge correctly.
+//
+// CHECK-LABEL: @merge_cores
+// CHECK:       amdaie.workgroup
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C8:.+]] = arith.constant 8 : index
+// CHECK-DAG:     %[[TILE_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
+// CHECK-DAG:     %[[TILE_1:.+]] = amdaie.tile(%[[C0]], %[[C1]])
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
+// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+// CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK-SAME:    %[[FROMMEMREF0]][] [] []
+// CHECK-SAME:    %[[FROMMEMREF1]][] [] []
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_0]])
+// CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA]])
+// CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
+// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_1]])
+// CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA]])
+// CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
+// CHECK:         amdaie.controlcode
+// CHECK:           %[[IPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
+// CHECK-SAME:      [] [] []
+// CHECK-SAME:      [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK:           amdaie.npu.dma_wait(%[[IPU_DMA]], S2MM)
+// CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
+func.func @merge_cores(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi32, 1>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %tile_0_0 = amdaie.tile(%c0, %c0)
+  %tile_0_1 = amdaie.tile(%c0, %c1)
+  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
+  %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+  %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  %core_0_0_0 = amdaie.core(%tile_0_0) {
+    amdaie.logicalobjectfifo.consume(%2)
+    amdaie.end
+  }
+  %core_0_1_0 = amdaie.core(%tile_0_1) {
+    amdaie.logicalobjectfifo.consume(%2)
+    amdaie.end
+  }
+  scf.for %arg2 = %c0 to %c8 step %c1  {
+    %core_0_0_1 = amdaie.core(%tile_0_0) {
+      amdaie.end
+    }
+    %core_0_1_1 = amdaie.core(%tile_0_1) {
+      amdaie.end
+    }
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @complex_example
+// CHECK:       amdaie.workgroup
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:     %[[C8:.+]] = arith.constant 8 : index
+// CHECK-DAG:     %[[TILE_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
+// CHECK-DAG:     %[[TILE_1:.+]] = amdaie.tile(%[[C0]], %[[C1]])
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
+// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+// CHECK-DAG:     %[[FROMMEMREF2:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<1x1x16x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x16x16xi32, 2>>
+// CHECK-DAG:     %[[FROMMEMREF3:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<16x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<16x16xi32, 1>>
+// CHECK-DAG:     %[[FROMMEMREF4:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<1x1x32x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x32x16xi32, 2>>
+// CHECK-DAG:     %[[FROMMEMREF5:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<32x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>
+// CHECK-DAG:     %[[DMA0:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK-SAME:    %[[FROMMEMREF0]][] [] []
+// CHECK-SAME:    %[[FROMMEMREF1]][] [] []
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+// CHECK-DAG:     %[[DMA1:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK-SAME:    %[[FROMMEMREF2]][] [] []
+// CHECK-SAME:    %[[FROMMEMREF3]][] [] []
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x16x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<16x16xi32, 1>>)
+// CHECK-DAG:     %[[DMA2:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK-SAME:    %[[FROMMEMREF4]][] [] []
+// CHECK-SAME:    %[[FROMMEMREF5]][] [] []
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x32x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>)
+// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_0]])
+// CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA0]])
+// CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
+// CHECK:             amdaie.logicalobjectfifo.consume(%[[DMA1]])
+// CHECK:             linalg.fill
+// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_1]])
+// CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA0]])
+// CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
+// CHECK:             amdaie.logicalobjectfifo.consume(%[[DMA2]])
+// CHECK:             linalg.fill
+// CHECK:         amdaie.controlcode
+// CHECK:           %[[IPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[DMA0]]
+// CHECK-SAME:      [] [] []
+// CHECK-SAME:      [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK:           amdaie.npu.dma_wait(%[[IPU_DMA_0]], S2MM)
+// CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
+// CHECK:             %[[IPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[DMA1]]
+// CHECK-SAME:        [] [] []
+// CHECK-SAME:        [0, 0, 0, 0] [1, 1, 16, 16] [128, 16, 8, 1]
+// CHECK:             amdaie.npu.dma_wait(%[[IPU_DMA_1]], S2MM)
+// CHECK:             %[[IPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[DMA2]]
+// CHECK-SAME:        [] [] []
+// CHECK-SAME:        [0, 0, 0, 0] [1, 1, 32, 16] [128, 16, 8, 1]
+// CHECK:             amdaie.npu.dma_wait(%[[IPU_DMA_2]], S2MM)
+func.func @complex_example(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi32, 1>, %arg2: memref<1x1x16x16xi32, 2>, %arg3: memref<16x16xi32, 1>, %arg4: memref<1x1x32x16xi32, 2>, %arg5: memref<32x16xi32, 1>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c8 = arith.constant 8 : index
+  %c0_i32 = arith.constant 0 : i32
+  %tile_0_0 = amdaie.tile(%c0, %c0)
+  %tile_0_1 = amdaie.tile(%c0, %c1)
+  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
+  %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+  %2 = amdaie.logicalobjectfifo.from_memref %arg2, {} : memref<1x1x16x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x16x16xi32, 2>>
+  %3 = amdaie.logicalobjectfifo.from_memref %arg3, {} : memref<16x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<16x16xi32, 1>>
+  %4 = amdaie.logicalobjectfifo.from_memref %arg4, {} : memref<1x1x32x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x32x16xi32, 2>>
+  %5 = amdaie.logicalobjectfifo.from_memref %arg5, {} : memref<32x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>
+  %dma_0 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  %core_0_0_0 = amdaie.core(%tile_0_0) {
+    amdaie.logicalobjectfifo.consume(%dma_0)
+    amdaie.end
+  }
+  %core_0_1_0 = amdaie.core(%tile_0_1) {
+    amdaie.logicalobjectfifo.consume(%dma_0)
+    amdaie.end
+  }
+  scf.for %iv0 = %c0 to %c8 step %c1  {
+    %dma_1 = amdaie.dma_cpy_nd(%2[] [] [], %3[0, 0, 0, 0] [1, 1, 16, 16] [128, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x16x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<16x16xi32, 1>>)
+    %dma_2 = amdaie.dma_cpy_nd(%4[] [] [], %5[0, 0, 0, 0] [1, 1, 32, 16] [128, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x32x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>)
+    %core_0_0_1 = amdaie.core(%tile_0_0) {
+      amdaie.logicalobjectfifo.consume(%dma_1)
+      linalg.fill ins(%c0_i32 : i32) outs(%arg2 : memref<1x1x16x16xi32, 2>)
+      amdaie.end
+    }
+    %core_0_1_1 = amdaie.core(%tile_0_1) {
+      amdaie.logicalobjectfifo.consume(%dma_2)
+      linalg.fill ins(%c0_i32 : i32) outs(%arg4 : memref<1x1x32x16xi32, 2>)
+      amdaie.end
+    }
+  }
+  return
+}


### PR DESCRIPTION
Adds a pass to create a single AIE workgroup. The workgroup will consist of:

1. A set of AIE core operations, with dataflow specified by circular DMA operations.
2. A control code block containing the NPU uController instructions.

This PR adds a few new `amdaie` operations:

- `NpuDmaCpyNdOp`: Represents a strided copy operation with an unlimited number of dimensions, executed by the Npu uController. This operation refers to a `CircularDmaCpyNdOp`, which will contain the necessary information about the source and target logical object fifos of the operation and which will instantiate the DMA connection.
- `NpuDmaWaitOp`: This wait operation will block on the referenced Npu DMA operation to complete execution on the provided `direction`. The `S2MM` direction will block on the destination side of the dma operation, ensuring complete execution. The `MM2S` direction will block on the source side of the dma operation, ensuring that the DMA has successfully started execution, but not guaranteeing that all data has been received on the destination side.

A few notes:

- I noticed that it's probably not necessary to create/insert workgroups before this pass, so I will probably get it out of `InsertAIEWorkgroup` in a follow-up. This will also resolve the unclarity of having both a `InsertAIEWorkgroup` and `CreateAIEWorkgroup` pass. This inconsistency is the result of some rewrites/refactoring after getting in the earlier transformations.
- After this pass, we're very close to MLIR-AIE and except for a few utility transformations, the next pass will take this code all the way to MLIR-AIE.