### PR TITLE
[Delegate] Converted delegate to expect f32 inputs

### DIFF
--- a/experimental/delegate/CMakeLists.txt
+++ b/experimental/delegate/CMakeLists.txt
@@ -65,10 +65,12 @@ iree_lit_test_suite(
     "matmul.mlir"
     "opt.mlir"
     "large-matmul.mlir"
+    "large-matmul-f32.mlir"
   DATA
     "linalg.pdl.mlir"
     "opt.pdl.mlir"
     "large-matmul.pdl.mlir"
+    "large-matmul-f32.pdl.mlir"
   TOOLS
     FileCheck
     iree-compile

--- a/experimental/delegate/large-matmul-f32.mlir
+++ b/experimental/delegate/large-matmul-f32.mlir
@@ -1,0 +1,45 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-preprocessing-apply-pdl-patterns{patterns-file=%p/large-matmul-f32.pdl.mlir}, cse)" %s | FileCheck %s
+
+#x86_64_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  native_vector_size = 32 : index,
+  target_triple = "x86_64-none-elf"
+}>
+
+// The target devices that the program will run on. We can compile and run with
+// multiple targets, but this example is maintaining an implicit requirement
+// that the custom kernel being spliced in is supported by the target device,
+// hence we only support llvm-cpu here.
+#cpu_target = #hal.device.target<"llvm-cpu", [
+  #x86_64_target
+]>
+
+module @example attributes {hal.device.targets = [#cpu_target]} {
+// CHECK-LABEL: module @example
+
+// Check that the stream executable uses the proper name format
+// CHECK: stream.executable private @mlp_external_f32_f32_f32_i32_i32_i32_executable {
+
+// Check that the external function is declared with the right dtypes
+// CHECK: builtin.module {
+// CHECK: func.func private @mlp_external(memref<f32>, index, memref<f32>, index, memref<f32>, index, i32, i32, i32)
+
+// Check that the call to the external function exists and is called with the right types
+// CHECK: func.func @mlp_external_entry_point({{.+}}) {
+// CHECK: call @mlp_external({{.+}}) : (memref<f32>, index, memref<f32>, index, memref<f32>, index, i32, i32, i32) -> ()
+
+
+  func.func @mlp_invocation(%lhs: tensor<8192x2432xf32>,
+                            %rhs: tensor<2432x9728xf32>) -> (tensor<8192x9728xf32>) {
+    %cst_206 = arith.constant 0.000000e+00 : f32
+    %44 = tensor.empty() : tensor<8192x9728xf32>
+    %64 = linalg.fill ins(%cst_206 : f32) outs(%44 : tensor<8192x9728xf32>) -> tensor<8192x9728xf32>
+    %65 = linalg.matmul ins(%lhs, %rhs :  tensor<8192x2432xf32>, tensor<2432x9728xf32>) outs(%64 : tensor<8192x9728xf32>) -> tensor<8192x9728xf32>
+
+// Check that the batch_matmul has been replaced with a call to the external function with the right types
+// CHECK: func.func @mlp_invocation({{.+}}) -> {{.+}} {
+// CHECK: flow.dispatch @mlp_external_f32_f32_f32_i32_i32_i32_executable::@mlp_external_entry_point({{.+}}) : (tensor<8192x2432xf32>, tensor<2432x9728xf32>, i32, i32, i32) -> tensor<8192x9728xf32>
+
+    return %65 : tensor<8192x9728xf32>
+  }
+}  // module

--- a/experimental/delegate/large-matmul-f32.pdl.mlir
+++ b/experimental/delegate/large-matmul-f32.pdl.mlir
@@ -1,0 +1,116 @@
+// PDL pattern spec to match an MLP of shape 8192x9728x2432 and offload to an
+// external function
+//
+// ```
+// void mlp_external(void *params, void *context, void *reserved)
+// ```
+//
+// which is the expected signature of an external function implemented
+// provided by a system plugin. See
+// samples/custom_dispatch/cpu/plugin/system_plugin.c for an example.
+//
+// The `params` is the following struct
+//
+// ```
+// using bfloat16_t = unsigned short;
+//
+// struct mlp_params_t {
+//   const bfloat16_t *restrict lhs;
+//   size_t lhs_offset;
+//   const bfloat16_t *restrict rhs;
+//   size_t rhs_offset;
+//   float *restrict result;
+//   size_t result_offset;
+//   int32_t M;
+//   int32_t N;
+//   int32_t K;
+// };
+// ```
+//
+// In MLIR this corresponds to the function
+//
+// ```
+// func.func private @mlp_external(%lhs : memref<f32>, lhs_offset : index,
+//   %rhs : memref<f32>, %rhs_offset : index, %result : memref<f32>,
+//   %result_offset : index, %M : i32, %N : i32, %K : i32)
+// ```
+//
+// Note: In the above struct a `pointer, offset` pair represents a buffer
+// passed into the external function. So any access to `lhs`, `rhs` and
+// `result` is valid only if accessed as `lhs[lhs_offset + ...]`,
+// `rhs[rhs_offset + ]` and `result[result_offset + ...]`.
+pdl.pattern @mlp : benefit(1) {
+
+  // PDL matcher to match the MLP computation. This pattern is expected to
+  // match
+  //
+  // ```
+  // linalg.matmul ins(%lhs, %rhs : tensor<8192x2432xf32>,
+  //   tensor<2432x9728xf32>) outs(%64 : tensor<8192x9728xf32>) ->
+  //   tensor<8192x9728xf32>
+  // ```
+  %lhs = pdl.operand
+  %rhs = pdl.operand
+  %empty = pdl.operand
+  
+  %lhs_type = pdl.type : tensor<8192x2432xf32>
+  %rhs_type = pdl.type : tensor<2432x9728xf32>
+  %matmul_type = pdl.type : tensor<8192x9728xf32>
+  %fixed_M = pdl.attribute = 8192 : i32
+  %fixed_N = pdl.attribute = 9728 : i32
+  %fixed_K = pdl.attribute = 2432 : i32
+  %one_attribute = pdl.attribute = 1 : i32
+
+  %index_type = pdl.type : index
+  %zero_val_attr = pdl.attribute = 0.0 : f32
+  %zero_fill_type = pdl.type : f32
+
+
+  %zero_fill_val_op = pdl.operation "arith.constant" {"value" = %zero_val_attr} -> (%zero_fill_type : !pdl.type)
+  %zero_fill_val = pdl.result 0 of %zero_fill_val_op
+
+  
+  %fill_op = pdl.operation "linalg.fill" (%zero_fill_val, %empty : !pdl.value, !pdl.value) -> (%matmul_type : !pdl.type)
+  %fill = pdl.result 0 of %fill_op
+  %matmul = pdl.operation "linalg.matmul" (%lhs, %rhs, %fill : !pdl.value, !pdl.value, !pdl.value) -> (%matmul_type : !pdl.type)
+  
+  pdl.rewrite %matmul {
+    %i32_type = pdl.type : i32
+    %m_op = pdl.operation "arith.constant" {"value" = %fixed_M} -> (%i32_type : !pdl.type)
+    %m = pdl.result 0 of %m_op
+    %n_op = pdl.operation "arith.constant" {"value" = %fixed_N} -> (%i32_type : !pdl.type)
+    %n = pdl.result 0 of %n_op
+    %k_op = pdl.operation "arith.constant" {"value" = %fixed_K} -> (%i32_type : !pdl.type)
+    %k = pdl.result 0 of %k_op
+
+    // %replaced_values_dims = pdl.range %one, %m, %n : !pdl.value, !pdl.value, !pdl.value
+    %replaced_values_dims = pdl.range : !pdl.range<value>
+    %input_values = pdl.range %lhs, %rhs : !pdl.value, !pdl.value
+    %replaced_value = pdl.result 0 of %matmul
+    %replaced_values = pdl.range %replaced_value : !pdl.value
+    %other_operands = pdl.range %m, %n, %k : !pdl.value, !pdl.value, !pdl.value
+
+    // The `rewriteAsFlowDispatch` is a rewrite function that allows
+    // converting the matched dag into a call to the external function call
+    // provided by a system plugin. The rewrite method expects the following
+    // arguments
+    // - the root of the matched DAG. This op will be erased after the call.
+    // - `fn_name` the name of the function that is provided externally
+    //   (using a plugin).
+    // - `input_values` are values that are captures as the part of the match
+    //   and are inputs to the match.
+    // - `replaced_values` are the values that are captured as part of the
+    //   match and are replaced by the `flow.dispatch`. The `flow.dispatch`
+    //   returns as many values as `replaced_values` (and of same type).
+    // - `replaced_values_dims` are the values for the dynamic dimensions of
+    //   all the `tensor` values in `replaced_values`. For matches that could
+    //   be static or dynamic, it should be assumed that the shape is dynamic
+    //   and the value needs to be passed to the rewrite function.
+    // - `other_operands` same as `input_values`, but kept separate to allow
+    //   flexibility of where the results are passed through the ABI boundary.
+    %fn_name = pdl.attribute = "mlp_external"
+    pdl.apply_native_rewrite "rewriteAsFlowDispatch"(
+        %matmul, %fn_name, %input_values, %replaced_values, %replaced_values_dims, %other_operands
+        : !pdl.operation, !pdl.attribute, !pdl.range<value>, !pdl.range<value>, !pdl.range<value>, !pdl.range<value>)
+  }
+}

--- a/experimental/delegate/mlp_aie_bf16_plugin.cpp
+++ b/experimental/delegate/mlp_aie_bf16_plugin.cpp
@@ -109,8 +109,8 @@ using B_DATATYPE = bfloat16_t;
 using C_DATATYPE = float; // bfloat16_t;
 
 // Types of the matmul LHS, RHS, and result, as seen by the model
-using ModelLhsDType = bfloat16_t;
-using ModelRhsDType = bfloat16_t;
+using ModelLhsDType = float; // bfloat16_t;
+using ModelRhsDType = float; // bfloat16_t;
 using ModelReturnDType = float;
 
 // Set to 1 if the kernel requires a pre-initialized buffer to be loaded


### PR DESCRIPTION
By default, the delegate now expects f32 inputs instead of bf16.

For the Large Matmul case, there are now two PDLs for rewriting to call the delegate, one that matches bf16 inputs (large-matmul.pdl.mlir) and one that matches f32 inputs (large-matmul-f32.pdl.mlir).