### PR TITLE
add missing deps in compiler target

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
@@ -18,5 +18,8 @@ iree_cc_library(
     iree::target::amd-aie::IR::AMDAIEDialect
     iree::target::amd-aie::Transforms
     iree::target::amd-aie::air::AIRDialectIR
+    iree::base::internal::flatcc::building
+    iree::base::internal::flatcc::parsing
+    iree-amd-aie::schemas::xrt_executable_def_c_fbs
   PUBLIC
 )


### PR DESCRIPTION
The following error when building was reported
```
.../iree-amd-aie/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp:28:10: fatal error: 'runtime/plugins/AMD-AIE/iree-amd-aie/schemas/xrt_executable_def_builder.h' file not found
   28 | #include "runtime/plugins/AMD-AIE/iree-amd-aie/schemas/xrt_executable_def_builder.h"
 ```
 Adding this deps should fix that.