### PR TITLE
Enable vectorization passes in pack-peel pipeline

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -584,6 +584,34 @@ run_matmul_test \
     --pipeline "pack-peel" \
     --lhs_rhs_type "i32" \
     --acc_type "i32" \
-    --m "64"  --n "64" --k "160"
+    --m "64"  --n "64" --k "128"
+
+run_matmul_test \
+    --name_prefix "packPeel" \
+    --pipeline "pack-peel" \
+    --lhs_rhs_type "bf16" \
+    --acc_type "f32" \
+    --m "64"  --n "64" --k "128"
+
+run_matmul_test \
+    --name_prefix "packPeelLarge" \
+    --pipeline "pack-peel" \
+    --lhs_rhs_type "i32" \
+    --acc_type "i32" \
+    --m "512"  --n "512" --k "512"
+
+run_matmul_test \
+    --name_prefix "packPeelLarge" \
+    --pipeline "pack-peel" \
+    --lhs_rhs_type "bf16" \
+    --acc_type "f32" \
+    --m "512"  --n "512" --k "512"
+
+run_matmul_test \
+    --name_prefix "packPeel2304" \
+    --pipeline "pack-peel" \
+    --lhs_rhs_type "bf16" \
+    --acc_type "f32" \
+    --m "128"  --n "128" --k "2304"
 
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -67,7 +67,6 @@ void appendVectorizationToPipeline(OpPassManager &funcPassManager) {
   funcPassManager.addPass(createAMDAIEInsertLoopsForVectorizationPass());
   funcPassManager.addPass(createAMDAIEVectorizationPass());
   funcPassManager.addPass(createCanonicalizerPass());
-  funcPassManager.addPass(createCSEPass());
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -282,6 +282,9 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
   funcPassManager.addPass(createCanonicalizerPass());
 
+  // Vectorization passes
+  appendVectorizationToPipeline(funcPassManager);
+  
   // Comprehensive bufferization
   addAMDAIEBufferizePasses(funcPassManager);
 }


### PR DESCRIPTION
New feature in MLIR-AIR:
- Added logic in `MemrefShrinkage` pattern (part of `AIRSegmentLoopFusion` pass) to support vectorized kernel code.