### PR TITLE
Just to confirm 2304 fails without fix 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,8 @@ jobs:
       - name: E2E correctness matmul test
         run: |
           source .venv/bin/activate
+          # See https://github.com/Xilinx/mlir-air/issues/566
+          sudo prlimit -lunlimited --pid $$
           bash build_tools/ci/run_matmul_test.sh test1 iree-install
 
       - name: Printing IR from aie2xclbin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,6 @@ jobs:
       - name: E2E correctness matmul test
         run: |
           source .venv/bin/activate
-          # See https://github.com/Xilinx/mlir-air/issues/566
-          sudo prlimit -lunlimited --pid $$
           bash build_tools/ci/run_matmul_test.sh test1 iree-install
 
       - name: Printing IR from aie2xclbin

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -574,7 +574,13 @@ run_matmul_test \
     --m "64"  --n "64" --k "64"
 
 run_matmul_test \
-    --name_prefix "bf16_2304" \
+    --name_prefix "bf16_mnk2304" \
+    --lhs_rhs_type "bf16" \
+    --acc_type "f32" \
+    --m "2304"  --n "2304" --k "2304"
+
+run_matmul_test \
+    --name_prefix "bf16_k2304" \
     --lhs_rhs_type "bf16" \
     --acc_type "f32" \
     --m "128"  --n "128" --k "2304"


### PR DESCRIPTION
see https://github.com/nod-ai/iree-amd-aie/pull/330 where the same shaped matmul is run, but there is a line in CI to remove any memory restriction on the runner 