### PR TITLE
Modify the config settings for pack-peel pipeline

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -73,11 +73,71 @@ FailureOr<std::array<uint32_t, 3>> getPackedSize(linalg::LinalgOp linalgOp,
   }
   return instructionSize;
 }
-}  // namespace
 
-static LogicalResult setRootConfigForPackPeelPipeline(
-    mlir::FunctionOpInterface entryPointFn, linalg::LinalgOp linalgOp,
-    AIEConfig cfg) {
+// Container class for the tiling at level 0 (the AIE shared memory) and level 1
+// (the AIE core) in the M-, N-, and K-dimensions of a matmul operation, using
+// the pad-pack approach to tiling a matmul. Also contains the packing sizes for
+// the M, N, and K dimensions. The packing sizes correspond to matmul
+// vector-instruction sizes for vectorizable types.
+class ParameterSetting {
+ public:
+  SmallVector<int64_t> getPackSizeL0() const {
+    return {m0Pack, n0Pack, k0Pack};
+  }
+  SmallVector<int64_t> getPackSizeL1() const {
+    return {m1Pack, n1Pack, k1Pack};
+  }
+
+  static FailureOr<ParameterSetting> create(linalg::LinalgOp linalgOp,
+                                            bool isPackPeel);
+
+  uint32_t getM0() const { return M0; }
+  uint32_t getN0() const { return N0; }
+  uint32_t getK0() const { return K0; }
+  uint32_t getM1() const { return M1; }
+  uint32_t getN1() const { return N1; }
+  uint32_t getK1() const { return K1; }
+  uint32_t getM0Pack() const { return m0Pack; }
+  uint32_t getN0Pack() const { return n0Pack; }
+  uint32_t getK0Pack() const { return k0Pack; }
+  uint32_t getM1Pack() const { return m1Pack; }
+  uint32_t getN1Pack() const { return n1Pack; }
+  uint32_t getK1Pack() const { return k1Pack; }
+
+ private:
+  ParameterSetting(uint32_t M0, uint32_t N0, uint32_t K0, uint32_t M1,
+                   uint32_t N1, uint32_t K1, uint32_t m0Pack, uint32_t n0Pack,
+                   uint32_t k0Pack, uint32_t m1Pack, uint32_t n1Pack,
+                   uint32_t k1Pack)
+      : M0(M0),
+        N0(N0),
+        K0(K0),
+        M1(M1),
+        N1(N1),
+        K1(K1),
+        m0Pack(m0Pack),
+        n0Pack(n0Pack),
+        k0Pack(k0Pack),
+        m1Pack(m1Pack),
+        n1Pack(n1Pack),
+        k1Pack(k1Pack) {}
+
+  uint32_t M0;
+  uint32_t N0;
+  uint32_t K0;
+  uint32_t M1;
+  uint32_t N1;
+  uint32_t K1;
+  uint32_t m0Pack;
+  uint32_t n0Pack;
+  uint32_t k0Pack;
+  uint32_t m1Pack;
+  uint32_t n1Pack;
+  uint32_t k1Pack;
+};
+
+FailureOr<ParameterSetting> ParameterSetting::create(linalg::LinalgOp linalgOp,
+                                                     bool isPackPeel) {
   auto initType =
       llvm::cast<ShapedType>(linalgOp.getDpsInitOperand(0)->get().getType());
   auto initShape = initType.getShape();
@@ -86,9 +146,10 @@ static LogicalResult setRootConfigForPackPeelPipeline(
       llvm::cast<ShapedType>(linalgOp.getDpsInputOperand(0)->get().getType());
   auto lhsShape = lhsType.getShape();
 
-  const auto M = initShape[0];
-  const auto N = initShape[1];
-  const auto K = lhsShape[1];
+  // Shape of the full matmul operation.
+  const uint64_t M = initShape[0];
+  const uint64_t N = initShape[1];
+  const uint64_t K = lhsShape[1];
 
   FailureOr<unsigned> maybeScaleFactor =
       getTilingScaleFactor(initType.getElementType());
@@ -97,16 +158,97 @@ static LogicalResult setRootConfigForPackPeelPipeline(
         "does not have the expected bitwidth (64, 32, 16, or 8), could not "
         "determine scale factor.");
   }
+
   unsigned scaleFactor = maybeScaleFactor.value();
-  const auto tileM0 = findLargestFactor(M, 32 * scaleFactor);
-  const auto tileN0 = findLargestFactor(N, 32 * scaleFactor);
+
+  auto maybePackedSize = getPackedSize(linalgOp, M, N, K);
+  if (failed(maybePackedSize)) return failure();
+  auto [m1Pack, n1Pack, k1Pack] = maybePackedSize.value();
+
+  // The current ad-hoc algorithm for determining the tiling at level 0 and
+  // level 1 is as follows:
+  //
+  // Step 1: Find the largest tiling for M and N on the AIE core, subject to
+  // constraints.
+  //
+  // Step 2: Find the largest tiling for M and N in AIE shared memory,
+  // subject to constraints.
+  //
+  // Tiling in the K-dimension is done differently TODO(newling)
+  // document/reconsider.
+
+  if (isPackPeel) {
+    // Assume working on a 2x2 AIE array, so the ideal level 1 tile sizes should
+    // be (tileM0/2, tileN0/2). Since packing happens before tiling, and an
+    // extra step is performed to fuse pack ops into the loops, the adjusted
+    // level 1 tile sizes should be (tileM0/2/packedM1, tileN0/2/packedN1).
+    auto maxL1Size = 16 * scaleFactor;
+    uint32_t M1 = findLargestFactor(M / m1Pack, maxL1Size / m1Pack, m1Pack);
+    uint32_t N1 = findLargestFactor(N / n1Pack, maxL1Size / n1Pack, n1Pack);
+
+    auto maxL0Size = 32 * scaleFactor;
+    uint32_t M0 = findLargestFactor(M, maxL0Size, m1Pack * M1);
+    uint32_t N0 = findLargestFactor(N, maxL0Size, n1Pack * N1);
+
+    // In pack-peel pipeline there is only one level of tiling for K dimension,
+    // so set K1 = 0. The packed outer K dimension needs to be 1, so set K0 = 1.
+    uint32_t K1 = 0;
+    uint32_t K0 = 1;
+
+    uint32_t m0Pack = M0;
+    uint32_t n0Pack = N0;
+    uint32_t k0Pack = findLargestFactor(K, maxL1Size);
+
+    return ParameterSetting{M0,     N0,     K0,     M1,     N1,     K1,
+                            m0Pack, n0Pack, k0Pack, m1Pack, n1Pack, k1Pack};
+  } else {
+    // Assume working on a 4x4 AIE array. The tile sizes are chosen empirically
+    // for large GEMM sizes, which are [64*s, 64*s, 256] for the first level and
+    // [16*s, 16*s, 16*s] for the second level, where 's' is the scaling factor
+    // based on the element type's bit width.
+    auto maxL1Size = 16 * scaleFactor;
+    uint32_t M1 = findLargestFactor(M, maxL1Size, m1Pack);
+    uint32_t N1 = findLargestFactor(N, maxL1Size, n1Pack);
+
+    auto maxL0Size = 64 * scaleFactor;
+    uint32_t M0 = findLargestFactor(M, maxL0Size, M1);
+    uint32_t N0 = findLargestFactor(N, maxL0Size, N1);
+
+    uint32_t K1 = findLargestFactor(K / k1Pack, 2 * scaleFactor);
+    uint32_t K0 = findLargestFactor(K, 256, k1Pack * K1);
+
+    // In pad-pack pipeline, there is only one level of packing, set pack
+    // parameters for level 0 as 0.
+    uint32_t m0Pack = 0;
+    uint32_t n0Pack = 0;
+    uint32_t k0Pack = 0;
+
+    // Tiling at level 0 (shared memory) should be no smaller than tiling at
+    // level 1 (AIE core memory).
+    assert(M0 >= M1 && N0 >= N1);
+
+    // Tiling at level 1 (AIE core memory) should be no smaller than the packing
+    // size (vector instruction size).
+    assert(M1 >= m1Pack && N1 >= n1Pack);
+
+    return ParameterSetting{M0,     N0,     K0,     M1,     N1,     K1,
+                            m0Pack, n0Pack, k0Pack, m1Pack, n1Pack, k1Pack};
+  }
+}
+}  // namespace
+
+static LogicalResult setRootConfigForPackPeelPipeline(
+    mlir::FunctionOpInterface entryPointFn, linalg::LinalgOp linalgOp,
+    AIEConfig cfg) {
+  auto maybePackPeelTiling = ParameterSetting::create(linalgOp, true);
+  if (failed(maybePackPeelTiling)) return failure();
+  auto packPeelTiling = maybePackPeelTiling.value();
 
   // ------------------------------------------------------
   // --------------- Set packing config -------------------
   // ------------------------------------------------------
   MLIRContext *context = entryPointFn.getContext();
-  const auto packedK0 = findLargestFactor(K, 16 * scaleFactor);
-  SmallVector<int64_t> packedSizes = {tileM0, tileN0, packedK0};
+
   // Transpose B matrix from [K N n k] to [K N k n]
   SmallVector<int64_t> transposePackIndices = {1};
   // There is no corresponding unpack for the specified pack operation
@@ -115,15 +257,17 @@ static LogicalResult setRootConfigForPackPeelPipeline(
   SmallVector<SmallVector<int64_t>> innerPerm = {{1, 0}};
   SmallVector<SmallVector<int64_t>> outerPerm = {{0, 1}};
   auto packingConfigLevel1Attr = getPackingConfigPackingLevelAttr(
-      context, packedSizes, transposePackIndices, unpackEmpty, innerPerm,
-      outerPerm);
+      context, packPeelTiling.getPackSizeL0(), transposePackIndices,
+      unpackEmpty, innerPerm, outerPerm);
 
   // Pack level => 2.
   // packed size for [M, N, K, m, n, k]
-  auto maybePackedSize = getPackedSize(linalgOp, M, N, K);
-  if (failed(maybePackedSize)) return failure();
-  const auto [m0, n0, k0] = maybePackedSize.value();
-  packedSizes = {0, 0, 0, m0, n0, k0};
+  SmallVector<int64_t> packedSizes = {0,
+                                      0,
+                                      0,
+                                      packPeelTiling.getM1Pack(),
+                                      packPeelTiling.getN1Pack(),
+                                      packPeelTiling.getK1Pack()};
 
   // Transpose A matrix from [M K m k m0 k0] to [M K k m m0 k0]
   // Transpose B matrix from [K N k n n0 k0] to [K N n k k0 n0]
@@ -147,18 +291,11 @@ static LogicalResult setRootConfigForPackPeelPipeline(
   // ------------------------------------------------------
   // -------------- Set lowering config -------------------
   // ------------------------------------------------------
-  // Currently, assume working on a 2x2 AIE array, so the second level tile
-  // sizes should be (tileM0/2, tileN0/2). Considering the packing sizes, the
-  // adjusted tile sizes should be (tileM0/2/packedM1, tileN0/2/packedN1).
-  const auto tileM1 = findLargestFactor(tileM0 / m0, 16 * scaleFactor / m0);
-  const auto tileN1 = findLargestFactor(tileN0 / n0, 16 * scaleFactor / n0);
-  // Set tile size for K as constant 1, so that the packed outer K dimension
-  // is 1.
-  const int tileK = 1;
-
-  SmallVector<int64_t> TileSizeLevel0 = {tileM0, tileN0};
-  SmallVector<int64_t> TileSizeLevel1 = {0, 0, tileK};
-  SmallVector<int64_t> TileSizeLevel2 = {0, 0, 0, tileM1, tileN1, 0};
+  SmallVector<int64_t> TileSizeLevel0 = {packPeelTiling.getM0(),
+                                         packPeelTiling.getN0()};
+  SmallVector<int64_t> TileSizeLevel1 = {0, 0, packPeelTiling.getK0()};
+  SmallVector<int64_t> TileSizeLevel2 = {
+      0, 0, 0, packPeelTiling.getM1(), packPeelTiling.getN1(), 0};
   TileSizesListType tileSizes = {TileSizeLevel0, TileSizeLevel1,
                                  TileSizeLevel2};
   if (failed(setOpConfigAndEntryPointFnTranslation(
@@ -169,127 +306,10 @@ static LogicalResult setRootConfigForPackPeelPipeline(
   return success();
 }
 
-namespace {
-
-// Container class for the tiling at level 0 (the AIE shared memory) and level 1
-// (the AIE core) in the M-, N-, and K-dimensions of a matmul operation, using
-// the pad-pack approach to tiling a matmul. Also contains the packing sizes for
-// the M, N, and K dimensions. The packing sizes correspond to matmul
-// vector-instruction sizes for vectorizable types.
-class PadPackTiling {
- public:
-  SmallVector<int64_t> getPackSize() const { return {mPack, nPack, kPack}; }
-
-  static FailureOr<PadPackTiling> create(linalg::LinalgOp linalgOp);
-
-  uint32_t getM0() const { return M0; }
-  uint32_t getN0() const { return N0; }
-  uint32_t getK0() const { return K0; }
-  uint32_t getM1() const { return M1; }
-  uint32_t getN1() const { return N1; }
-  uint32_t getK1() const { return K1; }
-  uint32_t getMPack() const { return mPack; }
-  uint32_t getNPack() const { return nPack; }
-  uint32_t getKPack() const { return kPack; }
-
- private:
-  PadPackTiling(uint32_t M0, uint32_t N0, uint32_t K0, uint32_t M1, uint32_t N1,
-                uint32_t K1, uint32_t mPack, uint32_t nPack, uint32_t kPack)
-      : M0(M0),
-        N0(N0),
-        K0(K0),
-        M1(M1),
-        N1(N1),
-        K1(K1),
-        mPack(mPack),
-        nPack(nPack),
-        kPack(kPack) {
-    // Tiling at level 0 (shared memory) should be no smaller that tiling at
-    // level 1 (AIE core memory).
-    assert(M0 >= M1 && N0 >= N1);
-
-    // Tiling at level 1 (AIE core memory) should be no smaller than the packing
-    // size (vector instruction size).
-    assert(M1 >= mPack && N1 >= nPack);
-  }
-
-  uint32_t M0;
-  uint32_t N0;
-  uint32_t K0;
-  uint32_t M1;
-  uint32_t N1;
-  uint32_t K1;
-  uint32_t mPack;
-  uint32_t nPack;
-  uint32_t kPack;
-};
-
-FailureOr<PadPackTiling> PadPackTiling::create(linalg::LinalgOp linalgOp) {
-  auto initType =
-      llvm::cast<ShapedType>(linalgOp.getDpsInitOperand(0)->get().getType());
-  auto initShape = initType.getShape();
-
-  auto lhsType =
-      llvm::cast<ShapedType>(linalgOp.getDpsInputOperand(0)->get().getType());
-  auto lhsShape = lhsType.getShape();
-
-  // Shape of the full matmul operation.
-  const uint64_t M = initShape[0];
-  const uint64_t N = initShape[1];
-  const uint64_t K = lhsShape[1];
-
-  FailureOr<unsigned> maybeScaleFactor =
-      getTilingScaleFactor(lhsType.getElementType());
-  if (failed(maybeScaleFactor)) {
-    return linalgOp.emitOpError(
-        "does not have the expected bitwidth (64, 32, 16, or 8), could not "
-        "determine scale factor.");
-  }
-
-  unsigned scaleFactor = maybeScaleFactor.value();
-
-  auto maybePackedSize = getPackedSize(linalgOp, M, N, K);
-  if (failed(maybePackedSize)) return failure();
-  auto [mPack, nPack, kPack] = maybePackedSize.value();
-
-  // The current ad-hoc algorithm for determining the tiling at level 0 and
-  // level 1 is as follows:
-  //
-  // Step 1: Find the largest tiling for M and N on the AIE core, subject to
-  // constraints.
-  //
-  // Step 2: Find the largest tiling for M and N in AIE shared memory,
-  // subject to constraints.
-  //
-  // Tiling in the K-dimension is done differently TODO(newling)
-  // document/reconsider.
-
-  auto maxL1Size = 16 * scaleFactor;
-  uint32_t M1 = findLargestFactor(M, maxL1Size, mPack);
-  uint32_t N1 = findLargestFactor(N, maxL1Size, nPack);
-
-  auto maxL0Size = 64 * scaleFactor;
-  uint32_t M0 = findLargestFactor(M, maxL0Size, M1);
-  uint32_t N0 = findLargestFactor(N, maxL0Size, N1);
-
-  uint32_t K1 = findLargestFactor(K / kPack, 2 * scaleFactor);
-  uint32_t K0 = findLargestFactor(K, 256, kPack * K1);
-
-  return PadPackTiling{M0, N0, K0, M1, N1, K1, mPack, nPack, kPack};
-}
-}  // namespace
-
 static LogicalResult setRootConfigForPadPackPipeline(
     mlir::FunctionOpInterface entryPointFn, linalg::LinalgOp linalgOp,
     AIEConfig cfg) {
-  // Currently, the tile sizes are chosen empirically for large GEMM sizes,
-  // which are [64*s, 64*s, 256] for the first level and [16*s, 16*s, 16*s] for
-  // the second level, where 's' is the scaling factor based on the element
-  // type's bit width. Basic min/max constraints are added to avoid failure for
-  // small GEMM sizes where possible. Assume for now that we are working on a
-  // 4x4 AIE array.
-
-  auto maybePadPackTiling = PadPackTiling::create(linalgOp);
+  auto maybePadPackTiling = ParameterSetting::create(linalgOp, false);
   if (failed(maybePadPackTiling)) return failure();
   auto padPackTiling = maybePadPackTiling.value();
 
@@ -305,7 +325,7 @@ static LogicalResult setRootConfigForPadPackPipeline(
   SmallVector<SmallVector<int64_t>> outerPerm{{1, 0}, {1, 0}, {1, 0}};
 
   auto packingConfigLevel1Attr = getPackingConfigPackingLevelAttr(
-      context, padPackTiling.getPackSize(), transposePackIndices, unpackEmpty,
+      context, padPackTiling.getPackSizeL1(), transposePackIndices, unpackEmpty,
       innerPerm, outerPerm);
   SmallVector<PackingConfigPackingLevelAttr> packingConfigLevelsVal{
       packingConfigLevel1Attr};
@@ -318,7 +338,6 @@ static LogicalResult setRootConfigForPadPackPipeline(
   // ------------------------------------------------------
   // -------------- Set lowering config -------------------
   // ------------------------------------------------------
-
   SmallVector<int64_t> level0{padPackTiling.getM0(), padPackTiling.getN0()};
   SmallVector<int64_t> level1{0, 0, padPackTiling.getK0()};
   SmallVector<int64_t> level2{padPackTiling.getM1(), padPackTiling.getN1()};

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy.mlir
@@ -132,7 +132,7 @@ builtin.module {
 
 // -----
 
-// CHECK-PAD-PACK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128], [0, 0, 128], [64, 64], [0, 0, 8]]>
+// CHECK-PAD-PACK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128], [0, 0, 128], [32, 32], [0, 0, 4]]>
 // CHECK-PAD-PACK{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[1, 0], [1, 0], [1, 0]]}]>
 builtin.module {
   func.func @matmul_2432x2432x2432_bf16xbf16xf32() {
@@ -169,6 +169,27 @@ builtin.module {
     // CHECK:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig}
     %7 = linalg.matmul ins(%3, %4 : tensor<2048x2048xi8>, tensor<2048x2048xi8>) outs(%6 : tensor<2048x2048xi32>) -> tensor<2048x2048xi32>
     flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : tensor<2048x2048xi32> -> !flow.dispatch.tensor<writeonly:tensor<2048x2048xi32>>
+    return
+  }
+}
+
+// -----
+
+// CHECK-PACK-PEEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[44, 128], [0, 0, 1], [0, 0, 0, 11, 16, 0]]>
+// CHECK-PACK-PEEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [44, 128, 64], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+module {
+  func.func @matmul_large_dispatch_0_matmul_308x2432x9728_bf16() {
+    %cst = arith.constant 0.000000e+00 : bf16
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<308x9728xbf16>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<9728x2432xbf16>>
+    %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<308x2432xbf16>>
+    %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [308, 9728], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<308x9728xbf16>> -> tensor<308x9728xbf16>
+    %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [9728, 2432], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<9728x2432xbf16>> -> tensor<9728x2432xbf16>
+    %5 = tensor.empty() : tensor<308x2432xbf16>
+    %6 = linalg.fill ins(%cst : bf16) outs(%5 : tensor<308x2432xbf16>) -> tensor<308x2432xbf16>
+    %7 = linalg.matmul ins(%3, %4 : tensor<308x9728xbf16>, tensor<9728x2432xbf16>) outs(%6 : tensor<308x2432xbf16>) -> tensor<308x2432xbf16>
+    flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [308, 2432], strides = [1, 1] : tensor<308x2432xbf16> -> !flow.dispatch.tensor<writeonly:tensor<308x2432xbf16>>
     return
   }
 }

--- a/tests/samples/pack_peel_pipeline_matmul.mlir
+++ b/tests/samples/pack_peel_pipeline_matmul.mlir
@@ -43,3 +43,25 @@ func.func @matmul_bf16(%lhs: tensor<512x1024xbf16>, %rhs: tensor<1024x512xbf16>)
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.sync
+
+// -----
+
+func.func @matmul_bf16_large(%arg0: tensor<308x9728xbf16>, %arg1: tensor<9728x2432xbf16>) -> tensor<308x2432xbf16> {
+  %0 = tensor.empty() : tensor<308x2432xbf16>
+  %cst = arith.constant 0.000000e+00 : bf16
+  %1 = linalg.fill ins(%cst : bf16) outs(%0 : tensor<308x2432xbf16>) -> tensor<308x2432xbf16>
+  %2 = linalg.matmul ins(%arg0, %arg1 : tensor<308x9728xbf16>, tensor<9728x2432xbf16>) outs(%1 : tensor<308x2432xbf16>) -> tensor<308x2432xbf16>
+  return %2 : tensor<308x2432xbf16>
+}
+
+
+// CHECK-LABEL: hal.executable.export public @matmul_bf16_large_dispatch_0_matmul_308x2432x9728_bf16
+//       CHECK:    aie.device(npu)
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    aie.shim_dma_allocation
+//       CHECK:    func.func @matmul_bf16_large_dispatch_0_matmul_308x2432x9728_bf16(%arg0: memref<1498112xi32>, %arg1: memref<11829248xi32>, %arg2: memref<374528xi32>)
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.dma_memcpy_nd
+//       CHECK:      aiex.npu.sync


### PR DESCRIPTION
- This PR modified the tiling and packing parameter settings for pack-peel pipeline following the existing strategy for pad-pack pipeline. These changes are specially made to make challenging matmul input sizes compiling and running on the device. The performance is not the main concern at this time.
- Bump MLIR-AIR to include several fixes in AIR.
- With this PR 7/8 matmul tests added here https://github.com/nod-ai/iree-amd-aie/pull/334 have passed using pack-peel pipeline. The remaining one failed at AIE level. @erwei-xilinx will help take a further look.