### PR TITLE
Revert "Modify the config settings for pack-peel pipeline"

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy.mlir
@@ -132,7 +132,7 @@ builtin.module {
 
 // -----
 
-// CHECK-PAD-PACK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128], [0, 0, 128], [32, 32], [0, 0, 4]]>
+// CHECK-PAD-PACK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128], [0, 0, 128], [64, 64], [0, 0, 8]]>
 // CHECK-PAD-PACK{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[1, 0], [1, 0], [1, 0]]}]>
 builtin.module {
   func.func @matmul_2432x2432x2432_bf16xbf16xf32() {
@@ -169,27 +169,6 @@ builtin.module {
     // CHECK:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig}
     %7 = linalg.matmul ins(%3, %4 : tensor<2048x2048xi8>, tensor<2048x2048xi8>) outs(%6 : tensor<2048x2048xi32>) -> tensor<2048x2048xi32>
     flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [2048, 2048], strides = [1, 1] : tensor<2048x2048xi32> -> !flow.dispatch.tensor<writeonly:tensor<2048x2048xi32>>
-    return
-  }
-}
-
-// -----
-
-// CHECK-PACK-PEEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[44, 128], [0, 0, 1], [0, 0, 0, 11, 16, 0]]>
-// CHECK-PACK-PEEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [44, 128, 64], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
-module {
-  func.func @matmul_large_dispatch_0_matmul_308x2432x9728_bf16() {
-    %cst = arith.constant 0.000000e+00 : bf16
-    %c0 = arith.constant 0 : index
-    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<308x9728xbf16>>
-    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<9728x2432xbf16>>
-    %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<308x2432xbf16>>
-    %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [308, 9728], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<308x9728xbf16>> -> tensor<308x9728xbf16>
-    %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [9728, 2432], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<9728x2432xbf16>> -> tensor<9728x2432xbf16>
-    %5 = tensor.empty() : tensor<308x2432xbf16>
-    %6 = linalg.fill ins(%cst : bf16) outs(%5 : tensor<308x2432xbf16>) -> tensor<308x2432xbf16>
-    %7 = linalg.matmul ins(%3, %4 : tensor<308x9728xbf16>, tensor<9728x2432xbf16>) outs(%6 : tensor<308x2432xbf16>) -> tensor<308x2432xbf16>
-    flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [308, 2432], strides = [1, 1] : tensor<308x2432xbf16> -> !flow.dispatch.tensor<writeonly:tensor<308x2432xbf16>>
     return
   }
 }

--- a/tests/samples/pack_peel_pipeline_matmul.mlir
+++ b/tests/samples/pack_peel_pipeline_matmul.mlir
@@ -43,25 +43,3 @@ func.func @matmul_bf16(%lhs: tensor<512x1024xbf16>, %rhs: tensor<1024x512xbf16>)
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.sync
-
-// -----
-
-func.func @matmul_bf16_large(%arg0: tensor<308x9728xbf16>, %arg1: tensor<9728x2432xbf16>) -> tensor<308x2432xbf16> {
-  %0 = tensor.empty() : tensor<308x2432xbf16>
-  %cst = arith.constant 0.000000e+00 : bf16
-  %1 = linalg.fill ins(%cst : bf16) outs(%0 : tensor<308x2432xbf16>) -> tensor<308x2432xbf16>
-  %2 = linalg.matmul ins(%arg0, %arg1 : tensor<308x9728xbf16>, tensor<9728x2432xbf16>) outs(%1 : tensor<308x2432xbf16>) -> tensor<308x2432xbf16>
-  return %2 : tensor<308x2432xbf16>
-}
-
-
-// CHECK-LABEL: hal.executable.export public @matmul_bf16_large_dispatch_0_matmul_308x2432x9728_bf16
-//       CHECK:    aie.device(npu)
-//       CHECK:    aie.shim_dma_allocation
-//       CHECK:    aie.shim_dma_allocation
-//       CHECK:    aie.shim_dma_allocation
-//       CHECK:    func.func @matmul_bf16_large_dispatch_0_matmul_308x2432x9728_bf16(%arg0: memref<1498112xi32>, %arg1: memref<11829248xi32>, %arg2: memref<374528xi32>)
-//       CHECK:      aiex.npu.dma_memcpy_nd
-//       CHECK:      aiex.npu.dma_memcpy_nd
-//       CHECK:      aiex.npu.dma_memcpy_nd
-//       CHECK:      aiex.npu.sync


### PR DESCRIPTION
Reverts nod-ai/iree-amd-aie#335, since it seems to have caused intermittent numerical issue.