### PR TITLE
Pipeline not used in ukernel matching pattern 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -383,7 +383,6 @@ void addPadPackBasedPassPipeline(OpPassManager &funcPassManager,
   // Lower to UKernels
   {
     AMDAIELowerToUKernelsOptions options;
-    options.passPipeline = AIEPassPipeline::PadPackPipeline;
     options.pathToUkernels = clPathToUkernels;
     funcPassManager.addPass(createAMDAIELowerToUKernelsPass(options));
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -212,16 +212,6 @@ def AMDAIELowerToUKernels :
   let constructor =
       "mlir::iree_compiler::AMDAIE::createAMDAIELowerToUKernelsPass()";
   let options = [
-    Option<"passPipeline", "pass-pipeline",
-      "mlir::iree_compiler::AMDAIE::AIEPassPipeline",
-      /*default=*/"mlir::iree_compiler::AMDAIE::AIEPassPipeline::PadPackPipeline",
-      "Pass pipeline to use while lowering to AIR dialect",
-      [{::llvm::cl::values(
-        clEnumValN(mlir::iree_compiler::AMDAIE::AIEPassPipeline::PackPeelPipeline, "pack-peel",
-                   "Use the more advanced pack-based lowering strategy, including peeling and double-buffering."),
-        clEnumValN(mlir::iree_compiler::AMDAIE::AIEPassPipeline::PadPackPipeline, "pad-pack",
-                   "Use the pad-pack based lowering strategy.")
-      )}]>,
     Option<"pathToUkernels", "path-to-ukernels", "std::string", /*default=*/"",
       "Path to microkernels' directory">
   ];

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_ukernel.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_ukernel.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-amdaie-lower-to-ukernels{pass-pipeline=pad-pack path-to-ukernels="/custom/path/to/ukernels"},cse,canonicalize))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-amdaie-lower-to-ukernels{path-to-ukernels="/custom/path/to/ukernels"},cse,canonicalize))" %s | FileCheck %s
 
 // This first case demonstrates no lowering to ukernel when the corresponding
 // config is set to "none".


### PR DESCRIPTION
Not sure why the pipeline was being passed to the ukernel patterns, maybe some historical artifact?