### PR TITLE
Remove redundant data copy of elementwise op

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPropagateDataLayout.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPropagateDataLayout.cpp
@@ -6,6 +6,7 @@
 
 #include "iree-amd-aie/Transforms/Passes.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -14,6 +15,52 @@
 namespace mlir::iree_compiler::AMDAIE {
 
 namespace {
+
+/// Forces `outs` operands of linalg operations to use `tensor.empty` if the
+/// value of the `outs` operand is not used within the op.  This is only
+/// implemented for `linalg.generic` operations for now, but should hold for all
+/// linalg structured ops.
+struct RemoveOutsDependency : public OpRewritePattern<linalg::GenericOp> {
+  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::GenericOp op,
+                                PatternRewriter &rewriter) const override {
+    rewriter.startOpModification(op);
+    bool modifiedOutput = false;
+    Location loc = op.getLoc();
+    for (OpOperand &opOperand : op.getDpsInitsMutable()) {
+      if (!op.payloadUsesValueFromOperand(&opOperand)) {
+        Value operandVal = opOperand.get();
+        auto operandType = dyn_cast<RankedTensorType>(operandVal.getType());
+        if (!operandType) continue;
+
+        // If outs is sparse, leave it to the sparsifier.
+        if (sparse_tensor::getSparseTensorEncoding(operandVal.getType()))
+          continue;
+
+        // If outs is already an `empty` operation, nothing to do.
+        auto definingOp = operandVal.getDefiningOp<tensor::EmptyOp>();
+        if (definingOp) continue;
+        modifiedOutput = true;
+        SmallVector<OpFoldResult> mixedSizes =
+            tensor::getMixedSizes(rewriter, loc, operandVal);
+        Value emptyTensor = rewriter.create<tensor::EmptyOp>(
+            loc, mixedSizes, operandType.getElementType());
+        op->setOperand(opOperand.getOperandNumber(), emptyTensor);
+      }
+    }
+    if (!modifiedOutput) {
+      rewriter.cancelOpModification(op);
+      return failure();
+    }
+    rewriter.finalizeOpModification(op);
+    return success();
+  }
+};
+
+void populateElementwiseOpsFusionPatterns(RewritePatternSet &patterns) {
+  patterns.add<RemoveOutsDependency>(patterns.getContext());
+}
 
 class AMDAIEPropagateDataLayoutPass
     : public impl::AMDAIEPropagateDataLayoutBase<
@@ -31,8 +78,11 @@ class AMDAIEPropagateDataLayoutPass
 void AMDAIEPropagateDataLayoutPass::runOnOperation() {
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
+
   linalg::populateDataLayoutPropagationPatterns(
       patterns, [](Operation *op) { return true; });
+  populateElementwiseOpsFusionPatterns(patterns);
+
   if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
     return signalPassFailure();
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -77,18 +77,10 @@ void appendVectorizationToPipeline(OpPassManager &funcPassManager) {
 static FailureOr<Value> aieComprehensiveBufferizeAllocationFn(
     OpBuilder &builder, Location loc, MemRefType memRefType,
     ValueRange dynamicSizes, unsigned alignment) {
-  int64_t numDims = memRefType.getShape().size();
-  AMDAIEMemSpace memSpace = AMDAIEMemSpace::Shared;
-  if (clUsePipeline == AIEPassPipeline::PadPackPipeline && numDims == 4) {
-    memSpace = AMDAIEMemSpace::Local;
-  } else if (clUsePipeline == AIEPassPipeline::PackPeelPipeline &&
-             numDims == 6) {
-    memSpace = AMDAIEMemSpace::Local;
-  }
-
   OpBuilder::InsertionGuard g(builder);
+  // Set the memory space attribute as local for now
   auto memorySpaceAttr =
-      AMDAIEMemSpaceAttr::get(builder.getContext(), memSpace);
+      AMDAIEMemSpaceAttr::get(builder.getContext(), AMDAIEMemSpace::Local);
   MemRefType allocType =
       MemRefType::get(memRefType.getShape(), memRefType.getElementType(),
                       AffineMap(), memorySpaceAttr);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/propagate_data_layout.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/propagate_data_layout.mlir
@@ -86,10 +86,10 @@ func.func @matmul_elementwise_1024x1024x512_i8xi8xi32(%arg0: tensor<1024x512xi8>
 // CHECK-LABEL: matmul_elementwise_1024x1024x512_i8xi8xi32
 //       CHECK: %[[PACK_0:.*]] = tensor.pack {{.*}} : tensor<64x512xi8> -> tensor<1x16x64x32xi8>
 //       CHECK: %[[PACK_1:.*]] = tensor.pack {{.*}} : tensor<512x64xi8> -> tensor<16x1x32x64xi8>
+//       CHECK: %[[EMPTY:.*]] = tensor.empty() : tensor<1x1x64x64xi32>
 //       CHECK: %[[FILL:.*]] = linalg.fill {{.*}} -> tensor<1x1x64x64xi32>
 //       CHECK: %[[MATMUL:.*]] = linalg.generic {{.*}} ins(%[[PACK_0]], %[[PACK_1]] : tensor<1x16x64x32xi8>, tensor<16x1x32x64xi8>) outs(%[[FILL]] : tensor<1x1x64x64xi32>)
 //   CHECK-NOT: tensor.unpack
 //       CHECK: %[[PACK_2:.*]] = tensor.pack {{.*}} : tensor<64x64xi32> -> tensor<1x1x64x64xi32>
-//       CHECK: %[[PACK_3:.*]] = tensor.pack {{.*}} : tensor<64x64xi32> -> tensor<1x1x64x64xi32>
-//       CHECK: %[[ELEMENT:.*]] = linalg.generic {{.*}} ins(%[[MATMUL]], %[[PACK_3]] : tensor<1x1x64x64xi32>, tensor<1x1x64x64xi32>) outs(%[[PACK_2]] : tensor<1x1x64x64xi32>)
+//       CHECK: %[[ELEMENT:.*]] = linalg.generic {{.*}} ins(%[[MATMUL]], %[[PACK_2]] : tensor<1x1x64x64xi32>, tensor<1x1x64x64xi32>) outs(%[[EMPTY]] : tensor<1x1x64x64xi32>)
 //       CHECK: %[[UNPACK:.*]] = tensor.unpack %[[ELEMENT:.*]] {{.*}} :  tensor<1x1x64x64xi32> -> tensor<64x64xi32>

--- a/tests/samples/pack_peel_pipeline_matmul_elementwise.mlir
+++ b/tests/samples/pack_peel_pipeline_matmul_elementwise.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pack-peel --iree-amdaie-matmul-elementwise-fusion --split-input-file | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pack-peel --iree-amdaie-matmul-elementwise-fusion --iree-amdaie-enable-vectorization-passes=false --split-input-file | FileCheck %s
 
 func.func @matmul_elementwise_i32(%lhs: tensor<1024x512xi32>, %rhs: tensor<512x1024xi32>, %ele: tensor<1024x1024xi32>) -> tensor<1024x1024xi32>
 {
@@ -56,7 +56,7 @@ func.func @matmul_elementwise_bf16(%arg0: tensor<1024x512xbf16>, %arg1: tensor<5
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
-//       CHECK:    func.func @matmul_elementwise_bf16_dispatch_0_matmul_1024x1024x512_bf16(%arg0: memref<262144xi32>, %arg1: memref<262144xi32>, %arg2: memref<524288xi32>, %arg3: memref<512xi32>)
+//       CHECK:    func.func @matmul_elementwise_bf16_dispatch_0_matmul_1024x1024x512_bf16(%arg0: memref<262144xi32>, %arg1: memref<262144xi32>, %arg2: memref<512xi32>, %arg3: memref<524288xi32>)
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd
@@ -96,7 +96,7 @@ func.func @matmul_elementwise_transpose_b(%arg0: tensor<256x512xbf16>, %arg1: te
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
-//       CHECK:    func.func @matmul_elementwise_transpose_b_dispatch_0_matmul_transpose_b_256x1024x512_bf16(%arg0: memref<65536xi32>, %arg1: memref<262144xi32>, %arg2: memref<131072xi32>, %arg3: memref<512xi32>)
+//       CHECK:    func.func @matmul_elementwise_transpose_b_dispatch_0_matmul_transpose_b_256x1024x512_bf16(%arg0: memref<65536xi32>, %arg1: memref<262144xi32>, %arg2: memref<512xi32>, %arg3: memref<131072xi32>)
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd


### PR DESCRIPTION
- Add [upstream support](https://github.com/shark-infra/llvm-project/blob/f2d824e381755993b6e8c32f4de89192189ca9a7/mlir/lib/Dialect/Linalg/Transforms/ElementwiseOpFusion.cpp#L1864) locally to remove output dependency, since the pattern is not exposed and cannot be called directly. This pattern is added in `AMDAIEPropagateDataLayoutPass`, so that whenever we do data layout propagation it will get the desirable output for matmul-elementwise fusion. @MaheshRavishankar please let me know if it is reasonable to add it here, otherwise I'm open to move it into a separate pass or add the pattern to the cleanup pass.
- Currently, tests without vectorization compile through, but crash at `AIRToAIESchedulingUtilsPass` with vectorization. @erwei-xilinx 