### PR TITLE
[Delegate] Support for 16k matmul

### DIFF
--- a/experimental/delegate/CMakeLists.txt
+++ b/experimental/delegate/CMakeLists.txt
@@ -63,12 +63,14 @@ iree_lit_test_suite(
   SRCS
     "mlp.mlir"
     "matmul.mlir"
+    "matmul-16k.mlir"
     "opt.mlir"
     "large-matmul.mlir"
     "large-matmul-f32.mlir"
     "matmul-elementwise-f32.mlir"
   DATA
     "linalg.pdl.mlir"
+    "matmul-16k.pdl.mlir"
     "opt.pdl.mlir"
     "large-matmul.pdl.mlir"
     "large-matmul-f32.pdl.mlir"

--- a/experimental/delegate/kernels/CMakeLists.txt
+++ b/experimental/delegate/kernels/CMakeLists.txt
@@ -17,6 +17,7 @@ set(AIE_DELEGATE_KERNELS
     "matmul/matmul-bf16-256x256x256-v1"  # ref matmul
     "matmul/matmul-bf16-f32-8x768x768-v1"  # for OPT, 4x4 vec matmul
     "matmul/matmul-bf16-f32-8192x9728x2432-v1"  # Large Matmul
+    "matmul/matmul-bf16-f32-16384x16384X512-phx-v1"  # 16k phoenix matmul
 )
 
 # List of all kernel file extensions

--- a/experimental/delegate/matmul-16k.mlir
+++ b/experimental/delegate/matmul-16k.mlir
@@ -1,0 +1,45 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-preprocessing-apply-pdl-patterns{patterns-file=%p/matmul-16k.pdl.mlir}, cse)" %s | FileCheck %s
+
+#x86_64_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  native_vector_size = 32 : index,
+  target_triple = "x86_64-none-elf"
+}>
+
+// The target devices that the program will run on. We can compile and run with
+// multiple targets, but this example is maintaining an implicit requirement
+// that the custom kernel being spliced in is supported by the target device,
+// hence we only support llvm-cpu here.
+#cpu_target = #hal.device.target<"llvm-cpu", [
+  #x86_64_target
+]>
+
+module @example attributes {hal.device.targets = [#cpu_target]} {
+// CHECK-LABEL: module @example
+
+// Check that the stream executable uses the proper name format
+// CHECK: stream.executable private @mlp_external_bf16_bf16_f32_i32_i32_i32_executable {
+
+// Check that the external function is declared with the right dtypes
+// CHECK: builtin.module {
+// CHECK: func.func private @mlp_external(memref<bf16>, index, memref<bf16>, index, memref<f32>, index, i32, i32, i32)
+
+// Check that the call to the external function exists and is called with the right types
+// CHECK: func.func @mlp_external_entry_point({{.+}}) {
+// CHECK: call @mlp_external({{.+}}) : (memref<bf16>, index, memref<bf16>, index, memref<f32>, index, i32, i32, i32) -> ()
+
+
+  func.func @mlp_invocation(%lhs: tensor<1x16384x512xbf16>,
+                            %rhs: tensor<1x512x16384xbf16>) -> (tensor<1x16384x16384xf32>) {
+    %cst_206 = arith.constant 0.000000e+00 : f32
+    %44 = tensor.empty() : tensor<1x16384x16384xf32>
+    %64 = linalg.fill ins(%cst_206 : f32) outs(%44 : tensor<1x16384x16384xf32>) -> tensor<1x16384x16384xf32>
+    %65 = linalg.batch_matmul ins(%lhs, %rhs : tensor<1x16384x512xbf16>, tensor<1x512x16384xbf16>) outs(%64 : tensor<1x16384x16384xf32>) -> tensor<1x16384x16384xf32>
+
+// Check that the batch_matmul has been replaced with a call to the external function with the right types
+// CHECK: func.func @mlp_invocation({{.+}}) -> {{.+}} {
+// CHECK: flow.dispatch @mlp_external_bf16_bf16_f32_i32_i32_i32_executable::@mlp_external_entry_point({{.+}}) : (tensor<1x16384x512xbf16>, tensor<1x512x16384xbf16>, i32, i32, i32) -> tensor<1x16384x16384xf32>
+
+    return %65 : tensor<1x16384x16384xf32>
+  }
+}  // module

--- a/experimental/delegate/matmul-16k.pdl.mlir
+++ b/experimental/delegate/matmul-16k.pdl.mlir
@@ -1,0 +1,118 @@
+// PDL pattern spec to match an MLP of shape 16384x16384x512 and offload to an
+// external function
+//
+// ```
+// void mlp_external(void *params, void *context, void *reserved)
+// ```
+//
+// which is the expected signature of an external function implemented
+// provided by a system plugin. See
+// samples/custom_dispatch/cpu/plugin/system_plugin.c for an example.
+//
+// The `params` is the following struct
+//
+// ```
+// using bfloat16_t = unsigned short;
+//
+// struct mlp_params_t {
+//   const bfloat16_t *restrict lhs;
+//   size_t lhs_offset;
+//   const bfloat16_t *restrict rhs;
+//   size_t rhs_offset;
+//   float *restrict result;
+//   size_t result_offset;
+//   int32_t M;
+//   int32_t N;
+//   int32_t K;
+// };
+// ```
+//
+// In MLIR this corresponds to the function
+//
+// ```
+// func.func private @mlp_external(%lhs : memref<bf16>, lhs_offset : index,
+//   %rhs : memref<bf16>, %rhs_offset : index, %result : memref<f32>,
+//   %result_offset : index, %M : i32, %N : i32, %K : i32)
+// ```
+//
+// Note: In the above struct a `pointer, offset` pair represents a buffer
+// passed into the external function. So any access to `lhs`, `rhs` and
+// `result` is valid only if accessed as `lhs[lhs_offset + ...]`,
+// `rhs[rhs_offset + ]` and `result[result_offset + ...]`.
+pdl.pattern @mlp : benefit(1) {
+
+  // PDL matcher to match the MLP computation. This pattern is expected to
+  // match
+  //
+  // ```
+  // linalg.batch_matmul ins(%lhs, %rhs : tensor<1x16384x512xbf16>,
+  //   tensor<1x512x16384xbf16>) outs(%64 : tensor<1x16384x16384xbf16>) ->
+  //   tensor<1x16384x16384xbf16>
+  // ```
+  
+  %lhs_type = pdl.type : tensor<1x16384x512xbf16>
+  %rhs_type = pdl.type : tensor<1x512x16384xbf16>
+  %matmul_type = pdl.type : tensor<1x16384x16384xf32>
+  %fixed_M = pdl.attribute = 16384 : i32
+  %fixed_N = pdl.attribute = 16384 : i32
+  %fixed_K = pdl.attribute = 512 : i32
+  
+  // %index_type = pdl.type : index
+
+  %zero_attr = pdl.attribute = 0.0 : f32
+  %zero_type = pdl.type : f32
+  %zero_op = pdl.operation "arith.constant" {"value" = %zero_attr} -> (%zero_type : !pdl.type)
+  %zero = pdl.result 0 of %zero_op
+  
+  %empty = pdl.operand
+  %fill_op = pdl.operation "linalg.fill" (%zero, %empty : !pdl.value, !pdl.value) -> (%matmul_type : !pdl.type)
+  %fill = pdl.result 0 of %fill_op
+
+  %lhs = pdl.operand : %lhs_type
+  %rhs = pdl.operand : %rhs_type
+  %matmul = pdl.operation "linalg.batch_matmul" (%lhs, %rhs, %fill : !pdl.value, !pdl.value, !pdl.value) -> (%matmul_type : !pdl.type)
+  
+  pdl.rewrite %matmul {
+    %i32_type = pdl.type : i32
+    %m_op = pdl.operation "arith.constant" {"value" = %fixed_M} -> (%i32_type : !pdl.type)
+    %m = pdl.result 0 of %m_op
+    %n_op = pdl.operation "arith.constant" {"value" = %fixed_N} -> (%i32_type : !pdl.type)
+    %n = pdl.result 0 of %n_op
+    %k_op = pdl.operation "arith.constant" {"value" = %fixed_K} -> (%i32_type : !pdl.type)
+    %k = pdl.result 0 of %k_op
+
+    %one_attribute = pdl.attribute = 1 : i32
+    %one_op = pdl.operation "arith.constant" {"value" = %one_attribute} -> (%i32_type : !pdl.type)
+    %one = pdl.result 0 of %one_op
+
+    // %replaced_values_dims = pdl.range %one, %m, %n : !pdl.value, !pdl.value, !pdl.value
+    %replaced_values_dims = pdl.range : !pdl.range<value>
+    %input_values = pdl.range %lhs, %rhs : !pdl.value, !pdl.value
+    %replaced_value = pdl.result 0 of %matmul
+    %replaced_values = pdl.range %replaced_value : !pdl.value
+    %other_operands = pdl.range %m, %n, %k : !pdl.value, !pdl.value, !pdl.value
+
+    // The `rewriteAsFlowDispatch` is a rewrite function that allows
+    // converting the matched dag into a call to the external function call
+    // provided by a system plugin. The rewrite method expects the following
+    // arguments
+    // - the root of the matched DAG. This op will be erased after the call.
+    // - `fn_name` the name of the function that is provided externally
+    //   (using a plugin).
+    // - `input_values` are values that are captures as the part of the match
+    //   and are inputs to the match.
+    // - `replaced_values` are the values that are captured as part of the
+    //   match and are replaced by the `flow.dispatch`. The `flow.dispatch`
+    //   returns as many values as `replaced_values` (and of same type).
+    // - `replaced_values_dims` are the values for the dynamic dimensions of
+    //   all the `tensor` values in `replaced_values`. For matches that could
+    //   be static or dynamic, it should be assumed that the shape is dynamic
+    //   and the value needs to be passed to the rewrite function.
+    // - `other_operands` same as `input_values`, but kept separate to allow
+    //   flexibility of where the results are passed through the ABI boundary.
+    %fn_name = pdl.attribute = "mlp_external"
+    pdl.apply_native_rewrite "rewriteAsFlowDispatch"(
+        %matmul, %fn_name, %input_values, %replaced_values, %replaced_values_dims, %other_operands
+        : !pdl.operation, !pdl.attribute, !pdl.range<value>, !pdl.range<value>, !pdl.range<value>, !pdl.range<value>)
+  }
+}

--- a/experimental/delegate/mlp_aie_bf16_plugin.cpp
+++ b/experimental/delegate/mlp_aie_bf16_plugin.cpp
@@ -88,23 +88,14 @@
 #endif
 
 #ifdef ENABLE_TRACE_DELEGATE
-#define TRACE_DELEGATE(str_)                                      \
-  do {                                                            \
-    std::cout << "[AIE Delegate Trace]: " << (str_) << std::endl; \
-  } while (0)
-#define TRACE_DELEGATE1(str_, arg1_)                                         \
-  do {                                                                       \
-    std::cout << "[AIE Delegate Trace]: " << (str_) << (arg1_) << std::endl; \
-  } while (0)
-#else
 #define TRACE_DELEGATE(str_) \
-  do {                       \
-    ;                        \
-  } while (0)
+  std::cout << "[AIE Delegate Trace]: " << (str_) << std::endl
+
 #define TRACE_DELEGATE1(str_, arg1_) \
-  do {                               \
-    ;                                \
-  } while (0)
+  std::cout << "[AIE Delegate Trace]: " << (str_) << (arg1_) << std::endl
+#else
+#define TRACE_DELEGATE(str_)
+#define TRACE_DELEGATE1(str_, arg1_)
 #endif
 
   // Fake bfloat16 type (assuming no C++ 23)


### PR DESCRIPTION
Several enhancements in support of a 16384x16384x512 matmul with bf16 inputs and f32 outputs:

- New PDL for 16k matmul
- timers added for NPU setup and kernel execution
- cleanup of delegate tracing for better code readability
- re-indentation of some functions for consistency
- kernel (on Azure) generated via AIE direct codegen