### PR TITLE
Fix linker error seen when using different IREE branch

### DIFF
--- a/tools/plugins/CMakeLists.txt
+++ b/tools/plugins/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_binary(
   DEPS
     iree::compiler::Dialect::HAL::IR::HALDialect
     iree::compiler::Dialect::LinalgExt::IR
+    iree::compiler::Dialect::LinalgExt::Transforms
     iree::compiler::Dialect::Stream::IR
     iree::target::amd-aie::Translation::AIESerializer
     MLIRGPUDialect


### PR DESCRIPTION
When attempting to bump IREE (or use a branch off a more rencent IREE than we have) I see some linker errors of the form 

```
ld.lld: error: undefined symbol: mlir::iree_compiler::IREE::LinalgExt::AttentionOp::getLoopIteratorTypes()
>>> referenced by TilingInterface.h.inc:292 (llvm-project/tools/mlir/include/mlir/Interfaces/TilingInterface.h.inc:292)
>>>               ../compiler/src/iree/compiler/Dialect/LinalgExt/IR/CMakeFiles/iree_compiler_Dialect_LinalgExt_IR_IR.objects.dir/LinalgExtDialect.cpp.o:(mlir::detail::TilingInterfaceInterfaceTraits::Model<mlir::iree_compiler::IREE::LinalgExt::AttentionOp>::getLoopIteratorTypes(mlir::detail::TilingInterfaceInterfaceTraits::Concept const*, mlir::Operation*)) in archive lib/libiree_compiler_Dialect_LinalgExt_IR_IR.a
```


This PR fixes these linker errors 