### PR TITLE
[Delegate] Dual xclbin support

### DIFF
--- a/experimental/delegate/kernels/CMakeLists.txt
+++ b/experimental/delegate/kernels/CMakeLists.txt
@@ -18,6 +18,7 @@ set(AIE_DELEGATE_KERNELS
     "matmul/matmul-bf16-f32-8x768x768-v1"  # for OPT, 4x4 vec matmul
     "matmul/matmul-bf16-f32-8192x9728x2432-v1"  # Large Matmul
     "matmul/matmul-bf16-f32-16384x16384X512-phx-v1"  # 16k phoenix matmul
+    "matmul/matmul-bf16-f32-16384x512x16384-phx-v1"  # 16k phx matmul alt shape
 )
 
 # List of all kernel file extensions

--- a/experimental/delegate/matmul-16k.pdl.mlir
+++ b/experimental/delegate/matmul-16k.pdl.mlir
@@ -1,5 +1,5 @@
-// PDL pattern spec to match an MLP of shape 16384x16384x512 and offload to an
-// external function
+// PDL pattern spec to match an MLP of shape 16384x16384x512 or 16384x512x16384
+// (MxNxK) and offload to an external function
 //
 // ```
 // void mlp_external(void *params, void *context, void *reserved)
@@ -39,15 +39,16 @@
 // passed into the external function. So any access to `lhs`, `rhs` and
 // `result` is valid only if accessed as `lhs[lhs_offset + ...]`,
 // `rhs[rhs_offset + ]` and `result[result_offset + ...]`.
-pdl.pattern @mlp : benefit(1) {
 
-  // PDL matcher to match the MLP computation. This pattern is expected to
-  // match
+pdl.pattern @bmm1 : benefit(1) {
+
+  // PDL matcher to match the batch matmul computation. This pattern is
+  // expected to match
   //
   // ```
   // linalg.batch_matmul ins(%lhs, %rhs : tensor<1x16384x512xbf16>,
-  //   tensor<1x512x16384xbf16>) outs(%64 : tensor<1x16384x16384xbf16>) ->
-  //   tensor<1x16384x16384xbf16>
+  //   tensor<1x512x16384xbf16>) outs(%64 : tensor<1x16384x16384xf32>) ->
+  //   tensor<1x16384x16384xf32>
   // ```
   
   %lhs_type = pdl.type : tensor<1x16384x512xbf16>
@@ -85,7 +86,6 @@ pdl.pattern @mlp : benefit(1) {
     %one_op = pdl.operation "arith.constant" {"value" = %one_attribute} -> (%i32_type : !pdl.type)
     %one = pdl.result 0 of %one_op
 
-    // %replaced_values_dims = pdl.range %one, %m, %n : !pdl.value, !pdl.value, !pdl.value
     %replaced_values_dims = pdl.range : !pdl.range<value>
     %input_values = pdl.range %lhs, %rhs : !pdl.value, !pdl.value
     %replaced_value = pdl.result 0 of %matmul
@@ -110,6 +110,65 @@ pdl.pattern @mlp : benefit(1) {
     //   and the value needs to be passed to the rewrite function.
     // - `other_operands` same as `input_values`, but kept separate to allow
     //   flexibility of where the results are passed through the ABI boundary.
+    %fn_name = pdl.attribute = "mlp_external"
+    pdl.apply_native_rewrite "rewriteAsFlowDispatch"(
+        %matmul, %fn_name, %input_values, %replaced_values, %replaced_values_dims, %other_operands
+        : !pdl.operation, !pdl.attribute, !pdl.range<value>, !pdl.range<value>, !pdl.range<value>, !pdl.range<value>)
+  }
+}
+
+pdl.pattern @bmm2 : benefit(1) {
+
+  // PDL matcher to match the batch matmul computation. This pattern is
+  // expected to match
+  //
+  // ```
+  // linalg.batch_matmul ins(%lhs, %rhs : tensor<1x16384x16384xbf16>,
+  //   tensor<1x16384x512xbf16>) outs(%64 : tensor<1x16384x512xf32>) ->
+  //   tensor<1x16384x512xf32>
+  // ```
+  
+  %lhs_type = pdl.type : tensor<1x16384x16384xbf16>
+  %rhs_type = pdl.type : tensor<1x16384x512xbf16>
+  %matmul_type = pdl.type : tensor<1x16384x512xf32>
+  %fixed_M = pdl.attribute = 16384 : i32
+  %fixed_N = pdl.attribute = 512 : i32
+  %fixed_K = pdl.attribute = 16384 : i32
+  
+  // %index_type = pdl.type : index
+
+  %zero_attr = pdl.attribute = 0.0 : f32
+  %zero_type = pdl.type : f32
+  %zero_op = pdl.operation "arith.constant" {"value" = %zero_attr} -> (%zero_type : !pdl.type)
+  %zero = pdl.result 0 of %zero_op
+  
+  %empty = pdl.operand
+  %fill_op = pdl.operation "linalg.fill" (%zero, %empty : !pdl.value, !pdl.value) -> (%matmul_type : !pdl.type)
+  %fill = pdl.result 0 of %fill_op
+
+  %lhs = pdl.operand : %lhs_type
+  %rhs = pdl.operand : %rhs_type
+  %matmul = pdl.operation "linalg.batch_matmul" (%lhs, %rhs, %fill : !pdl.value, !pdl.value, !pdl.value) -> (%matmul_type : !pdl.type)
+  
+  pdl.rewrite %matmul {
+    %i32_type = pdl.type : i32
+    %m_op = pdl.operation "arith.constant" {"value" = %fixed_M} -> (%i32_type : !pdl.type)
+    %m = pdl.result 0 of %m_op
+    %n_op = pdl.operation "arith.constant" {"value" = %fixed_N} -> (%i32_type : !pdl.type)
+    %n = pdl.result 0 of %n_op
+    %k_op = pdl.operation "arith.constant" {"value" = %fixed_K} -> (%i32_type : !pdl.type)
+    %k = pdl.result 0 of %k_op
+
+    %one_attribute = pdl.attribute = 1 : i32
+    %one_op = pdl.operation "arith.constant" {"value" = %one_attribute} -> (%i32_type : !pdl.type)
+    %one = pdl.result 0 of %one_op
+
+    %replaced_values_dims = pdl.range : !pdl.range<value>
+    %input_values = pdl.range %lhs, %rhs : !pdl.value, !pdl.value
+    %replaced_value = pdl.result 0 of %matmul
+    %replaced_values = pdl.range %replaced_value : !pdl.value
+    %other_operands = pdl.range %m, %n, %k : !pdl.value, !pdl.value, !pdl.value
+
     %fn_name = pdl.attribute = "mlp_external"
     pdl.apply_native_rewrite "rewriteAsFlowDispatch"(
         %matmul, %fn_name, %input_values, %replaced_values, %replaced_values_dims, %other_operands

--- a/experimental/delegate/mlp_aie_bf16_plugin.cpp
+++ b/experimental/delegate/mlp_aie_bf16_plugin.cpp
@@ -893,10 +893,12 @@ void aie_matmul(const KernelInfo &kernelInfo, Params *params) {
   TRACE_DELEGATE1("aie_matmul LHS volume: ", kernelInfo.getLhsVolume());
   TRACE_DELEGATE1("aie_matmul RHS volume: ", kernelInfo.getRhsVolume());
   TRACE_DELEGATE1("aie_matmul Result volume: ", kernelInfo.getResultVolume());
+  auto bufferStartTime = std::chrono::high_resolution_clock::now();
   xrtState->lhsBinder->bind(params->lhs.get(), kernelInfo.getLhsVolume());
   xrtState->rhsBinder->bind(params->rhs.get(), kernelInfo.getRhsVolume());
   xrtState->resultBinder->bind(params->result.get(),
                                kernelInfo.getResultVolume());
+  auto bufferEndTime = std::chrono::high_resolution_clock::now();
 
   // Copy inputs to kernel input BOs and sync the BOs
   TRACE_DELEGATE("aie_matmul copy inputs");
@@ -932,6 +934,11 @@ void aie_matmul(const KernelInfo &kernelInfo, Params *params) {
 
   // Collect and display performance metrics
   auto endTime = std::chrono::high_resolution_clock::now();
+  auto bufferDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            bufferEndTime - copyInStartTime)
+                            .count();
+  std::cout << "[AIE Delegate]: NPU buffer creation time: " << bufferDuration
+            << " ms" << std::endl;
   auto copyInDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
                             copyInEndTime - copyInStartTime)
                             .count();

--- a/experimental/delegate/mlp_aie_bf16_plugin.cpp
+++ b/experimental/delegate/mlp_aie_bf16_plugin.cpp
@@ -80,7 +80,7 @@
 
 // Turn this on to enable running the kernel.  Disabling the kernel is for
 // testing and debugging only.
-// #define ENABLE_KERNEL_RUN 1
+#define ENABLE_KERNEL_RUN 1
 
 //#############################################################################
 
@@ -744,6 +744,8 @@ struct XrtState {
 
 // Sets up XRT to use the specified kernel, if not already done
 void setupNPUAccelerator(const KernelInfo &kernelInfo) {
+  static std::string libPath;  // Location of delegate .so/.dll
+
   TRACE_DELEGATE("setupNPUAccelerator");
   auto startTime = std::chrono::high_resolution_clock::now();
 
@@ -756,10 +758,15 @@ void setupNPUAccelerator(const KernelInfo &kernelInfo) {
     return;
   }
 
+  // Determine the path to the kernel files from the .so/.dll.  Only needs
+  // to be done once, as the files don't change location.
+  if (libPath.empty()) {
+    libPath = getLibraryPath();
+    std::cout << "[AIE Delegate]: Using delegate installation at: " << libPath
+              << std::endl;
+  }
+
   // Load the instruction sequence from its file
-  std::string libPath = getLibraryPath();
-  std::cout << "[AIE Delegate]: Using delegate installation at: " << libPath
-            << std::endl;
   std::string instrFilePath =
       libPath + "/kernels/" + kernelInfo.kernelFileName + ".insts.txt";
   std::vector<uint32_t> instrV = loadInstrSequence(instrFilePath);

--- a/experimental/delegate/mlp_aie_bf16_plugin.cpp
+++ b/experimental/delegate/mlp_aie_bf16_plugin.cpp
@@ -66,7 +66,7 @@
 // #define USE_BF16_CPU_ACCUMULATOR 1
 
 // Turn this on to print debug messages throughout the delegate run
-// #define ENABLE_TRACE_DELEGATE 1
+#define ENABLE_TRACE_DELEGATE 1
 
 // Turn this on to dump matmul operand and result tensor values
 // #define DEBUG_VALUES 1
@@ -78,13 +78,17 @@
 // being done
 // #define ENABLE_PERFORMANCE_WARNING 1
 
+// Turn this on to enable running the kernel.  Disabling the kernel is for
+// testing and debugging only.
+// #define ENABLE_KERNEL_RUN 1
+
 //#############################################################################
 
 #if DEBUG_VALUE_CONVERSIONS
-  static bool DebugValueConversions = false;
-  #define CONVERSION_DEBUG(turnOn_) DebugValueConversions = (turnOn_);
+static bool DebugValueConversions = false;
+#define CONVERSION_DEBUG(turnOn_) DebugValueConversions = (turnOn_);
 #else
-  #define CONVERSION_DEBUG(turnOn_) ;
+#define CONVERSION_DEBUG(turnOn_) ;
 #endif
 
 #ifdef ENABLE_TRACE_DELEGATE
@@ -98,27 +102,57 @@
 #define TRACE_DELEGATE1(str_, arg1_)
 #endif
 
-  // Fake bfloat16 type (assuming no C++ 23)
-  using bfloat16_t = std::uint16_t;
+// Fake bfloat16 type (assuming no C++ 23)
+using bfloat16_t = std::uint16_t;
 
-  //#############################################################################
-  //
-  // Configuration of the kernel that the AIE delegate uses
-  //
+// Integral data type for tensor dimensions
+//
+// Must be same type as HAL uses for plug-ins.
+using TensorDim = std::int32_t;
+
+// Kernel characteristics
+struct KernelInfo {
+  // Shape that the kernel handles
+  TensorDim m;
+  TensorDim n;
+  TensorDim k;
+
+  // Kernel file names (without extension) relative to installation root
+  std::string kernelFileName;
+
+  // Kernel name inside the xclbin file
+  std::string kernelName;
+
+  bool isMatch(TensorDim m, TensorDim n, TensorDim k) const {
+    return m == this->m && n == this->n && k == this->k;
+  }
+
+  TensorDim getLhsVolume() const { return m * k; }
+  TensorDim getRhsVolume() const { return k * n; }
+  TensorDim getResultVolume() const { return m * n; }
+  inline std::size_t getLhsNumBytes() const;
+  inline std::size_t getRhsNumBytes() const;
+  inline std::size_t getResultNumBytes() const;
+};
+
+//#############################################################################
+//
+// Configuration of the kernel that the AIE delegate uses
+//
 
 #if DELEGATE_KERNEL_TO_USE == MATMUL_16K_DELEGATE_KERNEL
-// Kernel file names (without extension) relative to installation root
-const std::string kernelFileName =
-    "matmul/matmul-bf16-f32-16384x16384X512-phx-v1";  // From AIE codegen
 
-// Kernel name inside the xclbin file
-const std::string KernelName =
-    "matmul_16384x16384_512xbf16__dispatch_0_matmul_1";
+// Table of descriptions of kernels available
+static KernelInfo KernelInfos[] = {
+    {16384, 16384, 512, "matmul/matmul-bf16-f32-16384x16384X512-phx-v1",
+     "matmul_16384x16384_512xbf16__dispatch_0_matmul_1"},
+    {16384, 512, 16384, "matmul/matmul-bf16-f32-16384x512x16384-phx-v1",
+     "matmul_16384x512_16384xbf16__dispatch_0_matmul_1"}};
 
 // Fixed shape of the matmul kernel
-#define MLP_M 16384
-#define MLP_K 512
-#define MLP_N 16384
+// #define MLP_M 16384
+// #define MLP_K 512
+// #define MLP_N 16384
 
 // Types of the matmul LHS, RHS, and result, as defined by the kernel
 using A_DATATYPE = bfloat16_t;
@@ -135,6 +169,10 @@ using ModelReturnDType = float;
 #define KERNEL_REQUIRES_RESULT_PRELOAD 0
 
 //-----------------------------------------------------------------------------
+
+//
+// TODO: UPDATE ALL THE OTHER DEMOS TO USE KernelInfo!!!
+//
 
 #elif DELEGATE_KERNEL_TO_USE == LARGE_MATMUL_DELEGATE_KERNEL
 // Kernel file names (without extension) relative to installation root
@@ -226,6 +264,22 @@ using ModelReturnDType = float;
 Set DELEGATE_KERNEL_TO_USE to a supported kernel."
 #endif
 
+//=============================================================================
+
+// Kernel support functions
+
+std::size_t KernelInfo::getLhsNumBytes() const {
+  return getLhsVolume() * sizeof(A_DATATYPE);
+}
+
+std::size_t KernelInfo::getRhsNumBytes() const {
+  return getRhsVolume() * sizeof(B_DATATYPE);
+}
+
+std::size_t KernelInfo::getResultNumBytes() const {
+  return getResultVolume() * sizeof(C_DATATYPE);
+}
+
 //#############################################################################
 //
 // AIE delegate implementation
@@ -239,6 +293,19 @@ public:
   }
 };
 
+// Given the shape of a matmul (MxNxK), return the index into KernelInfos
+// of the kernel that matches the shape.
+//
+// Throws a runtime exception if no kernel matches the shape.
+static const KernelInfo &getKernelInfo(TensorDim m, TensorDim n, TensorDim k) {
+  for (const KernelInfo &ki : KernelInfos)
+    if (ki.m == m && ki.n == n && ki.k == k) return ki;
+
+  std::ostringstream oss;
+  oss << "[AIE Delegate] FATAL ERROR: No kernel available for shape " << m
+      << "x" << n << "x" << k << std::endl;
+  throw DelegateException(oss.str());
+}
 
 // Get the path of this plugin's .so
 
@@ -617,78 +684,102 @@ std::vector<uint32_t> loadInstrSequence(std::string instr_path) {
 }
 
 // Holder of AIE hardware resources of which there should be only one of each.
-// This class is used as a singleton via `getInstance()`.
+//
+// This class is used as a singleton via `getInstance()`.  An `XrtState` is
+// either "uninitialed", in which case XRT needs to be set up before the
+// AIE kernel can be used, or it's "initialized", in which case XRT has already
+// been set up for the kernel.
+//
+// When requesting the singleton, you need to give a pointer to the
+// `KernelInfo` of the kernel to use.  If the singleton was previously created
+// with the same `KernelInfo` pointer, the singleton is returned as is,
+// initialized or not.  Otherwise, the singleton is destroyed and re-created.
 struct XrtState {
-    using LhsBinder = ConstTensorBinder<ModelLhsDType, A_DATATYPE>;
-    using RhsBinder = ConstTensorBinder<ModelRhsDType, B_DATATYPE>;
-    using ResultBinder = MutableTensorBinder<ModelReturnDType, C_DATATYPE>;
+  using LhsBinder = ConstTensorBinder<ModelLhsDType, A_DATATYPE>;
+  using RhsBinder = ConstTensorBinder<ModelRhsDType, B_DATATYPE>;
+  using ResultBinder = MutableTensorBinder<ModelReturnDType, C_DATATYPE>;
 
-    xrt::device device;
-    xrt::kernel kernel;
-    xrt::bo boInstr;
-    std::unique_ptr<LhsBinder> lhsBinder;
-    std::unique_ptr<RhsBinder> rhsBinder;
-    std::unique_ptr<ResultBinder> resultBinder;
+  xrt::device device;
+  xrt::kernel kernel;
+  xrt::bo boInstr;
+  std::unique_ptr<LhsBinder> lhsBinder;
+  std::unique_ptr<RhsBinder> rhsBinder;
+  std::unique_ptr<ResultBinder> resultBinder;
+  std::size_t instrSize = 0;
+  bool isInitialized = false;
 
-    static XrtState *getInstance(bool shouldDelete = false) {
-        // TODO: handle multiple simultaneous dispatches, multiple kernels
-        static XrtState *instance = nullptr;
-        if (shouldDelete) {
-            delete instance;
-            instance = nullptr;
-            return nullptr;
-        }
-        if (instance == nullptr)
-            instance = new XrtState();
-        return instance;
+  // Returns the `XrtState` singleton, unless `shouldDelete` is true, in which
+  // case the singleton is instead destroyed and nullptr returned.
+  static XrtState *getInstance(const KernelInfo *kernelInfo,
+                               bool shouldDelete = false) {
+    // TODO: handle multiple simultaneous dispatches
+    static XrtState *instance = nullptr;
+
+    // If clean-up was requested, delete the singleton
+    if (shouldDelete) {
+      delete instance;
+      instance = nullptr;
+      return nullptr;
     }
+
+    // If the existing singleton doesn't match the requested kernel,
+    // clean up the singleton (can't reuse it)
+    if (instance != nullptr && kernelInfo != instance->kernelInfo) {
+      delete instance;
+      instance = nullptr;
+    }
+
+    // If there never was a singleton or it got cleaned up, create a new one
+    if (instance == nullptr) {
+      instance = new XrtState();
+      instance->kernelInfo = kernelInfo;
+    }
+
+    return instance;
+  }
+
+ private:
+  const KernelInfo *kernelInfo = nullptr;
 };
 
-constexpr int M = MLP_M;
-constexpr int K = MLP_K;
-constexpr int N = MLP_N;
-
-constexpr int aVolume = M * K;
-constexpr int bVolume = K * N;
-constexpr int cVolume = M * N;
-
-constexpr int aSize = (aVolume * sizeof(A_DATATYPE));
-constexpr int bSize = (bVolume * sizeof(B_DATATYPE));
-constexpr int cSize = (cVolume * sizeof(C_DATATYPE));
-
-bool aie_setup = false;
-int instrSize = 0;
-int aie_matmuls_done = 0;
-int matmuls_done = 0;
-
-void setupNPUAccelerator() {
+// Sets up XRT to use the specified kernel, if not already done
+void setupNPUAccelerator(const KernelInfo &kernelInfo) {
   TRACE_DELEGATE("setupNPUAccelerator");
   auto startTime = std::chrono::high_resolution_clock::now();
+
+  // Clear out any old XRT state and create a new one for the specified kernel
+  auto xrtState = XrtState::getInstance(&kernelInfo);
+
+  // If setup was previously done for this kernel, skip doing it again
+  if (xrtState->isInitialized) {
+    TRACE_DELEGATE("setupNPUAccelerator kernel already initialized");
+    return;
+  }
+
+  // Load the instruction sequence from its file
   std::string libPath = getLibraryPath();
   std::cout << "[AIE Delegate]: Using delegate installation at: " << libPath
             << std::endl;
   std::string instrFilePath =
-      libPath + "/kernels/" + kernelFileName + ".insts.txt";
+      libPath + "/kernels/" + kernelInfo.kernelFileName + ".insts.txt";
   std::vector<uint32_t> instrV = loadInstrSequence(instrFilePath);
-  instrSize = instrV.size();
-  if (instrSize == 0) {
+  xrtState->instrSize = instrV.size();
+  if (xrtState->instrSize == 0) {
     std::ostringstream oss;
     oss << "[AIE Delegate]: Couldn't load instructions from file "
         << instrFilePath << std::endl;
     throw DelegateException(oss.str());
   }
-  std::cout << "[AIE Delegate]: Sequence instr count: " << instrV.size()
-            << "\n";
+  TRACE_DELEGATE1("Sequence instr count: ", instrV.size());
 
-  // Start the XRT test code
-  // Get a device handle
-  auto xrtState = XrtState::getInstance();
+  // Clear out the saved XRT state and get a device handle
   unsigned int deviceIndex = 0;
   TRACE_DELEGATE("setupNPUAccelerator get device");
   xrtState->device = xrt::device(deviceIndex);
 
   // Load the xclbin
-  std::string xclbinPath = libPath + "/kernels/" + kernelFileName + ".xclbin";
+  std::string xclbinPath =
+      libPath + "/kernels/" + kernelInfo.kernelFileName + ".xclbin";
   TRACE_DELEGATE("setupNPUAccelerator get xclbin");
   auto xclbin = xrt::xclbin(xclbinPath);
 
@@ -700,15 +791,17 @@ void setupNPUAccelerator() {
                                 [&](xrt::xclbin::kernel &k) {
                                   auto name = k.get_name();
                                   kernelNames.push_back(name);
-                                  return name.rfind(KernelName, 0) == 0;
+                                  return name.rfind(kernelInfo.kernelName, 0) ==
+                                         0;
                                 });
 
   // If the kernel name we're looking for doesn't exist, error out with a
   // list of all the kernel names in the xclbin
   if (foundIter == xkernels.end()) {
     std::ostringstream oss;
-    oss << "[AIE Delegate] FATAL ERROR: No such kernel " << KernelName << " in "
-        << xclbinPath << ".  Possible kernel names are:" << std::endl;
+    oss << "[AIE Delegate] FATAL ERROR: No such kernel "
+        << kernelInfo.kernelName << " in " << xclbinPath
+        << ".  Possible kernel names are:" << std::endl;
     for (const std::string &kernelName : kernelNames)
       oss << "    " << kernelName << std::endl;
     throw DelegateException(oss.str());
@@ -730,17 +823,27 @@ void setupNPUAccelerator() {
   TRACE_DELEGATE("setupNPUAccelerator create kernel");
   xrtState->kernel = xrt::kernel(context, kernelName);
 
+  // Create XRT buffer objects for lhs, rhs, and result tensors
   TRACE_DELEGATE("setupNPUAccelerator create BOs");
   xrtState->boInstr =
       xrt::bo(xrtState->device, instrV.size() * sizeof(int),
               XCL_BO_FLAGS_CACHEABLE, xrtState->kernel.group_id(0));
 
+  TRACE_DELEGATE1("setupNPUAccelerator LHS # bytes: ",
+                  kernelInfo.getLhsNumBytes());
+  TRACE_DELEGATE1("setupNPUAccelerator RHS # bytes: ",
+                  kernelInfo.getRhsNumBytes());
+  TRACE_DELEGATE1("setupNPUAccelerator Result # bytes: ",
+                  kernelInfo.getResultNumBytes());
   xrtState->lhsBinder = std::make_unique<XrtState::LhsBinder>(
-      xrtState->device, xrtState->kernel.group_id(2), aSize);
+      xrtState->device, xrtState->kernel.group_id(2),
+      kernelInfo.getLhsNumBytes());
   xrtState->rhsBinder = std::make_unique<XrtState::RhsBinder>(
-      xrtState->device, xrtState->kernel.group_id(3), bSize);
+      xrtState->device, xrtState->kernel.group_id(3),
+      kernelInfo.getRhsNumBytes());
   xrtState->resultBinder = std::make_unique<XrtState::ResultBinder>(
-      xrtState->device, xrtState->kernel.group_id(4), cSize);
+      xrtState->device, xrtState->kernel.group_id(4),
+      kernelInfo.getResultNumBytes());
 
   // copy instruction stream to NPU
   void *bufInstr = xrtState->boInstr.map<void *>();
@@ -748,38 +851,45 @@ void setupNPUAccelerator() {
   TRACE_DELEGATE("setupNPUAccelerator sync instruction BO");
   xrtState->boInstr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
 
-  std::cout << "[AIE Delegate]: NPU setup done." << std::endl;
-
-  aie_setup = true;
+  // Calculate and display NPU setup time
   auto endTime = std::chrono::high_resolution_clock::now();
   auto duration =
       std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime)
           .count();
   std::cout << "[AIE Delegate]: NPU setup time: " << duration << " ms"
             << std::endl;
+  xrtState->isInitialized = true;
   TRACE_DELEGATE("setupNPUAccelerator done");
 }
 
-void aie_matmul(Params *params) {
+void aie_matmul(const KernelInfo &kernelInfo, Params *params) {
   TRACE_DELEGATE("aie_matmul");
   std::cout << "[AIE Delegate]: Computing AIE matmul of "
             << params->getShapeStr() << std::endl;
+
+  // Set up XRT for the requested kernel (if not already done)
+  setupNPUAccelerator(kernelInfo);
+
+  // Start timing the kernel run from this point
   auto startTime = std::chrono::high_resolution_clock::now();
-  int cnt = 0;
-  auto xrtState = XrtState::getInstance();
 
 #ifdef DEBUG_VALUES
   std::cout << "LHS Tensor" << std::endl;
-  params->lhs.dumpVals(std::cout, aVolume);
+  params->lhs.dumpVals(std::cout, kernelInfo.getLhsVolume());
   std::cout << "RHS Tensor" << std::endl;
-  params->rhs.dumpVals(std::cout, bVolume);
+  params->rhs.dumpVals(std::cout, kernelInfo.getRhsVolume());
 #endif
 
   // Set up binders to map HAL buffers to XRT buffers
   TRACE_DELEGATE("aie_matmul binder setup");
-  xrtState->lhsBinder->bind(params->lhs.get(), aVolume);
-  xrtState->rhsBinder->bind(params->rhs.get(), bVolume);
-  xrtState->resultBinder->bind(params->result.get(), cVolume);
+  auto xrtState = XrtState::getInstance(&kernelInfo);
+  TRACE_DELEGATE1("aie_matmul LHS volume: ", kernelInfo.getLhsVolume());
+  TRACE_DELEGATE1("aie_matmul RHS volume: ", kernelInfo.getRhsVolume());
+  TRACE_DELEGATE1("aie_matmul Result volume: ", kernelInfo.getResultVolume());
+  xrtState->lhsBinder->bind(params->lhs.get(), kernelInfo.getLhsVolume());
+  xrtState->rhsBinder->bind(params->rhs.get(), kernelInfo.getRhsVolume());
+  xrtState->resultBinder->bind(params->result.get(),
+                               kernelInfo.getResultVolume());
 
   // Copy inputs to kernel input BOs and sync the BOs
   TRACE_DELEGATE("aie_matmul copy inputs");
@@ -792,12 +902,16 @@ void aie_matmul(Params *params) {
 #endif
 
   // execute the kernel on NPU
+#ifdef ENABLE_KERNEL_RUN
   TRACE_DELEGATE("aie_matmul run kernel");
   auto run = xrtState->kernel(
-      xrtState->boInstr, instrSize, xrtState->lhsBinder->getBo(),
+      xrtState->boInstr, xrtState->instrSize, xrtState->lhsBinder->getBo(),
       xrtState->rhsBinder->getBo(), xrtState->resultBinder->getBo());
   TRACE_DELEGATE("aie_matmul wait");
   run.wait();
+#else
+  TRACE_DELEGATE("aie_matmul kernel run skipped");
+#endif
 
   // sync output to host and copy the data from the BO
   TRACE_DELEGATE("aie_matmul copy output");
@@ -831,21 +945,25 @@ using CpuAccDType =
   float;
 #endif
 
-static void cpu_matmul(Params *params) {
+static void cpu_matmul(const KernelInfo &kernelInfo, Params *params) {
   std::cout << "[AIE Delegate]: Computing CPU scalar matmul of " << params->getShapeStr() << std::endl;
   for (int32_t i = 0; i < params->M; i++) {
     for (int32_t j = 0; j < params->N; j++) {
       CpuAccDType curr_result = Converter<float, CpuAccDType>::convert(0.0);
       for (int32_t k = 0; k < params->K; k++) {
-        float a = Converter<ModelLhsDType, float>::convert(params->lhs.getElement(i, k, K));
-        float b = Converter<ModelRhsDType, float>::convert(params->rhs.getElement(k, j, N));
+        float a = Converter<ModelLhsDType, float>::convert(
+            params->lhs.getElement(i, k, kernelInfo.k));
+        float b = Converter<ModelRhsDType, float>::convert(
+            params->rhs.getElement(k, j, kernelInfo.n));
         curr_result = Converter<float, CpuAccDType>::convert(
           Converter<CpuAccDType, float>::convert(curr_result)
           + Converter<float, CpuAccDType>::convert(a * b)
         );
       }
       // curr_result = curr_result < 0.0 ? 0.0 : curr_result;  ref matmul doesn't seem to have this
-      params->result.setElement(i, j, N, Converter<CpuAccDType, ModelReturnDType>::convert(curr_result));
+      params->result.setElement(
+          i, j, kernelInfo.n,
+          Converter<CpuAccDType, ModelReturnDType>::convert(curr_result));
     }
   }
 }
@@ -895,22 +1013,10 @@ static int mlp_external(void* params_ptr, void* context, void* reserved) {
   TRACE_DELEGATE("mlp_external");
 
 #ifdef USE_CPU_IMPLEMENTATION
-  cpu_matmul(params);  // enable this if CPU fallback desired
+  cpu_matmul(kernelInfo, params);  // enable this if CPU fallback desired
 #else
-  // If the input shapes do not match the AIE kernel, deliberately fail to
-  // make sure AIE version is getting used
-  if (params->M != MLP_M || params->K != MLP_K || params->N != MLP_N) {
-    std::ostringstream oss;
-    oss << "[AIE Delegate] FATAL ERROR: Shape mismatch between model and kernel."
-        << std::endl;
-    oss << "    Model shape: M=" << params->M << ", N=" << params->N << ", K="
-        << params->K << std::endl;
-    oss << "    Kernel shape: M=" << MLP_M << ", N=" << MLP_N << ", K="
-        << MLP_K << std::endl;
-    throw DelegateException(oss.str());
-  }
-
-  aie_matmul(params);
+  const auto &kernelInfo = getKernelInfo(params->M, params->N, params->K);
+  aie_matmul(kernelInfo, params);
 #endif
   TRACE_DELEGATE("mlp_external done");
   return 0;
@@ -942,11 +1048,6 @@ static iree_hal_executable_plugin_status_t mlp_plugin_load(
   // stateful/side-effecting things.
   plugin->file = stdout;
 
-#ifndef USE_CPU_IMPLEMENTATION
-  // Initialize XRT with the one-and-only xclbin and instruction file
-  setupNPUAccelerator();
-#endif
-
   // Pass back the plugin instance that'll be passed to resolve.
   *out_self = plugin;
   TRACE_DELEGATE("mlp_plugin_load done");
@@ -965,7 +1066,7 @@ static void mlp_plugin_unload(void* self) {
   plugin->file = NULL;
 
 #ifndef USE_CPU_IMPLEMENTATION
-  XrtState::getInstance(true); // delete singleton data
+  XrtState::getInstance(nullptr, true);  // delete singleton data
 #endif
 
   // Free the plugin state using the same allocator it came from.


### PR DESCRIPTION
Support for running 2 different AIE matmul kernels in one model.

- PDL now replaces matmuls for both 16384x16384x512 and 16384x512x16384 (MxNxK)
- delegate now uses M, N, and K from HAL to determine which matmul kernel to use instead of having shapes hard-coded
- If the MRU kernel is not the same shape as the requested matmul, the right xclbin/instructions are loaded before doing the matmul
- New kernel for 16384x512x16384 checked in to Azure