### PR TITLE
Fix deprecated cast warnings

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
@@ -138,11 +138,11 @@ LogicalResult acquireOpToAIE(IRRewriter &rewriter,
            << "acquire doesn't operate on a `amdaie.circular_dma_cpy_nd`";
   }
   MemRefType srcType =
-      dmaOp.getSourceType().cast<LogicalObjectFifoType>().getElementType();
+      cast<LogicalObjectFifoType>(dmaOp.getSourceType()).getElementType();
   MemRefType newSrcType = MemRefType::Builder(srcType).setMemorySpace(
       rewriter.getI64IntegerAttr(1));
   MemRefType dstType =
-      dmaOp.getTargetType().cast<LogicalObjectFifoType>().getElementType();
+      cast<LogicalObjectFifoType>(dmaOp.getTargetType()).getElementType();
   MemRefType newDstType = MemRefType::Builder(dstType).setMemorySpace(
       rewriter.getI64IntegerAttr(1));
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUnrollAndDistributeWorkgroup.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUnrollAndDistributeWorkgroup.cpp
@@ -297,7 +297,7 @@ LogicalResult assignLocalAieTiles(ModuleOp moduleOp) {
     rewriter.setInsertionPoint(logicalObjectFifo);
     rewriter.replaceOpWithNewOp<AMDAIE::LogicalObjectFifoFromMemrefOp>(
         logicalObjectFifo,
-        logicalObjectFifo.getOutput().getType().cast<LogicalObjectFifoType>(),
+        cast<LogicalObjectFifoType>(logicalObjectFifo.getOutput().getType()),
         logicalObjectFifo.getMemref(), tiles.takeVector());
   }
   return success();
@@ -444,7 +444,7 @@ class AssignAieTiles
               std::back_inserter(tileResults));
     rewriter.replaceOpWithNewOp<AMDAIE::LogicalObjectFifoFromMemrefOp>(
         logicalObjectFifo,
-        logicalObjectFifo.getOutput().getType().cast<LogicalObjectFifoType>(),
+        cast<LogicalObjectFifoType>(logicalObjectFifo.getOutput().getType()),
         logicalObjectFifo.getMemref(), tileResults);
     return success();
   }


### PR DESCRIPTION
Fix deprecated `.cast<U>` and `.dyn_cast<U>` warnings. Use `mlir::cast<U>()` and `mlir::dyn_cast<U>()` instead.