### PR TITLE
[Delegate] Added support for Strix

### DIFF
--- a/experimental/delegate/kernels/CMakeLists.txt
+++ b/experimental/delegate/kernels/CMakeLists.txt
@@ -17,7 +17,7 @@ set(AIE_DELEGATE_KERNELS
     "matmul/matmul-bf16-256x256x256-v1"  # ref matmul
     "matmul/matmul-bf16-f32-8x768x768-v1"  # for OPT, 4x4 vec matmul
     "matmul/matmul-bf16-f32-8192x9728x2432-v1"  # Large Matmul
-    "matmul/matmul-bf16-f32-16384x16384X512-phx-v1"  # 16k phoenix matmul
+    "matmul/matmul-bf16-f32-16384x16384x512-phx-v1"  # 16k phoenix matmul
     "matmul/matmul-bf16-f32-16384x512x16384-phx-v1"  # 16k phx matmul alt shape
     "matmul/matmul-bf16-f32-16384x16384x512-stx-v1"  # 16k strix matmul
     "matmul/matmul-bf16-f32-16384x512x16384-stx-v1"  # 16k stx matmul alt shape

--- a/experimental/delegate/kernels/CMakeLists.txt
+++ b/experimental/delegate/kernels/CMakeLists.txt
@@ -19,6 +19,8 @@ set(AIE_DELEGATE_KERNELS
     "matmul/matmul-bf16-f32-8192x9728x2432-v1"  # Large Matmul
     "matmul/matmul-bf16-f32-16384x16384X512-phx-v1"  # 16k phoenix matmul
     "matmul/matmul-bf16-f32-16384x512x16384-phx-v1"  # 16k phx matmul alt shape
+    "matmul/matmul-bf16-f32-16384x16384x512-stx-v1"  # 16k strix matmul
+    "matmul/matmul-bf16-f32-16384x512x16384-stx-v1"  # 16k stx matmul alt shape
 )
 
 # List of all kernel file extensions

--- a/experimental/delegate/mlp_aie_bf16_plugin.cpp
+++ b/experimental/delegate/mlp_aie_bf16_plugin.cpp
@@ -79,7 +79,13 @@
 // #define ENABLE_PERFORMANCE_WARNING 1
 
 // Turn this on to suppress initializing and running the kernel
-#define DRY_RUN 1
+// #define DRY_RUN 1
+
+// Turn this on to run on Strix instead of the default Phoenix.
+// Also, you can instead compile for Strix by adding the following flag
+// to the iree cmake command line:
+// -DCMAKE_CXX_FLAGS="-DAMD_STRIX=1 ${CMAKE_CXX_FLAGS}"
+// #define AMD_STRIX 1
 
 //#############################################################################
 

--- a/experimental/delegate/mlp_aie_bf16_plugin.cpp
+++ b/experimental/delegate/mlp_aie_bf16_plugin.cpp
@@ -159,10 +159,20 @@ struct KernelInfo {
 static KernelInfo KernelInfos[] = {
     {16384, 16384, 512,
      "matmul/matmul-bf16-f32-16384x16384x512-" PLATFORM_SUFFIX "-v1",
-     "matmul_16384x16384_512xbf16__dispatch_0_matmul_1"},
+#ifdef AMD_STRIX
+     "MLIR_AIE"
+#else
+     "matmul_16384x16384_512xbf16__dispatch_0_matmul_1"
+#endif
+    },
     {16384, 512, 16384,
      "matmul/matmul-bf16-f32-16384x512x16384-" PLATFORM_SUFFIX "-v1",
-     "matmul_16384x512_16384xbf16__dispatch_0_matmul_1"}};
+#ifdef AMD_STRIX
+     "MLIR_AIE"
+#else
+     "matmul_16384x512_16384xbf16__dispatch_0_matmul_1"
+#endif
+    }};
 
 // Fixed shape of the matmul kernel
 // #define MLP_M 16384

--- a/experimental/delegate/mlp_aie_bf16_plugin.cpp
+++ b/experimental/delegate/mlp_aie_bf16_plugin.cpp
@@ -66,7 +66,7 @@
 // #define USE_BF16_CPU_ACCUMULATOR 1
 
 // Turn this on to print debug messages throughout the delegate run
-// #define ENABLE_TRACE_DELEGATE 1
+#define ENABLE_TRACE_DELEGATE 1
 
 // Turn this on to dump matmul operand and result tensor values
 // #define DEBUG_VALUES 1
@@ -78,11 +78,18 @@
 // being done
 // #define ENABLE_PERFORMANCE_WARNING 1
 
-// Turn this on to enable running the kernel.  Disabling the kernel is for
-// testing and debugging only.
-#define ENABLE_KERNEL_RUN 1
+// Turn this on to suppress initializing and running the kernel
+#define DRY_RUN 1
 
 //#############################################################################
+
+// String for which AIE platform
+const std::string NpuPlatformStr =
+#ifdef AMD_STRIX
+    "Strix";
+#else
+    "Phoenix";
+#endif
 
 #if DEBUG_VALUE_CONVERSIONS
 static bool DebugValueConversions = false;
@@ -140,13 +147,21 @@ struct KernelInfo {
 // Configuration of the kernel that the AIE delegate uses
 //
 
+#ifdef AMD_STRIX
+#define PLATFORM_SUFFIX "stx"
+#else
+#define PLATFORM_SUFFIX "phx"
+#endif
+
 #if DELEGATE_KERNEL_TO_USE == MATMUL_16K_DELEGATE_KERNEL
 
 // Table of descriptions of kernels available
 static KernelInfo KernelInfos[] = {
-    {16384, 16384, 512, "matmul/matmul-bf16-f32-16384x16384X512-phx-v1",
+    {16384, 16384, 512,
+     "matmul/matmul-bf16-f32-16384x16384X512-" PLATFORM_SUFFIX "-v1",
      "matmul_16384x16384_512xbf16__dispatch_0_matmul_1"},
-    {16384, 512, 16384, "matmul/matmul-bf16-f32-16384x512x16384-phx-v1",
+    {16384, 512, 16384,
+     "matmul/matmul-bf16-f32-16384x512x16384-" PLATFORM_SUFFIX "-v1",
      "matmul_16384x512_16384xbf16__dispatch_0_matmul_1"}};
 
 // Fixed shape of the matmul kernel
@@ -747,6 +762,9 @@ void setupNPUAccelerator(const KernelInfo &kernelInfo) {
   static std::string libPath;  // Location of delegate .so/.dll
 
   TRACE_DELEGATE("setupNPUAccelerator");
+  TRACE_DELEGATE1("setupNPUAccelerator kernel file: ",
+                  kernelInfo.kernelFileName);
+  TRACE_DELEGATE1("setupNPUAccelerator kernel name: ", kernelInfo.kernelName);
   auto startTime = std::chrono::high_resolution_clock::now();
 
   // Clear out any old XRT state and create a new one for the specified kernel
@@ -762,8 +780,8 @@ void setupNPUAccelerator(const KernelInfo &kernelInfo) {
   // to be done once, as the files don't change location.
   if (libPath.empty()) {
     libPath = getLibraryPath();
-    std::cout << "[AIE Delegate]: Using delegate installation at: " << libPath
-              << std::endl;
+    std::cout << "[AIE Delegate]: Using " << NpuPlatformStr
+              << " delegate installation at: " << libPath << std::endl;
   }
 
   // Load the instruction sequence from its file
@@ -855,8 +873,12 @@ void setupNPUAccelerator(const KernelInfo &kernelInfo) {
   // copy instruction stream to NPU
   void *bufInstr = xrtState->boInstr.map<void *>();
   std::memcpy(bufInstr, instrV.data(), instrV.size() * sizeof(int));
+#ifdef DRY_RUN
+  TRACE_DELEGATE("setupNPUAccelerator skipping sync instruction BO");
+#else
   TRACE_DELEGATE("setupNPUAccelerator sync instruction BO");
   xrtState->boInstr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+#endif
 
   // Calculate and display NPU setup time
   auto endTime = std::chrono::high_resolution_clock::now();
@@ -871,8 +893,8 @@ void setupNPUAccelerator(const KernelInfo &kernelInfo) {
 
 void aie_matmul(const KernelInfo &kernelInfo, Params *params) {
   TRACE_DELEGATE("aie_matmul");
-  std::cout << "[AIE Delegate]: Computing AIE matmul of "
-            << params->getShapeStr() << std::endl;
+  std::cout << "[AIE Delegate]: Computing " << NpuPlatformStr
+            << " AIE matmul of " << params->getShapeStr() << std::endl;
 
   // Set up XRT for the requested kernel (if not already done)
   setupNPUAccelerator(kernelInfo);
@@ -909,15 +931,15 @@ void aie_matmul(const KernelInfo &kernelInfo, Params *params) {
 #endif
 
   // execute the kernel on NPU
-#ifdef ENABLE_KERNEL_RUN
+#ifdef DRY_RUN
+  TRACE_DELEGATE("aie_matmul kernel run skipped");
+#else
   TRACE_DELEGATE("aie_matmul run kernel");
   auto run = xrtState->kernel(
       xrtState->boInstr, xrtState->instrSize, xrtState->lhsBinder->getBo(),
       xrtState->rhsBinder->getBo(), xrtState->resultBinder->getBo());
   TRACE_DELEGATE("aie_matmul wait");
   run.wait();
-#else
-  TRACE_DELEGATE("aie_matmul kernel run skipped");
 #endif
 
   // sync output to host and copy the data from the BO

--- a/experimental/delegate/mlp_aie_bf16_plugin.cpp
+++ b/experimental/delegate/mlp_aie_bf16_plugin.cpp
@@ -158,7 +158,7 @@ struct KernelInfo {
 // Table of descriptions of kernels available
 static KernelInfo KernelInfos[] = {
     {16384, 16384, 512,
-     "matmul/matmul-bf16-f32-16384x16384X512-" PLATFORM_SUFFIX "-v1",
+     "matmul/matmul-bf16-f32-16384x16384x512-" PLATFORM_SUFFIX "-v1",
      "matmul_16384x16384_512xbf16__dispatch_0_matmul_1"},
     {16384, 512, 16384,
      "matmul/matmul-bf16-f32-16384x512x16384-" PLATFORM_SUFFIX "-v1",


### PR DESCRIPTION
- new kernels for Strix
- fixed typo in Phoenix kernel name (Azure now has both versions, typo and post-typo)
- changed macro `ENABLE_KERNEL_RUN` to the more understandable `DRY_RUN` and flipped sense (+ve to -ve)
- leaving on tracing for now for better visibility on Strix