### PR TITLE
[AMD-AIE] Fix UnrollAndDistributeWorkgroup pass for non-normalised loop bound

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUnrollAndDistributeWorkgroup.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUnrollAndDistributeWorkgroup.cpp
@@ -166,7 +166,13 @@ class AMDAIEUnrollWorkgroupLoops : public OpRewritePattern<scf::ForOp> {
     int64_t lbInt = getConstantIntValue(forOp.getLowerBound()).value();
     int64_t ubInt = getConstantIntValue(forOp.getUpperBound()).value();
     int64_t stepInt = getConstantIntValue(forOp.getStep()).value();
-    if (lbInt != 0 || stepInt != 1) return failure();
+    // TODO(avarma): Either :-
+    //               1. Enforce loop normalisation before this pass.
+    //                  OR
+    //               2. Adapt this better during PR review.
+    if (lbInt != 0) return failure();
+    ubInt = std::ceil(ubInt / stepInt);
+    stepInt = 1;
     if (stepInt == (ubInt - lbInt)) return failure();
     Value forOpIV = forOp.getInductionVar();
     forOp.setUpperBound(


### PR DESCRIPTION
-- This commit adds a fix to `--iree-amdaie-unroll-and-distribute-workgroup`
   pass in order to handle non-normalised loop bounds.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>