### PR TITLE
[CI] Use merge groups 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
 
   pull_request:
 
+  merge_group:
+
   push:
     branches:
       - main


### PR DESCRIPTION
- Attempt to add merge trains / merge queues / merge groups to CI. 
- The goal of this PR is to free developers from having to "Update branch" if a patch lands between them submitting a PR and CI passing: 

![image](https://github.com/nod-ai/iree-amd-aie/assets/4902987/a37dee80-68a7-4938-bdf7-51ffc1bd7cf6)

- Nice description of how they work (gitlab equivalent): https://about.gitlab.com/blog/2020/01/30/all-aboard-merge-trains/#what-are-merge-trains-and-how-do-they-help%3F

- Based on PR from @stephenneuendorffer in mlir-aie: https://github.com/Xilinx/mlir-aie/pull/1461