### PR TITLE
Bump iree to latest shared/tresleches-cpu

### DIFF
--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,7 +7,7 @@
 ### Update with: shark-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "ff8072818e5996fbc9fb937ce21c8433bba001d5",
+  "iree": "06e05b3f86870cd5620df2f57ea8af4cb136c120",
 }
 
 ORIGINS = {


### PR DESCRIPTION
Previous PR accidentally pointed to iree main.  This PR points to the latest iree branch shared/tresleches-cpu, which includes performance improvements for the CPU target.