### PR TITLE
[Delegate] Use v2 strix kernels

### DIFF
--- a/experimental/delegate/kernels/CMakeLists.txt
+++ b/experimental/delegate/kernels/CMakeLists.txt
@@ -25,6 +25,8 @@ set(AIE_DELEGATE_KERNELS
     "matmul/matmul-bf16-f32-4096x512x4096-phx-v1"  # 4k phx matmul alt shape
     "matmul/matmul-bf16-f32-4096x4096x512-stx-v1"  # 4k strix matmul
     "matmul/matmul-bf16-f32-4096x512x4096-stx-v1"  # 4k stx matmul alt shape
+    "matmul/matmul-bf16-f32-4096x4096x512-stx-v2"  # 4k strix matmul v2
+    "matmul/matmul-bf16-f32-4096x512x4096-stx-v2"  # 4k stx matmul alt shape v2
 )
 
 # List of all kernel file extensions

--- a/experimental/delegate/mlp_aie_bf16_plugin.cpp
+++ b/experimental/delegate/mlp_aie_bf16_plugin.cpp
@@ -168,18 +168,20 @@ struct KernelInfo {
 // Table of descriptions of kernels available
 static KernelInfo KernelInfos[] = {
     {4096, 4096, 512,
-     "matmul/matmul-bf16-f32-4096x4096x512-" PLATFORM_SUFFIX "-v1",
 #ifdef AMD_STRIX
+     "matmul/matmul-bf16-f32-4096x4096x512-stx-v2",
      "MLIR_AIE"
 #else
+     "matmul/matmul-bf16-f32-4096x4096x512-phx-v1",
      "matmul_4096x4096_512xbf16__dispatch_0_matmul_409"
 #endif
     },
     {4096, 512, 4096,
-     "matmul/matmul-bf16-f32-4096x512x4096-" PLATFORM_SUFFIX "-v1",
 #ifdef AMD_STRIX
+     "matmul/matmul-bf16-f32-4096x512x4096-stx-v2",
      "MLIR_AIE"
 #else
+     "matmul/matmul-bf16-f32-4096x512x4096-phx-v1",
      "matmul_4096x512_4096xbf16__dispatch_0_matmul_409"
 #endif
     }};


### PR DESCRIPTION
v1 kernels had numerics issues.  The new v2 kernels, being 4x4 instead of 8x4, are a tad slower but produce more accurate results.