### PR TITLE
Update mlir-aie wheel and matmul_transpose_b ci test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,8 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024051921+7fb9fad-py3-none-manylinux_2_35_x86_64.whl
+          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024060222+6f70bfe-py3-none-manylinux_2_35_x86_64.whl
+
           pip install -r tests/matmul/requirements.txt
 
       - name: E2E correctness matmul test

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -555,17 +555,12 @@ run_matmul_test \
   --m "8" --n "16" --k "32" \
   --do_transpose_rhs "1"
 
-# TODO: fix this.
-#: error: 'aie.dma_bd' op Cannot give more than 4 dimensions for step sizes
-#  and wraps in this  tile (got 5 dimensions).
 run_matmul_test \
   --name_prefix "transpose_bf16" \
   --lhs_rhs_type "bf16" \
   --acc_type "f32" \
   --m "256" --n "256" --k "256" \
   --do_transpose_rhs "1" \
-  --expect_compile_failure "1"
-
 
 # The below matmul case passes with
 # tile_sizes = [[1, 1], [0, 0, 250], [1, 1], [0, 0, 2]], packedSizes = [1, 1, 5]


### PR DESCRIPTION
The latest mlir-aie wheel fixes the matmul_transpose_b ci test.