### PR TITLE
Update pack-peel pipeline and ci tests

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -690,7 +690,6 @@ run_matmul_test \
     --lhs_rhs_type "bf16" \
     --acc_type "f32" \
     --m "512"  --n "512" --k "512" \
-    --num_repeat_runs "0"
 
 run_matmul_test \
     --name_prefix "packPeel2304" \
@@ -698,7 +697,22 @@ run_matmul_test \
     --lhs_rhs_type "bf16" \
     --acc_type "f32" \
     --m "128"  --n "128" --k "2304" \
-    --num_repeat_runs "0"
+
+run_matmul_test \
+  --name_prefix "packPeel_t_i32" \
+  --pipeline "pack-peel" \
+  --lhs_rhs_type "i32" \
+  --acc_type "i32" \
+  --m "128" --n "256" --k "512" \
+  --do_transpose_rhs "1"
+
+run_matmul_test \
+  --name_prefix "packPeel_t_bf16" \
+  --pipeline "pack-peel" \
+  --lhs_rhs_type "bf16" \
+  --acc_type "f32" \
+  --m "128" --n "256" --k "512" \
+  --do_transpose_rhs "1" \
 
 ###################################################################
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPeelForLoop.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPeelForLoop.cpp
@@ -81,16 +81,6 @@ void AMDAIEPeelForLoopPass::runOnOperation() {
   mlir::FunctionOpInterface funcOp = getOperation();
   IRRewriter rewriter(context);
 
-  // Check if there is matmul-elementwise fusion opportunity. If so, overwrite
-  // the `peelingType` to PeelingType::FirstLast.
-  funcOp->walk<WalkOrder::PostOrder, ReverseIterator>([&](linalg::LinalgOp op) {
-    if (isMatmulProducerOfElementwise(op)) {
-      peelingType = PeelingType::FirstLast;
-      return WalkResult::interrupt();
-    }
-    return WalkResult::advance();
-  });
-
   funcOp->walk([&](scf::ForOp forOp) {
     auto lbInt = getConstantIntValue(forOp.getLowerBound());
     auto ubInt = getConstantIntValue(forOp.getUpperBound());

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -243,17 +243,13 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
 
   // Peel the first and last iteration. Note: Do not run CSE pass afterwards,
   // because it may bring problem for bufferization.
-  {
-    AMDAIEPeelForLoopOptions peelOptions;
-    peelOptions.peelingType = PeelingType::FirstLast;
-    funcPassManager.addPass(createAMDAIEPeelForLoopPass(peelOptions));
-  }
+  funcPassManager.addPass(createAMDAIEPeelForLoopPass());
   funcPassManager.addPass(createCanonicalizerPass());
 
   // Fuse fill op into the first inner forall loop
   funcPassManager.addPass(createAMDAIEFuseFillIntoForallPass());
 
-  // Fuse unpack and elementwise op into the last inner forall loop
+  // Fuse unpack/elementwise consumer ops into the last inner forall loop
   funcPassManager.addPass(createAMDAIEFuseConsumerIntoLoopPass());
 
   // Fuse pack ops into the last inner forall loop

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -304,7 +304,7 @@ def AMDAIEPeelForLoop :
   let options = [
     Option<"peelingType", "peeling-type",
       "mlir::iree_compiler::AMDAIE::PeelingType",
-      /*default=*/"",
+      /*default=*/"mlir::iree_compiler::AMDAIE::PeelingType::FirstLast",
       "Choose which type of loop peeling to perform",
       [{::llvm::cl::values(
         clEnumValN(mlir::iree_compiler::AMDAIE::PeelingType::First, "first",

--- a/tests/samples/pack_peel_pipeline_matmul_elementwise.mlir
+++ b/tests/samples/pack_peel_pipeline_matmul_elementwise.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pack-peel --iree-amdaie-matmul-elementwise-fusion --iree-amdaie-enable-vectorization-passes=false --split-input-file | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-use-pipeline=pack-peel --iree-amdaie-matmul-elementwise-fusion --split-input-file | FileCheck %s
 
 func.func @matmul_elementwise_i32(%lhs: tensor<1024x512xi32>, %rhs: tensor<512x1024xi32>, %ele: tensor<1024x1024xi32>) -> tensor<1024x1024xi32>
 {
@@ -32,71 +32,31 @@ func.func @matmul_elementwise_i32(%lhs: tensor<1024x512xi32>, %rhs: tensor<512x1
 
 // -----
 
-func.func @matmul_elementwise_bf16(%arg0: tensor<1024x512xbf16>, %arg1: tensor<512x1024xbf16>, %arg2: tensor<1024xbf16>) -> tensor<1024x1024xbf16> {
-  %cst = arith.constant 0.000000e+00 : bf16
-  %0 = tensor.empty() : tensor<1024x1024xbf16>
-  %1 = linalg.fill ins(%cst : bf16) outs(%0 : tensor<1024x1024xbf16>) -> tensor<1024x1024xbf16>
-  %2 = linalg.matmul ins(%arg0, %arg1 : tensor<1024x512xbf16>, tensor<512x1024xbf16>) outs(%1 : tensor<1024x1024xbf16>) -> tensor<1024x1024xbf16>
-  %3 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%2, %arg2 : tensor<1024x1024xbf16>, tensor<1024xbf16>) outs(%0 : tensor<1024x1024xbf16>) {
-  ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
-    %5 = arith.addf %in, %in_0 : bf16
-    linalg.yield %5 : bf16
-  } -> tensor<1024x1024xbf16>
-  %4 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%3 : tensor<1024x1024xbf16>) outs(%0 : tensor<1024x1024xbf16>) {
-  ^bb0(%in: bf16, %out: bf16):
-    %5 = arith.cmpf ugt, %in, %cst : bf16
-    %6 = arith.select %5, %in, %cst : bf16
-    linalg.yield %6 : bf16
-  } -> tensor<1024x1024xbf16>
-  return %4 : tensor<1024x1024xbf16>
+func.func @matmul_elementwise_bf16_f32(%arg0: tensor<1024x512xbf16>, %arg1: tensor<512x1024xbf16>, %arg2: tensor<1024xf32>) -> tensor<1024x1024xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : tensor<1024x1024xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
+  %2 = linalg.matmul ins(%arg0, %arg1 : tensor<1024x512xbf16>, tensor<512x1024xbf16>) outs(%1 : tensor<1024x1024xf32>) -> tensor<1024x1024xf32>
+  %3 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%2, %arg2 : tensor<1024x1024xf32>, tensor<1024xf32>) outs(%0 : tensor<1024x1024xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %out: f32):
+    %5 = arith.addf %in, %in_0 : f32
+    linalg.yield %5 : f32
+  } -> tensor<1024x1024xf32>
+  %4 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%3 : tensor<1024x1024xf32>) outs(%0 : tensor<1024x1024xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %5 = arith.cmpf ugt, %in, %cst : f32
+    %6 = arith.select %5, %in, %cst : f32
+    linalg.yield %6 : f32
+  } -> tensor<1024x1024xf32>
+  return %4 : tensor<1024x1024xf32>
 }
 
-// CHECK-LABEL: hal.executable.export public @matmul_elementwise_bf16_dispatch_0_matmul_1024x1024x512_bf16
+// CHECK-LABEL: hal.executable.export public @matmul_elementwise_bf16_f32_dispatch_0_matmul_1024x1024x512_bf16xbf16xf32
 //       CHECK:    aie.device(npu1_4col)
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
 //       CHECK:    aie.shim_dma_allocation
-//       CHECK:    func.func @matmul_elementwise_bf16_dispatch_0_matmul_1024x1024x512_bf16(%arg0: memref<262144xi32>, %arg1: memref<262144xi32>, %arg2: memref<512xi32>, %arg3: memref<524288xi32>)
-//       CHECK:      aiex.npu.dma_memcpy_nd
-//       CHECK:      aiex.npu.dma_memcpy_nd
-//       CHECK:      aiex.npu.dma_memcpy_nd
-//       CHECK:      aiex.npu.sync
-
-// -----
-
-#map = affine_map<(d0, d1) -> (d0, d1)>
-#map1 = affine_map<(d0, d1) -> (d1, d0)>
-#map2 = affine_map<(d0, d1) -> (d1)>
-func.func @matmul_elementwise_transpose_b(%arg0: tensor<256x512xbf16>, %arg1: tensor<1024x512xbf16>, %arg2: tensor<1024xbf16>) -> tensor<256x1024xbf16> {
-  %cst = arith.constant 0.000000e+00 : bf16
-  %0 = tensor.empty() : tensor<512x1024xbf16>
-  %1 = linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg1 : tensor<1024x512xbf16>) outs(%0 : tensor<512x1024xbf16>) {
-  ^bb0(%in: bf16, %out: bf16):
-    linalg.yield %in : bf16
-  } -> tensor<512x1024xbf16>
-  %2 = tensor.empty() : tensor<256x1024xbf16>
-  %3 = linalg.fill ins(%cst : bf16) outs(%2 : tensor<256x1024xbf16>) -> tensor<256x1024xbf16>
-  %4 = linalg.matmul ins(%arg0, %1 : tensor<256x512xbf16>, tensor<512x1024xbf16>) outs(%3 : tensor<256x1024xbf16>) -> tensor<256x1024xbf16>
-  %5 = linalg.generic {indexing_maps = [#map, #map2, #map], iterator_types = ["parallel", "parallel"]} ins(%4, %arg2 : tensor<256x1024xbf16>, tensor<1024xbf16>) outs(%2 : tensor<256x1024xbf16>) {
-  ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
-    %7 = arith.addf %in, %in_0 : bf16
-    linalg.yield %7 : bf16
-  } -> tensor<256x1024xbf16>
-  %6 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%5 : tensor<256x1024xbf16>) outs(%2 : tensor<256x1024xbf16>) {
-  ^bb0(%in: bf16, %out: bf16):
-    %7 = arith.cmpf ugt, %in, %cst : bf16
-    %8 = arith.select %7, %in, %cst : bf16
-    linalg.yield %8 : bf16
-  } -> tensor<256x1024xbf16>
-  return %6 : tensor<256x1024xbf16>
-}
-
-// CHECK-LABEL: hal.executable.export public @matmul_elementwise_transpose_b_dispatch_0_matmul_transpose_b_256x1024x512_bf16
-//       CHECK:    aie.device(npu1_4col)
-//       CHECK:    aie.shim_dma_allocation
-//       CHECK:    aie.shim_dma_allocation
-//       CHECK:    aie.shim_dma_allocation
-//       CHECK:    func.func @matmul_elementwise_transpose_b_dispatch_0_matmul_transpose_b_256x1024x512_bf16(%arg0: memref<65536xi32>, %arg1: memref<262144xi32>, %arg2: memref<512xi32>, %arg3: memref<131072xi32>)
+//       CHECK:    func.func @matmul_elementwise_bf16_f32_dispatch_0_matmul_1024x1024x512_bf16xbf16xf32(%arg0: memref<262144xi32>, %arg1: memref<262144xi32>, %arg2: memref<1024xf32>, %arg3: memref<1024x1024xf32>)
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd
 //       CHECK:      aiex.npu.dma_memcpy_nd


### PR DESCRIPTION
- With this work https://github.com/nod-ai/iree-amd-aie/pull/351, we change the pack-peel pipeline to always peel the first and the last iteration and fuse the unpack op into the inner forall loop for matmul only and matmul-elementwise dispatch.
- With this change, we have made progress on codegen for matmul-transpose-b and matmul-elementwise example dispatches to a reasonable state.
- A minor issue is with [upstream change](https://github.com/llvm/llvm-project/pull/90189), there is redundant data allocation and copy after bufferization ([example IR](https://gist.github.com/yzhang93/55f448368db32cccd2af31c730cc878a#file-gistfile1-txt-L342)). So currently I have to disable the canonicalization pass [here](https://github.com/nod-ai/iree-amd-aie/pull/392/files#diff-42f0d0bb098689f25ee68e8f05ec6c2eaa89ce41a6394d7d99c1d1c912943b38L256), but in the long term we may want to fix this issue.