### PR TITLE
[AMD-AIE] Fix the onus of controlling addressing for L3 DmaCpyNdOp

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
@@ -72,7 +72,7 @@ LogicalResult workgroupBuildForDmaCpyNdOp(
   Attribute sourceMemSpace = dmaOp.getSourceObjectFifo().getMemorySpace();
   Attribute targetMemSpace = dmaOp.getTargetObjectFifo().getMemorySpace();
   if (sourceMemSpace && targetMemSpace) {
-    dmaOp.emitOpError()
+    dmaOp.emitError()
         << "neither source nor target of the DmaCpyNd op is on L3";
     return failure();
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
@@ -71,6 +71,8 @@ LogicalResult workgroupBuildForDmaCpyNdOp(
   LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [amdaie.dma_cpy_nd] Start\n");
   Attribute sourceMemSpace = dmaOp.getSourceObjectFifo().getMemorySpace();
   Attribute targetMemSpace = dmaOp.getTargetObjectFifo().getMemorySpace();
+  // Error out if the DmaCpyNd involves transfer between L1/L2 as these are all
+  // circular_dma_cpy_nd operations by this stage.
   if (sourceMemSpace && targetMemSpace) {
     dmaOp.emitError()
         << "neither source nor target of the DmaCpyNd op is on L3";
@@ -116,8 +118,6 @@ LogicalResult workgroupBuildForDmaCpyNdOp(
     ipuDmaSourceSizes = empty;
     ipuDmaSourceStrides = empty;
   }
-  // In case of transfers between L1/L2 - the addressing is always controlled by
-  // the uController.
   auto newDmaOp = rewriter.createAndMap<AMDAIE::CircularDmaCpyNdOp>(
       rewriter.getUnknownLoc(), dmaOp, dmaOp.getTarget(),
       circularDmaTargetOffsets, circularDmaTargetSizes,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
@@ -73,7 +73,7 @@ LogicalResult workgroupBuildForDmaCpyNdOp(
   Attribute targetMemSpace = dmaOp.getTargetObjectFifo().getMemorySpace();
   if (sourceMemSpace && targetMemSpace) {
     dmaOp.emitOpError()
-        << "neither source nor target of the DmaNdCpy op is on L3";
+        << "neither source nor target of the DmaCpyNd op is on L3";
     return failure();
   }
   Location loc = rewriter.getUnknownLoc();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
@@ -45,7 +45,7 @@ func.func @core() {
 
 // -----
 
-// CHECK-LABEL: @dma_cpy_nd
+// CHECK-LABEL: @dma_cpy_nd_L1_L2
 // CHECK:       amdaie.workgroup
 // CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
 // CHECK-SAME:    memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
@@ -60,13 +60,83 @@ func.func @core() {
 // CHECK-SAME:      [] [] []
 // CHECK-SAME:      [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
 // CHECK:           amdaie.npu.dma_wait(%[[IPU_DMA]], S2MM)
-func.func @dma_cpy_nd(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi32, 1>) {
+func.func @dma_cpy_nd_L1_L2(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi32, 1>) {
   %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
   %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
   %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   return
 }
 
+// -----
+
+// CHECK-LABEL: @dma_cpy_nd_L2_L1
+// CHECK:       amdaie.workgroup
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 2>>
+// CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK-SAME:    %[[FROMMEMREF0]][] [] []
+// CHECK-SAME:    %[[FROMMEMREF1]][] [] []
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 2>>)
+// CHECK:         amdaie.controlcode
+// CHECK:           %[[IPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
+// CHECK-SAME:      [] [] []
+// CHECK-SAME:      [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK:           amdaie.npu.dma_wait(%[[IPU_DMA]], S2MM)
+func.func @dma_cpy_nd_L2_L1(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi32, 2>) {
+  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+  %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 2>>
+  %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 2>>)
+  return
+}
+// -----
+
+// CHECK-LABEL: @dma_cpy_nd_L2_L3
+// CHECK:       amdaie.workgroup
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+// CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK-SAME:    %[[FROMMEMREF0]][] [] []
+// CHECK-SAME:    %[[FROMMEMREF1]][] [] []
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+// CHECK:         amdaie.controlcode
+// CHECK:           %[[IPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
+// CHECK-SAME:      [] [] []
+// CHECK-SAME:      [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK:           amdaie.npu.dma_wait(%[[IPU_DMA]], MM2S)
+func.func @dma_cpy_nd_L2_L3(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi32>) {
+  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+  %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+  %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @dma_cpy_nd_L3_L2
+// CHECK:       amdaie.workgroup
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
+// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+// CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK-SAME:    %[[FROMMEMREF0]][] [] []
+// CHECK-SAME:    %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+// CHECK:         amdaie.controlcode
+// CHECK:           %[[IPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
+// CHECK-SAME:      [] [] []
+// CHECK-SAME:      [] [] []
+// CHECK:           amdaie.npu.dma_wait(%[[IPU_DMA]], S2MM)
+func.func @dma_cpy_nd_L3_L2(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) {
+  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
+  %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+  %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  return
+}
 // -----
 
 // CHECK-LABEL: @for

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
@@ -76,7 +76,7 @@ func.func @dma_cpy_nd_L3_L2(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi
 // CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
 // CHECK-SAME:    memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
-// CHECK-SAME:    %[[FROMMEMREF0]][] [] []
+// CHECK-SAME:    %[[FROMMEMREF0]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
 // CHECK-SAME:    %[[FROMMEMREF1]][] [] []
 // CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
 // CHECK:         amdaie.controlcode
@@ -176,28 +176,28 @@ func.func @for_cores() {
 // CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
 // CHECK-DAG:     %[[C8:.+]] = arith.constant 8 : index
-// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
 // CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
 // CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
 // CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK-SAME:    %[[FROMMEMREF0]][] [] []
 // CHECK-SAME:    %[[FROMMEMREF1]][] [] []
-// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>)
 // CHECK:         amdaie.controlcode
 // CHECK:           scf.for %[[ARG:.+]] = %[[C0]] to %[[C8]] step %[[C1]]
 // CHECK:             %[[IPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
 // CHECK-SAME:        [] [] []
 // CHECK-SAME:        [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, %[[ARG]], 1]
-// CHECK:             amdaie.npu.dma_wait(%[[IPU_DMA]], S2MM)
-func.func @for_dma(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi32, 1>) {
+// CHECK:             amdaie.npu.dma_wait(%[[IPU_DMA]], MM2S)
+func.func @for_dma(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c8 = arith.constant 8 : index
-  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
+  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
   %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
   scf.for %arg2 = %c0 to %c8 step %c1  {
-    %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, %arg2, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+    %2 = amdaie.dma_cpy_nd(%1[] [] [], %0[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, %arg2, 1]) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>)
   }
   return
 }
@@ -252,25 +252,25 @@ func.func @forall_cores() {
 //
 // CHECK-LABEL: @forall_dmas
 // CHECK:       amdaie.workgroup
-// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
 // CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
 // CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
 // CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK-SAME:    %[[FROMMEMREF0]][] [] []
 // CHECK-SAME:    %[[FROMMEMREF1]][] [] []
-// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>)
 // CHECK:         amdaie.controlcode
 // CHECK:           scf.forall (%[[ARG0:.*]], %[[ARG1:.*]]) in (2, 2)
 // CHECK:             %[[IPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
 // CHECK-SAME:        [] [] []
 // CHECK-SAME:        [0, 0, 0, 0] [1, 1, 8, 16] [128, %[[ARG1]], %[[ARG0]], 1]
-// CHECK:             amdaie.npu.dma_wait(%[[IPU_DMA]], S2MM)
-func.func @forall_dmas(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi32, 1>) {
-  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
+// CHECK:             amdaie.npu.dma_wait(%[[IPU_DMA]], MM2S)
+func.func @forall_dmas(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) {
+  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
   %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
   scf.forall (%arg2, %arg3) in (2, 2) {
-    %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, %arg3, %arg2, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+    %2 = amdaie.dma_cpy_nd(%1[] [] [], %0[0, 0, 0, 0] [1, 1, 8, 16] [128, %arg3, %arg2, 1]) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>)
   }
   return
 }
@@ -287,13 +287,13 @@ func.func @forall_dmas(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi32, 1
 // CHECK-DAG:     %[[TILE_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
 // CHECK-DAG:     %[[TILE_1:.+]] = amdaie.tile(%[[C0]], %[[C1]])
 // CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
+// CHECK-SAME:    memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
 // CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
 // CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
 // CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK-SAME:    %[[FROMMEMREF0]][] [] []
-// CHECK-SAME:    %[[FROMMEMREF1]][] [] []
-// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+// CHECK-SAME:    %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
 // CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_0]])
 // CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA]])
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
@@ -303,18 +303,18 @@ func.func @forall_dmas(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi32, 1
 // CHECK:         amdaie.controlcode
 // CHECK:           %[[IPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
 // CHECK-SAME:      [] [] []
-// CHECK-SAME:      [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK-SAME:      [] [] []
 // CHECK:           amdaie.npu.dma_wait(%[[IPU_DMA]], S2MM)
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
-func.func @merge_cores(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi32, 1>) {
+func.func @merge_cores(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c8 = arith.constant 8 : index
   %tile_0_0 = amdaie.tile(%c0, %c0)
   %tile_0_1 = amdaie.tile(%c0, %c1)
-  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
+  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
   %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
-  %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   %core_0_0_0 = amdaie.core(%tile_0_0) {
     amdaie.logicalobjectfifo.consume(%2)
     amdaie.end
@@ -344,29 +344,29 @@ func.func @merge_cores(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi32, 1
 // CHECK-DAG:     %[[TILE_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
 // CHECK-DAG:     %[[TILE_1:.+]] = amdaie.tile(%[[C0]], %[[C1]])
 // CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
+// CHECK-SAME:    memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
 // CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
 // CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
 // CHECK-DAG:     %[[FROMMEMREF2:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x16x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x16x16xi32, 2>>
+// CHECK-SAME:    memref<1x1x16x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x16x16xi32>>
 // CHECK-DAG:     %[[FROMMEMREF3:.+]] = amdaie.logicalobjectfifo.from_memref
 // CHECK-SAME:    memref<16x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<16x16xi32, 1>>
 // CHECK-DAG:     %[[FROMMEMREF4:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x32x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x32x16xi32, 2>>
+// CHECK-SAME:    memref<1x1x32x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x32x16xi32>>
 // CHECK-DAG:     %[[FROMMEMREF5:.+]] = amdaie.logicalobjectfifo.from_memref
 // CHECK-SAME:    memref<32x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>
 // CHECK-DAG:     %[[DMA0:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK-SAME:    %[[FROMMEMREF0]][] [] []
-// CHECK-SAME:    %[[FROMMEMREF1]][] [] []
-// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+// CHECK-SAME:    %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
 // CHECK-DAG:     %[[DMA1:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK-SAME:    %[[FROMMEMREF2]][] [] []
-// CHECK-SAME:    %[[FROMMEMREF3]][] [] []
-// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x16x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<16x16xi32, 1>>)
+// CHECK-SAME:    %[[FROMMEMREF3]][0, 0, 0, 0] [1, 1, 16, 16] [128, 16, 8, 1]
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x16x16xi32>>, !amdaie.logicalobjectfifo<memref<16x16xi32, 1>>)
 // CHECK-DAG:     %[[DMA2:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK-SAME:    %[[FROMMEMREF4]][] [] []
-// CHECK-SAME:    %[[FROMMEMREF5]][] [] []
-// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x32x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>)
+// CHECK-SAME:    %[[FROMMEMREF5]][0, 0, 0, 0] [1, 1, 32, 16] [128, 16, 8, 1]
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x32x16xi32>>, !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>)
 // CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_0]])
 // CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA0]])
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
@@ -380,31 +380,31 @@ func.func @merge_cores(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi32, 1
 // CHECK:         amdaie.controlcode
 // CHECK:           %[[IPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[DMA0]]
 // CHECK-SAME:      [] [] []
-// CHECK-SAME:      [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK-SAME:      [] [] []
 // CHECK:           amdaie.npu.dma_wait(%[[IPU_DMA_0]], S2MM)
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
 // CHECK:             %[[IPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[DMA1]]
 // CHECK-SAME:        [] [] []
-// CHECK-SAME:        [0, 0, 0, 0] [1, 1, 16, 16] [128, 16, 8, 1]
+// CHECK-SAME:        [] [] []
 // CHECK:             amdaie.npu.dma_wait(%[[IPU_DMA_1]], S2MM)
 // CHECK:             %[[IPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[DMA2]]
 // CHECK-SAME:        [] [] []
-// CHECK-SAME:        [0, 0, 0, 0] [1, 1, 32, 16] [128, 16, 8, 1]
+// CHECK-SAME:        [] [] []
 // CHECK:             amdaie.npu.dma_wait(%[[IPU_DMA_2]], S2MM)
-func.func @complex_example(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi32, 1>, %arg2: memref<1x1x16x16xi32, 2>, %arg3: memref<16x16xi32, 1>, %arg4: memref<1x1x32x16xi32, 2>, %arg5: memref<32x16xi32, 1>) {
+func.func @complex_example(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>, %arg2: memref<1x1x16x16xi32>, %arg3: memref<16x16xi32, 1>, %arg4: memref<1x1x32x16xi32>, %arg5: memref<32x16xi32, 1>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c8 = arith.constant 8 : index
   %c0_i32 = arith.constant 0 : i32
   %tile_0_0 = amdaie.tile(%c0, %c0)
   %tile_0_1 = amdaie.tile(%c0, %c1)
-  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
+  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
   %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
-  %2 = amdaie.logicalobjectfifo.from_memref %arg2, {} : memref<1x1x16x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x16x16xi32, 2>>
+  %2 = amdaie.logicalobjectfifo.from_memref %arg2, {} : memref<1x1x16x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x16x16xi32>>
   %3 = amdaie.logicalobjectfifo.from_memref %arg3, {} : memref<16x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<16x16xi32, 1>>
-  %4 = amdaie.logicalobjectfifo.from_memref %arg4, {} : memref<1x1x32x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x32x16xi32, 2>>
+  %4 = amdaie.logicalobjectfifo.from_memref %arg4, {} : memref<1x1x32x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x32x16xi32>>
   %5 = amdaie.logicalobjectfifo.from_memref %arg5, {} : memref<32x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>
-  %dma_0 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  %dma_0 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   %core_0_0_0 = amdaie.core(%tile_0_0) {
     amdaie.logicalobjectfifo.consume(%dma_0)
     amdaie.end
@@ -414,16 +414,16 @@ func.func @complex_example(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi3
     amdaie.end
   }
   scf.for %iv0 = %c0 to %c8 step %c1  {
-    %dma_1 = amdaie.dma_cpy_nd(%2[] [] [], %3[0, 0, 0, 0] [1, 1, 16, 16] [128, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x16x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<16x16xi32, 1>>)
-    %dma_2 = amdaie.dma_cpy_nd(%4[] [] [], %5[0, 0, 0, 0] [1, 1, 32, 16] [128, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x32x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>)
+    %dma_1 = amdaie.dma_cpy_nd(%2[] [] [], %3[0, 0, 0, 0] [1, 1, 16, 16] [128, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x16x16xi32>>, !amdaie.logicalobjectfifo<memref<16x16xi32, 1>>)
+    %dma_2 = amdaie.dma_cpy_nd(%4[] [] [], %5[0, 0, 0, 0] [1, 1, 32, 16] [128, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x32x16xi32>>, !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>)
     %core_0_0_1 = amdaie.core(%tile_0_0) {
       amdaie.logicalobjectfifo.consume(%dma_1)
-      linalg.fill ins(%c0_i32 : i32) outs(%arg2 : memref<1x1x16x16xi32, 2>)
+      linalg.fill ins(%c0_i32 : i32) outs(%arg2 : memref<1x1x16x16xi32>)
       amdaie.end
     }
     %core_0_1_1 = amdaie.core(%tile_0_1) {
       amdaie.logicalobjectfifo.consume(%dma_2)
-      linalg.fill ins(%c0_i32 : i32) outs(%arg4 : memref<1x1x32x16xi32, 2>)
+      linalg.fill ins(%c0_i32 : i32) outs(%arg4 : memref<1x1x32x16xi32>)
       amdaie.end
     }
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
@@ -45,54 +45,7 @@ func.func @core() {
 
 // -----
 
-// CHECK-LABEL: @dma_cpy_nd_L1_L2
-// CHECK:       amdaie.workgroup
-// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
-// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
-// CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
-// CHECK-SAME:    %[[FROMMEMREF0]][] [] []
-// CHECK-SAME:    %[[FROMMEMREF1]][] [] []
-// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-// CHECK:         amdaie.controlcode
-// CHECK:           %[[IPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
-// CHECK-SAME:      [] [] []
-// CHECK-SAME:      [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
-// CHECK:           amdaie.npu.dma_wait(%[[IPU_DMA]], S2MM)
-func.func @dma_cpy_nd_L1_L2(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<8x16xi32, 1>) {
-  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
-  %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
-  %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-  return
-}
-
-// -----
-
-// CHECK-LABEL: @dma_cpy_nd_L2_L1
-// CHECK:       amdaie.workgroup
-// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
-// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 2>>
-// CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
-// CHECK-SAME:    %[[FROMMEMREF0]][] [] []
-// CHECK-SAME:    %[[FROMMEMREF1]][] [] []
-// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 2>>)
-// CHECK:         amdaie.controlcode
-// CHECK:           %[[IPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
-// CHECK-SAME:      [] [] []
-// CHECK-SAME:      [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
-// CHECK:           amdaie.npu.dma_wait(%[[IPU_DMA]], S2MM)
-func.func @dma_cpy_nd_L2_L1(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi32, 2>) {
-  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
-  %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 2>>
-  %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 2>>)
-  return
-}
-// -----
-
-// CHECK-LABEL: @dma_cpy_nd_L2_L3
+// CHECK-LABEL: @dma_cpy_nd_L3_L2
 // CHECK:       amdaie.workgroup
 // CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
 // CHECK-SAME:    memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
@@ -107,7 +60,7 @@ func.func @dma_cpy_nd_L2_L1(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi
 // CHECK-SAME:      [] [] []
 // CHECK-SAME:      [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
 // CHECK:           amdaie.npu.dma_wait(%[[IPU_DMA]], MM2S)
-func.func @dma_cpy_nd_L2_L3(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi32>) {
+func.func @dma_cpy_nd_L3_L2(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi32>) {
   %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
   %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
   %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
@@ -116,7 +69,31 @@ func.func @dma_cpy_nd_L2_L3(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi
 
 // -----
 
-// CHECK-LABEL: @dma_cpy_nd_L3_L2
+// CHECK-LABEL: @dma_cpy_nd_L3_L2_target_addressing
+// CHECK:       amdaie.workgroup
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK-SAME:    memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+// CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK-SAME:    %[[FROMMEMREF0]][] [] []
+// CHECK-SAME:    %[[FROMMEMREF1]][] [] []
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+// CHECK:         amdaie.controlcode
+// CHECK:           %[[IPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
+// CHECK-SAME:      [] [] []
+// CHECK-SAME:      [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK:           amdaie.npu.dma_wait(%[[IPU_DMA]], MM2S)
+func.func @dma_cpy_nd_L3_L2_target_addressing(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi32>) {
+  %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+  %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+  %2 = amdaie.dma_cpy_nd(%0[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @dma_cpy_nd_L2_L3
 // CHECK:       amdaie.workgroup
 // CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
 // CHECK-SAME:    memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
@@ -131,12 +108,13 @@ func.func @dma_cpy_nd_L2_L3(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi
 // CHECK-SAME:      [] [] []
 // CHECK-SAME:      [] [] []
 // CHECK:           amdaie.npu.dma_wait(%[[IPU_DMA]], S2MM)
-func.func @dma_cpy_nd_L3_L2(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) {
+func.func @dma_cpy_nd_L2_L3(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) {
   %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
   %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
   %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   return
 }
+
 // -----
 
 // CHECK-LABEL: @for


### PR DESCRIPTION
-- This commit adds a fix to DmaCpyNd -> Circular/Npu DmaCpyNd.
-- If the source of DmaCpyNd op is from L3 then the addressing will be
   controlled by the uController.
-- If the target of DmaCpyNd op is from L3 - then addressing will be
   controlled by the circular DMA at shim tile.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>