### PR TITLE
Fix AMDAIEPackToDma.cpp on Mac

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPackToDma.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPackToDma.cpp
@@ -299,6 +299,7 @@ class AMDAIEPackToDmaPass
  public:
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<tensor::TensorDialect, linalg::LinalgDialect,
+                    IREE::LinalgExt::IREELinalgExtDialect,
                     xilinx::air::airDialect>();
   }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPackToDma.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPackToDma.cpp
@@ -6,6 +6,7 @@
 
 #include "air/Dialect/AIR/AIRDialect.h"
 #include "iree-amd-aie/Transforms/Passes.h"
+#include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtDialect.h"
 #include "iree/compiler/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"


### PR DESCRIPTION
I don't know why but the current form of the walk in this pass generates the following error on M1 Mac:

```
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  iree-opt                 0x000000010de3e880 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 56
1  iree-opt                 0x000000010de3ca34 llvm::sys::RunSignalHandlers() + 112
2  iree-opt                 0x000000010de3ef2c SignalHandler(int) + 344
3  libsystem_platform.dylib 0x0000000199fc7584 _sigtramp + 56
4  iree-opt                 0x0000000108758228 mlir::TypeID::operator!=(mlir::TypeID const&) const + 32
5  iree-opt                 0x00000001087581f8 mlir::OperationName::Impl::isRegistered() const + 48
6  iree-opt                 0x0000000108758168 mlir::OperationName::isRegistered() const + 28
7  iree-opt                 0x0000000108758058 mlir::OperationName::getRegisteredInfo() const + 28
8  iree-opt                 0x0000000108758e40 mlir::Operation::getRegisteredInfo() + 40
9  iree-opt                 0x0000000106d96490 mlir::Op<mlir::iree_compiler::IREE::LinalgExt::UnPackOp, mlir::OpTrait::ZeroRegions, mlir::OpTrait::VariadicResults, mlir::OpTrait::ZeroSuccessors, mlir::OpTrait::VariadicOperands, mlir::OpTrait::AttrSizedOperandSegments, mlir::OpTrait::SingleBlock, mlir::OpTrait::SingleBlockImplicitTerminator<mlir::iree_compiler::IREE::LinalgExt::YieldOp>::Impl, mlir::OpTrait::OpInvariants, mlir::BytecodeOpInterface::Trait, mlir::ReifyRankedShapedTypeOpInterface::Trait, mlir::iree_compiler::IREE::LinalgExt::LinalgExtOp::Trait, mlir::TilingInterface::Trait, mlir::MemoryEffectOpInterface::Trait, mlir::DestinationStyleOpInterface::Trait>::classof(mlir::Operation*) + 36
10 iree-opt                 0x0000000106d96408 llvm::CastInfo<mlir::iree_compiler::IREE::LinalgExt::UnPackOp, mlir::Operation*, void>::isPossible(mlir::Operation*) + 24
11 iree-opt                 0x0000000106d963bc llvm::DefaultDoCastIfPossible<mlir::iree_compiler::IREE::LinalgExt::UnPackOp, mlir::Operation*, llvm::CastInfo<mlir::iree_compiler::IREE::LinalgExt::UnPackOp, mlir::Operation*, void>>::doCastIfPossible(mlir::Operation*) + 24
12 iree-opt                 0x0000000106d983e0 auto llvm::dyn_cast_if_present<mlir::iree_compiler::IREE::LinalgExt::UnPackOp, mlir::Operation>(mlir::Operation*) + 64
13 iree-opt                 0x0000000106d8f83c auto llvm::dyn_cast_or_null<mlir::iree_compiler::IREE::LinalgExt::UnPackOp, mlir::Operation>(mlir::Operation*) + 24
14 iree-opt                 0x0000000106d8f6dc mlir::iree_compiler::AMDAIE::AMDAIEPackToDmaPass::runOnOperation()::$_0::operator()(mlir::Operation*) const + 132
15 iree-opt                 0x0000000106d8f644 mlir::WalkResult llvm::function_ref<mlir::WalkResult (mlir::Operation*)>::callback_fn<mlir::iree_compiler::AMDAIE::AMDAIEPackToDmaPass::runOnOperation()::$_0>(long, mlir::Operation*) + 32
16 iree-opt                 0x0000000108757060 llvm::function_ref<mlir::WalkResult (mlir::Operation*)>::operator()(mlir::Operation*) const + 40
17 iree-opt                 0x0000000108756fcc mlir::WalkResult mlir::detail::walk<mlir::ForwardIterator>(mlir::Operation*, llvm::function_ref<mlir::WalkResult (mlir::Operation*)>, mlir::WalkOrder) + 532
18 iree-opt                 0x0000000108756f54 mlir::WalkResult mlir::detail::walk<mlir::ForwardIterator>(mlir::Operation*, llvm::function_ref<mlir::WalkResult (mlir::Operation*)>, mlir::WalkOrder) + 412
19 iree-opt                 0x0000000108756f54 mlir::WalkResult mlir::detail::walk<mlir::ForwardIterator>(mlir::Operation*, llvm::function_ref<mlir::WalkResult (mlir::Operation*)>, mlir::WalkOrder) + 412
20 iree-opt                 0x0000000108756f54 mlir::WalkResult mlir::detail::walk<mlir::ForwardIterator>(mlir::Operation*, llvm::function_ref<mlir::WalkResult (mlir::Operation*)>, mlir::WalkOrder) + 412
21 iree-opt                 0x0000000108756f54 mlir::WalkResult mlir::detail::walk<mlir::ForwardIterator>(mlir::Operation*, llvm::function_ref<mlir::WalkResult (mlir::Operation*)>, mlir::WalkOrder) + 412
22 iree-opt                 0x0000000108756f54 mlir::WalkResult mlir::detail::walk<mlir::ForwardIterator>(mlir::Operation*, llvm::function_ref<mlir::WalkResult (mlir::Operation*)>, mlir::WalkOrder) + 412
23 iree-opt                 0x0000000106d8f598 std::__1::enable_if<llvm::is_one_of<mlir::Operation*, mlir::Operation*, mlir::Region*, mlir::Block*>::value, mlir::WalkResult>::type mlir::detail::walk<(mlir::WalkOrder)1, mlir::ForwardIterator, mlir::iree_compiler::AMDAIE::AMDAIEPackToDmaPass::runOnOperation()::$_0, mlir::Operation*, mlir::WalkResult>(mlir::Operation*, mlir::iree_compiler::AMDAIE::AMDAIEPackToDmaPass::runOnOperation()::$_0&&) + 68
24 iree-opt                 0x0000000106d8f204 std::__1::enable_if<llvm::function_traits<__decay(mlir::iree_compiler::AMDAIE::AMDAIEPackToDmaPass::runOnOperation()::$_0)>::num_args == 1, mlir::WalkResult>::type mlir::Operation::walk<(mlir::WalkOrder)1, mlir::ForwardIterator, mlir::iree_compiler::AMDAIE::AMDAIEPackToDmaPass::runOnOperation()::$_0, mlir::WalkResult>(mlir::iree_compiler::AMDAIE::AMDAIEPackToDmaPass::runOnOperation()::$_0&&) + 32
25 iree-opt                 0x0000000106d8f1ac mlir::iree_compiler::AMDAIE::AMDAIEPackToDmaPass::runOnOperation() + 76
26 iree-opt                 0x000000010d9c1b44 mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int) + 584
27 iree-opt                 0x000000010d9c2240 mlir::detail::OpToOpPassAdaptor::runPipeline(mlir::OpPassManager&, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int, mlir::PassInstrumentor*, mlir::PassInstrumentation::PipelineParentInfo const*) + 320
28 iree-opt                 0x000000010d9c3324 mlir::detail::OpToOpPassAdaptor::runOnOperationAsyncImpl(bool) + 1868
29 iree-opt                 0x000000010d9c1ca0 mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int) + 932
30 iree-opt                 0x000000010d9c2240 mlir::detail::OpToOpPassAdaptor::runPipeline(mlir::OpPassManager&, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int, mlir::PassInstrumentor*, mlir::PassInstrumentation::PipelineParentInfo const*) + 320
31 iree-opt                 0x00000001052d2604 llvm::function_ref<mlir::LogicalResult (mlir::OpPassManager&, mlir::Operation*)>::operator()(mlir::OpPassManager&, mlir::Operation*) const + 48
32 iree-opt                 0x00000001052c872c mlir::Pass::runPipeline(mlir::OpPassManager&, mlir::Operation*) + 52
33 iree-opt                 0x0000000107bcb22c mlir::iree_compiler::IREE::HAL::(anonymous namespace)::TranslateTargetExecutableVariantsPass::runOnOperation() + 468
34 iree-opt                 0x000000010d9c1b44 mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int) + 584
35 iree-opt                 0x000000010d9c2240 mlir::detail::OpToOpPassAdaptor::runPipeline(mlir::OpPassManager&, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int, mlir::PassInstrumentor*, mlir::PassInstrumentation::PipelineParentInfo const*) + 320
36 iree-opt                 0x000000010d9c3324 mlir::detail::OpToOpPassAdaptor::runOnOperationAsyncImpl(bool) + 1868
37 iree-opt                 0x000000010d9c1ca0 mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int) + 932
38 iree-opt                 0x000000010d9c2240 mlir::detail::OpToOpPassAdaptor::runPipeline(mlir::OpPassManager&, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int, mlir::PassInstrumentor*, mlir::PassInstrumentation::PipelineParentInfo const*) + 320
39 iree-opt                 0x000000010d9c3324 mlir::detail::OpToOpPassAdaptor::runOnOperationAsyncImpl(bool) + 1868
40 iree-opt                 0x000000010d9c1ca0 mlir::detail::OpToOpPassAdaptor::run(mlir::Pass*, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int) + 932
41 iree-opt                 0x000000010d9c2240 mlir::detail::OpToOpPassAdaptor::runPipeline(mlir::OpPassManager&, mlir::Operation*, mlir::AnalysisManager, bool, unsigned int, mlir::PassInstrumentor*, mlir::PassInstrumentation::PipelineParentInfo const*) + 320
42 iree-opt                 0x000000010d9c4114 mlir::PassManager::run(mlir::Operation*) + 1136
43 iree-opt                 0x000000010754a858 performActions(llvm::raw_ostream&, std::__1::shared_ptr<llvm::SourceMgr> const&, mlir::MLIRContext*, mlir::MlirOptMainConfig const&) + 616
44 iree-opt                 0x000000010754a554 mlir::LogicalResult llvm::function_ref<mlir::LogicalResult (std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)>::callback_fn<mlir::MlirOptMain(llvm::raw_ostream&, std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, mlir::DialectRegistry&, mlir::MlirOptMainConfig const&)::$_2>(long, std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&) + 476
45 iree-opt                 0x000000010dd34c5c mlir::splitAndProcessBuffer(std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, llvm::function_ref<mlir::LogicalResult (std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, llvm::raw_ostream&)>, llvm::raw_ostream&, llvm::StringRef, llvm::StringRef) + 624
46 iree-opt                 0x00000001075454f0 mlir::MlirOptMain(llvm::raw_ostream&, std::__1::unique_ptr<llvm::MemoryBuffer, std::__1::default_delete<llvm::MemoryBuffer>>, mlir::DialectRegistry&, mlir::MlirOptMainConfig const&) + 220
47 iree-opt                 0x0000000104f430f4 ireeOptMainFromCL(int, char**, llvm::StringRef, mlir::DialectRegistry&) + 1376
48 iree-opt                 0x0000000104f42af4 ireeOptRunMain + 116
49 iree-opt                 0x0000000104f42a74 main + 36
50 dyld                     0x0000000199c0e0e0 start + 2360
```

while this form does not.