### PR TITLE
Add jtuyls to compiler in CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 # CMakeLists.txt file to always ping a bunch of people.
 
 # Compiler
-/compiler/ @MaheshRavishankar @nirvedhmeshram @yzhang93 @Abhishek-Varma
+/compiler/ @MaheshRavishankar @nirvedhmeshram @yzhang93 @Abhishek-Varma @jtuyls
 
 # Runtime
 /runtime/ @nirvedhmeshram


### PR DESCRIPTION
Adding myself to the CODEOWNERS file for compiler to automatically get notifications and requests for review on PRs.