### PR TITLE
[AMD-AIE] Refactor + clone most of the operations based on IRMapper

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
@@ -64,9 +64,9 @@ LogicalResult workgroupBuildForCircularDmaCpyNdOp(
 
 /// DmaCpyNd operations are converted into CircularDmaCpyNd operations by moving
 /// the strided access specifiers to an npu dma instruction, followed by a wait.
-LogicalResult workgroupBuildForDmaCpyNdOp(
-    IRRewriterAndMapper &rewriter, AMDAIE::DmaCpyNdOp dmaOp, Block *target,
-    Block *controlCode, CoreContext &coreContext, Block::iterator targetBegin,
+LogicalResult WorkgroupBuilder::buildForDmaCpyNdOp(
+    AMDAIE::DmaCpyNdOp dmaOp, Block *target, Block *controlCode,
+    CoreContext &coreContext, Block::iterator targetBegin,
     Block::iterator controlCodeBegin, Block::iterator controlCodeEnd) {
   LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [amdaie.dma_cpy_nd] Start\n");
   Attribute sourceMemSpace = dmaOp.getSourceObjectFifo().getMemorySpace();
@@ -125,14 +125,14 @@ LogicalResult workgroupBuildForDmaCpyNdOp(
       circularDmaSourceSizes, circularDmaSourceStrides);
 
   IRRewriter::InsertPoint dmaInsertionPoint = rewriter.saveInsertionPoint();
-  rewriter.setInsertionPoint(controlCode, controlCodeEnd);
-  auto ipuDmaCpy = rewriter.createAndLookup<AMDAIE::NpuDmaCpyNdOp>(
+  controlCodeRewriter.setInsertionPoint(controlCode, controlCodeEnd);
+  auto ipuDmaCpy = controlCodeRewriter.createAndLookup<AMDAIE::NpuDmaCpyNdOp>(
       loc, newDmaOp.getResult(), ipuDmaTargetOffsets, ipuDmaTargetSizes,
       ipuDmaTargetStrides, ipuDmaSourceOffsets, ipuDmaSourceSizes,
       ipuDmaSourceStrides);
   DMAChannelDir direction =
       !sourceMemSpace ? DMAChannelDir::MM2S : DMAChannelDir::S2MM;
-  rewriter.createAndLookup<AMDAIE::NpuDmaWaitOp>(
+  controlCodeRewriter.createAndLookup<AMDAIE::NpuDmaWaitOp>(
       rewriter.getUnknownLoc(), SmallVector<Type, 1>{}, ipuDmaCpy.getResult(),
       direction);
   rewriter.restoreInsertionPoint(dmaInsertionPoint);
@@ -180,44 +180,47 @@ FailureOr<OpTy> createNewLoopOp(IRRewriterAndMapper &rewriter,
 ///   2. Create a new operation from the provided operation of type `OpTy` and
 ///   insert it in the control code block around the existing control code body.
 template <typename OpTy>
-LogicalResult workgroupBuildForSingleBody(
-    IRRewriterAndMapper &rewriter, OpTy op, Block *target, Block *controlCode,
-    CoreContext &coreContext, Block::iterator targetBegin,
-    Block::iterator controlCodeBegin, Block::iterator controlCodeEnd) {
+LogicalResult WorkgroupBuilder::buildForSingleBody(
+    OpTy op, Block *target, Block *controlCode, CoreContext &coreContext,
+    Block::iterator targetBegin, Block::iterator controlCodeBegin,
+    Block::iterator controlCodeEnd) {
   LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [" << OpTy::getOperationName()
                           << "] Start\n");
+  IRRewriter::InsertPoint oldInsertionPoint = rewriter.saveInsertionPoint();
+  controlCodeRewriter.setInsertionPoint(controlCode, controlCodeEnd);
   FailureOr<OpTy> maybeControlCodeOp =
-      createNewLoopOp<CreateAndMapFunctor, OpTy>(rewriter, op);
+      createNewLoopOp<CreateAndMapFunctor, OpTy>(controlCodeRewriter, op);
   if (failed(maybeControlCodeOp)) {
     return op.emitOpError("failed to create a new loop");
   }
+  rewriter.restoreInsertionPoint(oldInsertionPoint);
   OpTy newControlCodeForOp = maybeControlCodeOp.value();
 
   // Create a new core map and control code block for visiting the nested ops.
   CoreContext nestedCoreContext(rewriter);
   Block *nestedControlCode = rewriter.createBlock(controlCode->getParent());
-  if (failed(workgroupBuild(
-          rewriter, op.getBody(), target, nestedControlCode, nestedCoreContext,
-          op.getBody()->begin(), std::prev(op.getBody()->end()), target->end(),
-          nestedControlCode->begin(), nestedControlCode->end()))) {
+  if (failed(build(op.getBody(), target, nestedControlCode, nestedCoreContext,
+                   op.getBody()->begin(), std::prev(op.getBody()->end()),
+                   target->end(), nestedControlCode->begin(),
+                   nestedControlCode->end()))) {
     return op.emitOpError() << "failed to add scf.for body to workgroup";
   }
 
   // Create a new scf.for for every nested core and insert into the core
   // op around all existing ops, except for the terminator.
   for (auto &&[coordinate, coreOp] : nestedCoreContext.getCoreMap()) {
-    FailureOr<OpTy> maybeCoreOp =
+    FailureOr<OpTy> maybeOp =
         createNewLoopOp<CreateAndLookupFunctor, OpTy>(rewriter, op);
-    if (failed(maybeCoreOp)) {
+    if (failed(maybeOp)) {
       return op.emitOpError("failed to create a new loop");
     }
-    auto newCoreOp = maybeCoreOp.value();
-    Block::iterator insertIt = newCoreOp.getBody()->begin();
+    auto newOp = maybeOp.value();
+    Block::iterator insertIt = newOp.getBody()->begin();
     Block::iterator coreBegin = coreOp.getBody()->begin();
     Block::iterator coreEnd = coreOp.getBody()->getTerminator()->getIterator();
-    newCoreOp.getBody()->getOperations().splice(
+    newOp.getBody()->getOperations().splice(
         insertIt, coreOp.getBody()->getOperations(), coreBegin, coreEnd);
-    rewriter.moveOpBefore(newCoreOp, coreOp.getBody()->getTerminator());
+    rewriter.moveOpBefore(newOp, coreOp.getBody()->getTerminator());
   }
   coreContext.mergeContext(nestedCoreContext);
 
@@ -232,19 +235,15 @@ LogicalResult workgroupBuildForSingleBody(
 
 /// Skip workgroup operations and just build their bodies.
 /// TODO(jornt): Get rid of the insertion of workgroups before this pass.
-LogicalResult workgroupBuildForWorkgroupOp(IRRewriterAndMapper &rewriter,
-                                           AMDAIE::WorkgroupOp workgroupOp,
-                                           Block *target, Block *controlCode,
-                                           CoreContext &coreContext,
-                                           Block::iterator targetBegin,
-                                           Block::iterator controlCodeBegin,
-                                           Block::iterator controlCodeEnd) {
+LogicalResult WorkgroupBuilder::buildForWorkgroupOp(
+    AMDAIE::WorkgroupOp workgroupOp, Block *target, Block *controlCode,
+    CoreContext &coreContext, Block::iterator targetBegin,
+    Block::iterator controlCodeBegin, Block::iterator controlCodeEnd) {
   LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [amdaie.workgroup] Start\n");
-  if (failed(workgroupBuild(rewriter, workgroupOp.getBody(), target,
-                            controlCode, coreContext,
-                            workgroupOp.getBody()->begin(),
-                            std::prev(workgroupOp.getBody()->end()),
-                            target->end(), controlCodeBegin, controlCodeEnd))) {
+  if (failed(build(workgroupOp.getBody(), target, controlCode, coreContext,
+                   workgroupOp.getBody()->begin(),
+                   std::prev(workgroupOp.getBody()->end()), target->end(),
+                   controlCodeBegin, controlCodeEnd))) {
     return workgroupOp.emitOpError()
            << "failed to add workgroup body to workgroup";
   }
@@ -253,12 +252,13 @@ LogicalResult workgroupBuildForWorkgroupOp(IRRewriterAndMapper &rewriter,
 }
 
 /// Recursive workgroup build function for an operation.
-LogicalResult workgroupBuild(IRRewriterAndMapper &rewriter, Operation *op,
-                             Block *target, Block *controlCode,
-                             CoreContext &coreContext,
-                             Block::iterator targetBegin,
-                             Block::iterator controlCodeBegin,
-                             Block::iterator controlCodeEnd) {
+LogicalResult WorkgroupBuilder::build(Operation *op, Block *target,
+                                      Block *controlCode,
+                                      CoreContext &coreContext,
+                                      Block::iterator targetBegin,
+                                      Block::iterator controlCodeBegin,
+                                      Block::iterator controlCodeEnd) {
+  OpBuilder::InsertionGuard guard(rewriter);
   return TypeSwitch<Operation *, LogicalResult>(op)
       .Case<AMDAIE::CoreOp>([&](auto coreOp) {
         return workgroupBuildForCoreOp(rewriter, coreOp, target, controlCode,
@@ -271,28 +271,41 @@ LogicalResult workgroupBuild(IRRewriterAndMapper &rewriter, Operation *op,
             controlCodeBegin, controlCodeEnd);
       })
       .Case<AMDAIE::DmaCpyNdOp>([&](auto dmaOp) {
-        return workgroupBuildForDmaCpyNdOp(rewriter, dmaOp, target, controlCode,
-                                           coreContext, targetBegin,
-                                           controlCodeBegin, controlCodeEnd);
+        return buildForDmaCpyNdOp(dmaOp, target, controlCode, coreContext,
+                                  targetBegin, controlCodeBegin,
+                                  controlCodeEnd);
       })
       .Case<scf::ForallOp>([&](auto forallOp) {
-        return workgroupBuildForSingleBody<scf::ForallOp>(
-            rewriter, forallOp, target, controlCode, coreContext, targetBegin,
+        return buildForSingleBody<scf::ForallOp>(
+            forallOp, target, controlCode, coreContext, targetBegin,
             controlCodeBegin, controlCodeEnd);
       })
       .Case<scf::ForOp>([&](auto forOp) {
-        return workgroupBuildForSingleBody<scf::ForOp>(
-            rewriter, forOp, target, controlCode, coreContext, targetBegin,
-            controlCodeBegin, controlCodeEnd);
+        return buildForSingleBody<scf::ForOp>(forOp, target, controlCode,
+                                              coreContext, targetBegin,
+                                              controlCodeBegin, controlCodeEnd);
       })
       .Case<AMDAIE::WorkgroupOp>([&](auto workgroupOp) {
-        return workgroupBuildForWorkgroupOp(
-            rewriter, workgroupOp, target, controlCode, coreContext,
-            targetBegin, controlCodeBegin, controlCodeEnd);
+        return buildForWorkgroupOp(workgroupOp, target, controlCode,
+                                   coreContext, targetBegin, controlCodeBegin,
+                                   controlCodeEnd);
       })
       .Default([&](Operation *) {
         // All other operations are cloned.
-        rewriter.cloneAndMap(*op);
+        // Case 1: Try to clone in workgroup.
+        if (llvm::all_of(op->getOperands(), [&](Value operand) {
+              return rewriter.contains(operand);
+            })) {
+          rewriter.cloneAndMap(*op);
+        }
+        // Case 2: Try to clone in controlcode.
+        if (llvm::all_of(op->getOperands(), [&](Value operand) {
+              return controlCodeRewriter.contains(operand);
+            })) {
+          controlCodeRewriter.setInsertionPoint(controlCode, controlCodeEnd);
+          controlCodeRewriter.cloneAndMap(*op);
+        }
+        // TODO(avarma): Case 3: Try to clone in core.
         return success();
       });
   return success();
@@ -300,18 +313,17 @@ LogicalResult workgroupBuild(IRRewriterAndMapper &rewriter, Operation *op,
 
 /// Recursive workgroup build function for a block with a provided source and
 /// end point.
-LogicalResult workgroupBuild(
-    IRRewriterAndMapper &rewriter, Block *source, Block *target,
-    Block *controlCode, CoreContext &coreContext, Block::iterator sourceBegin,
-    Block::iterator sourceEnd, Block::iterator targetBegin,
-    Block::iterator controlCodeBegin, Block::iterator controlCodeEnd) {
+LogicalResult WorkgroupBuilder::build(
+    Block *source, Block *target, Block *controlCode, CoreContext &coreContext,
+    Block::iterator sourceBegin, Block::iterator sourceEnd,
+    Block::iterator targetBegin, Block::iterator controlCodeBegin,
+    Block::iterator controlCodeEnd) {
   OpBuilder::InsertionGuard guard(rewriter);
   rewriter.setInsertionPoint(target, targetBegin);
   for (Block::iterator it = sourceBegin; it != sourceEnd; ++it) {
     OpBuilder::InsertionGuard guard(rewriter);
-    if (failed(workgroupBuild(rewriter, &(*it), target, controlCode,
-                              coreContext, targetBegin, controlCodeBegin,
-                              controlCodeEnd))) {
+    if (failed(build(&(*it), target, controlCode, coreContext, targetBegin,
+                     controlCodeBegin, controlCodeEnd))) {
       return failure();
     }
   }
@@ -324,8 +336,23 @@ namespace {
 /// code.
 LogicalResult createSingleWorkgroupAndControlCode(func::FuncOp funcOp) {
   IRRewriterAndMapper rewriter(funcOp.getContext());
+  IRRewriterAndMapper controlCodeRewriter(funcOp.getContext());
   Block *funcBlock = &funcOp.getBody().front();
   Block *newBlock = rewriter.createBlock(&funcOp.getRegion());
+
+  // Create an idempotent mapping of FuncOp's blockArgument with itself.
+  // The reason to do this is -> while building the workgroup of a function
+  // we would be cloning an operation to :-
+  // 1. Workgroup body.
+  // 2. Controlcode.
+  // 3. Core op (TODO(avarma): Not implemented yet).
+  // Each of these cloning would be dependent on the respective IRMapper.
+  // Specifically we would be checking if the IRMapper has the necessary operand
+  // values to perform a successful clone.
+  for (Value val : funcBlock->getArguments()) {
+    rewriter.map(val, val);
+    controlCodeRewriter.map(val, val);
+  }
 
   // Create the workgroup op to be filled in with AIE DMAs, cores and the
   // control code.
@@ -339,11 +366,12 @@ LogicalResult createSingleWorkgroupAndControlCode(func::FuncOp funcOp) {
 
   // Recursively build the workgroup and control code.
   CoreContext coreContext(rewriter);
-  if (failed(workgroupBuild(rewriter, funcBlock, newWorkgroupBlock,
-                            controlCodeBlock, coreContext, funcBlock->begin(),
-                            std::prev(funcBlock->end()),
-                            newWorkgroupBlock->begin(),
-                            controlCodeBlock->begin(), controlCodeEnd))) {
+  WorkgroupBuilder builder(rewriter, controlCodeRewriter);
+  if (failed(builder.build(funcBlock, newWorkgroupBlock, controlCodeBlock,
+                           coreContext, funcBlock->begin(),
+                           std::prev(funcBlock->end()),
+                           newWorkgroupBlock->begin(),
+                           controlCodeBlock->begin(), controlCodeEnd))) {
     return failure();
   }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
@@ -186,14 +186,12 @@ LogicalResult WorkgroupBuilder::buildForSingleBody(
     Block::iterator controlCodeEnd) {
   LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [" << OpTy::getOperationName()
                           << "] Start\n");
-  IRRewriter::InsertPoint oldInsertionPoint = rewriter.saveInsertionPoint();
   controlCodeRewriter.setInsertionPoint(controlCode, controlCodeEnd);
   FailureOr<OpTy> maybeControlCodeOp =
       createNewLoopOp<CreateAndMapFunctor, OpTy>(controlCodeRewriter, op);
   if (failed(maybeControlCodeOp)) {
     return op.emitOpError("failed to create a new loop");
   }
-  rewriter.restoreInsertionPoint(oldInsertionPoint);
   OpTy newControlCodeForOp = maybeControlCodeOp.value();
 
   // Create a new core map and control code block for visiting the nested ops.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.h
@@ -218,12 +218,17 @@ class WorkgroupBuilder {
                       Block::iterator controlCodeEnd);
 
  private:
+  /// Build function that handles `amdaie.dma_cpy_nd` by converting it into a
+  /// workgroup DMA with potentially corresponding control code.
   LogicalResult buildForDmaCpyNdOp(AMDAIE::DmaCpyNdOp dmaOp, Block *target,
                                    Block *controlCode, CoreContext &coreContext,
                                    Block::iterator targetBegin,
                                    Block::iterator controlCodeBegin,
                                    Block::iterator controlCodeEnd);
 
+  /// Build function that handles operations with a single body and inserts in
+  /// both the control code as well as inside all the cores after visiting the
+  /// body.
   template <typename OpTy>
   LogicalResult buildForSingleBody(OpTy op, Block *target, Block *controlCode,
                                    CoreContext &coreContext,
@@ -231,6 +236,8 @@ class WorkgroupBuilder {
                                    Block::iterator controlCodeBegin,
                                    Block::iterator controlCodeEnd);
 
+  /// Build function that handles `amdaie.workgroup` by visiting the body and
+  /// converting and inserting it into the single `amdaie.workgroup`.
   LogicalResult buildForWorkgroupOp(AMDAIE::WorkgroupOp workgroupOp,
                                     Block *target, Block *controlCode,
                                     CoreContext &coreContext,
@@ -238,7 +245,8 @@ class WorkgroupBuilder {
                                     Block::iterator controlCodeBegin,
                                     Block::iterator controlCodeEnd);
 
-  /// The rewriter to be used.
+  /// The main rewriter to be used for the workgroup body, excluding control
+  /// code and core operations (future work).
   IRRewriterAndMapper &rewriter;
 
   /// Rewriter and mapper for the control code context.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.h
@@ -31,10 +31,17 @@ class IRRewriterAndMapper : public IRRewriter {
     return IRRewriter::clone(op, mapper);
   }
 
+  /// Checks to see if a mapping for 'from' exists.
+  bool contains(Value from) const { return mapper.contains(from); }
+
+  /// Inserts a new mapping for 'from' to 'to'. If there is an existing mapping,
+  /// it is overwritten.
+  void map(Value from, Value to) { mapper.map(from, to); }
+
   /// Create an operation of the specific op type at the current insertion point
   /// and lookup and replace the operands based on IR map.
   template <typename OpTy, typename... Args>
-  OpTy createAndLookup(Location location, Args &&... args) {
+  OpTy createAndLookup(Location location, Args &&...args) {
     OpTy newOp =
         IRRewriter::create<OpTy>(location, std::forward<Args>(args)...);
     for (unsigned i = 0, e = newOp->getNumOperands(); i != e; ++i) {
@@ -48,7 +55,7 @@ class IRRewriterAndMapper : public IRRewriter {
   /// operands are looked up and replaced with values found in the IR map if
   /// found.
   template <typename OpTy, typename... Args>
-  OpTy createAndMap(Location location, Operation *op, Args &&... args) {
+  OpTy createAndMap(Location location, Operation *op, Args &&...args) {
     assert(op && "expected non-null op");
     OpTy newOp = createAndLookup<OpTy>(location, std::forward<Args>(args)...);
     mapOperations(op, newOp.getOperation());
@@ -91,7 +98,7 @@ class IRRewriterAndMapper : public IRRewriter {
 struct CreateAndMapFunctor {
   template <typename OpTy, typename... Args>
   static OpTy Call(IRRewriterAndMapper &rewriter, Location location,
-                   Operation *op, Args &&... args) {
+                   Operation *op, Args &&...args) {
     return rewriter.createAndMap<OpTy>(location, op,
                                        std::forward<Args>(args)...);
   }
@@ -101,7 +108,7 @@ struct CreateAndMapFunctor {
 struct CreateAndLookupFunctor {
   template <typename OpTy, typename... Args>
   static OpTy Call(IRRewriterAndMapper &rewriter, Location location,
-                   Operation *op, Args &&... args) {
+                   Operation *op, Args &&...args) {
     return rewriter.createAndLookup<OpTy>(location,
                                           std::forward<Args>(args)...);
   }
@@ -110,7 +117,7 @@ struct CreateAndLookupFunctor {
 /// Utility to create a new op using the provided `TFunctor`.
 template <class TFunctor, typename OpTy, typename... Args>
 OpTy createOp(IRRewriterAndMapper &rewriter, Location location, Operation *op,
-              Args &&... args) {
+              Args &&...args) {
   return TFunctor::template Call<OpTy>(rewriter, location, op,
                                        std::forward<Args>(args)...);
 }
@@ -188,24 +195,55 @@ class CoreContext {
 // Recursive workgroup builder functions
 //===----------------------------------------------------------------------===//
 
-/// Recursive workgroup build function for an operation.
-LogicalResult workgroupBuild(IRRewriterAndMapper &rewriter, Operation *op,
-                             Block *target, Block *controlCode,
-                             CoreContext &contextCoreMap,
-                             Block::iterator targetBegin,
-                             Block::iterator controlCodeBegin,
-                             Block::iterator controlCodeEnd);
+class WorkgroupBuilder {
+ public:
+  WorkgroupBuilder(IRRewriterAndMapper &rewriter,
+                   IRRewriterAndMapper &controlCodeRewriter)
+      : rewriter(rewriter), controlCodeRewriter(controlCodeRewriter) {}
+  WorkgroupBuilder(IRRewriterAndMapper &&rewriter,
+                   IRRewriterAndMapper &controlCodeRewriter) = delete;
 
-/// Recursive workgroup build function for a block with a provided source and
-/// end point.
-LogicalResult workgroupBuild(IRRewriterAndMapper &rewriter, Block *source,
-                             Block *target, Block *controlCode,
-                             CoreContext &contextCoreMap,
-                             Block::iterator sourceBegin,
-                             Block::iterator sourceEnd,
-                             Block::iterator targetBegin,
-                             Block::iterator controlCodeBegin,
-                             Block::iterator controlCodeEnd);
+  /// Recursive workgroup build function for an operation.
+  LogicalResult build(Operation *op, Block *target, Block *controlCode,
+                      CoreContext &contextCoreMap, Block::iterator targetBegin,
+                      Block::iterator controlCodeBegin,
+                      Block::iterator controlCodeEnd);
+
+  /// Recursive workgroup build function for a block with a provided source and
+  /// end point.
+  LogicalResult build(Block *source, Block *target, Block *controlCode,
+                      CoreContext &contextCoreMap, Block::iterator sourceBegin,
+                      Block::iterator sourceEnd, Block::iterator targetBegin,
+                      Block::iterator controlCodeBegin,
+                      Block::iterator controlCodeEnd);
+
+ private:
+  LogicalResult buildForDmaCpyNdOp(AMDAIE::DmaCpyNdOp dmaOp, Block *target,
+                                   Block *controlCode, CoreContext &coreContext,
+                                   Block::iterator targetBegin,
+                                   Block::iterator controlCodeBegin,
+                                   Block::iterator controlCodeEnd);
+
+  template <typename OpTy>
+  LogicalResult buildForSingleBody(OpTy op, Block *target, Block *controlCode,
+                                   CoreContext &coreContext,
+                                   Block::iterator targetBegin,
+                                   Block::iterator controlCodeBegin,
+                                   Block::iterator controlCodeEnd);
+
+  LogicalResult buildForWorkgroupOp(AMDAIE::WorkgroupOp workgroupOp,
+                                    Block *target, Block *controlCode,
+                                    CoreContext &coreContext,
+                                    Block::iterator targetBegin,
+                                    Block::iterator controlCodeBegin,
+                                    Block::iterator controlCodeEnd);
+
+  /// The rewriter to be used.
+  IRRewriterAndMapper &rewriter;
+
+  /// Rewriter and mapper for the control code context.
+  IRRewriterAndMapper &controlCodeRewriter;
+};
 
 }  // namespace mlir::iree_compiler::AMDAIE
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
@@ -153,10 +153,13 @@ func.func @error_dma_cpy_nd_L2_L1(%arg0: memref<1x1x8x16xi32, 2>, %arg1: memref<
 
 // CHECK-LABEL: @for
 // CHECK:       amdaie.workgroup
-// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:     %[[C8:.+]] = arith.constant 8 : index
+// CHECK-DAG:     arith.constant 0 : index
+// CHECK-DAG:     arith.constant 1 : index
+// CHECK-DAG:     arith.constant 8 : index
 // CHECK:         amdaie.controlcode
+// CHECK-DAG:       %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:       %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:       %[[C8:.+]] = arith.constant 8 : index
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
 func.func @for() {
   %c0 = arith.constant 0 : index
@@ -183,7 +186,10 @@ func.func @for() {
 // CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_1]])
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
 // CHECK:         amdaie.controlcode
-// CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
+// CHECK-DAG:       %[[C0_1:.+]] = arith.constant 0 : index
+// CHECK-DAG:       %[[C1_1:.+]] = arith.constant 1 : index
+// CHECK-DAG:       %[[C8_1:.+]] = arith.constant 8 : index
+// CHECK:           scf.for %{{.*}} = %[[C0_1]] to %[[C8_1]] step %[[C1_1]]
 func.func @for_cores() {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -219,7 +225,10 @@ func.func @for_cores() {
 // CHECK-SAME:    %[[FROMMEMREF1]][] [] []
 // CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>)
 // CHECK:         amdaie.controlcode
-// CHECK:           scf.for %[[ARG:.+]] = %[[C0]] to %[[C8]] step %[[C1]]
+// CHECK-DAG:       %[[C0_1:.+]] = arith.constant 0 : index
+// CHECK-DAG:       %[[C1_1:.+]] = arith.constant 1 : index
+// CHECK-DAG:       %[[C8_1:.+]] = arith.constant 8 : index
+// CHECK:           scf.for %[[ARG:.+]] = %[[C0_1]] to %[[C8_1]] step %[[C1_1]]
 // CHECK:             %[[IPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
 // CHECK-SAME:        [] [] []
 // CHECK-SAME:        [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, %[[ARG]], 1]
@@ -335,11 +344,14 @@ func.func @forall_dmas(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) 
 // CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA]])
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
 // CHECK:         amdaie.controlcode
+// CHECK-DAG:       %[[C0_1:.+]] = arith.constant 0 : index
+// CHECK-DAG:       %[[C1_1:.+]] = arith.constant 1 : index
+// CHECK-DAG:       %[[C8_1:.+]] = arith.constant 8 : index
 // CHECK:           %[[IPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
 // CHECK-SAME:      [] [] []
 // CHECK-SAME:      [] [] []
 // CHECK:           amdaie.npu.dma_wait(%[[IPU_DMA]], S2MM)
-// CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
+// CHECK:           scf.for %{{.*}} = %[[C0_1]] to %[[C8_1]] step %[[C1_1]]
 func.func @merge_cores(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -412,11 +424,14 @@ func.func @merge_cores(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) 
 // CHECK:             amdaie.logicalobjectfifo.consume(%[[DMA2]])
 // CHECK:             linalg.fill
 // CHECK:         amdaie.controlcode
+// CHECK-DAG:       %[[C0_1:.+]] = arith.constant 0 : index
+// CHECK-DAG:       %[[C1_1:.+]] = arith.constant 1 : index
+// CHECK-DAG:       %[[C8_1:.+]] = arith.constant 8 : index
 // CHECK:           %[[IPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[DMA0]]
 // CHECK-SAME:      [] [] []
 // CHECK-SAME:      [] [] []
 // CHECK:           amdaie.npu.dma_wait(%[[IPU_DMA_0]], S2MM)
-// CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
+// CHECK:           scf.for %{{.*}} = %[[C0_1]] to %[[C8_1]] step %[[C1_1]]
 // CHECK:             %[[IPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[DMA1]]
 // CHECK-SAME:        [] [] []
 // CHECK-SAME:        [] [] []


### PR DESCRIPTION
-- This commit makes changes to the `iree-amdaie-create-aie-workgroup` pass.
-- Adds a few refactoring.
-- While building the workgroup of a function we would be cloning an operation to :-
  1. Workgroup body.
  2. Controlcode.
  3. Core op (To be implemented).

-- Each of these cloning would be dependent on the respective IRMapper.
  Specifically we would be checking if the IRMapper has the necessary operand values to perform a successful clone.

Co-authored-by: Jorn Tuyls <jorn.tuyls@amd.com>
Co-authored-by: Abhishek Varma <abhvarma@amd.com>