### PR TITLE
Bump mlir-aie wheel to switch to transaction binary flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024060222+6f70bfe-py3-none-manylinux_2_35_x86_64.whl
+          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024061222+3ac9566-py3-none-manylinux_2_35_x86_64.whl
 
           pip install -r tests/matmul/requirements.txt
 

--- a/runtime/src/iree-amd-aie/driver/xrt/direct_command_buffer.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/direct_command_buffer.cc
@@ -326,13 +326,19 @@ static iree_status_t iree_hal_xrt_direct_command_buffer_dispatch(
 
   xrt::run run = xrt::run(kernel);
 
+  // set opcode for transaction binary execution
+  unsigned int opcode = 3;
+
   // Index to push arguments on the kernel.
   iree_host_size_t arg_index = 0;
 
-  // First argument is the LX6 instructions.
+  // First argument is the opcode.
+  run.set_arg(arg_index++, opcode);
+
+  // Second argument is the LX6 instructions.
   run.set_arg(arg_index++, instr);
 
-  // Second argument is the number of LX6 instructions.
+  // Third argument is the number of LX6 instructions.
   run.set_arg(arg_index++, num_instr);
 
   // Copy descriptors from all sets to the end of the current segment for later

--- a/runtime/src/iree-amd-aie/driver/xrt/native_executable.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/native_executable.cc
@@ -199,11 +199,11 @@ iree_status_t iree_hal_xrt_native_executable_create(
       kernel = std::make_unique<xrt::kernel>(context, entry_name);
       // XCL_BO_FLAGS_CACHEABLE is used to indicate that this is an instruction
       // buffer that resides in instr_memory. This buffer is always passed as
-      // the first argument to the kernel and we can use the
-      // kernel.group_id(/*index of first argument*/=0) to get the group_id.
+      // the second argument to the kernel and we can use the
+      // kernel.group_id(/*index of second argument*/=1) to get the group_id.
       instr = std::make_unique<xrt::bo>(device, num_instr * sizeof(uint32_t),
                                         XCL_BO_FLAGS_CACHEABLE,
-                                        kernel.get()->group_id(0));
+                                        kernel.get()->group_id(1));
     } catch (...) {
       iree_hal_executable_destroy((iree_hal_executable_t*)executable);
       IREE_TRACE_ZONE_END(z0);


### PR DESCRIPTION
This PR makes the required changes to switch to executing kernels with transaction binary flow with no control packets. This is done by simply updating the mlir-aie wheel to latest so that this PR is contained in it,
https://github.com/Xilinx/mlir-aie/pull/1517