### PR TITLE
Hoist the bias allocation

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -269,7 +269,7 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
     funcPassManager.addPass(createAMDAIEFusePackIntoLoopPass(fusePackOptions));
   }
 
-  // Promote the elementwise input to local memory
+  // Promote the elementwise input to local memory, and hoist the allocation.
   {
     AMDAIEBufferizeToAllocationOptions bufferizeOptions;
     bufferizeOptions.memorySpace = 2;
@@ -277,6 +277,7 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
     bufferizeOptions.bufferizeOperand = BufferizeOperand::Input;
     funcPassManager.addPass(
         createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
+    funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
   }
 
   // Lower to UKernels.


### PR DESCRIPTION
The elementwise input is promoted to local memory after the pass to hoist statically bound allocations. It is the only tensor which is promoted after the hoisting pass. This PR is just a tidy-up, so that all of the allocations are hoisted before bufferization. 