### PR TITLE
Adding error message whenever the xclbin tool fails to produce xclbin

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -349,10 +349,12 @@ LogicalResult AIETargetBackend::serializeExecutable(
 
     {
       SmallVector<StringRef> cmdEnvRefs{cmdEnv.begin(), cmdEnv.end()};
-      int result = llvm::sys::ExecuteAndWait(cmdArgs[0], cmdArgs, cmdEnvRefs);
+      int result = llvm::sys::ExecuteAndWait(cmdArgs[0], cmdArgs, cmdEnvRefs,
+                                             {}, 0, 0, &errorMessage);
       if (result != 0)
-        return moduleOp.emitOpError(
-            "Failed to produce an XCLBin with external tool.");
+        return moduleOp.emitOpError()
+               << "Failed to produce an XCLBin with external tool: "
+               << errorMessage;
     }
 
     std::ifstream instrFile(static_cast<std::string>(npuInstPath));


### PR DESCRIPTION
I noticed that whenever the xclbin compilation process fails (say that iree is not able to find the binary), it just fails but it is hard to find the reason. 

This just makes sure that the error message is displayed as well. 

