### PR TITLE
[DistributeCoresAndObjectFifos] Fix local memref DMA access pattern

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaUtils.h
@@ -7,9 +7,12 @@
 #ifndef IREE_AMD_AIE_TRANSFORMS_AMDAIEDMAUTILS_H_
 #define IREE_AMD_AIE_TRANSFORMS_AMDAIEDMAUTILS_H_
 
+#include "iree-amd-aie/IR/AMDAIEAttrs.h"
+#include "iree-amd-aie/IR/AMDAIEDmaOpInterface.h"
 #include "llvm/ADT/SmallVector.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
 
 namespace mlir::iree_compiler::AMDAIE {
 
@@ -37,6 +40,75 @@ LogicalResult foldUnitDims(const SmallVector<OpFoldResult> &offsets,
                            SmallVector<OpFoldResult> &newOffsets,
                            SmallVector<OpFoldResult> &newStrides,
                            SmallVector<OpFoldResult> &newSizes);
+
+/// Utility to discard all non-zero offsets that have dimension equal to 1 on
+/// the same index of the provided shape. This helps with updating DMA
+/// operations for a shape change. If an empty shape is passed, all non-zero
+/// offsets will be removed.
+template <CopyOpOperateOn OperateOn>
+AMDAIE::DoublyStridedOpInterface discardAllNonZeroOffsets(
+    RewriterBase &rewriter, AMDAIE::DoublyStridedOpInterface op,
+    SmallVector<int64_t> &shape) {
+  SmallVector<OpFoldResult> newSourceOffsets;
+  SmallVector<OpFoldResult> newSourceSizes;
+  SmallVector<OpFoldResult> newSourceStrides;
+  SmallVector<OpFoldResult> newTargetOffsets;
+  SmallVector<OpFoldResult> newTargetSizes;
+  SmallVector<OpFoldResult> newTargetStrides;
+  if constexpr (OperateOn == CopyOpOperateOn::Source) {
+    SmallVector<OpFoldResult> offsets = op.getSourceMixedOffsets();
+    SmallVector<OpFoldResult> sizes = op.getSourceMixedSizes();
+    SmallVector<OpFoldResult> strides = op.getSourceMixedStrides();
+    // Set shape to a vector of ones as a default.
+    if (shape.empty()) {
+      SmallVector<int64_t> ones(offsets.size(), 1);
+      shape = ones;
+    }
+    if (shape.size() != offsets.size()) return op;
+    // Fill source offsets/sizes/strides.
+    for (auto &&[offset, size, stride, dim] :
+         llvm::zip(offsets, sizes, strides, shape)) {
+      std::optional<int64_t> constantOffset = getConstantIntValue(offset);
+      if (dim == 1 && !constantOffset) continue;
+      if (dim == 1 && constantOffset && constantOffset.value() != 0) continue;
+      newSourceOffsets.push_back(offset);
+      newSourceSizes.push_back(size);
+      newSourceStrides.push_back(stride);
+    }
+    newTargetOffsets = op.getTargetMixedOffsets();
+    newTargetSizes = op.getTargetMixedSizes();
+    newTargetStrides = op.getTargetMixedStrides();
+  } else if constexpr (OperateOn == CopyOpOperateOn::Target) {
+    SmallVector<OpFoldResult> offsets = op.getTargetMixedOffsets();
+    SmallVector<OpFoldResult> sizes = op.getTargetMixedSizes();
+    SmallVector<OpFoldResult> strides = op.getTargetMixedStrides();
+    // Set shape to a vector of ones as a default.
+    if (shape.empty()) {
+      SmallVector<int64_t> ones(offsets.size(), 1);
+      shape = ones;
+    }
+    if (shape.size() != offsets.size()) return op;
+    // Fill source offsets/sizes/strides.
+    for (auto &&[offset, size, stride, dim] :
+         llvm::zip(offsets, sizes, strides, shape)) {
+      std::optional<int64_t> constantOffset = getConstantIntValue(offset);
+      if (dim == 1 && !constantOffset) continue;
+      if (dim == 1 && constantOffset && constantOffset.value() != 0) continue;
+      newTargetOffsets.push_back(offset);
+      newTargetSizes.push_back(size);
+      newTargetStrides.push_back(stride);
+    }
+    newSourceOffsets = op.getSourceMixedOffsets();
+    newSourceSizes = op.getSourceMixedSizes();
+    newSourceStrides = op.getSourceMixedStrides();
+  }
+  rewriter.setInsertionPointAfter(op);
+  auto newDoublyStridedOp = op.createDoublyStridedOp(
+      rewriter, newTargetOffsets, newTargetSizes, newTargetStrides,
+      newSourceOffsets, newSourceSizes, newSourceStrides);
+  rewriter.replaceOp(op, newDoublyStridedOp.getOperation());
+  return newDoublyStridedOp;
+}
 
 }  // namespace mlir::iree_compiler::AMDAIE
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
@@ -19,7 +19,7 @@ iree_lit_test_suite(
     "create_aie_workgroup.mlir"
     "create_logical_objectfifo_link.mlir"
     "disable_vectorization.mlir"
-    "distribute-cores-and-objectfifos.mlir"
+    "distribute_cores_and_objectfifos.mlir"
     "dma_to_circular_dma.mlir"
     "fuse_consumer_into_loop_scf_for.mlir"
     "fuse_consumer_into_loop_scf_forall.mlir"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/distribute_cores_and_objectfifos.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/distribute_cores_and_objectfifos.mlir
@@ -607,6 +607,83 @@ module {
 
 // -----
 
+// Ensure subviews on local memrefs inside cores are handled correctly by discarding the consuming DMAs' non-zero offsets. 
+// CHECK-LABEL: @local_subview_output
+// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG:   %[[C3:.+]] = arith.constant 3 : index
+// CHECK-DAG:   %[[C32:.+]] = arith.constant 32 : index
+// CHECK-DAG:   %[[ALLOC_0:.+]] = memref.alloc() : memref<1x1x32x32xi32, 2>
+// CHECK-DAG:   %[[ALLOC_1:.+]] = memref.alloc() : memref<2x2x32x32xi32, 1>
+// CHECK-DAG:   %[[ALLOC_2:.+]] = memref.alloc() : memref<64x64xi32>
+// CHECK:       scf.forall (%{{.+}}, %[[ARG1:.+]]) in (2, 2)
+// CHECK-DAG:     %[[TILE_0_2:.+]] = amdaie.tile(%[[C0]], %[[C2]])
+// CHECK-DAG:     %[[TILE_0_3:.+]] = amdaie.tile(%[[C0]], %[[C3]])
+// CHECK-DAG:     %[[TILE_1_2:.+]] = amdaie.tile(%[[C1]], %[[C2]])
+// CHECK-DAG:     %[[TILE_1_3:.+]] = amdaie.tile(%[[C1]], %[[C3]])
+// CHECK-DAG:     %[[TILE_0_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
+// CHECK-DAG:     %[[TILE_0_1:.+]] = amdaie.tile(%[[C0]], %[[C1]])
+// CHECK-DAG:     %[[FROM_MEMREF_0:.+]] = amdaie.logicalobjectfifo.from_memref %[[ALLOC_0]], {%[[TILE_0_2]]}
+// CHECK-DAG:     %[[FROM_MEMREF_1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ALLOC_0]], {%[[TILE_1_2]]}
+// CHECK-DAG:     %[[FROM_MEMREF_2:.+]] = amdaie.logicalobjectfifo.from_memref %[[ALLOC_0]], {%[[TILE_0_3]]}
+// CHECK-DAG:     %[[FROM_MEMREF_3:.+]] = amdaie.logicalobjectfifo.from_memref %[[ALLOC_0]], {%[[TILE_1_3]]}
+// CHECK-DAG:     %[[FROM_MEMREF_4:.+]] = amdaie.logicalobjectfifo.from_memref %[[ALLOC_1]], {%[[TILE_0_1]]}
+// CHECK-DAG:     %[[FROM_MEMREF_5:.+]] = amdaie.logicalobjectfifo.from_memref %[[ALLOC_2]], {%[[TILE_0_0]]}
+// CHECK-DAG:     %[[DMA_0:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_4]][%c0, %c0] [%c1, %c1] [%c1, %c1], %[[FROM_MEMREF_0]][%c0, %c0] [%c32, %c32] [%c32, %c1]
+// CHECK-DAG:     %[[CORE_0_2:.*]] = amdaie.core(%[[TILE_0_2]])
+// CHECK-DAG:       %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_0]], Write)
+// CHECK-DAG:       linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_0]] : memref<1x1x32x32xi32, 2>)
+// CHECK-DAG:       amdaie.logicalobjectfifo.produce(%[[DMA_0]])
+// CHECK-DAG:     %[[DMA_1:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_4]][%c0, %c1] [%c1, %c1] [%c1, %c1], %[[FROM_MEMREF_1]][%c0, %c0] [%c32, %c32] [%c32, %c1]
+// CHECK-DAG:     %[[CORE_1_2:.*]] = amdaie.core(%[[TILE_1_2]])
+// CHECK-DAG:       %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_1]], Write)
+// CHECK-DAG:       linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_0]] : memref<1x1x32x32xi32, 2>)
+// CHECK-DAG:       amdaie.logicalobjectfifo.produce(%[[DMA_1]])
+// CHECK-DAG:     %[[DMA_2:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_4]][%c1, %c0] [%c1, %c1] [%c1, %c1], %[[FROM_MEMREF_2]][%c0, %c0] [%c32, %c32] [%c32, %c1]
+// CHECK-DAG:     %[[CORE_0_3:.*]] = amdaie.core(%[[TILE_0_3]])
+// CHECK-DAG:       %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_2]], Write)
+// CHECK-DAG:       linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_0]] : memref<1x1x32x32xi32, 2>)
+// CHECK-DAG:       amdaie.logicalobjectfifo.produce(%[[DMA_2]])
+// CHECK-DAG:     %[[DMA_3:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_4]][%c1, %c1] [%c1, %c1] [%c1, %c1], %[[FROM_MEMREF_3]][%c0, %c0] [%c32, %c32] [%c32, %c1]
+// CHECK-DAG:     %[[CORE_1_3:.*]] = amdaie.core(%[[TILE_1_3]])
+// CHECK-DAG:       %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_3]], Write)
+// CHECK-DAG:       linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_0]] : memref<1x1x32x32xi32, 2>)
+// CHECK-DAG:       amdaie.logicalobjectfifo.produce(%[[DMA_3]])
+module {
+  func.func @local_subview_output() {
+    %c0_i32 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %alloc_0 = memref.alloc() : memref<2x2x32x32xi32, 2>
+    %alloc_1 = memref.alloc() : memref<2x2x32x32xi32, 1>
+    %alloc_2 = memref.alloc() : memref<64x64xi32>
+    scf.forall (%arg0, %arg1) in (2, 2) {
+      %0 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<2x2x32x32xi32, 2> -> !amdaie.logicalobjectfifo<memref<2x2x32x32xi32, 2>>
+      %1 = amdaie.logicalobjectfifo.from_memref %alloc_1, {} : memref<2x2x32x32xi32, 1> -> !amdaie.logicalobjectfifo<memref<2x2x32x32xi32, 1>>
+      %2 = amdaie.logicalobjectfifo.from_memref %alloc_2, {} : memref<64x64xi32> -> !amdaie.logicalobjectfifo<memref<64x64xi32>>
+      scf.forall (%arg2, %arg3) in (2, 2) {
+        %subview = memref.subview %alloc_0[%arg2, %arg3, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : memref<2x2x32x32xi32, 2> to memref<1x1x32x32xi32, strided<[2048, 1024, 32, 1], offset: ?>, 2>
+        %8 = amdaie.dma_cpy_nd(%1[%arg2, %arg3] [%c1, %c1] [%c1, %c1], %0[%arg2, %arg3, 0, 0] [1, 1, 32, 32] [1, 1, 32, 1]) : (!amdaie.logicalobjectfifo<memref<2x2x32x32xi32, 1>>, !amdaie.logicalobjectfifo<memref<2x2x32x32xi32, 2>>)
+        %add = arith.addi %arg2, %c2 : index
+        %tile = amdaie.tile(%arg3, %add)
+        %core = amdaie.core(%tile) {
+          linalg.fill ins(%c0_i32 : i32) outs(%subview : memref<1x1x32x32xi32, strided<[2048, 1024, 32, 1], offset: ?>, 2>)
+          amdaie.logicalobjectfifo.produce(%8)
+          amdaie.end
+        }
+      } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
+      %9 = amdaie.dma_cpy_nd(%2[%arg1] [%c1] [%c1], %1[] [] []) : (!amdaie.logicalobjectfifo<memref<64x64xi32>>, !amdaie.logicalobjectfifo<memref<2x2x32x32xi32, 1>>)
+    } {mapping = [#gpu.block<y>, #gpu.block<x>]}
+    memref.dealloc %alloc_2 : memref<64x64xi32>
+    memref.dealloc %alloc_1 : memref<2x2x32x32xi32, 1>
+    memref.dealloc %alloc_0 : memref<2x2x32x32xi32, 2>
+    return
+  }
+}
+
+// -----
+
 // CHECK-LABEL:   @distribute_cores_and_objectfifos
 // CHECK-DAG:       %[[IN_B:.*]] = hal.interface.binding.subspan set(0) binding(1)
 // CHECK-DAG:       %[[IN_A:.*]] = hal.interface.binding.subspan set(0) binding(0)


### PR DESCRIPTION
Contains fixes for 2 related issues:

1. On local memory distribution, static offsets/strides/sizes were not propagated.
2. Fix for DMA operations still containing offsets after a larger local memref + subview has been distributed across different cores by replacing it with multiple smaller memrefs.