### PR TITLE
Bump iree, mlir-air, mlir-aie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024061222+3ac9566-py3-none-manylinux_2_35_x86_64.whl
+          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024062422+7917990-py3-none-manylinux_2_35_x86_64.whl 
 
           pip install -r tests/matmul/requirements.txt
 

--- a/compiler/plugins/target/AMD-AIE/aie/AIEDmaToNpu.cpp
+++ b/compiler/plugins/target/AMD-AIE/aie/AIEDmaToNpu.cpp
@@ -290,7 +290,6 @@ struct DmaToNpuPattern : OpConversionPattern<NpuDmaMemcpyNdOp> {
 
     // initialize fields to zero
     auto column = zero;
-    auto ddr_id = zero;
     auto bd_id = zero;
     auto buffer_length = zero;
     auto buffer_offset = zero;
@@ -332,7 +331,7 @@ struct DmaToNpuPattern : OpConversionPattern<NpuDmaMemcpyNdOp> {
     // column
     column = IntegerAttr::get(i32ty, col);
 
-    // ddr_id
+    // arg_idx
     Block &entryBB = op->getParentOfType<func::FuncOp>().getBody().front();
     int arg_idx = -1;
     for (int i = 0, e = entryBB.getNumArguments(); i < e; i++) {
@@ -342,7 +341,6 @@ struct DmaToNpuPattern : OpConversionPattern<NpuDmaMemcpyNdOp> {
       }
     }
     if (arg_idx < 0) return failure();
-    ddr_id = IntegerAttr::get(i32ty, arg_idx);
 
     // bd_id
     bd_id = IntegerAttr::get(i32ty, op.getId());
@@ -400,7 +398,7 @@ struct DmaToNpuPattern : OpConversionPattern<NpuDmaMemcpyNdOp> {
     if (!isMM2S) issue_token = BoolAttr::get(ctx, true);
 
     rewriter.create<NpuWriteBdOp>(
-        op->getLoc(), column, ddr_id, bd_id, buffer_length, buffer_offset,
+        op->getLoc(), column, bd_id, buffer_length, buffer_offset,
         enable_packet, out_of_order_id, packet_id, packet_type, d0_size,
         d0_stride, d1_size, d1_stride, d2_stride, iteration_current,
         iteration_size, iteration_stride, next_bd, row, use_next_bd, valid_bd,

--- a/compiler/plugins/target/AMD-AIE/aie/test/aiert_insts.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/aiert_insts.mlir
@@ -7,6 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: iree-opt --aie-dma-to-npu %s | FileCheck %s
+// XFAIL: *
+// waiting on catching up to https://github.com/Xilinx/mlir-aie/pull/1559
+// i.e. we're still outputting ddr_id here
 
 // CHECK: aiex.npu.writebd {bd_id = 1 : i32, buffer_length = 32 : i32, buffer_offset = 0 : i32, column = 0 : i32, d0_size = 0 : i32, d0_stride = 0 : i32, d1_size = 0 : i32, d1_stride = 0 : i32, d2_stride = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
 // CHECK: aiex.npu.write32 {address = 119300 : ui32, column = 0 : i32, row = 0 : i32, value = 2147483649 : ui32}

--- a/compiler/plugins/target/AMD-AIE/aie/test/aiert_insts.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/aiert_insts.mlir
@@ -7,9 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: iree-opt --aie-dma-to-npu %s | FileCheck %s
-// XFAIL: *
-// waiting on catching up to https://github.com/Xilinx/mlir-aie/pull/1559
-// i.e. we're still outputting ddr_id here
 
 // CHECK: aiex.npu.writebd {bd_id = 1 : i32, buffer_length = 32 : i32, buffer_offset = 0 : i32, column = 0 : i32, d0_size = 0 : i32, d0_stride = 0 : i32, d1_size = 0 : i32, d1_stride = 0 : i32, d2_stride = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
 // CHECK: aiex.npu.write32 {address = 119300 : ui32, column = 0 : i32, row = 0 : i32, value = 2147483649 : ui32}

--- a/compiler/plugins/target/AMD-AIE/aie/test/dma_to_npu.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/dma_to_npu.mlir
@@ -1,5 +1,8 @@
 
 // RUN: iree-opt --split-input-file --aie-dma-to-npu %s | FileCheck %s
+// XFAIL: *
+// waiting on catching up to https://github.com/Xilinx/mlir-aie/pull/1559
+// i.e. we're still outputting ddr_id here
 
 // CHECK-LABEL:   aie.device(npu1_4col) {
 // CHECK:           memref.global "public" @toMem : memref<16xi32>

--- a/compiler/plugins/target/AMD-AIE/aie/test/dma_to_npu.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/dma_to_npu.mlir
@@ -1,8 +1,5 @@
 
 // RUN: iree-opt --split-input-file --aie-dma-to-npu %s | FileCheck %s
-// XFAIL: *
-// waiting on catching up to https://github.com/Xilinx/mlir-aie/pull/1559
-// i.e. we're still outputting ddr_id here
 
 // CHECK-LABEL:   aie.device(npu1_4col) {
 // CHECK:           memref.global "public" @toMem : memref<16xi32>

--- a/compiler/plugins/target/AMD-AIE/aie/test/dma_to_npu_issue_token.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/dma_to_npu_issue_token.mlir
@@ -1,5 +1,8 @@
 
 // RUN: iree-opt --aie-dma-to-npu %s | FileCheck %s
+// XFAIL: *
+// waiting on catching up to https://github.com/Xilinx/mlir-aie/pull/1559
+// i.e. we're still outputting ddr_id here
 
 // CHECK-LABEL:   aie.device(npu1_4col) {
 // CHECK:           memref.global "public" @toMem : memref<16xi32>

--- a/compiler/plugins/target/AMD-AIE/aie/test/dma_to_npu_issue_token.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/dma_to_npu_issue_token.mlir
@@ -1,8 +1,5 @@
 
 // RUN: iree-opt --aie-dma-to-npu %s | FileCheck %s
-// XFAIL: *
-// waiting on catching up to https://github.com/Xilinx/mlir-aie/pull/1559
-// i.e. we're still outputting ddr_id here
 
 // CHECK-LABEL:   aie.device(npu1_4col) {
 // CHECK:           memref.global "public" @toMem : memref<16xi32>

--- a/compiler/plugins/target/AMD-AIE/air/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/air/CMakeLists.txt
@@ -177,7 +177,6 @@ iree_cc_library(
     "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Conversion/AIRRtToNpuPass.cpp"
     "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Conversion/AIRToAIEPass.cpp"
     "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Conversion/AIRToAIESchedulingUtils.cpp"
-    "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Conversion/AIRPipeline.cpp"
   DEPS
     ::defs
     ::AIRConversionPassHeaders

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlCodeLoopUnroll.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlCodeLoopUnroll.cpp
@@ -7,9 +7,9 @@
 #include "iree-amd-aie/IR/AMDAIEOps.h"
 #include "iree-amd-aie/Transforms/Passes.h"
 #include "iree-amd-aie/Transforms/Transforms.h"
+#include "llvm/Support/MathExtras.h"
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
-#include "mlir/Support/MathExtras.h"
 
 #define DEBUG_TYPE "iree-amdaie-controlcode-loop-unroll"
 
@@ -50,7 +50,7 @@ LogicalResult controlCodeLoopUnroll(RewriterBase &rewriter,
           int64_t lbInt = lbCstOp.value();
           int64_t ubInt = ubCstOp.value();
           int64_t stepInt = stepCstOp.value();
-          int64_t tripCount = mlir::ceilDiv(ubInt - lbInt, stepInt);
+          int64_t tripCount = llvm::divideCeilSigned(ubInt - lbInt, stepInt);
           if (failed(loopUnrollByFactor(forOp, tripCount))) {
             forOp.emitOpError() << "failed to unroll scf.for";
             return WalkResult::interrupt();

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,7 +7,7 @@
 ### Update with: shark-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "42ac74291a81f495d9b34fcf444bf4b23b5a7966",
+  "iree": "36aec8a79cc616d126fe50f213d8b93ef298d6ba",
 }
 
 ORIGINS = {


### PR DESCRIPTION
Changes in updated submodules that require adaptation in iree-amd-aie:

- `NpuWriteBdOp` lost its ddr_id argument
- AIRPipeline.cpp was removed
- `mlir::ceilDiv` and the rest of `mlir/Support/MathExtras.h` was removed in favor of the LLVM equivalents (https://github.com/llvm/llvm-project/pull/95087)