### PR TITLE
[vectorization] Apply tiling only if element types vectorizable

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -565,9 +565,9 @@ run_matmul_test \
     --name_prefix "multiple_matmuls" \
     --lhs_rhs_type "i32" \
     --acc_type "i32" \
-    --m "512,8,16,7" \
-    --n "512,32,16,15" \
-    --k "256,16,8,9" \
+    --m "512,8,16" \
+    --n "512,32,16" \
+    --k "256,16,8" \
     --num_repeat_runs "0"
 
 run_matmul_test \
@@ -582,11 +582,13 @@ run_matmul_test \
     --acc_type "i32" \
     --m "8"  --n "32" --k "16"
 
-run_matmul_test \
-    --name_prefix "small" \
-    --lhs_rhs_type "i32" \
-    --acc_type "i32" \
-    --m "9"  --n "7" --k "16"
+# Disabled until the following issue is resolved:
+# https://github.com/Xilinx/llvm-aie/issues/102
+# run_matmul_test \
+#     --name_prefix "small" \
+#     --lhs_rhs_type "i32" \
+#     --acc_type "i32" \
+#     --m "9"  --n "7" --k "16"
 
 run_matmul_test \
     --name_prefix "large" \

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -504,11 +504,26 @@ run_matmul_test \
     --m "256"  --k "256" --n "256" \
     --use_ukernel "1"
 
+# Disabled until the following issue is resolved:
+# https://github.com/Xilinx/llvm-aie/issues/102
+#
+# Note I'm not using the --expect_compile_failure flag here,
+# as that would require all developers to use the same verion
+# of peano, which we currently don't enforce. 
+#
+# run_matmul_test \
+#   --name_prefix "transpose_int32" \
+#   --lhs_rhs_type "i32" \
+#   --acc_type "i32" \
+#   --m "8" --n "16" --k "32" \
+#   --do_transpose_rhs "1"
+
+
 run_matmul_test \
-  --name_prefix "transpose_int32" \
-  --lhs_rhs_type "i32" \
+  --name_prefix "transpose_i8_i32" \
+  --lhs_rhs_type "i8" \
   --acc_type "i32" \
-  --m "8" --n "16" --k "32" \
+  --m "16" --n "32" --k "64" \
   --do_transpose_rhs "1"
 
 run_matmul_test \
@@ -654,13 +669,6 @@ run_matmul_test \
     --acc_type "f32" \
     --m "128"  --n "128" --k "2304" \
 
-run_matmul_test \
-  --name_prefix "packPeel_t_i32" \
-  --pipeline "pack-peel" \
-  --lhs_rhs_type "i32" \
-  --acc_type "i32" \
-  --m "128" --n "256" --k "512" \
-  --do_transpose_rhs "1"
 
 run_matmul_test \
   --name_prefix "packPeel_t_bf16" \

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -507,10 +507,6 @@ run_matmul_test \
 # Disabled until the following issue is resolved:
 # https://github.com/Xilinx/llvm-aie/issues/102
 #
-# Note I'm not using the --expect_compile_failure flag here,
-# as that would require all developers to use the same verion
-# of peano, which we currently don't enforce. 
-#
 # run_matmul_test \
 #   --name_prefix "transpose_int32" \
 #   --lhs_rhs_type "i32" \
@@ -539,12 +535,14 @@ run_matmul_test \
 # with the error LLVM ERROR: unable to legalize instruction: %152:_(<2 x s32>) = G_FMUL %148:_, %150:_ (in function: core_0_2)
 # The later is what a more vectorization friendly packing looks like so this test is expected failing the test here.
 # TODO: check if the test will pass with a more recent llvm-aie and if it doesnt, report it upstream.
-run_matmul_test \
-   --name_prefix "failure_0" \
-   --lhs_rhs_type "i32" \
-   --acc_type "i32" \
-   --m "1"  --n "1" --k "1000" \
-   --expect_compile_failure "1"
+# Disabled until the following issue is resolved:
+# https://github.com/Xilinx/llvm-aie/issues/102
+# run_matmul_test \
+#    --name_prefix "failure_0" \
+#    --lhs_rhs_type "i32" \
+#    --acc_type "i32" \
+#    --m "1"  --n "1" --k "1000" \
+#    --expect_compile_failure "1"
 
 # The below matmul case passes with
 # tile_sizes = [52, 52], [0, 0, 63], [26, 26], [0, 0, 3], packedSizes = [2, 2, 7]


### PR DESCRIPTION
Vectorization in iree-amd-aie consists of 2 passes:

1) tile linalg.generic ops in all leading dimensions, so that batched matmuls, and matmuls which have been packed into high-dimesions with multiple reduction dimensions, get replaced by unbatched 'atomic' matmuls with scf.for loops

2) lower the 'atomic' matmuls to the vector dialect (vector.contract and other vector dialect casts/copies). 

Before this PR, pass 1 applied to all linalg.generics, irrespective of their element type. However, pass 2 only applies to linalg.generics for which the operand element types have hardware support on AIE for vectorization. All linalg.generics with other types, like matmuls with i32 operands and result, are not converted to the vector dialect, they are later unrolled in a pass, linalg-to-loop (or something). 

So basically pass 1, before this PR, might transform linalg.generics in preparation for vectorization, even though in pass 2 they are not vectorized. This is not a problem, but unnecessarily changes IR. More importantly, there has been a request to make pass 1 more conservative and leave unvectorizable ops alone, so make a later object-fifo related pass easier (@yzhang93 @Abhishek-Varma)

So that's what this PR does: makes the loop tiling only apply when the element types are vectorizable for AIE. 