### PR TITLE
Bump iree, mlir-air

### DIFF
--- a/compiler/plugins/target/AMD-AIE/air/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/air/CMakeLists.txt
@@ -246,6 +246,7 @@ iree_cc_library(
     "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Transform/AIRDependency.cpp"
     "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Transform/AIRDependencyScheduleOpt.cpp"
     "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Transform/AIRDependencyCanonicalize.cpp"
+    "${IREE_MLIR_AIR_SOURCE_DIR}/lib/Transform/AIRDmaToChannel.cpp"
   DEPS
     ::defs
     iree::target::amd-aie::aie::AIEDialectIR

--- a/compiler/plugins/target/AMD-AIE/air/ConversionPasses.cpp
+++ b/compiler/plugins/target/AMD-AIE/air/ConversionPasses.cpp
@@ -17,7 +17,6 @@ void registerAIRConversionPasses() {
   registerAIRLoweringPass();
   registerAIRRtToNpuPass();
   registerCopyToDma();
-  registerDmaToChannel();
   registerParallelToHerd();
   registerParallelToLaunch();
 }

--- a/compiler/plugins/target/AMD-AIE/air/TransformPasses.cpp
+++ b/compiler/plugins/target/AMD-AIE/air/TransformPasses.cpp
@@ -30,5 +30,6 @@ void registerAIRTransformPasses() {
   registerAIRUnrollOuterPerfectlyNestedLoopsPass();
   registerAffineLoopOptPass();
   registerAIRSplitL2MemrefForBufferConstraintPass();
+  registerDmaToChannel();
 }
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,7 +7,7 @@
 ### Update with: shark-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "36aec8a79cc616d126fe50f213d8b93ef298d6ba",
+  "iree": "4294a5b0ebaec6dcca483bf16f5918108b09ea0a",
 }
 
 ORIGINS = {


### PR DESCRIPTION
Bump iree to 4294a5b
Bump mlir-air to 4559217
mlir-aie remains unchanged, as mlir-air's pin of mlir-aie is unchanged.

Submodule changes that required adaptation in iree-amd-aie:

- AIR DmaToChannel pass moved from Conversion to Transform