### PR TITLE
Use only in-tree AIE/AIEX passes

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aie/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/aie/CMakeLists.txt
@@ -21,23 +21,6 @@ iree_cc_library(
 # AIE Dialect
 ###############################################################################
 
-iree_cc_library(
-  NAME
-    AIEDialectIR
-  SRCS
-    ${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/IR/AIEDialect.cpp
-    ${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/IR/AIETargetModel.cpp
-  DEPS
-    ::defs
-    ::AIEAttrsGen
-    ::AIEDialectGen
-    ::AIEInterfacesGen
-    ::AIEOpsGen
-    ::AIETypesGen
-    MLIRIR
-    MLIREmitCDialect
-)
-
 iree_tablegen_library(
   NAME
     AIEAttrsGen
@@ -62,6 +45,66 @@ iree_tablegen_library(
 
 iree_tablegen_library(
   NAME
+    AIEInterfacesGen
+  TD_FILE
+    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIE/IR/AIEInterfaces.td"
+  OUTS
+    -gen-op-interface-decls Dialect/AIE/IR/AIEInterfaces.h.inc
+    -gen-op-interface-defs Dialect/AIE/IR/AIEInterfaces.cpp.inc
+)
+
+iree_tablegen_library(
+  NAME
+    AIEOpsGen
+  TD_FILE
+    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIE/IR/AIEOps.td"
+  OUTS
+    -gen-op-decls Dialect/AIE/IR/AIEOps.h.inc
+    -gen-op-defs Dialect/AIE/IR/AIEOps.cpp.inc
+)
+
+iree_tablegen_library(
+  NAME
+    AIETypesGen
+  TD_FILE
+    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIE/IR/AIETypes.td"
+  OUTS
+    -gen-typedef-decls -typedefs-dialect=AIE Dialect/AIE/IR/AIETypes.h.inc
+    -gen-typedef-defs -typedefs-dialect=AIE Dialect/AIE/IR/AIETypes.cpp.inc
+)
+
+iree_tablegen_library(
+  NAME
+    AIENormalizeAddressSpacesGen
+  TD_FILE
+    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIE/Transforms/AIENormalizeAddressSpaces.td"
+  OUTS
+    -gen-rewriters Dialect/AIE/Transforms/AIENormalizeAddressSpaces.inc
+)
+
+iree_cc_library(
+  NAME
+    AIEDialectIR
+  SRCS
+    ${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/IR/AIEDialect.cpp
+    ${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/IR/AIETargetModel.cpp
+  DEPS
+    ::defs
+    ::AIEAttrsGen
+    ::AIEDialectGen
+    ::AIEInterfacesGen
+    ::AIEOpsGen
+    ::AIETypesGen
+    MLIRIR
+    MLIREmitCDialect
+)
+
+###############################################################################
+# AIEX Dialect
+###############################################################################
+
+iree_tablegen_library(
+  NAME
     AIEXDialectGen
   TD_FILE
     "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIEX/IR/AIEX.td"
@@ -69,6 +112,33 @@ iree_tablegen_library(
     -gen-dialect-decls -dialect=aiex Dialect/AIEX/IR/AIEXDialect.h.inc
     -gen-dialect-defs -dialect=aiex Dialect/AIEX/IR/AIEXDialect.cpp.inc
 )
+
+iree_tablegen_library(
+  NAME
+    AIEXOpsGen
+  TD_FILE
+    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIEX/IR/AIEX.td"
+  OUTS
+    -gen-op-decls Dialect/AIEX/IR/AIEX.h.inc
+    -gen-op-defs Dialect/AIEX/IR/AIEX.cpp.inc
+)
+
+iree_cc_library(
+  NAME
+    AIEXDialectIR
+  SRCS
+    ${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+  DEPS
+    ::defs
+    ::AIEDialectIR
+    ::AIEXOpsGen
+    ::AIEXDialectGen
+    MLIRIR
+)
+
+###############################################################################
+# AIEVec Dialect
+###############################################################################
 
 iree_tablegen_library(
   NAME
@@ -155,76 +225,6 @@ iree_tablegen_library(
     -gen-llvmir-conversions Dialect/XLLVM/IR/XLLVMConversions.inc
 )
 
-iree_tablegen_library(
-  NAME
-    AIEInterfacesGen
-  TD_FILE
-    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIE/IR/AIEInterfaces.td"
-  OUTS
-    -gen-op-interface-decls Dialect/AIE/IR/AIEInterfaces.h.inc
-    -gen-op-interface-defs Dialect/AIE/IR/AIEInterfaces.cpp.inc
-)
-
-iree_tablegen_library(
-  NAME
-    AIEOpsGen
-  TD_FILE
-    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIE/IR/AIEOps.td"
-  OUTS
-    -gen-op-decls Dialect/AIE/IR/AIEOps.h.inc
-    -gen-op-defs Dialect/AIE/IR/AIEOps.cpp.inc
-)
-
-iree_tablegen_library(
-  NAME
-    AIETypesGen
-  TD_FILE
-    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIE/IR/AIETypes.td"
-  OUTS
-    -gen-typedef-decls -typedefs-dialect=AIE Dialect/AIE/IR/AIETypes.h.inc
-    -gen-typedef-defs -typedefs-dialect=AIE Dialect/AIE/IR/AIETypes.cpp.inc
-)
-
-iree_tablegen_library(
-  NAME
-    AIENormalizeAddressSpacesGen
-  TD_FILE
-    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIE/Transforms/AIENormalizeAddressSpaces.td"
-  OUTS
-    -gen-rewriters Dialect/AIE/Transforms/AIENormalizeAddressSpaces.inc
-)
-
-###############################################################################
-# AIEX Dialect
-###############################################################################
-
-iree_cc_library(
-  NAME
-    AIEXDialectIR
-  SRCS
-    ${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/IR/AIEXDialect.cpp
-  DEPS
-    ::defs
-    ::AIEDialectIR
-    ::AIEXOpsGen
-    ::AIEXDialectGen
-    MLIRIR
-)
-
-iree_tablegen_library(
-  NAME
-    AIEXOpsGen
-  TD_FILE
-    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIEX/IR/AIEX.td"
-  OUTS
-    -gen-op-decls Dialect/AIEX/IR/AIEX.h.inc
-    -gen-op-defs Dialect/AIEX/IR/AIEX.cpp.inc
-)
-
-###############################################################################
-# AIEVec Dialect
-###############################################################################
-
 iree_cc_library(
   NAME
     AIEVecDialectIR
@@ -268,82 +268,28 @@ iree_cc_library(
 )
 
 ###############################################################################
-# AIE Transform Passes
+# in-tree AIE and AIEX passes
 ###############################################################################
-
-iree_tablegen_library(
-  NAME
-    AIETransformPassesIncGen
-  TD_FILE
-    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIE/Transforms/AIEPasses.td"
-  OUTS
-    -gen-pass-decls Dialect/AIE/Transforms/AIEPasses.h.inc
-)
-
-###############################################################################
-# AIEX Transform Passes
-###############################################################################
-
-iree_tablegen_library(
-  NAME
-    AIEXTransformPassesIncGen
-  TD_FILE
-    "${IREE_MLIR_AIE_SOURCE_DIR}/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td"
-  OUTS
-    -gen-pass-decls Dialect/AIEX/Transforms/AIEXPasses.h.inc
-)
 
 iree_cc_library(
   NAME
     AIEPasses
   SRCS
-  "AMDAIEAssignBufferAddressesBasic.cpp"
-  "AMDAIEAssignBufferDescriptorIDs.cpp"
-  "AMDAIEAssignLockIDs.cpp"
-  "AMDAIECoreToStandard.cpp"
-  "AMDAIECreatePathFindFlows.cpp"
-  "AMDAIEDmaToNpu.cpp"
-  "AMDAIELocalizeLocks.cpp"
-  "AMDAIENormalizeAddressSpaces.cpp"
-  "AMDAIEObjectFifoStatefulTransform.cpp"
-  "AMDAIEXToStandard.cpp"
+    AMDAIEAssignBufferAddressesBasic.cpp
+    AMDAIEAssignBufferDescriptorIDs.cpp
+    AMDAIEAssignLockIDs.cpp
+    AMDAIECoreToStandard.cpp
+    AMDAIECreatePathFindFlows.cpp
+    AMDAIEDmaToNpu.cpp
+    AMDAIELocalizeLocks.cpp
+    AMDAIENormalizeAddressSpaces.cpp
+    AMDAIEObjectFifoStatefulTransform.cpp
+    AMDAIEXToStandard.cpp
   DEPS
     ::defs
     ::AIEDialectIR
     ::AIEXDialectIR
     ::AIENormalizeAddressSpacesGen
-)
-
-iree_cc_library(
-  NAME
-    AIEPassesFromMLIRAIE
-  SRCS
-    # Passes needed by AIR-AIE lowering
-    # AIE dialect
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEAssignBufferDescriptorIDs.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIECanonicalizeDevice.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIECreatePacketFlows.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIELocalizeLocks.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIENormalizeAddressSpaces.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp"
-    # AIEX dialect
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/Transforms/AIELowerMulticast.cpp"
-    "${IREE_MLIR_AIE_SOURCE_DIR}/lib/Dialect/AIEX/Transforms/AIEXToStandard.cpp"
-  DEPS
-    ::defs
-    ::AIEDialectIR
-    ::AIENormalizeAddressSpacesGen
-    ::AIEXDialectIR
-    ::AIEXTransformPassesIncGen
-    ::AIETransformPassesIncGen
 )
 
 add_subdirectory(test)

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/PluginRegistration.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/PluginRegistration.cpp
@@ -5,9 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
-#include "aie/Dialect/AIE/Transforms/AIEPasses.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
-#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
+#include "aie/Passes.h"
 #include "air/Dialect/AIR/AIRDialect.h"
 #include "air/Passes.h"
 #include "iree-amd-aie/IR/AMDAIEDialect.h"
@@ -18,20 +17,6 @@
 #include "iree/compiler/PluginAPI/Client.h"
 
 namespace mlir::iree_compiler {
-
-namespace AMDAIE {
-extern void registerAMDAIEAssignBufferAddressesBasic();
-extern void registerAMDAIEAssignBufferDescriptorIDs();
-extern void registerAMDAIEAssignLockIDs();
-extern void registerAMDAIECoreToStandard();
-extern void registerAMDAIELocalizeLocks();
-extern void registerAMDAIENormalizeAddressSpaces();
-extern void registerAMDAIEObjectFifoStatefulTransform();
-extern void registerAMDAIERoutePathfinderFlows();
-extern void registerAMDAIEDmaToNpu();
-extern void registerAMDAIEXToStandardPass();
-}  // namespace AMDAIE
-
 namespace {
 
 struct AMDAIESession
@@ -51,17 +36,6 @@ struct AMDAIESession
     AMDAIE::registerAMDAIEXToStandardPass();
     AMDAIE::registerAIRConversionPasses();
     AMDAIE::registerAIRTransformPasses();
-
-    xilinx::AIE::registerAIEAssignBufferAddresses();
-    xilinx::AIE::registerAIEAssignBufferDescriptorIDs();
-    xilinx::AIE::registerAIEAssignLockIDs();
-    xilinx::AIE::registerAIECoreToStandard();
-    xilinx::AIE::registerAIELocalizeLocks();
-    xilinx::AIE::registerAIENormalizeAddressSpaces();
-    xilinx::AIE::registerAIEObjectFifoStatefulTransform();
-    xilinx::AIE::registerAIERoutePathfinderFlows();
-    xilinx::AIEX::registerAIEDmaToNpu();
-    xilinx::AIEX::registerAIEXToStandardPass();
   }
 
   void onRegisterDialects(DialectRegistry &registry) override {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -10,11 +10,9 @@
 
 #include "XCLBinGen.h"
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
-#include "aie/Dialect/AIE/Transforms/AIEPasses.h"
 #include "aie/Dialect/AIEVec/IR/AIEVecDialect.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
 #include "aie/Dialect/XLLVM/XLLVMDialect.h"
-#include "aie/Passes.h"
 #include "aie/Target/LLVMIR/Dialect/XLLVM/XLLVMToLLVMIRTranslation.h"
 #include "air/Dialect/AIR/AIRDialect.h"
 #include "air/Dialect/AIRRt/AIRRtDialect.h"
@@ -367,8 +365,8 @@ LogicalResult AIETargetBackend::serializeExecutable(
     OwningOpRef<ModuleOp> owningModuleOp =
         parseSourceFile<ModuleOp>(inputMlirPath, srcMgr, pcfg);
 
-    if (failed(aie2xclbin(variantOp->getContext(), *owningModuleOp, TK, npuInstPath,
-                          xclbinPath)))
+    if (failed(aie2xclbin(variantOp->getContext(), *owningModuleOp, TK,
+                          npuInstPath, xclbinPath)))
       return failure();
 
     std::ifstream instrFile(static_cast<std::string>(npuInstPath));

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
@@ -21,15 +21,9 @@ iree_cc_library(
     "AMDAIETargetLdScript.cpp"
     "XCLBinGen.cpp"
   DEPS
-    iree::target::amd-aie::aie::AIEDialectIR
-    iree::target::amd-aie::aie::AIEXDialectIR
-    iree::target::amd-aie::aie::AIEPasses
-    iree::target::amd-aie::aie::AIEVecDialectIR
-    iree::target::amd-aie::aie::AIEVecConvertToLLVM
-    MLIRToLLVMIRTranslationRegistration
-    MLIRFuncAllExtensions
     ${UUID}
     iree-amd-aie::aie_runtime::iree_aie_runtime_static
+    iree::target::amd-aie::Transforms
 )
 
 iree_cc_library(
@@ -43,13 +37,13 @@ iree_cc_library(
     "AIETargetDirect.cpp"
   DEPS
     ::AIETargets
+    iree-amd-aie::schemas::xrt_executable_def_c_fbs
+    iree::base::internal::flatcc::building
+    iree::base::internal::flatcc::parsing
     iree::compiler::Dialect::HAL::Target
     iree::target::amd-aie::IR::AMDAIEDialect
     iree::target::amd-aie::Transforms
     iree::target::amd-aie::air::AIRDialectIR
-    iree::base::internal::flatcc::building
-    iree::base::internal::flatcc::parsing
-    iree-amd-aie::schemas::xrt_executable_def_c_fbs
     MLIRLLVMDialect
   PUBLIC
 )

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
@@ -87,8 +87,6 @@ iree_cc_library(
   DEPS
     ::PassHeaders
     ::PassesIncGen
-    iree::target::amd-aie::IR::AMDAIEDialect
-    MLIRSupport
     iree::compiler::Codegen::Common::TransformDialectInterpreterPass
     iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
     iree::compiler::Dialect::HAL::IR
@@ -96,16 +94,22 @@ iree_cc_library(
     iree::compiler::Dialect::LinalgExt::IR
     iree::compiler::Dialect::LinalgExt::Transforms
     iree::compiler::Utils
-    iree::target::amd-aie::aie::AIEPassesFromMLIRAIE
+    iree::target::amd-aie::IR::AMDAIEDialect
+    iree::target::amd-aie::aie::AIEDialectIR
+    iree::target::amd-aie::aie::AIEPasses
+    iree::target::amd-aie::aie::AIEVecConvertToLLVM
+    iree::target::amd-aie::aie::AIEVecDialectIR
+    iree::target::amd-aie::aie::AIEXDialectIR
     iree::target::amd-aie::air::AIRConversionPasses
     iree::target::amd-aie::air::AIRTransformPasses
     IREELinalgTransformDialectPasses
+    MLIRFuncAllExtensions
     MLIRFuncDialect
     MLIRFunctionInterfaces
-    MLIRLinalgDialect
-    MLIRLinalgTransforms
     MLIRLLVMCommonConversion
     MLIRLLVMDialect
+    MLIRLinalgDialect
+    MLIRLinalgTransforms
     MLIRMemRefDialect
     MLIRPDLDialect
     MLIRPDLInterpDialect
@@ -114,8 +118,10 @@ iree_cc_library(
     MLIRSCFToControlFlow
     MLIRSCFTransforms
     MLIRSCFUtils
+    MLIRSupport
     MLIRTensorDialect
     MLIRTensorTransforms
+    MLIRToLLVMIRTranslationRegistration
     MLIRTransforms
     MLIRVectorDialect
     MLIRVectorToLLVM

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -6,19 +6,22 @@
 
 #include "iree-amd-aie/Transforms/Passes.h"
 
-#include "aie/Dialect/AIE/Transforms/AIEPasses.h"
-#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
+#include "aie/Conversion/AIEVecToLLVM/AIEVecToLLVM.h"
 #include "aie/Passes.h"
 #include "air/Conversion/Passes.h"
 #include "air/Transform/Passes.h"
 #include "iree-amd-aie/IR/AMDAIEAttrs.h"
 #include "iree-dialects/Dialect/LinalgTransform/Passes.h"
-#include "iree/compiler/Codegen/Common/PassUtils.h"
 #include "iree/compiler/Codegen/Common/Passes.h"
-#include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h"
 #include "iree/compiler/Utils/PassUtils.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
+#include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
+#include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
+#include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVMPass.h"
+#include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
+#include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
+#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVMPass.h"
 #include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Passes.h"
@@ -695,19 +698,16 @@ void addMLIRAIRLoweringPasses(OpPassManager &passManager, bool packPeel) {
 void addMLIRAIELoweringPasses(OpPassManager &passManager) {
   passManager.addPass(createLowerAffinePass());
   OpPassManager &devicePM = passManager.nest<xilinx::AIE::DeviceOp>();
-  devicePM.addPass(xilinx::AIE::createAIEAssignLockIDsPass());
-  devicePM.addPass(xilinx::AIE::createAIEObjectFifoRegisterProcessPass());
-  devicePM.addPass(xilinx::AIE::createAIEObjectFifoStatefulTransformPass());
-  devicePM.addPass(xilinx::AIE::createAIEAssignBufferDescriptorIDsPass());
-  devicePM.addPass(xilinx::AIEX::createAIEBroadcastPacketPass());
-  devicePM.addPass(xilinx::AIE::createAIERoutePacketFlowsPass());
-  devicePM.addPass(xilinx::AIEX::createAIELowerMulticastPass());
-  devicePM.addPass(xilinx::AIE::createAIEAssignBufferAddressesPass());
+  devicePM.addPass(createAMDAIEAssignBufferAddressesBasicPass());
+  devicePM.addPass(createAMDAIEAssignLockIDsPass());
+  devicePM.addPass(createAMDAIEAssignBufferDescriptorIDsPass());
+  devicePM.addPass(createAMDAIEObjectFifoStatefulTransformPass());
+  devicePM.addPass(createAMDAIEPathfinderPass());
   passManager.addPass(createConvertSCFToCFPass());
   passManager.addNestedPass<xilinx::AIE::DeviceOp>(
-      xilinx::AIE::createAIELocalizeLocksPass());
+      createAMDAIELocalizeLocksPass());
   passManager.addNestedPass<xilinx::AIE::DeviceOp>(
-      xilinx::AIE::createAIENormalizeAddressSpacesPass());
+      createAMDAIENormalizeAddressSpacesPass());
 }
 
 // NOTE: this runs on the top-level program module containing all hal.executable
@@ -719,6 +719,28 @@ void buildAMDAIELinkingPassPipeline(OpPassManager &passManager) {
   // Cleanup IR duplication.
   passManager.addNestedPass<IREE::HAL::ExecutableOp>(
       mlir::createCanonicalizerPass());
+}
+
+void addLowerToLLVMPasses(OpPassManager &pm) {
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+  pm.addPass(xilinx::aievec::createConvertAIEVecToLLVMPass());
+  pm.addPass(createConvertVectorToLLVMPass());
+  pm.addPass(memref::createExpandStridedMetadataPass());
+  pm.addPass(createLowerAffinePass());
+  pm.addPass(createConvertMathToLLVMPass());
+  pm.addPass(createArithToLLVMConversionPass());
+  pm.addPass(createFinalizeMemRefToLLVMConversionPass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+  ConvertFuncToLLVMPassOptions opts;
+  opts.useBarePtrCallConv = true;
+  pm.addPass(createConvertFuncToLLVMPass(opts));
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+  pm.addPass(createConvertControlFlowToLLVMPass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
 }
 
 namespace {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -28,6 +28,8 @@ void buildAMDAIETransformPassPipeline(OpPassManager &pm);
 
 void buildAMDAIELowerObjectFIFO(OpPassManager &variantPassManager);
 
+void addLowerToLLVMPasses(OpPassManager &pm);
+
 /// Populates passes needed to lower the IR via a Pack-Peel based approach.
 void addPackPeelBasedPassPipeline(OpPassManager &passManager,
                                   TilingConfig &tilingConfig);


### PR DESCRIPTION
Let's pull the bandaid off and use only in-tree passes. My apologies @nirvedhmeshram for giving you the run-around last week just do throw it away :(

Note, after this PR we should be fixing/patching in-tree passes first and upstreaming (those fixes) second. 