### PR TITLE
[CreateAIEWorkgroup] Remove unused buildForWorkgroupOp function

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.h
@@ -236,15 +236,6 @@ class WorkgroupBuilder {
                                    Block::iterator controlCodeBegin,
                                    Block::iterator controlCodeEnd);
 
-  /// Build function that handles `amdaie.workgroup` by visiting the body and
-  /// converting and inserting it into the single `amdaie.workgroup`.
-  LogicalResult buildForWorkgroupOp(AMDAIE::WorkgroupOp workgroupOp,
-                                    Block *target, Block *controlCode,
-                                    CoreContext &coreContext,
-                                    Block::iterator targetBegin,
-                                    Block::iterator controlCodeBegin,
-                                    Block::iterator controlCodeEnd);
-
   /// The main rewriter to be used for the workgroup body, excluding control
   /// code and core operations (future work).
   IRRewriterAndMapper &rewriter;


### PR DESCRIPTION
Noticed this remaining piece of logic which is handling `amdaie.workgroup` inside the `AMDAIECreateAIEWorkgroup` pass, but is not needed anymore after https://github.com/nod-ai/iree-amd-aie/pull/406 as there shouldn't be any `amdaie.workgroup` ops inside the IR before this pass.