### PR TITLE
Vendor `bootgen` and `xclbinutil`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,14 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install static libs
+        run: |
+          dnf install -y almalinux-release-devel
+          yum remove -y openssl-devel zlib-devel boost boost-all || true
+          yum install -y openssl-static  zlib-static
+          yum install -y protobuf-devel protobuf-compiler
+          yum install -y boost-static
+
       - name: Sync source deps
         run: |
           python ./sync_deps.py
@@ -149,4 +157,4 @@ jobs:
       - name: Printing IR from aie2xclbin
         run: |
           source .venv/bin/activate
-          bash build_tools/ci/print_ir_aie2xclbin/print_ir_aie2xclbin.sh iree-install/bin print_ir_aie2xclbin_results
+          bash build_tools/ci/print_ir_aie2xclbin/print_ir_aie2xclbin.sh iree-install print_ir_aie2xclbin_results

--- a/build_tools/ci/cpu_comparison/run_test.sh
+++ b/build_tools/ci/cpu_comparison/run_test.sh
@@ -221,6 +221,7 @@ function run_test() {
   # =====================
   local peano_install_path="${PEANO}"
   local mlir_aie_install_path="${MLIR_AIE_INSTALL}"
+  local amd_aie_install_path="${IREE_INSTALL_DIR}"
   local vitis_path="${VITIS}"
   local pipeline="pad-pack"
   local rtol="1e-6"
@@ -246,6 +247,10 @@ function run_test() {
         ;;
       --mlir_aie_install_path)
         mlir_aie_install_path="$2"
+        shift 2
+        ;;
+      --amd_aie_install_path)
+        amd_aie_install_path="$2"
         shift 2
         ;;
      --vitis_path)
@@ -300,6 +305,7 @@ function run_test() {
       --iree-amdaie-matmul-elementwise-fusion \
       --iree-amd-aie-peano-install-dir=${peano_install_path} \
       --iree-amd-aie-mlir-aie-install-dir=${mlir_aie_install_path} \
+      --iree-amd-aie-install-dir=${amd_aie_install_path} \
       --iree-amd-aie-vitis-install-dir=${vitis_path} \
       --iree-hal-dump-executable-files-to=$PWD \
       --mlir-disable-threading \

--- a/build_tools/ci/print_ir_aie2xclbin/print_ir_aie2xclbin.sh
+++ b/build_tools/ci/print_ir_aie2xclbin/print_ir_aie2xclbin.sh
@@ -56,15 +56,15 @@ if [ "$#" -eq 6 ]; then
   MLIR_AIE="$6"
 fi
 
-IREE_COMPILE="$1"
-if [ -d "${IREE_COMPILE}" ]; then
-   IREE_COMPILE=`realpath "${IREE_COMPILE}"`
-else
-  echo "IREE_COMPILE does not exist: ${IREE_COMPILE}."
+IREE_INSTALL_DIR="$1"
+if [ ! -d "${IREE_INSTALL_DIR}/bin" ]; then
+  echo "IREE_INSTALL_DIR/bin does not exist: ${IREE_INSTALL_DIR}/bin."
   exit 1
+else
+  IREE_INSTALL_DIR=`realpath "${IREE_INSTALL_DIR}"`
 fi
 
-IREE_COMPILE_EXE="${IREE_COMPILE}/iree-compile"
+IREE_COMPILE_EXE="${IREE_INSTALL_DIR}/bin/iree-compile"
 if [ ! -x "${IREE_COMPILE_EXE}" ]; then
   echo "IREE_COMPILE_EXE does not exist or isn't executable: ${IREE_COMPILE_EXE}."
   exit 1
@@ -103,14 +103,14 @@ else
   exit 1
 fi
 
-# There might be a FileCheck program in the IREE_COMPILE. Check.
+# There might be a FileCheck program in the IREE_INSTALL_DIR. Check.
 # Do not fail if it is not there, we can also check if it already on PATH.
-if [ -x "${IREE_COMPILE}/FileCheck" ]; then
-  FILECHECK_EXE="${IREE_COMPILE}/FileCheck"
+if [ -x "${IREE_INSTALL_DIR}/bin/FileCheck" ]; then
+  FILECHECK_EXE="${IREE_INSTALL_DIR}/bin/FileCheck"
 elif [ -x "$(command -v FileCheck)" ]; then
   FILECHECK_EXE="$(command -v FileCheck)"
 else
-  echo "FileCheck does not exist or isn't executable in ${IREE_COMPILE} or on PATH."
+  echo "FileCheck does not exist or isn't executable in ${IREE_INSTALL_DIR}/bin or on PATH."
   exit 1
 fi
 
@@ -126,6 +126,7 @@ ${SOURCE_MLIR_FILE} \
 --iree-hal-target-backends=amd-aie \
 --iree-amd-aie-peano-install-dir=${PEANO} \
 --iree-amd-aie-mlir-aie-install-dir=${MLIR_AIE} \
+--iree-amd-aie-install-dir=${IREE_INSTALL_DIR} \
 --iree-amd-aie-vitis-install-dir=${VITIS} \
 --iree-hal-dump-executable-files-to=${OUTPUT} \
 --aie2xclbin-print-ir-after-all \
@@ -193,6 +194,7 @@ ${SOURCE_MLIR_FILE} \
 --iree-hal-target-backends=amd-aie-direct \
 --iree-amd-aie-peano-install-dir=${PEANO} \
 --iree-amd-aie-mlir-aie-install-dir=${MLIR_AIE} \
+--iree-amd-aie-install-dir=${IREE_INSTALL_DIR} \
 --iree-amd-aie-vitis-install-dir=${VITIS} \
 --iree-hal-dump-executable-intermediates-to=${OUTPUT} \
 --iree-hal-dump-executable-files-to=${OUTPUT} \
@@ -216,6 +218,7 @@ ${SOURCE_MLIR_FILE} \
 --iree-hal-target-backends=amd-aie-direct \
 --iree-amd-aie-peano-install-dir=${PEANO} \
 --iree-amd-aie-mlir-aie-install-dir=${MLIR_AIE} \
+--iree-amd-aie-install-dir=${IREE_INSTALL_DIR} \
 --iree-amd-aie-vitis-install-dir=${VITIS} \
 --iree-hal-dump-executable-intermediates-to=${OUTPUT} \
 --iree-hal-dump-executable-files-to=${OUTPUT} \
@@ -239,6 +242,7 @@ ${SOURCE_MLIR_FILE} \
 --iree-hal-target-backends=amd-aie-direct \
 --iree-amd-aie-peano-install-dir=${PEANO} \
 --iree-amd-aie-mlir-aie-install-dir=${MLIR_AIE} \
+--iree-amd-aie-install-dir=${IREE_INSTALL_DIR} \
 --iree-amd-aie-vitis-install-dir=${VITIS} \
 --iree-hal-dump-executable-intermediates-to=${OUTPUT} \
 --iree-hal-dump-executable-files-to=${OUTPUT} \

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -188,6 +188,8 @@ function run_matmul_test() {
 
   local mlir_aie_install_path="${MLIR_AIE_INSTALL}"
 
+  local amd_aie_install_path="${IREE_INSTALL_DIR}"
+
   local vitis_path="${VITIS}"
 
   local tile_pipeline="pad-pack"
@@ -268,6 +270,10 @@ function run_matmul_test() {
         ;;
       --mlir_aie_install_path)
         mlir_aie_install_path="$2"
+        shift 2
+        ;;
+      --amd_aie_install_path)
+        amd_aie_install_path="$2"
         shift 2
         ;;
      --vitis_path)
@@ -379,6 +385,7 @@ function run_matmul_test() {
                       --iree-amdaie-tile-pipeline=${tile_pipeline} \
                       --iree-amd-aie-peano-install-dir=${peano_install_path} \
                       --iree-amd-aie-mlir-aie-install-dir=${mlir_aie_install_path} \
+                      --iree-amd-aie-install-dir=${amd_aie_install_path} \
                       --iree-amd-aie-vitis-install-dir=${vitis_path} \
                       --iree-hal-dump-executable-files-to=$PWD \
                       --iree-amd-aie-show-invoked-commands"
@@ -491,6 +498,7 @@ run_matmul_test \
     --device "xrt" \
     --peano_install_path "${PEANO}" \
     --mlir_aie_install_path "${MLIR_AIE_INSTALL}" \
+    --amd_aie_install_path "${IREE_INSTALL_DIR}" \
     --vitis_path  "${VITIS}" \
     --lower_to_aie_pipeline "air" \
     --tile_pipeline "pad-pack" \

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -356,7 +356,8 @@ LogicalResult AIETargetBackend::serializeExecutable(
     SmallString<64> aieToolsDir(options.vitisInstallDir);
     llvm::sys::path::append(aieToolsDir, "aietools");
     TK.AIEToolsDir = aieToolsDir.str();
-    TK.InstallDir = options.mlirAieInstallDir;
+    TK.MLIRAIEInstallDir = options.mlirAieInstallDir;
+    TK.AMDAIEInstallDir = options.amdAieInstallDir;
     TK.PeanoDir = options.peanoInstallDir;
 
     ParserConfig pcfg(variantOp->getContext());

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
@@ -20,6 +20,8 @@ struct AMDAIEOptions {
   // TODO(MaheshRavishankar): Remove this dependency.
   std::string mlirAieInstallDir;
 
+  std::string amdAieInstallDir;
+
   // Path to Peano installation directory.
   std::string peanoInstallDir;
 
@@ -52,6 +54,11 @@ struct AMDAIEOptions {
         "iree-amd-aie-mlir-aie-install-dir", mlirAieInstallDir,
         llvm::cl::cat(category),
         llvm::cl::desc("Path to MLIR-AIE installation directory"));
+
+    binder.opt<std::string>(
+        "iree-amd-aie-install-dir", amdAieInstallDir, llvm::cl::cat(category),
+        llvm::cl::desc("Path to AMDAIE installation directory (typically the "
+                       "IREE install directory)"));
 
     binder.opt<std::string>(
         "iree-amd-aie-peano-install-dir", peanoInstallDir,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETargetDirect.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETargetDirect.cpp
@@ -360,7 +360,8 @@ LogicalResult AIETargetDirectBackend::serializeExecutable(
     SmallString<64> aieToolsDir(options.vitisInstallDir);
     llvm::sys::path::append(aieToolsDir, "aietools");
     TK.AIEToolsDir = aieToolsDir.str();
-    TK.InstallDir = options.mlirAieInstallDir;
+    TK.MLIRAIEInstallDir = options.mlirAieInstallDir;
+    TK.AMDAIEInstallDir = options.amdAieInstallDir;
     TK.PeanoDir = options.peanoInstallDir;
 
     if (failed(aie2xclbin(variantOp->getContext(), moduleOp, TK, npuInstPath,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
@@ -28,7 +28,7 @@ iree_cc_library(
 
 add_dependencies(iree_target_amd-aie_Target_AIETargets
         iree-amd-aie_aie_runtime_amdaie_xclbinutil
-        iree-amd-aie_aie_runtime_bootgen)
+        iree-amd-aie_aie_runtime_amdaie_bootgen)
 
 iree_cc_library(
   NAME

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
@@ -26,6 +26,10 @@ iree_cc_library(
     iree::target::amd-aie::Transforms
 )
 
+add_dependencies(iree_target_amd-aie_Target_AIETargets
+        iree-amd-aie_aie_runtime_amdaie_xclbinutil
+        iree-amd-aie_aie_runtime_bootgen)
+
 iree_cc_library(
   NAME
     Target

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
@@ -533,7 +533,11 @@ static LogicalResult generateXCLBin(MLIRContext *context, ModuleOp moduleOp,
                                       "-w"};
 
     SmallString<64> bootgenBin(TK.AMDAIEInstallDir);
-    sys::path::append(bootgenBin, "bin", "bootgen");
+    sys::path::append(bootgenBin, "bin", "amdaie_bootgen");
+    if (!sys::fs::exists(bootgenBin)) {
+      bootgenBin = TK.AMDAIEInstallDir;
+      sys::path::append(bootgenBin, "tools", "amdaie_bootgen");
+    }
     if (runTool(bootgenBin, flags, TK.Verbose) != 0)
       return moduleOp.emitOpError("failed to execute bootgen");
   }
@@ -544,6 +548,10 @@ static LogicalResult generateXCLBin(MLIRContext *context, ModuleOp moduleOp,
       "AIE_PARTITION:JSON:" + std::string(aiePartitionJsonFile);
   SmallString<64> xclbinutilBin(TK.AMDAIEInstallDir);
   sys::path::append(xclbinutilBin, "bin", "amdaie_xclbinutil");
+  if (!sys::fs::exists(xclbinutilBin)) {
+    xclbinutilBin = TK.AMDAIEInstallDir;
+    sys::path::append(xclbinutilBin, "tools", "amdaie_xclbinutil");
+  }
   {
     if (!inputXclbin.empty()) {
       // Create aie_partition.json.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
@@ -251,7 +251,7 @@ static LogicalResult generateCoreElfFiles(ModuleOp moduleOp,
           extractedIncludes.push_back(i->str(1));
       }
 
-      SmallString<64> chessWrapperBin(TK.InstallDir);
+      SmallString<64> chessWrapperBin(TK.MLIRAIEInstallDir);
       sys::path::append(chessWrapperBin, "bin", "xchesscc_wrapper");
       SmallString<64> chessworkDir(TK.TempDir);
       sys::path::append(chessworkDir, "chesswork");
@@ -293,7 +293,7 @@ static LogicalResult generateCoreElfFiles(ModuleOp moduleOp,
         std::string targetFlag = "--target=" + targetLower + "-none-elf";
         flags.push_back(targetFlag);
         flags.emplace_back(objFile);
-        SmallString<64> meBasicPath(TK.InstallDir);
+        SmallString<64> meBasicPath(TK.MLIRAIEInstallDir);
         sys::path::append(meBasicPath, "aie_runtime_lib",
                           StringRef(TK.TargetArch).upper(), "me_basic.o");
         flags.emplace_back(meBasicPath);
@@ -532,7 +532,7 @@ static LogicalResult generateXCLBin(MLIRContext *context, ModuleOp moduleOp,
                                       "-o",     std::string(designPdiFile),
                                       "-w"};
 
-    SmallString<64> bootgenBin(TK.InstallDir);
+    SmallString<64> bootgenBin(TK.AMDAIEInstallDir);
     sys::path::append(bootgenBin, "bin", "bootgen");
     if (runTool(bootgenBin, flags, TK.Verbose) != 0)
       return moduleOp.emitOpError("failed to execute bootgen");
@@ -542,6 +542,8 @@ static LogicalResult generateXCLBin(MLIRContext *context, ModuleOp moduleOp,
   std::string memArg = "MEM_TOPOLOGY:JSON:" + std::string(memTopologyJsonFile);
   std::string partArg =
       "AIE_PARTITION:JSON:" + std::string(aiePartitionJsonFile);
+  SmallString<64> xclbinutilBin(TK.AMDAIEInstallDir);
+  sys::path::append(xclbinutilBin, "bin", "amdaie_xclbinutil");
   {
     if (!inputXclbin.empty()) {
       // Create aie_partition.json.
@@ -553,12 +555,9 @@ static LogicalResult generateXCLBin(MLIRContext *context, ModuleOp moduleOp,
       SmallVector<std::string, 20> inputFlags{"--dump-section", inputPartArg,
                                               "--force", "--input",
                                               std::string(inputXclbin)};
-      if (auto xclbinutil = sys::findProgramByName("xclbinutil")) {
-        if (runTool(*xclbinutil, inputFlags, TK.Verbose) != 0)
-          return moduleOp.emitOpError("failed to execute xclbinutil");
-      } else {
-        return moduleOp.emitOpError("could not find xclbinutil");
-      }
+
+      if (runTool(xclbinutilBin, inputFlags, TK.Verbose) != 0)
+        return moduleOp.emitOpError("failed to execute xclbinutil");
       auto aieInputPartitionOut =
           openInputFile(aieInputPartitionJsonFile, &errorMessage);
       if (!aieInputPartitionOut) return moduleOp.emitOpError(errorMessage);
@@ -586,7 +585,6 @@ static LogicalResult generateXCLBin(MLIRContext *context, ModuleOp moduleOp,
       aiePartitionJsonOut->os() << formatv("{0:2}", *aieInputPartitionOutValue);
       aiePartitionJsonOut->keep();
       flags.insert(flags.end(), {"--input", std::string(inputXclbin)});
-
     } else {
       flags.insert(flags.end(), {"--add-replace-section", memArg});
     }
@@ -594,12 +592,8 @@ static LogicalResult generateXCLBin(MLIRContext *context, ModuleOp moduleOp,
                                "--add-replace-section", partArg, "--force",
                                "--output", std::string(Output)});
 
-    if (auto xclbinutil = sys::findProgramByName("xclbinutil")) {
-      if (runTool(*xclbinutil, flags, TK.Verbose) != 0)
-        return moduleOp.emitOpError("failed to execute xclbinutil");
-    } else {
-      return moduleOp.emitOpError("could not find xclbinutil");
-    }
+    if (runTool(xclbinutilBin, flags, TK.Verbose) != 0)
+      return moduleOp.emitOpError("failed to execute xclbinutil");
   }
   return success();
 }
@@ -732,13 +726,13 @@ static LogicalResult generateUnifiedObject(MLIRContext *context,
   }
 
   if (TK.UseChess) {
-    SmallString<64> chessWrapperBin(TK.InstallDir);
+    SmallString<64> chessWrapperBin(TK.MLIRAIEInstallDir);
     sys::path::append(chessWrapperBin, "bin", "xchesscc_wrapper");
 
     SmallString<64> chessworkDir(TK.TempDir);
     sys::path::append(chessworkDir, "chesswork");
 
-    SmallString<64> chessIntrinsicsLL(TK.InstallDir);
+    SmallString<64> chessIntrinsicsLL(TK.MLIRAIEInstallDir);
     sys::path::append(chessIntrinsicsLL, "aie_runtime_lib",
                       StringRef(TK.TargetArch).upper(),
                       "chess_intrinsic_wrapper.ll");

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.h
@@ -19,7 +19,8 @@ namespace xilinx {
 struct XCLBinGenConfig {
   std::string TargetArch;
   std::string PeanoDir;
-  std::string InstallDir;
+  std::string MLIRAIEInstallDir;
+  std::string AMDAIEInstallDir;
   std::string AIEToolsDir;
   std::string TempDir;
   bool Verbose;

--- a/iree_runtime_plugin.cmake
+++ b/iree_runtime_plugin.cmake
@@ -15,8 +15,15 @@ if("xrt" IN_LIST IREE_EXTERNAL_HAL_DRIVERS)
 endif()
 
 if(IREE_AMD_AIE_ENABLE_XRT_DRIVER)
+  set(Boost_USE_STATIC_LIBS ON CACHE BOOL "" FORCE)
   find_package(XRT REQUIRED)
-  find_package(Boost REQUIRED)
+  find_package(Threads REQUIRED)
+  find_package(Boost REQUIRED COMPONENTS system program_options filesystem)
+  message(STATUS "Boost include directories:" ${Boost_INCLUDE_DIRS})
+
+  if(NOT WIN32)
+    find_package(RapidJSON REQUIRED)
+  endif()
 endif()
 
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/runtime/src AMD-AIE)

--- a/runtime/src/iree-amd-aie/aie_runtime/CMakeLists.txt
+++ b/runtime/src/iree-amd-aie/aie_runtime/CMakeLists.txt
@@ -22,6 +22,7 @@ cmake_minimum_required(VERSION 3.23)
 # We use our own, slightly modified, FindOpenSSL because of issues in
 # CMake's distribution of the same for versions prior to 3.29.
 # https://gitlab.kitware.com/cmake/cmake/-/issues/25702
+set(OPENSSL_USE_STATIC_LIBS TRUE CACHE BOOL "" FORCE)
 find_package(OpenSSL)
 if(NOT DEFINED OPENSSL_FOUND OR NOT ${OPENSSL_FOUND})
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
@@ -35,16 +36,47 @@ if(NOT DEFINED OPENSSL_FOUND OR NOT ${OPENSSL_FOUND})
 endif()
 message(STATUS "OpenSSL include directories:" ${OPENSSL_INCLUDE_DIR})
 
+# https://stackoverflow.com/a/49216539/9045206
+macro(remove_flag_from_target _target _flag)
+    get_target_property(_target_cxx_flags ${_target} COMPILE_OPTIONS)
+    if(_target_cxx_flags)
+        list(REMOVE_ITEM _target_cxx_flags ${_flag})
+        set_target_properties(${_target} PROPERTIES COMPILE_OPTIONS "${_target_cxx_flags}")
+    endif()
+endmacro()
+
+macro(replace_string_in_file _file _match_string _replace_string)
+    file(READ ${_file} _file_contents)
+    string(REPLACE ${_match_string} ${_replace_string} __file_contents "${_file_contents}")
+    file(WRITE ${_file}  "${__file_contents}")
+endmacro()
+
+find_package(Threads REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system program_options filesystem)
+message(STATUS "Boost include directories:" ${Boost_INCLUDE_DIRS})
+
+if(NOT WIN32)
+    find_package(RapidJSON REQUIRED)
+endif()
+
 # ##############################################################################
 # Bootgen
 # ##############################################################################
 
 set(_bootgen_source_dir ${IREE_AMD_AIE_SOURCE_DIR}/third_party/bootgen)
+
+# malloc.h is deprecated and should not be used
+# https://stackoverflow.com/a/56463133 If you want to use malloc, then include stdlib.h
+replace_string_in_file(${_bootgen_source_dir}/cdo-npi.c "#include <malloc.h>" "#include <stdlib.h>")
+replace_string_in_file(${_bootgen_source_dir}/cdo-alloc.c "#include <malloc.h>" "#include <stdlib.h>")
+
 file(GLOB _bootgen_sources "${_bootgen_source_dir}/*.c"
      "${_bootgen_source_dir}/*.cpp")
+# build exe separately
 list(REMOVE_ITEM _bootgen_sources "${_bootgen_source_dir}/main.cpp")
 
 add_library(bootgen-lib STATIC ${_bootgen_sources})
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_compile_definitions(bootgen-lib PUBLIC YY_NO_UNISTD_H)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
@@ -68,7 +100,7 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
       -Wno-deprecated-copy -Wno-non-virtual-dtor -Wno-overloaded-virtual
       -Wno-register -Wno-reorder -Wno-suggest-override)
 endif()
-target_compile_options(bootgen-lib PRIVATE
+target_compile_options(bootgen-lib PUBLIC
                        $<$<COMPILE_LANGUAGE:C>:${bootgen_c_warning_ignores}>
                        $<$<COMPILE_LANGUAGE:CXX>:${bootgen_c_warning_ignores};${bootgen_cxx_warning_ignores}>)
 target_include_directories(bootgen-lib PUBLIC ${_bootgen_source_dir}
@@ -76,16 +108,18 @@ target_include_directories(bootgen-lib PUBLIC ${_bootgen_source_dir}
 target_compile_definitions(bootgen-lib PUBLIC OPENSSL_USE_APPLINK)
 target_link_libraries(bootgen-lib PUBLIC OpenSSL::SSL OpenSSL::applink)
 
-# malloc.h is deprecated and should not be used
-# https://stackoverflow.com/a/56463133 If you want to use malloc, then include
-# stdlib.h
-file(READ ${_bootgen_source_dir}/cdo-npi.c _file_contents)
-string(REPLACE "#include <malloc.h>" "" __file_contents "${_file_contents}")
-file(WRITE ${_bootgen_source_dir}/cdo-npi.c "${__file_contents}")
+iree_cc_binary(
+  NAME
+    bootgen
+  SRCS
+    "${_bootgen_source_dir}/main.cpp"
+  COPTS
+    -fexceptions
+  INSTALL_COMPONENT
+    IREETools-Runtime
+)
 
-file(READ ${_bootgen_source_dir}/cdo-alloc.c _file_contents)
-string(REPLACE "#include <malloc.h>" "" __file_contents "${_file_contents}")
-file(WRITE ${_bootgen_source_dir}/cdo-alloc.c "${__file_contents}")
+target_link_libraries(iree-amd-aie_aie_runtime_bootgen PRIVATE bootgen-lib)
 
 # ##############################################################################
 # cdo-drver
@@ -353,6 +387,83 @@ iree_install_targets(
   COMPONENT IREEBundledLibraries
   EXPORT_SET Runtime
 )
+
+# ##############################################################################
+# xclbinutil
+# ##############################################################################
+
+# obv we have python but XRT uses this var to look for an ancient version of pybind (and fail)
+replace_string_in_file(${IREE_XRT_SOURCE_DIR}/python/pybind11/CMakeLists.txt "if (HAS_PYTHON)" "if (FALSE)")
+
+# remove ssl dep
+replace_string_in_file(${IREE_XRT_SOURCE_DIR}/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx "bValidateSignature == true" "false")
+
+set(_xclbinutil_source_dir
+    ${IREE_AMD_AIE_SOURCE_DIR}/third_party/XRT/src/runtime_src/tools/xclbinutil)
+
+# transformcdo target
+add_subdirectory(${_xclbinutil_source_dir}/aie-pdi-transform aie-pdi-transform)
+
+configure_file(${IREE_XRT_SOURCE_DIR}/CMake/config/version.h.in ${_xclbinutil_source_dir}/version.h)
+
+file(
+  GLOB
+  _xclbinutil_srcs
+  "${_xclbinutil_source_dir}/DTC*.cxx"
+  "${_xclbinutil_source_dir}/FDT*.cxx"
+  "${_xclbinutil_source_dir}/CBOR.cxx"
+  "${_xclbinutil_source_dir}/RapidJsonUtilities.cxx"
+  "${_xclbinutil_source_dir}/KernelUtilities.cxx"
+  "${_xclbinutil_source_dir}/ElfUtilities.cxx"
+  "${_xclbinutil_source_dir}/FormattedOutput.cxx"
+  "${_xclbinutil_source_dir}/ParameterSectionData.cxx"
+  "${_xclbinutil_source_dir}/Section.cxx"
+  # Note: Due to linking dependency issue, this entry needs to be before the other sections
+  "${_xclbinutil_source_dir}/Section*.cxx"
+  "${_xclbinutil_source_dir}/Resources*.cxx"
+  "${_xclbinutil_source_dir}/XclBinClass.cxx"
+  NoOpXclBinSignature.cxx
+  "${_xclbinutil_source_dir}/XclBinUtilities.cxx")
+
+# shared not static because static will let linker trim SectionMemTopology
+# initializers...
+add_library(xclbinutil-lib STATIC ${_xclbinutil_srcs})
+
+if(NOT WIN32)
+  target_compile_definitions(xclbinutil-lib
+                             PUBLIC ENABLE_JSON_SCHEMA_VALIDATION)
+  target_link_libraries(xclbinutil-lib PUBLIC transformcdo)
+else()
+  target_compile_options(xclbinutil-lib PUBLIC "/EHsc")
+  # if you get LINK : fatal error LNK1104: cannot open file
+  # 'libboost_filesystem-vc142-mt-gd-x64-1_74.lib'
+  # target_compile_definitions(xclbinutil-lib PUBLIC BOOST_ALL_DYN_LINK)
+endif()
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+target_link_libraries(xclbinutil-lib PUBLIC ${Boost_LIBRARIES} Threads::Threads)
+target_include_directories(xclbinutil-lib PUBLIC ${XRT_BINARY_DIR}/gen
+                                                 ${Boost_INCLUDE_DIRS}
+                                                 ${IREE_XRT_SOURCE_DIR}/runtime_src/core/include
+                                                 ${_xclbinutil_source_dir})
+
+iree_cc_binary(
+  NAME
+    amdaie_xclbinutil
+  SRCS
+    "${_xclbinutil_source_dir}/xclbinutil.cxx"
+    "${_xclbinutil_source_dir}/XclBinUtilMain.cxx"
+  DEPS
+    xclbinutil-lib
+  COPTS
+    -fexceptions
+    -frtti
+  INSTALL_COMPONENT
+    IREETools-Runtime
+  PUBLIC
+)
+
+target_link_libraries(iree-amd-aie_aie_runtime_amdaie_xclbinutil PRIVATE xclbinutil-lib)
 
 # ##############################################################################
 # iree-aie-runtime-static

--- a/runtime/src/iree-amd-aie/aie_runtime/CMakeLists.txt
+++ b/runtime/src/iree-amd-aie/aie_runtime/CMakeLists.txt
@@ -51,14 +51,6 @@ macro(replace_string_in_file _file _match_string _replace_string)
     file(WRITE ${_file}  "${__file_contents}")
 endmacro()
 
-find_package(Threads REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system program_options filesystem)
-message(STATUS "Boost include directories:" ${Boost_INCLUDE_DIRS})
-
-if(NOT WIN32)
-    find_package(RapidJSON REQUIRED)
-endif()
-
 # ##############################################################################
 # Bootgen
 # ##############################################################################
@@ -80,7 +72,7 @@ add_library(bootgen-lib STATIC ${_bootgen_sources})
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_compile_definitions(bootgen-lib PUBLIC YY_NO_UNISTD_H)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-  set(bootgen_c_warning_ignores
+  set(_bootgen_c_warning_ignores
       -Wno-cast-qual
       -Wno-covered-switch-default
       -Wno-date-time
@@ -96,13 +88,13 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
       -Wno-sign-compare
       -Wno-tautological-overlap-compare
       -Wno-unused)
-  set(bootgen_cxx_warning_ignores
+  set(_bootgen_cxx_warning_ignores
       -Wno-deprecated-copy -Wno-non-virtual-dtor -Wno-overloaded-virtual
       -Wno-register -Wno-reorder -Wno-suggest-override)
 endif()
 target_compile_options(bootgen-lib PUBLIC
-                       $<$<COMPILE_LANGUAGE:C>:${bootgen_c_warning_ignores}>
-                       $<$<COMPILE_LANGUAGE:CXX>:${bootgen_c_warning_ignores};${bootgen_cxx_warning_ignores}>)
+                       $<$<COMPILE_LANGUAGE:C>:${_bootgen_c_warning_ignores}>
+                       $<$<COMPILE_LANGUAGE:CXX>:${_bootgen_c_warning_ignores};${_bootgen_cxx_warning_ignores}>)
 target_include_directories(bootgen-lib PUBLIC ${_bootgen_source_dir}
                                               ${OPENSSL_INCLUDE_DIR})
 target_compile_definitions(bootgen-lib PUBLIC OPENSSL_USE_APPLINK)
@@ -110,7 +102,7 @@ target_link_libraries(bootgen-lib PUBLIC OpenSSL::SSL OpenSSL::applink)
 
 iree_cc_binary(
   NAME
-    bootgen
+    amdaie_bootgen
   SRCS
     "${_bootgen_source_dir}/main.cpp"
   COPTS
@@ -119,7 +111,9 @@ iree_cc_binary(
     IREETools-Runtime
 )
 
-target_link_libraries(iree-amd-aie_aie_runtime_bootgen PRIVATE bootgen-lib)
+target_link_libraries(iree-amd-aie_aie_runtime_amdaie_bootgen PRIVATE bootgen-lib)
+set_target_properties(iree-amd-aie_aie_runtime_amdaie_bootgen
+                      PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/tools")
 
 # ##############################################################################
 # cdo-drver
@@ -392,18 +386,31 @@ iree_install_targets(
 # xclbinutil
 # ##############################################################################
 
+# Note: we do not simply add the subdirectory and use the imported target because
+# XRT will build in its entirety when we do `ninja install` for IREE.
+
 # obv we have python but XRT uses this var to look for an ancient version of pybind (and fail)
 replace_string_in_file(${IREE_XRT_SOURCE_DIR}/python/pybind11/CMakeLists.txt "if (HAS_PYTHON)" "if (FALSE)")
 
 # remove ssl dep
 replace_string_in_file(${IREE_XRT_SOURCE_DIR}/runtime_src/tools/xclbinutil/XclBinUtilMain.cxx "bValidateSignature == true" "false")
 
-set(_xclbinutil_source_dir
-    ${IREE_AMD_AIE_SOURCE_DIR}/third_party/XRT/src/runtime_src/tools/xclbinutil)
+set(_xclbinutil_source_dir ${IREE_XRT_SOURCE_DIR}/runtime_src/tools/xclbinutil)
 
 # transformcdo target
 add_subdirectory(${_xclbinutil_source_dir}/aie-pdi-transform aie-pdi-transform)
 
+# otherwise the various stois that read these will explode...
+# XRT/src/runtime_src/tools/xclbinutil/XclBinClass.cxx#L55
+file(READ ${IREE_XRT_SOURCE_DIR}/CMakeLists.txt _xrt_cmake_file_contents)
+string(REGEX MATCH "XRT_VERSION_MAJOR ([0-9]+)" XRT_VERSION_MAJOR ${_xrt_cmake_file_contents})
+# note CMAKE_MATCH_0 is the whole match...
+set(XRT_VERSION_MAJOR ${CMAKE_MATCH_1})
+string(REGEX MATCH "XRT_VERSION_MINOR ([0-9]+)" XRT_VERSION_MINOR ${_xrt_cmake_file_contents})
+set(XRT_VERSION_MINOR ${CMAKE_MATCH_1})
+string(REGEX MATCH "XRT_VERSION_PATCH ([0-9]+)" XRT_VERSION_PATCH ${_xrt_cmake_file_contents})
+set(XRT_VERSION_PATCH ${CMAKE_MATCH_1})
+set(XRT_VERSION_STRING ${XRT_VERSION_MAJOR}.${XRT_VERSION_MINOR}.${XRT_VERSION_PATCH} CACHE INTERNAL "")
 configure_file(${IREE_XRT_SOURCE_DIR}/CMake/config/version.h.in ${_xclbinutil_source_dir}/version.h)
 
 file(
@@ -423,38 +430,20 @@ file(
   "${_xclbinutil_source_dir}/Resources*.cxx"
   "${_xclbinutil_source_dir}/XclBinClass.cxx"
   NoOpXclBinSignature.cxx
-  "${_xclbinutil_source_dir}/XclBinUtilities.cxx")
-
-# shared not static because static will let linker trim SectionMemTopology
-# initializers...
-add_library(xclbinutil-lib STATIC ${_xclbinutil_srcs})
-
-if(NOT WIN32)
-  target_compile_definitions(xclbinutil-lib
-                             PUBLIC ENABLE_JSON_SCHEMA_VALIDATION)
-  target_link_libraries(xclbinutil-lib PUBLIC transformcdo)
-else()
-  target_compile_options(xclbinutil-lib PUBLIC "/EHsc")
-  # if you get LINK : fatal error LNK1104: cannot open file
-  # 'libboost_filesystem-vc142-mt-gd-x64-1_74.lib'
-  # target_compile_definitions(xclbinutil-lib PUBLIC BOOST_ALL_DYN_LINK)
-endif()
-
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-target_link_libraries(xclbinutil-lib PUBLIC ${Boost_LIBRARIES} Threads::Threads)
-target_include_directories(xclbinutil-lib PUBLIC ${XRT_BINARY_DIR}/gen
-                                                 ${Boost_INCLUDE_DIRS}
-                                                 ${IREE_XRT_SOURCE_DIR}/runtime_src/core/include
-                                                 ${_xclbinutil_source_dir})
+  "${_xclbinutil_source_dir}/XclBinUtilities.cxx"
+  # Unlike bootgen, xclbinutil cannot be built separately as a static archive (I wish!)
+  # because the linker will DCE static initializers in SectionMemTopology.cxx
+  # and then --add-replace-section:MEM_TOPOLOGY won't work...
+  # XRT/src/runtime_src/tools/xclbinutil/SectionMemTopology.cxx#L26-L41
+  "${_xclbinutil_source_dir}/xclbinutil.cxx"
+  "${_xclbinutil_source_dir}/XclBinUtilMain.cxx"
+)
 
 iree_cc_binary(
   NAME
     amdaie_xclbinutil
   SRCS
-    "${_xclbinutil_source_dir}/xclbinutil.cxx"
-    "${_xclbinutil_source_dir}/XclBinUtilMain.cxx"
-  DEPS
-    xclbinutil-lib
+    ${_xclbinutil_srcs}
   COPTS
     -fexceptions
     -frtti
@@ -463,7 +452,31 @@ iree_cc_binary(
   PUBLIC
 )
 
-target_link_libraries(iree-amd-aie_aie_runtime_amdaie_xclbinutil PRIVATE xclbinutil-lib)
+set(_xclbin_libs ${Boost_LIBRARIES} Threads::Threads)
+
+if(WIN32)
+  target_compile_options(iree-amd-aie_aie_runtime_amdaie_xclbinutil
+                         PRIVATE "/EHsc")
+  # Uncomment if you get LINK : fatal error LNK1104: cannot open file
+  # 'libboost_filesystem-vc142-mt-gd-x64-1_74.lib'
+  # target_compile_definitions(xclbinutil-lib PUBLIC BOOST_ALL_DYN_LINK
+else()
+  target_compile_definitions(iree-amd-aie_aie_runtime_amdaie_xclbinutil
+                             PRIVATE ENABLE_JSON_SCHEMA_VALIDATION)
+  list(APPEND _xclbin_libs transformcdo)
+endif()
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+target_link_libraries(iree-amd-aie_aie_runtime_amdaie_xclbinutil
+                      PRIVATE ${_xclbin_libs})
+target_include_directories(iree-amd-aie_aie_runtime_amdaie_xclbinutil
+                           PRIVATE ${XRT_BINARY_DIR}/gen
+                                   ${Boost_INCLUDE_DIRS}
+                                   ${IREE_XRT_SOURCE_DIR}/runtime_src/core/include
+                                   ${_xclbinutil_source_dir})
+
+set_target_properties(iree-amd-aie_aie_runtime_amdaie_xclbinutil
+                      PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/tools")
 
 # ##############################################################################
 # iree-aie-runtime-static

--- a/runtime/src/iree-amd-aie/aie_runtime/NoOpXclBinSignature.cxx
+++ b/runtime/src/iree-amd-aie/aie_runtime/NoOpXclBinSignature.cxx
@@ -1,0 +1,20 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions. See
+// https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: # Apache-2.0 WITH LLVM-exception
+
+#include "XclBinSignature.h"
+
+void signXclBinImage(const std::string& _fileOnDisk,
+                     const std::string& _sPrivateKey,
+                     const std::string& _sCertificate,
+                     const std::string& _sDigestAlgorithm,
+                     bool _bEnableDebugOutput) {}
+void verifyXclBinImage(const std::string& _fileOnDisk,
+                       const std::string& _sCertificate,
+                       bool _bEnableDebugOutput) {}
+void dumpSignatureFile(const std::string& _fileOnDisk,
+                       const std::string& _signatureFile) {}
+void getXclBinPKCSStats(const std::string& _xclBinFile,
+                        XclBinPKCSImageStats& _xclBinPKCSImageStats) {}


### PR DESCRIPTION
This PR adds executable targets to our CMakes to build both `xclbinutil` and `bootgen`; previously these were fetched/gotten from a distro of `mlir-aie` and/or env. We already have these same submodules (`XRT` and `bootgen`) so the only thing we're really vendoring here is the CMake. The advantages of this are :

1. After this PR and a follow-up taking care of `me_basic.o` (once https://github.com/Xilinx/llvm-aie/pull/109 lands) we will no longer need a distro of `mlir-aie` (but obv still need the submodule for a little while longer);
    * Also we will be able to run lit tests for xclbin generation (i.e., during the build test step in CI);
3. We eliminate one dependency on OpenSSL (within `XRT`'s xclbinutil);
4. We will eventually move to not shelling out to these utilities and just calling the APIs directly (like [xaiepy](https://github.com/nod-ai/prototype-aie-toolchain/blob/main/xaiepy/xclbinutil.cpp#L58-L70)) so this was going to happen anyway[^1].

Note, all of the CMake shenanigans are very necessary because the respective code bases are quite questionable...............

Note also that it's clear `XCLBinGenConfig` needlessly duplicates many of the options in `AMDAIEOptions`. I'll get rid of the former in the a follow-up PR (see https://github.com/nod-ai/iree-amd-aie/issues/504).

[^1]: Indeed `bootgen` is already here as `bootgen-lib`.