### PR TITLE
[AMD-AIE] Support implicit source/target addressing in amdaie.npu.dma_cpy_nd

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -753,3 +753,11 @@ run_matmul_test \
     --lhs_rhs_type "i32" \
     --acc_type "i32" \
     --m "128" --k "256" --n "128"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "i32" \
+    --acc_type "i32" \
+    --m "32" --k "32" --n "32"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -241,6 +241,29 @@ def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd",
   let extraClassDeclaration = [{
     // Check whether this dma operation has a wait user.
     bool hasDmaWaitOpUser();
+
+    // Helper method to return the memory space of source as an integer. If
+    // no memory space attribute, this indicates a global memory space and
+    // we return 0. Else cast the memory space attribute to an integer. 
+    uint64_t getSourceMemorySpaceAsUInt() {
+      MemRefType sourceMemrefType =
+          cast<LogicalObjectFifoType>(getDmaCpyNdOp().getSourceType())
+          .getElementType();
+      Attribute memSpace = sourceMemrefType.getMemorySpace();
+      return memSpace ? dyn_cast<IntegerAttr>(memSpace).getInt() : 0;
+    }
+    
+    // Helper method to return the memory space of target as an integer. If
+    // no memory space attribute, this indicates a global memory space and
+    // we return 0. Else cast the memory space attribute to an integer. 
+    uint64_t getTargetMemorySpaceAsUInt() {
+      MemRefType targetMemrefType =
+          cast<LogicalObjectFifoType>(getDmaCpyNdOp().getTargetType())
+          .getElementType();
+      Attribute memSpace = targetMemrefType.getMemorySpace();
+      return memSpace ? dyn_cast<IntegerAttr>(memSpace).getInt() : 0;
+    }
+    
     // Check whether this operation has addressing on the source side.
     bool hasSourceAddressing() {
       return !getSourceMixedOffsets().empty() || !getSourceMixedSizes().empty() 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
@@ -404,24 +404,35 @@ LogicalResult getStaticDimsForExplicitAddressing(
 /// Utility to get the static offsets, sizes and strides for
 /// `AIEX::NpuDmaMemcpyNdOp` with implicit addressing.
 LogicalResult getStaticDimsForImplicitAddressing(
-    Operation *op, MemRefType memrefType, SmallVectorImpl<int64_t> &staticSizes,
+    Operation *op, MemRefType memrefType,
+    SmallVectorImpl<int64_t> &staticOffsets,
+    SmallVectorImpl<int64_t> &staticSizes,
     SmallVectorImpl<int64_t> &staticStrides) {
+  // 1. Static offsets.
+  for (unsigned i = 0, n = staticOffsets.size(); i < n; i++) {
+    staticOffsets[i] = 0;
+  }
+  // 2. Static sizes.
   SmallVector<int64_t> shapeArr;
   for (auto shape : memrefType.getShape()) shapeArr.push_back(shape);
   int64_t sizeIndex = staticSizes.size() - 1;
   for (int64_t i = shapeArr.size() - 1; i >= 0; i--) {
     staticSizes[sizeIndex--] = shapeArr[i];
   }
+  for (int64_t i = sizeIndex; i >= 0; i--) {
+    staticSizes[i] = 0;
+  }
+  // 3. Static strides.
   int64_t strideIndex = staticStrides.size() - 1;
-  // Since aiex.npu.dma_cpy_nd expects 3-dimensional stride attribute, it has
-  // the 4-th implicit dimension as 1. Hence we store that in `prevStride`.
+  // Since aiex.npu.dma_cpy_nd always has the 4-th dimension as 1, we store that
+  // in `prevStride`.
   int64_t prevStride = 1;
   for (int64_t i = shapeArr.size() - 1; i >= 0; i--) {
-    staticStrides[strideIndex] = shapeArr[i] * prevStride;
-    prevStride = staticStrides[strideIndex--];
+    staticStrides[strideIndex] = prevStride;
+    prevStride = staticStrides[strideIndex--] * shapeArr[i];
   }
   for (int64_t i = strideIndex; i >= 0; i--) {
-    staticStrides[i] = staticStrides[i + 1];
+    staticStrides[i] = prevStride;
   }
   return success();
 }
@@ -433,47 +444,28 @@ LogicalResult npuDmaCpyNdOpToAIE(IRRewriter &rewriter,
                                  IRMapping &mapper, IRMapping &bindingsMapper) {
   rewriter.setInsertionPoint(dmaOp);
   // Convert bidirectional `amdaie.npu.dma_cpy_nd` op into two halves.
-
-  // TODO(avarma): The logic for checking implicit L3 addressing should just be
-  // part of AMDAIEOps.td. Confirm and address during PR.
-  MemRefType sourceMemrefType =
-      cast<LogicalObjectFifoType>(dmaOp.getDmaCpyNdOp().getSourceType())
-          .getElementType();
-  Attribute sourceMemSpaceAttr = sourceMemrefType.getMemorySpace();
-  MemRefType targetMemrefType =
-      cast<LogicalObjectFifoType>(dmaOp.getDmaCpyNdOp().getTargetType())
-          .getElementType();
-  Attribute targetMemSpaceAttr = targetMemrefType.getMemorySpace();
-  if (dmaOp.hasSourceAddressing() || !sourceMemSpaceAttr) {
+  if (dmaOp.hasSourceAddressing() || dmaOp.getSourceMemorySpaceAsUInt() == 0) {
     // DmaOp has source addressing on L3 either explicitly or implicitly.
     SmallVector<Value> empty;
-    SmallVector<int64_t, 4> staticOffsets;
-    SmallVector<int64_t, 4> staticSizes;
-    SmallVector<int64_t, 3> staticStrides;
+    SmallVector<int64_t, 4> staticOffsets(4, 1);
+    SmallVector<int64_t, 4> staticSizes(4, 1);
+    SmallVector<int64_t, 3> staticStrides(4, 1);
     if (dmaOp.hasSourceAddressing()) {
-      SmallVector<int64_t, 4> _staticOffsets(4, 1);
-      SmallVector<int64_t, 4> _staticSizes(4, 1);
-      SmallVector<int64_t, 3> _staticStrides(4, 1);
       if (failed(getStaticDimsForExplicitAddressing(
               dmaOp, dmaOp.getSourceMixedOffsets(), dmaOp.getSourceMixedSizes(),
-              dmaOp.getSourceMixedStrides(), _staticOffsets, _staticSizes,
-              _staticStrides))) {
+              dmaOp.getSourceMixedStrides(), staticOffsets, staticSizes,
+              staticStrides))) {
         return failure();
       }
-      staticOffsets = _staticOffsets;
-      staticSizes = _staticSizes;
-      staticStrides = _staticStrides;
     } else {
-      SmallVector<int64_t, 4> _staticOffsets(4, 0);
-      SmallVector<int64_t, 4> _staticSizes(4, 0);
-      SmallVector<int64_t, 3> _staticStrides(4, 1);
-      if (failed(getStaticDimsForImplicitAddressing(
-              dmaOp, sourceMemrefType, _staticSizes, _staticStrides))) {
+      MemRefType sourceMemrefType =
+          cast<LogicalObjectFifoType>(dmaOp.getDmaCpyNdOp().getSourceType())
+              .getElementType();
+      if (failed(getStaticDimsForImplicitAddressing(dmaOp, sourceMemrefType,
+                                                    staticOffsets, staticSizes,
+                                                    staticStrides))) {
         return failure();
       }
-      staticOffsets = _staticOffsets;
-      staticSizes = _staticSizes;
-      staticStrides = _staticStrides;
     }
 
     AMDAIE::CircularDmaCpyNdOp dmaCpyNd = dmaOp.getDmaCpyNdOp();
@@ -492,36 +484,28 @@ LogicalResult npuDmaCpyNdOpToAIE(IRRewriter &rewriter,
         empty, empty, staticOffsets, staticSizes, staticStrides,
         objFifo.getName(), 0, issueToken);
   }
-  if (dmaOp.hasTargetAddressing() || !targetMemSpaceAttr) {
+  if (dmaOp.hasTargetAddressing() || dmaOp.getTargetMemorySpaceAsUInt() == 0) {
     // DmaOp has target addressing on L3 either explicitly or implicitly.
     SmallVector<Value> empty;
-    SmallVector<int64_t, 4> staticOffsets;
-    SmallVector<int64_t, 4> staticSizes;
-    SmallVector<int64_t, 3> staticStrides;
+    SmallVector<int64_t, 4> staticOffsets(4, 1);
+    SmallVector<int64_t, 4> staticSizes(4, 1);
+    SmallVector<int64_t, 3> staticStrides(4, 1);
     if (dmaOp.hasTargetAddressing()) {
-      SmallVector<int64_t, 4> _staticOffsets(4, 1);
-      SmallVector<int64_t, 4> _staticSizes(4, 1);
-      SmallVector<int64_t, 3> _staticStrides(4, 1);
       if (failed(getStaticDimsForExplicitAddressing(
               dmaOp, dmaOp.getTargetMixedOffsets(), dmaOp.getTargetMixedSizes(),
-              dmaOp.getTargetMixedStrides(), _staticOffsets, _staticSizes,
-              _staticStrides))) {
+              dmaOp.getTargetMixedStrides(), staticOffsets, staticSizes,
+              staticStrides))) {
         return failure();
       }
-      staticOffsets = _staticOffsets;
-      staticSizes = _staticSizes;
-      staticStrides = _staticStrides;
     } else {
-      SmallVector<int64_t, 4> _staticOffsets(4, 0);
-      SmallVector<int64_t, 4> _staticSizes(4, 0);
-      SmallVector<int64_t, 3> _staticStrides(4, 1);
-      if (failed(getStaticDimsForImplicitAddressing(
-              dmaOp, targetMemrefType, _staticSizes, _staticStrides))) {
+      MemRefType targetMemrefType =
+          cast<LogicalObjectFifoType>(dmaOp.getDmaCpyNdOp().getTargetType())
+              .getElementType();
+      if (failed(getStaticDimsForImplicitAddressing(dmaOp, targetMemrefType,
+                                                    staticOffsets, staticSizes,
+                                                    staticStrides))) {
         return failure();
       }
-      staticOffsets = _staticOffsets;
-      staticSizes = _staticSizes;
-      staticStrides = _staticStrides;
     }
     AMDAIE::CircularDmaCpyNdOp dmaCpyNd = dmaOp.getDmaCpyNdOp();
     Value memref =

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
@@ -408,6 +408,12 @@ LogicalResult getStaticDimsForImplicitAddressing(
     SmallVectorImpl<int64_t> &staticStrides) {
   // 1. Static sizes.
   SmallVector<int64_t> shapeArr = llvm::to_vector(memrefType.getShape());
+  // staticOffsets/staticSizes/staticStrides all have same size.
+  if (shapeArr.size() > staticSizes.size()) {
+    op->emitError() << "implicit source/target L3 memref has rank greater than "
+                       "the expected static offsets/sizes/strides rank (4)";
+    return failure();
+  }
   std::copy(shapeArr.begin(), shapeArr.end(),
             staticSizes.end() - shapeArr.size());
   // 2. Static strides.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
@@ -401,38 +401,22 @@ LogicalResult getStaticDimsForExplicitAddressing(
   return success();
 }
 
-/// Utility to get the static offsets, sizes and strides for
-/// `AIEX::NpuDmaMemcpyNdOp` with implicit addressing.
+/// Utility to get the static sizes and strides for `AIEX::NpuDmaMemcpyNdOp`
+/// with implicit addressing.
 LogicalResult getStaticDimsForImplicitAddressing(
-    Operation *op, MemRefType memrefType,
-    SmallVectorImpl<int64_t> &staticOffsets,
-    SmallVectorImpl<int64_t> &staticSizes,
+    Operation *op, MemRefType memrefType, SmallVectorImpl<int64_t> &staticSizes,
     SmallVectorImpl<int64_t> &staticStrides) {
-  // 1. Static offsets.
-  for (unsigned i = 0, n = staticOffsets.size(); i < n; i++) {
-    staticOffsets[i] = 0;
-  }
-  // 2. Static sizes.
-  SmallVector<int64_t> shapeArr;
-  for (auto shape : memrefType.getShape()) shapeArr.push_back(shape);
-  int64_t sizeIndex = staticSizes.size() - 1;
-  for (int64_t i = shapeArr.size() - 1; i >= 0; i--) {
-    staticSizes[sizeIndex--] = shapeArr[i];
-  }
-  for (int64_t i = sizeIndex; i >= 0; i--) {
-    staticSizes[i] = 0;
-  }
-  // 3. Static strides.
+  // 1. Static sizes.
+  SmallVector<int64_t> shapeArr = llvm::to_vector(memrefType.getShape());
+  std::copy(shapeArr.begin(), shapeArr.end(),
+            staticSizes.end() - shapeArr.size());
+  // 2. Static strides.
   int64_t strideIndex = staticStrides.size() - 1;
-  // Since aiex.npu.dma_cpy_nd always has the 4-th dimension as 1, we store that
-  // in `prevStride`.
+  // For contiguous access the strides for the last dimension is always 1.
   int64_t prevStride = 1;
   for (int64_t i = shapeArr.size() - 1; i >= 0; i--) {
     staticStrides[strideIndex] = prevStride;
     prevStride = staticStrides[strideIndex--] * shapeArr[i];
-  }
-  for (int64_t i = strideIndex; i >= 0; i--) {
-    staticStrides[i] = prevStride;
   }
   return success();
 }
@@ -445,11 +429,12 @@ LogicalResult npuDmaCpyNdOpToAIE(IRRewriter &rewriter,
   rewriter.setInsertionPoint(dmaOp);
   // Convert bidirectional `amdaie.npu.dma_cpy_nd` op into two halves.
   if (dmaOp.hasSourceAddressing() || dmaOp.getSourceMemorySpaceAsUInt() == 0) {
-    // DmaOp has source addressing on L3 either explicitly or implicitly.
+    // DmaOp either has explicit source addressing OR the defining op of its
+    // source has its source on L3.
     SmallVector<Value> empty;
-    SmallVector<int64_t, 4> staticOffsets(4, 1);
+    SmallVector<int64_t, 4> staticOffsets(4, 0);
     SmallVector<int64_t, 4> staticSizes(4, 1);
-    SmallVector<int64_t, 3> staticStrides(4, 1);
+    SmallVector<int64_t, 4> staticStrides(4, 0);
     if (dmaOp.hasSourceAddressing()) {
       if (failed(getStaticDimsForExplicitAddressing(
               dmaOp, dmaOp.getSourceMixedOffsets(), dmaOp.getSourceMixedSizes(),
@@ -461,9 +446,8 @@ LogicalResult npuDmaCpyNdOpToAIE(IRRewriter &rewriter,
       MemRefType sourceMemrefType =
           cast<LogicalObjectFifoType>(dmaOp.getDmaCpyNdOp().getSourceType())
               .getElementType();
-      if (failed(getStaticDimsForImplicitAddressing(dmaOp, sourceMemrefType,
-                                                    staticOffsets, staticSizes,
-                                                    staticStrides))) {
+      if (failed(getStaticDimsForImplicitAddressing(
+              dmaOp, sourceMemrefType, staticSizes, staticStrides))) {
         return failure();
       }
     }
@@ -485,11 +469,12 @@ LogicalResult npuDmaCpyNdOpToAIE(IRRewriter &rewriter,
         objFifo.getName(), 0, issueToken);
   }
   if (dmaOp.hasTargetAddressing() || dmaOp.getTargetMemorySpaceAsUInt() == 0) {
-    // DmaOp has target addressing on L3 either explicitly or implicitly.
+    // DmaOp either has explicit target addressing OR the defining op of its
+    // source has its target on L3.
     SmallVector<Value> empty;
-    SmallVector<int64_t, 4> staticOffsets(4, 1);
+    SmallVector<int64_t, 4> staticOffsets(4, 0);
     SmallVector<int64_t, 4> staticSizes(4, 1);
-    SmallVector<int64_t, 3> staticStrides(4, 1);
+    SmallVector<int64_t, 4> staticStrides(4, 0);
     if (dmaOp.hasTargetAddressing()) {
       if (failed(getStaticDimsForExplicitAddressing(
               dmaOp, dmaOp.getTargetMixedOffsets(), dmaOp.getTargetMixedSizes(),
@@ -501,9 +486,8 @@ LogicalResult npuDmaCpyNdOpToAIE(IRRewriter &rewriter,
       MemRefType targetMemrefType =
           cast<LogicalObjectFifoType>(dmaOp.getDmaCpyNdOp().getTargetType())
               .getElementType();
-      if (failed(getStaticDimsForImplicitAddressing(dmaOp, targetMemrefType,
-                                                    staticOffsets, staticSizes,
-                                                    staticStrides))) {
+      if (failed(getStaticDimsForImplicitAddressing(
+              dmaOp, targetMemrefType, staticSizes, staticStrides))) {
         return failure();
       }
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
@@ -406,6 +406,8 @@ LogicalResult getStaticDimsForExplicitAddressing(
 LogicalResult getStaticDimsForImplicitAddressing(
     Operation *op, MemRefType memrefType, SmallVectorImpl<int64_t> &staticSizes,
     SmallVectorImpl<int64_t> &staticStrides) {
+  assert((staticSizes.size() == staticStrides.size()) &&
+         "static size and strides should be of same size");
   // 1. Static sizes.
   SmallVector<int64_t> shapeArr = llvm::to_vector(memrefType.getShape());
   // staticOffsets/staticSizes/staticStrides all have same size.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
@@ -375,6 +375,46 @@ module {
 
 // -----
 
+// Test to demonstrate invalid implicit L3 memref type that has rank greater than that
+// expected for static offsets/sizes/strides.
+module {
+  func.func @controlcode_invalid_implicit_l3_memref() {
+    amdaie.workgroup {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
+      %c32 = arith.constant 32 : index
+      %c64 = arith.constant 64 : index
+      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : memref<32x16x64x128x32xi32>
+      memref.assume_alignment %2, 64 : memref<32x16x64x128x32xi32>
+      %tile_0_0 = amdaie.tile(%c0, %c0)
+      %tile_0_1 = amdaie.tile(%c0, %c1)
+      %tile_0_2 = amdaie.tile(%c0, %c2)
+      %alloc_1 = memref.alloc() : memref<32x32xi32, 1>
+      %alloc_2 = memref.alloc() : memref<4x8x4x8xi32, 2>
+      %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x16x64x128x32xi32> -> !amdaie.logicalobjectfifo<memref<32x16x64x128x32xi32>>
+      %obj1 = amdaie.logicalobjectfifo.from_memref %alloc_1, {%tile_0_1} : memref<32x32xi32, 1> -> !amdaie.logicalobjectfifo<memref<32x32xi32, 1>>
+      %obj2 = amdaie.logicalobjectfifo.from_memref %alloc_2, {%tile_0_2} : memref<4x8x4x8xi32, 2> -> !amdaie.logicalobjectfifo<memref<4x8x4x8xi32, 2>>
+      %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj2[] [] []) : (!amdaie.logicalobjectfifo<memref<32x32xi32, 1>>, !amdaie.logicalobjectfifo<memref<4x8x4x8xi32, 2>>)
+      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<32x16x64x128x32xi32>>, !amdaie.logicalobjectfifo<memref<32x32xi32, 1>>)
+      amdaie.logicalobjectfifo.link[%dma0] -> [%dma_target_l3] ()
+      memref.dealloc %alloc_2 : memref<4x8x4x8xi32, 2>
+      memref.dealloc %alloc_1 : memref<32x32xi32, 1>
+      // expected-error @+1 {{could not convert to AIEDialect ops}}
+      amdaie.controlcode {
+        // expected-error @+1 {{implicit source/target L3 memref has rank greater than the expected static offsets/sizes/strides rank (4)}}
+        %npu_dma_1 = amdaie.npu.dma_cpy_nd %dma_target_l3([] [] [], [] [] [])
+        amdaie.npu.dma_wait(%npu_dma_1, S2MM)
+        
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
 // CHECK:       aie.device
 // CHECK-DAG:   %[[TILE_1_2:.+]] = aie.tile(1, 2)
 // CHECK-DAG:   %[[TILE_0_2:.+]] = aie.tile(0, 2)

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
@@ -300,26 +300,37 @@ module {
 
 // -----
 
+// Test to show mix of implicit/explicit source/target addressing in amdaie.npu.dma_cpy_nd.
+
 // CHECK:       aie.device
 // CHECK-DAG:   %[[TILE_0_2:.+]] = aie.tile(0, 2)
 // CHECK-DAG:   %[[TILE_0_1:.+]] = aie.tile(0, 1)
 // CHECK-DAG:   %[[TILE_0_0:.+]] = aie.tile(0, 0)
 // CHECK:       aie.objectfifo @[[OBJ0:.+]](%[[TILE_0_2]], {%[[TILE_0_1]]}
 // CHECK-NEXT:  aie.objectfifo @[[OBJ1:.+]](%[[TILE_0_1]], {%[[TILE_0_0]]}
-// CHECK-NEXT:  aie.objectfifo.link
-// CHECK-SAME:  @[[OBJ0]]
-// CHECK-SAME:  @[[OBJ1]]
-// CHECK:       func.func @controlcode
-// CHECK-SAME:  %[[ARG0:.+]]: memref<32x64xi32>
+// CHECK-NEXT:  aie.objectfifo @[[OBJ2:.+]](%[[TILE_0_0]], {%[[TILE_0_1]]}
+// CHECK:       aie.objectfifo.link [@[[OBJ0]]] -> [@[[OBJ1]]]
+// CHECK:       func.func @controlcode(%[[ARG0:.+]]: memref<32x64xi32>
 // CHECK:         aiex.npu.dma_memcpy_nd
-// CHECK-SAME:    %[[ARG0]]
-// CHECK-SAME:    [1, 1, 0, 32]
-// CHECK-SAME:    [1, 1, 32, 32]
-// CHECK-SAME:    [1, 1, 64, 1]
-// CHECK-SAME:    issue_token = true
-// CHECK-SAME:    @[[OBJ1]]
-// CHECK-NEXT:    aiex.npu.dma_wait
-// CHECK-SAME:    @[[OBJ1]]
+// CHECK-SAME:            %[[ARG0]][1, 1, 0, 32][1, 1, 32, 32][1, 1, 64, 1]
+// CHECK-SAME:            issue_token = true
+// CHECK-SAME:            metadata = @[[OBJ1]]
+// CHECK-NEXT:    aiex.npu.dma_wait {symbol = @[[OBJ1]]}
+// CHECK:         aiex.npu.dma_memcpy_nd
+// CHECK-SAME:            %[[ARG0]][0, 0, 0, 0][0, 0, 32, 64][2048, 2048, 64, 1]
+// CHECK-SAME:            issue_token = true
+// CHECK-SAME:            metadata = @[[OBJ1]]
+// CHECK-NEXT:    aiex.npu.dma_wait {symbol = @[[OBJ1]]}
+// CHECK:         aiex.npu.dma_memcpy_nd
+// CHECK-SAME:            %[[ARG0]][1, 1, 0, 32][1, 1, 32, 32][1, 1, 64, 1]
+// CHECK-SAME:            issue_token = true
+// CHECK-SAME:            metadata = @[[OBJ2]]
+// CHECK-NEXT:    aiex.npu.dma_wait {symbol = @[[OBJ2]]}
+// CHECK:         aiex.npu.dma_memcpy_nd
+// CHECK-SAME:            %[[ARG0]][0, 0, 0, 0][0, 0, 32, 64][2048, 2048, 64, 1]
+// CHECK-SAME:            issue_token = true
+// CHECK-SAME:            metadata = @[[OBJ2]]
+// CHECK-NEXT:    aiex.npu.dma_wait {symbol = @[[OBJ2]]}
 module {
   func.func @controlcode() {
     amdaie.workgroup {
@@ -339,13 +350,22 @@ module {
       %obj1 = amdaie.logicalobjectfifo.from_memref %alloc_1, {%tile_0_1} : memref<32x32xi32, 1> -> !amdaie.logicalobjectfifo<memref<32x32xi32, 1>>
       %obj2 = amdaie.logicalobjectfifo.from_memref %alloc_2, {%tile_0_2} : memref<4x8x4x8xi32, 2> -> !amdaie.logicalobjectfifo<memref<4x8x4x8xi32, 2>>
       %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj2[] [] []) : (!amdaie.logicalobjectfifo<memref<32x32xi32, 1>>, !amdaie.logicalobjectfifo<memref<4x8x4x8xi32, 2>>)
+      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<32x64xi32>>, !amdaie.logicalobjectfifo<memref<32x32xi32, 1>>)
+      %dma_source_l3 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj0[] [] []) : (!amdaie.logicalobjectfifo<memref<32x32xi32, 1>>, !amdaie.logicalobjectfifo<memref<32x64xi32>>)
       %dma1 = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<32x64xi32>>, !amdaie.logicalobjectfifo<memref<32x32xi32, 1>>)
-      amdaie.logicalobjectfifo.link[%dma0] -> [%dma1] ()
+      amdaie.logicalobjectfifo.link[%dma0] -> [%dma_target_l3] ()
       memref.dealloc %alloc_2 : memref<4x8x4x8xi32, 2>
       memref.dealloc %alloc_1 : memref<32x32xi32, 1>
       amdaie.controlcode {
-        %npu_dma = amdaie.npu.dma_cpy_nd %dma1([%c0, %c32] [%c32, %c32] [%c64, %c1], [] [] [])
-        amdaie.npu.dma_wait(%npu_dma, S2MM)
+        %npu_dma_0 = amdaie.npu.dma_cpy_nd %dma_target_l3([%c0, %c32] [%c32, %c32] [%c64, %c1], [] [] [])
+        amdaie.npu.dma_wait(%npu_dma_0, S2MM)
+        %npu_dma_1 = amdaie.npu.dma_cpy_nd %dma_target_l3([] [] [], [] [] [])
+        amdaie.npu.dma_wait(%npu_dma_1, S2MM)
+        %npu_dma_2 = amdaie.npu.dma_cpy_nd %dma_source_l3([] [] [], [%c0, %c32] [%c32, %c32] [%c64, %c1])
+        amdaie.npu.dma_wait(%npu_dma_2, MM2S)
+        %npu_dma_3 = amdaie.npu.dma_cpy_nd %dma_source_l3([] [] [], [] [] [])
+        amdaie.npu.dma_wait(%npu_dma_3, MM2S)
+
         amdaie.end
       }
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
@@ -312,22 +312,22 @@ module {
 // CHECK:       aie.objectfifo.link [@[[OBJ0]]] -> [@[[OBJ1]]]
 // CHECK:       func.func @controlcode(%[[ARG0:.+]]: memref<32x64xi32>
 // CHECK:         aiex.npu.dma_memcpy_nd
-// CHECK-SAME:            %[[ARG0]][1, 1, 0, 32][1, 1, 32, 32][1, 1, 64, 1]
+// CHECK-SAME:            %[[ARG0]][0, 0, 0, 32][1, 1, 32, 32][0, 0, 64, 1]
 // CHECK-SAME:            issue_token = true
 // CHECK-SAME:            metadata = @[[OBJ1]]
 // CHECK-NEXT:    aiex.npu.dma_wait {symbol = @[[OBJ1]]}
 // CHECK:         aiex.npu.dma_memcpy_nd
-// CHECK-SAME:            %[[ARG0]][0, 0, 0, 0][0, 0, 32, 64][2048, 2048, 64, 1]
+// CHECK-SAME:            %[[ARG0]][0, 0, 0, 0][1, 1, 32, 64][0, 0, 64, 1]
 // CHECK-SAME:            issue_token = true
 // CHECK-SAME:            metadata = @[[OBJ1]]
 // CHECK-NEXT:    aiex.npu.dma_wait {symbol = @[[OBJ1]]}
 // CHECK:         aiex.npu.dma_memcpy_nd
-// CHECK-SAME:            %[[ARG0]][1, 1, 0, 32][1, 1, 32, 32][1, 1, 64, 1]
+// CHECK-SAME:            %[[ARG0]][0, 0, 0, 32][1, 1, 32, 32][0, 0, 64, 1]
 // CHECK-SAME:            issue_token = true
 // CHECK-SAME:            metadata = @[[OBJ2]]
 // CHECK-NEXT:    aiex.npu.dma_wait {symbol = @[[OBJ2]]}
 // CHECK:         aiex.npu.dma_memcpy_nd
-// CHECK-SAME:            %[[ARG0]][0, 0, 0, 0][0, 0, 32, 64][2048, 2048, 64, 1]
+// CHECK-SAME:            %[[ARG0]][0, 0, 0, 0][1, 1, 32, 64][0, 0, 64, 1]
 // CHECK-SAME:            issue_token = true
 // CHECK-SAME:            metadata = @[[OBJ2]]
 // CHECK-NEXT:    aiex.npu.dma_wait {symbol = @[[OBJ2]]}
@@ -415,9 +415,9 @@ module {
 // CHECK-SAME:  %[[ARG0:.+]]: memref<32x64xi32>
 // CHECK:         aiex.npu.dma_memcpy_nd
 // CHECK-SAME:    %[[ARG0]]
-// CHECK-SAME:    [1, 1, 0, 32]
+// CHECK-SAME:    [0, 0, 0, 32]
 // CHECK-SAME:    [1, 1, 32, 32]
-// CHECK-SAME:    [1, 1, 64, 1]
+// CHECK-SAME:    [0, 0, 64, 1]
 // CHECK-SAME:    issue_token = true
 // CHECK-SAME:    @[[OBJ0]]
 // CHECK-NEXT:    aiex.npu.dma_wait

--- a/tests/samples/matmul_peeled_objectfifo.mlir
+++ b/tests/samples/matmul_peeled_objectfifo.mlir
@@ -14,8 +14,8 @@
 // CHECK-SAME:    %[[ARG0]]
 // CHECK-DAG:     aiex.npu.dma_memcpy_nd
 // CHECK-SAME:    %[[ARG1]]
-// CHECK-DAG:     aiex.npu.dma_memcpy_nd(0, 0, %[[ARG2]][1, 1, 0, 0][1, 1, 32, 32][1, 1, 64, 1]
-// CHECK-DAG:     aiex.npu.dma_memcpy_nd(0, 0, %[[ARG2]][1, 1, 0, 32][1, 1, 32, 32][1, 1, 64, 1]
+// CHECK-DAG:     aiex.npu.dma_memcpy_nd(0, 0, %[[ARG2]][0, 0, 0, 0][1, 1, 32, 32][0, 0, 64, 1]
+// CHECK-DAG:     aiex.npu.dma_memcpy_nd(0, 0, %[[ARG2]][0, 0, 0, 32][1, 1, 32, 32][0, 0, 64, 1]
 #map = affine_map<(d0) -> (d0 * 32)>
 #map1 = affine_map<(d0) -> (d0 * 64)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d0, d3, d5)>

--- a/tests/samples/matmul_peeled_objectfifo_e2e.mlir
+++ b/tests/samples/matmul_peeled_objectfifo_e2e.mlir
@@ -12,11 +12,11 @@
 // CHECK-DAG:   aie.core(%[[TILE_0_3]])
 // CHECK-DAG:   aie.core(%[[TILE_1_3]])
 // CHECK-DAG:   func.func @matmul_i32_dispatch_0_matmul_128x128x256_i32(%[[ARG0:.+]]: memref<128x256xi32>, %[[ARG1:.+]]: memref<256x128xi32>, %[[ARG2:.+]]: memref<128x128xi32>)
-// CHECK-DAG:     aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][1, 1, 0, 0][1, 1, 64, 32][1, 1, 256, 1]) {id = 0 : i64, issue_token = true, metadata = @[[OBJ0:.+]]}
+// CHECK-DAG:     aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 0, 0][1, 1, 64, 32][0, 0, 256, 1]) {id = 0 : i64, issue_token = true, metadata = @[[OBJ0:.+]]}
 // CHECK-DAG:     aiex.npu.dma_wait {symbol = @[[OBJ0]]}
-// CHECK-DAG:     aiex.npu.dma_memcpy_nd(0, 0, %[[ARG1]][1, 0, 0, 0][1, 2, 32, 32][1, 32, 128, 1]) {id = 0 : i64, issue_token = true, metadata = @[[OBJ1:.+]]}
+// CHECK-DAG:     aiex.npu.dma_memcpy_nd(0, 0, %[[ARG1]][0, 0, 0, 0][1, 2, 32, 32][0, 32, 128, 1]) {id = 0 : i64, issue_token = true, metadata = @[[OBJ1:.+]]}
 // CHECK-DAG:     aiex.npu.dma_wait {symbol = @[[OBJ1]]}
-// CHECK-DAG:     aiex.npu.dma_memcpy_nd(0, 0, %[[ARG2]][1, 1, 0, 0][1, 1, 64, 64][1, 1, 128, 1]) {id = 0 : i64, issue_token = true, metadata = @[[OBJ10:.+]]}
+// CHECK-DAG:     aiex.npu.dma_memcpy_nd(0, 0, %[[ARG2]][0, 0, 0, 0][1, 1, 64, 64][0, 0, 128, 1]) {id = 0 : i64, issue_token = true, metadata = @[[OBJ10:.+]]}
 // CHECK-DAG:     aiex.npu.dma_wait {symbol = @[[OBJ10]]}
 // CHECK-DAG:   aie.shim_dma_allocation @[[OBJ0]](MM2S, 0, 0)
 // CHECK-DAG:   aie.shim_dma_allocation @[[OBJ1]](MM2S, 1, 0)


### PR DESCRIPTION
-- This commit adds a fix for supporting implicit source/target addressing in amdaie.npu.dma_cpy_nd ops as part of `--iree-amdaie-lower-to-aie` pass.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>