### PR TITLE
[WiP] Enable compilation with latest Peano

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
           python3 -m venv .venv
           source .venv/bin/activate
           pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024070222+76460fe-py3-none-manylinux_2_35_x86_64.whl
+          pip install https://github.com/Xilinx/llvm-aie/releases/download/nightly/llvm_aie-18.0.0.2024071001+6bfc265c-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
 
           pip install -r tests/matmul/requirements.txt
 

--- a/build_tools/ci/cpu_comparison/run_test.sh
+++ b/build_tools/ci/cpu_comparison/run_test.sh
@@ -88,7 +88,7 @@ fi
 
 # Parameter 4) <peano-install-dir>
 if [ -z "${4-}" ]; then
-  PEANO=/opt/llvm-aie
+  PEANO=`realpath .venv/lib/python3.10/site-packages/llvm-aie`
 else
   PEANO=`realpath "$4"`
 fi

--- a/build_tools/ci/print_ir_aie2xclbin/print_ir_aie2xclbin.sh
+++ b/build_tools/ci/print_ir_aie2xclbin/print_ir_aie2xclbin.sh
@@ -39,7 +39,7 @@ mkdir -p ${OUTPUT}
 # The CI case:
 if [ "$#" -eq 2 ]; then
   echo "Assuming that this is the 'CI case' as 2 parameters were provided."
-  PEANO=/opt/llvm-aie
+  PEANO=`realpath .venv/lib/python3.10/site-packages/llvm-aie`
   XRT=/opt/xilinx/xrt
   VITIS=/opt/Xilinx/Vitis/2023.2
   MLIR_AIE=`realpath .venv/lib/python3.10/site-packages/mlir_aie`

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -96,7 +96,7 @@ fi
 
 # Parameter 4) <peano-install-dir>
 if [ -z "${4-}" ]; then
-  PEANO=/opt/llvm-aie
+  PEANO=`realpath .venv/lib/python3.10/site-packages/llvm-aie`
 else
   PEANO=`realpath "$4"`
 fi

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AMDAIETargetBCF.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AMDAIETargetBCF.cpp
@@ -119,7 +119,7 @@ LogicalResult AIETranslateToBCF(ModuleOp module, raw_ostream &output,
       if (tile.getCoreOp() && tile.getCoreOp().getLinkWith())
         output << "_include _file "
                << tile.getCoreOp().getLinkWith().value().str() << "\n";
-      output << "_resolve _main core_" << tile.getCol() << "_" << tile.getRow()
+      output << "_resolve main core_" << tile.getCol() << "_" << tile.getRow()
              << "\n";
     }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AMDAIETargetLdScript.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AMDAIETargetLdScript.cpp
@@ -158,7 +158,7 @@ SECTIONS
         if (auto fileAttr = coreOp.getLinkWith())
           output << "INPUT(" << fileAttr.value().str() << ")\n";
 
-        output << "PROVIDE(_main = core_" << tile.getCol() << "_"
+        output << "PROVIDE(main = core_" << tile.getCol() << "_"
                << tile.getRow() << ");\n";
       }
     }


### PR DESCRIPTION
There are (at least) two issues that prevent the current AMD AIE plugin to work with the latest version of Peano (LLVM AIE single core compiler):

* Peano now provides initialization code through crt0, so linking against `me_basic.o` is unnecessary and creates redefined symbols.

* Peano expect the entry point to be named `main`, not `_main`.