### PR TITLE
Make aie2xclbin stop when any intermediate step fails 

### DIFF
--- a/build_tools/ci/cpu_comparison/run_test.sh
+++ b/build_tools/ci/cpu_comparison/run_test.sh
@@ -328,6 +328,7 @@ function run_test() {
       --iree-amd-aie-install-dir=${amd_aie_install_path} \
       --iree-amd-aie-vitis-install-dir=${vitis_path} \
       --iree-hal-dump-executable-files-to=$PWD \
+      --iree-amd-aie-show-invoked-commands \
       --mlir-disable-threading -o ${aie_vmfb}"
 
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
@@ -206,8 +206,8 @@ std::optional<std::string> runTool(
   }
 
   if (result != 0) {
-    llvm::errs() << "Failed to run tool: " << program << " "
-                 << llvm::join(args, " ") << " with error: " << errMsg << "\n";
+    llvm::errs() << "Failed to run tool: " << program << ". Error: '" << errMsg
+                 << "'\n";
     return {};
   }
 


### PR DESCRIPTION
Fix for bug introduced in https://github.com/nod-ai/iree-amd-aie/commit/7d530aff2146bc5d73e6b051d65f45757aa6c3b2 where aie2xclbin keeps running even after a tool fails. Tested locally. 