### PR TITLE
[AMD-AIE][Objectfifo] Add Ukernel support in create-aie-workgroup

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
@@ -314,6 +314,10 @@ namespace {
 /// Traverse the function operation and create a single workgroup and control
 /// code.
 LogicalResult createSingleWorkgroupAndControlCode(func::FuncOp funcOp) {
+  // Skip processing Ukernel function declarations which will be marked private.
+  if (funcOp.isPrivate()) {
+    return success();
+  }
   IRRewriterAndMapper rewriter(funcOp.getContext());
   IRRewriterAndMapper controlCodeRewriter(funcOp.getContext());
   Block *funcBlock = &funcOp.getBody().front();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
@@ -9,6 +9,20 @@ func.func @func() {
 
 // -----
 
+// CHECK-LABEL: module
+//       CHECK: @ukernel
+//       CHECK: @func
+//       CHECK:   amdaie.workgroup
+//       CHECK:     amdaie.controlcode
+module {
+  func.func private @ukernel(memref<i32, 2 : i32>, index) attributes {link_with = "/path/to/ukernels.o", llvm.bareptr = true}
+  func.func @func() {
+    return
+  }
+}
+
+// -----
+
 // CHECK-LABEL: @circular_dma_cpy_nd
 // CHECK:       amdaie.workgroup
 // CHECK:         amdaie.circular_dma_cpy_nd


### PR DESCRIPTION
-- This commit adds Ukernel support in `--iree-amdaie-create-aie-workgroup` pass.
-- The pass is used to create amdaie.workgroup and we can simply skip this processing for a private function declaration.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>