### PR TITLE
fix `deviceModel.isLegalMemtileConnection`

### DIFF
--- a/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.cc
+++ b/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.cc
@@ -421,6 +421,8 @@ bool AMDAIEDeviceModel::isLegalMemtileConnection(uint8_t col, uint8_t row,
   assert(tileType == AMDAIETileType::MEMTILE && "expected memtile");
   const XAie_StrmMod *strmMod =
       devInst.DevProp.DevMod[static_cast<uint8_t>(tileType)].StrmSw;
+  if (srcChan >= strmMod->SlvConfig[srcBundle].NumPorts) return false;
+  if (dstChan >= strmMod->MstrConfig[dstBundle].NumPorts) return false;
   AieRC RC = strmMod->PortVerify(/*slave*/ srcBundle, srcChan,
                                  /*master*/ dstBundle, dstChan);
   if (RC != XAIE_OK) {

--- a/runtime/src/iree-amd-aie/aie_runtime/test/DeviceModelTest.cpp
+++ b/runtime/src/iree-amd-aie/aie_runtime/test/DeviceModelTest.cpp
@@ -404,7 +404,7 @@ TEST_P(AMDAIENPUDeviceModelParameterizedSixTupleNPU4ColTestFixture,
     return;
   if (srcStrmSwPortType == TRACE && srcChan > 0) return;
   if (srcStrmSwPortType == NORTH && srcChan > 3) return;
-  if (destStrmSwPortType == SOUTH && srcChan > 3) return;
+  if (destStrmSwPortType == SOUTH && dstChan > 3) return;
 
   auto srcSw = static_cast<StrmSwPortType>(srcStrmSwPortType);
   auto srcWireB = STRM_SW_PORT_TYPE_TO_WIRE_BUNDLE(srcSw);
@@ -422,14 +422,27 @@ TEST_P(AMDAIENPUDeviceModelParameterizedSixTupleNPU4ColTestFixture,
             {srcStrmSwPortType, srcChan, destStrmSwPortType, dstChan}))
       EXPECT_NE(deviceModelIsLegal, targetModelIsLegal)
           << "c,r: " << c << ", " << r << "\n"
-          << "src: " << srcSw << srcChan << "\n"
-          << "dst: " << destSw << dstChan << "\n\n";
+          << "src: " << to_string(srcSw) << ", " << srcChan << "\n"
+          << "dst: " << to_string(destSw) << ", " << dstChan << "\n\n";
     else
       EXPECT_EQ(deviceModelIsLegal, targetModelIsLegal)
           << "c,r: " << c << ", " << r << "\n"
-          << "src: " << srcSw << srcChan << "\n"
-          << "dst: " << destSw << dstChan << "\n\n";
+          << "src: " << to_string(srcSw) << ", " << srcChan << "\n"
+          << "dst: " << to_string(destSw) << ", " << dstChan << "\n\n";
   }
+}
+
+TEST(IsLegalMemtileConnectionSouth4, Test0) {
+  AMDAIEDeviceModel deviceModel =
+      mlir::iree_compiler::AMDAIE::getDeviceModel(AMDAIEDevice::npu1_4col);
+  const xilinx::AIE::AIETargetModel &targetModel =
+      xilinx::AIE::getTargetModel(xilinx::AIE::AIEDevice::npu1_4col);
+
+  auto deviceModelIsLegal = deviceModel.isLegalMemtileConnection(
+      0, 1, StrmSwPortType::DMA, 2, StrmSwPortType::SOUTH, 4);
+  auto targetModelIsLegal = targetModel.isLegalMemtileConnection(
+      xilinx::AIE::WireBundle::DMA, 2, xilinx::AIE::WireBundle::South, 4);
+  EXPECT_NE(deviceModelIsLegal, targetModelIsLegal);
 }
 
 // setting a partition (i.e. using XAie_SetupPartitionConfig) actually changes


### PR DESCRIPTION
@erwei-xilinx noticed that `deviceModel.isLegalMemtileConnection` was returning legal for `(DMA, 0) -> (South, 4)` even though port/channel 4 isn't a legal channel for `South`. Closer reading of the [relevant fn](https://github.com/Xilinx/aie-rt/blob/d748ddc696702ac7e7e0d2012c93e251add84691/driver/src/stream_switch/xaie_ss_aieml.c#L102) in `aie-rt` shows

> The method assumes both ports exist, and the relevant tile is an MEM-Tile.

So we add a check to see if the ports/channels exist. This of course contradicts mlir-aie at the current commit but it's actually fixed in tip (maybe?).