### PR TITLE
Rolling back to using the previous mlir-aie wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024071522+9530ac4-py3-none-manylinux_2_35_x86_64.whl
+          pip install https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024070222+76460fe-py3-none-manylinux_2_35_x86_64.whl
 
           pip install -r tests/matmul/requirements.txt
 


### PR DESCRIPTION
`me_basic.o` is removed from `aie_runtime_lib` in a recent commit: https://github.com/Xilinx/mlir-aie/commit/1acb6fe98e1613bc5e1b6bb8cf02cbf555d2fd3a