### PR TITLE
[DmaLoopSubsumption] Fix for strided op in loop without induction var dependency

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -735,6 +735,7 @@ run_matmul_test \
     --acc_type "f32" \
     --m "8192" --k "2432" --n "7296"
 
+###################################################################
 # ObjectFifo Matmul tests
 ###################################################################
 
@@ -744,7 +745,7 @@ run_matmul_test \
     --tile_pipeline "pack-peel" \
     --lhs_rhs_type "i32" \
     --acc_type "i32" \
-    --m "128" --k "256" --n "128"
+    --m "32" --k "32" --n "32"
 
 run_matmul_test \
     --name_prefix "small" \
@@ -752,7 +753,16 @@ run_matmul_test \
     --tile_pipeline "pack-peel" \
     --lhs_rhs_type "i32" \
     --acc_type "i32" \
-    --m "32" --k "32" --n "32"
+    --m "128" --k "32" --n "64" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "i32" \
+    --acc_type "i32" \
+    --m "128" --k "256" --n "128"
 
 run_matmul_test \
     --name_prefix "medium" \

--- a/tests/samples/matmul_peeled_objectfifo.mlir
+++ b/tests/samples/matmul_peeled_objectfifo.mlir
@@ -10,10 +10,8 @@
 // CHECK-DAG:   aie.core(%[[TILE_1_2]])
 // CHECK:         aie.objectfifo.acquire @[[OBJ1]](Produce, 1)
 // CHECK:       func.func @matmul_i32(%[[ARG0:.+]]: memref<32x1024xi32>, %[[ARG1:.+]]: memref<1024x64xi32>, %[[ARG2:.+]]: memref<32x64xi32>)
-// CHECK-DAG:     aiex.npu.dma_memcpy_nd
-// CHECK-SAME:    %[[ARG0]]
-// CHECK-DAG:     aiex.npu.dma_memcpy_nd
-// CHECK-SAME:    %[[ARG1]]
+// CHECK-DAG:     aiex.npu.dma_memcpy_nd(0, 0, %[[ARG0]][0, 0, 0, 0][1, 1, 32, 64][0, 0, 1024, 1]
+// CHECK-DAG:     aiex.npu.dma_memcpy_nd(0, 0, %[[ARG1]][0, 0, 0, 0][1, 1, 64, 32][0, 0, 64, 1]
 // CHECK-DAG:     aiex.npu.dma_memcpy_nd(0, 0, %[[ARG2]][0, 0, 0, 0][1, 1, 32, 32][0, 0, 64, 1]
 // CHECK-DAG:     aiex.npu.dma_memcpy_nd(0, 0, %[[ARG2]][0, 0, 0, 32][1, 1, 32, 32][0, 0, 64, 1]
 #map = affine_map<(d0) -> (d0 * 32)>


### PR DESCRIPTION
Fixes an issue exposed by a 128x32x64 matmul: https://github.com/nod-ai/iree-amd-aie/issues/556.

This issue would come up in partial loop dependencies in case of `scf.forall`:

```
scf.forall (%arg2, %arg3) in (2, 6) {
  %1 = amdaie.npu.dma_cpy_nd %0([0, %arg3] [8, 16] [16, 1], [] [] [])
  amdaie.npu.dma_wait(%2, S2MM)
}
```

In this case, the outer iteration upon which the NPU DMA operation didn't depend ( `%arg2`) would not be considered, resulting in incorrect output IR:

```
%1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0] [6, 8, 16] [1, 16, 1], [] [] [])
amdaie.npu.dma_wait(%2, S2MM)
```

However, the outer iteration should be considered as well, making sure the above DMA operation is executed twice, resulting in the below output IR:

```
%1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [2, 6, 8, 16] [0, 1, 16, 1], [] [] [])
amdaie.npu.dma_wait(%2, S2MM)
```

This PR fixes the issue by adding general support for subsuming loop iterations into strided operations without any loop induction variable dependency.