### PR TITLE
[DmaLoopSubsumption] Add option to only support repeat on outer dim

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -753,6 +753,15 @@ run_matmul_test \
     --tile_pipeline "pack-peel" \
     --lhs_rhs_type "i32" \
     --acc_type "i32" \
+    --m "64" --k "32" --n "128" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "i32" \
+    --acc_type "i32" \
     --m "128" --k "32" --n "64" \
     --num_repeat_runs "10"
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -106,7 +106,8 @@ std::unique_ptr<Pass> createAMDAIEDistributeCoresAndObjectFifosPass();
 
 /// Create a pass to subsume loop iterations into DMA operations' access
 /// patterns.
-std::unique_ptr<Pass> createAMDAIEDmaLoopSubsumptionPass();
+std::unique_ptr<Pass> createAMDAIEDmaLoopSubsumptionPass(
+    AMDAIEDmaLoopSubsumptionOptions options = {});
 
 /// Create a pass to convert dma operations to circular dma operations.
 std::unique_ptr<Pass> createAMDAIEDmaToCircularDmaPass();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -127,6 +127,11 @@ def AMDAIEDmaLoopSubsumption :
   Pass<"iree-amdaie-dma-loop-subsumption"> {
   let summary = "Subsume loop iterations into DMA operations' access patterns.";
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIEDmaLoopSubsumptionPass()";
+  let options = [
+    Option<"onlyZeroStrideOnOuterDim", "only-zero-stride-on-outer-dim", "bool", /*default=*/"true",
+      "Whether a stride of zero indicating a repeat is only supported on the "
+      "outer dimension. This is the case of AIE2(+).">
+  ];
 }
 
 def AMDAIEDmaToCircularDma :


### PR DESCRIPTION
Fixes an issue exposed by a 64x32x128 matmul: https://github.com/nod-ai/iree-amd-aie/issues/556.

As the hardware (AIE2(+)) doesn't support `stride == 0` with buffer descriptors, only a last repeat iteration can be achieved using the repeat count feature. This PR adjusts the DMA loop subsumption pass to optionally not perform any subsumption if this would be violated. For example, the following NPU DMA instruction is not supported on HW:

```
%1 = amdaie.npu.dma_cpy_nd %0([0, 0, %arg3] [8, 2, 16] [16, 0, 1], [] [] [])
```

due to `stride == 0` on the second (middle) dimension. However, the following is:

```
%1 = amdaie.npu.dma_cpy_nd %0([0, 0, %arg3] [2, 8, 16] [0, 16, 1], [] [] [])
```

but the outer repeat dimension needs to be moved to the first/most outer dimension for the AIE lowering passes. This is achieved with the logic added in `LowerToAIE`.
