### PR TITLE
[CanonicalizeDoublyStridedOp] Make single dims explicit by default and require this in LowerToAIE

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -771,6 +771,24 @@ run_matmul_test \
     --tile_pipeline "pack-peel" \
     --lhs_rhs_type "i32" \
     --acc_type "i32" \
+    --m "128" --k "32" --n "128" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "i32" \
+    --acc_type "i32" \
+    --m "256" --k "32" --n "256" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "i32" \
+    --acc_type "i32" \
     --m "128" --k "256" --n "128"
 
 run_matmul_test \

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeDoublyStridedOp.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeDoublyStridedOp.cpp
@@ -114,6 +114,9 @@ class AMDAIECanonicalizeDoublyStridedOpPass
   AMDAIECanonicalizeDoublyStridedOpPass() = default;
   AMDAIECanonicalizeDoublyStridedOpPass(
       const AMDAIECanonicalizeDoublyStridedOpPass &pass){};
+  AMDAIECanonicalizeDoublyStridedOpPass(
+      const AMDAIECanonicalizeDoublyStridedOpOptions &options)
+      : AMDAIECanonicalizeDoublyStridedOpBase(options) {}
   void runOnOperation() override;
 };
 
@@ -134,15 +137,17 @@ void AMDAIECanonicalizeDoublyStridedOpPass::runOnOperation() {
   });
 
   // Make DMA accesses with single dimension implicit.
-  parentOp->walk([&](AMDAIE::DoublyStridedOpInterface dmaOp) {
-    (void)foldDmaOpSingleDims(rewriter, dmaOp);
-  });
+  if (foldSingleDims) {
+    parentOp->walk([&](AMDAIE::DoublyStridedOpInterface dmaOp) {
+      (void)foldDmaOpSingleDims(rewriter, dmaOp);
+    });
+  }
 }
 
 }  // namespace
 
-std::unique_ptr<Pass> createAMDAIECanonicalizeDoublyStridedOpPass() {
-  return std::make_unique<AMDAIECanonicalizeDoublyStridedOpPass>();
+std::unique_ptr<Pass> createAMDAIECanonicalizeDoublyStridedOpPass(AMDAIECanonicalizeDoublyStridedOpOptions options) {
+  return std::make_unique<AMDAIECanonicalizeDoublyStridedOpPass>(options);
 }
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -72,7 +72,8 @@ std::unique_ptr<Pass> createAMDAIEBufferizeToAllocationPass(
 std::unique_ptr<Pass> createAMDAIECanonicalizeDmaPass();
 
 /// Create pass to canonicalize doubly strided operations.
-std::unique_ptr<Pass> createAMDAIECanonicalizeDoublyStridedOpPass();
+std::unique_ptr<Pass> createAMDAIECanonicalizeDoublyStridedOpPass(
+    AMDAIECanonicalizeDoublyStridedOpOptions options = {});
 
 /// Pass to unroll the loops within the control code regions.
 std::unique_ptr<Pass> createAMDAIEControlCodeLoopUnrollPass();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -71,6 +71,10 @@ def AMDAIECanonicalizeDoublyStridedOp :
     Pass<"iree-amdaie-canonicalize-doubly-strided-op", ""> {
   let summary = "Canonicalize doubly strided DMA operations.";
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIECanonicalizeDoublyStridedOpPass()";
+  let options = [
+    Option<"foldSingleDims", "fold-single-dims", "bool", /*default=*/"false",
+      "Whether to fold single strided dimensions and make then implicit.">
+  ];
 }
 
 def AMDAIECleanup :

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_doubly_strided_op.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_doubly_strided_op.mlir
@@ -1,13 +1,21 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-canonicalize-doubly-strided-op,canonicalize))" %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-canonicalize-doubly-strided-op{fold-single-dims=true},canonicalize))" %s | FileCheck %s --check-prefix=FOLD-SINGLE-DIMS
 
 // Verify that source and target of `amdaie.circular_dma_cpy_nd` is still correct after canonicalization.
 //
-// CHECK-LABEL: func.func @circular_dma_cpy_nd_source_target
-// CHECK-SAME:  %[[ARG0:.+]]: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
-// CHECK-SAME:  %[[ARG1:.+]]: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
-// CHECK:       amdaie.circular_dma_cpy_nd
-// CHECK-SAME:  %[[ARG0]]
-// CHECK-SAME:  %[[ARG1]]
+// CHECK-LABEL:             func.func @circular_dma_cpy_nd_source_target
+// CHECK-SAME:              %[[ARG0:.+]]: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+// CHECK-SAME:              %[[ARG1:.+]]: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+// CHECK-DAG:               %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:               %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:               %[[C64:.+]] = arith.constant 64 : index
+// CHECK-DAG:               %[[C128:.+]] = arith.constant 128 : index
+// CHECK:                   amdaie.circular_dma_cpy_nd(%[[ARG0]][%[[C0]]] [%[[C128]]] [%[[C1]]], %[[ARG1]][%[[C0]]] [%[[C64]]] [%[[C1]]])
+
+// FOLD-SINGLE-DIMS-LABEL:  func.func @circular_dma_cpy_nd_source_target
+// FOLD-SINGLE-DIMS-SAME:   %[[ARG0:.+]]: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+// FOLD-SINGLE-DIMS-SAME:   %[[ARG1:.+]]: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+// FOLD-SINGLE-DIMS:        amdaie.circular_dma_cpy_nd(%[[ARG0]][] [] [], %[[ARG1]][] [] [])
 func.func @circular_dma_cpy_nd_source_target(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[0, 0, 0, 0] [1, 4, 2, 8] [64, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   amdaie.logicalobjectfifo.consume(%0)
@@ -16,10 +24,13 @@ func.func @circular_dma_cpy_nd_source_target(%arg0: !amdaie.logicalobjectfifo<me
 
 // -----
 
-// CHECK-LABEL: func.func @circular_dma_cpy_nd_linear_implicit
-// CHECK:       amdaie.circular_dma_cpy_nd
-// CHECK-SAME:  [] [] []
-// CHECK-SAME:  [] [] []
+// CHECK-LABEL:       func.func @circular_dma_cpy_nd_linear_implicit
+// CHECK-DAG:         %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:         %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:         %[[C64:.+]] = arith.constant 64 : index
+// CHECK-DAG:         %[[C128:.+]] = arith.constant 128 : index
+// CHECK:             amdaie.circular_dma_cpy_nd(%{{.+}}[%[[C0]]] [%[[C128]]] [%[[C1]]], %{{.+}}[%[[C0]]] [%[[C64]]] [%[[C1]]])
+// FOLD-SINGLE-DIMS:  amdaie.circular_dma_cpy_nd(%{{.+}}[] [] [], %{{.+}}[] [] [])
 func.func @circular_dma_cpy_nd_linear_implicit(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[0, 0, 0, 0] [1, 4, 2, 8] [64, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   amdaie.logicalobjectfifo.consume(%0)
@@ -28,16 +39,21 @@ func.func @circular_dma_cpy_nd_linear_implicit(%arg0: !amdaie.logicalobjectfifo<
 
 // -----
 
-// CHECK-LABEL: func.func @circular_dma_cpy_nd_linear
-// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:   %[[C8:.+]] = arith.constant 8 : index
-// CHECK-DAG:   %[[C16:.+]] = arith.constant 16 : index
-// CHECK-DAG:   %[[C64:.+]] = arith.constant 64 : index
-// CHECK-DAG:   %[[C128:.+]] = arith.constant 128 : index
-// CHECK:       amdaie.circular_dma_cpy_nd
-// CHECK-SAME:  [%[[C0]], %[[C0]]] [%[[C16]], %[[C8]]] [%[[C16]], %[[C1]]]
-// CHECK-SAME:  [%[[C0]], %[[C0]], %[[C0]]] [%[[C64]], %[[C16]], %[[C128]]] [%[[C128]], %[[C16]], %[[C1]]]
+// CHECK-LABEL:           func.func @circular_dma_cpy_nd_linear
+// CHECK-DAG:             %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:             %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:             %[[C8:.+]] = arith.constant 8 : index
+// CHECK-DAG:             %[[C16:.+]] = arith.constant 16 : index
+// CHECK-DAG:             %[[C64:.+]] = arith.constant 64 : index
+// CHECK-DAG:             %[[C128:.+]] = arith.constant 128 : index
+// CHECK:                 amdaie.circular_dma_cpy_nd(%{{.+}}[%[[C0]], %[[C0]]] [%[[C16]], %[[C8]]] [%[[C16]], %[[C1]]], %{{.+}}[%[[C0]], %[[C0]], %[[C0]]] [%[[C64]], %[[C16]], %[[C128]]] [%[[C128]], %[[C16]], %[[C1]]])
+// FOLD-SINGLE-DIMS-DAG:  %[[C0:.+]] = arith.constant 0 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C1:.+]] = arith.constant 1 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C8:.+]] = arith.constant 8 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C16:.+]] = arith.constant 16 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C64:.+]] = arith.constant 64 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C128:.+]] = arith.constant 128 : index
+// FOLD-SINGLE-DIMS:      amdaie.circular_dma_cpy_nd(%{{.+}}[%[[C0]], %[[C0]]] [%[[C16]], %[[C8]]] [%[[C16]], %[[C1]]], %{{.+}}[%[[C0]], %[[C0]], %[[C0]]] [%[[C64]], %[[C16]], %[[C128]]] [%[[C128]], %[[C16]], %[[C1]]])
 func.func @circular_dma_cpy_nd_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %c16 = arith.constant 16 : index
   %0 = amdaie.circular_dma_cpy_nd(%arg0[0, 0, 0, 0] [1, 2, 8, 8] [256, 128, %c16, 1], %arg1[0, 0, 0, 0] [64, 16, 8, %c16] [128, %c16, %c16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
@@ -47,10 +63,9 @@ func.func @circular_dma_cpy_nd_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x
 
 // -----
 
-// CHECK-LABEL: func.func @circular_dma_cpy_nd_no_linear
-// CHECK:       amdaie.circular_dma_cpy_nd
-// CHECK-SAME:  [0, 0, 0, 0] [2, 2, 8, 8] [256, 64, 16, 1]
-// CHECK-SAME:  [0, 0, 0, 0] [2, 2, 8, 16] [128, 16, 8, 1]
+// CHECK-LABEL:       func.func @circular_dma_cpy_nd_no_linear
+// CHECK:             amdaie.circular_dma_cpy_nd(%{{.+}}[0, 0, 0, 0] [2, 2, 8, 8] [256, 64, 16, 1], %{{.+}}[0, 0, 0, 0] [2, 2, 8, 16] [128, 16, 8, 1])
+// FOLD-SINGLE-DIMS:  amdaie.circular_dma_cpy_nd(%{{.+}}[0, 0, 0, 0] [2, 2, 8, 8] [256, 64, 16, 1], %{{.+}}[0, 0, 0, 0] [2, 2, 8, 16] [128, 16, 8, 1])
 func.func @circular_dma_cpy_nd_no_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[0, 0, 0, 0] [2, 2, 8, 8] [256, 64, 16, 1], %arg1[0, 0, 0, 0] [2, 2, 8, 16] [128, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   amdaie.logicalobjectfifo.consume(%0)
@@ -59,15 +74,20 @@ func.func @circular_dma_cpy_nd_no_linear(%arg0: !amdaie.logicalobjectfifo<memref
 
 // -----
 
-// CHECK-LABEL: func.func @circular_dma_cpy_nd_unit
-// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
-// CHECK-DAG:   %[[C8:.+]] = arith.constant 8 : index
-// CHECK-DAG:   %[[C16:.+]] = arith.constant 16 : index
-// CHECK:       amdaie.circular_dma_cpy_nd
-// CHECK-SAME:  [] [] []
-// CHECK-SAME:  [%[[C0]], %[[C0]], %[[C0]]] [%[[C2]], %[[C8]], %[[C8]]] [%[[C8]], %[[C16]], %[[C1]]]
+// CHECK-LABEL:           func.func @circular_dma_cpy_nd_unit
+// CHECK-DAG:             %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:             %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:             %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG:             %[[C8:.+]] = arith.constant 8 : index
+// CHECK-DAG:             %[[C16:.+]] = arith.constant 16 : index
+// CHECK-DAG:             %[[C128:.+]] = arith.constant 128 : index
+// CHECK:                 amdaie.circular_dma_cpy_nd(%{{.+}}[%[[C0]]] [%[[C128]]] [%[[C1]]], %{{.+}}[%[[C0]], %[[C0]], %[[C0]]] [%[[C2]], %[[C8]], %[[C8]]] [%[[C8]], %[[C16]], %[[C1]]])
+// FOLD-SINGLE-DIMS-DAG:  %[[C0:.+]] = arith.constant 0 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C1:.+]] = arith.constant 1 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C2:.+]] = arith.constant 2 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C8:.+]] = arith.constant 8 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C16:.+]] = arith.constant 16 : index
+// FOLD-SINGLE-DIMS:      amdaie.circular_dma_cpy_nd(%{{.+}}[] [] [], %{{.+}}[%[[C0]], %[[C0]], %[[C0]]] [%[[C2]], %[[C8]], %[[C8]]] [%[[C8]], %[[C16]], %[[C1]]])
 func.func @circular_dma_cpy_nd_unit(%arg0: !amdaie.logicalobjectfifo<memref<1x1x2x2x4x8xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[0, 0, 0, 0, 0, 0] [1, 1, 2, 2, 4, 8] [128, 128, 64, 32, 8, 1], %arg1[0, 0, 0, 0, 0, 0] [1, 1, 2, 2, 4, 8] [128, 128, 8, 64, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x2x2x4x8xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>)
   amdaie.logicalobjectfifo.consume(%0)
@@ -76,10 +96,12 @@ func.func @circular_dma_cpy_nd_unit(%arg0: !amdaie.logicalobjectfifo<memref<1x1x
 
 // -----
 
-// CHECK-LABEL: func.func @circular_dma_cpy_nd_unit_between_linear
-// CHECK:       amdaie.circular_dma_cpy_nd
-// CHECK-SAME:  [] [] []
-// CHECK-SAME:  [] [] []
+// CHECK-LABEL:       func.func @circular_dma_cpy_nd_unit_between_linear
+// CHECK-DAG:         %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:         %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:         %[[C128:.+]] = arith.constant 128 : index
+// CHECK:             amdaie.circular_dma_cpy_nd(%{{.+}}[%[[C0]]] [%[[C128]]] [%[[C1]]], %{{.+}}[%[[C0]]] [%[[C128]]] [%[[C1]]])
+// FOLD-SINGLE-DIMS:  amdaie.circular_dma_cpy_nd(%{{.+}}[] [] [], %{{.+}}[] [] [])
 func.func @circular_dma_cpy_nd_unit_between_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x2x2x4x8xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[0, 0, 0, 0, 0, 0] [1, 2, 2, 4, 1, 8] [128, 64, 32, 8, 8, 1], %arg1[0, 0, 0, 0, 0, 0] [2, 2, 1, 4, 8, 1] [64, 32, 32, 8, 1, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x2x2x4x8xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>)
   amdaie.logicalobjectfifo.consume(%0)
@@ -88,10 +110,9 @@ func.func @circular_dma_cpy_nd_unit_between_linear(%arg0: !amdaie.logicalobjectf
 
 // -----
 
-// CHECK-LABEL: func.func @circular_dma_cpy_nd_non_zero_offset
-// CHECK:       amdaie.circular_dma_cpy_nd
-// CHECK-SAME:  [1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1]
-// CHECK-SAME:  [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1]
+// CHECK-LABEL:       func.func @circular_dma_cpy_nd_non_zero_offset
+// CHECK:             amdaie.circular_dma_cpy_nd(%{{.+}}[1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], %{{.+}}[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
+// FOLD-SINGLE-DIMS:  amdaie.circular_dma_cpy_nd(%{{.+}}[1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], %{{.+}}[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
 func.func @circular_dma_cpy_nd_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   amdaie.logicalobjectfifo.consume(%0)
@@ -100,13 +121,15 @@ func.func @circular_dma_cpy_nd_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<
 
 // -----
 
-// CHECK-LABEL: func.func @circular_dma_cpy_nd_partial_non_zero_offset
-// CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:   %[[C64:.+]] = arith.constant 64 : index
-// CHECK-DAG:   %[[C128:.+]] = arith.constant 128 : index
-// CHECK:       amdaie.circular_dma_cpy_nd
-// CHECK-SAME:  [%[[C1]]] [%[[C128]]] [%[[C1]]]
-// CHECK-SAME:  [%[[C1]]] [%[[C64]]] [%[[C1]]]
+// CHECK-LABEL:           func.func @circular_dma_cpy_nd_partial_non_zero_offset
+// CHECK-DAG:             %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:             %[[C64:.+]] = arith.constant 64 : index
+// CHECK-DAG:             %[[C128:.+]] = arith.constant 128 : index
+// CHECK:                 amdaie.circular_dma_cpy_nd(%{{.+}}[%[[C1]]] [%[[C128]]] [%[[C1]]], %{{.+}}[%[[C1]]] [%[[C64]]] [%[[C1]]])
+// FOLD-SINGLE-DIMS-DAG:  %[[C1:.+]] = arith.constant 1 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C64:.+]] = arith.constant 64 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C128:.+]] = arith.constant 128 : index
+// FOLD-SINGLE-DIMS:      amdaie.circular_dma_cpy_nd(%{{.+}}[%[[C1]]] [%[[C128]]] [%[[C1]]], %{{.+}}[%[[C1]]] [%[[C64]]] [%[[C1]]])
 func.func @circular_dma_cpy_nd_partial_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[0, 0, 0, 1] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[0, 0, 0, 1] [1, 4, 2, 8] [64, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   amdaie.logicalobjectfifo.consume(%0)
@@ -116,13 +139,20 @@ func.func @circular_dma_cpy_nd_partial_non_zero_offset(%arg0: !amdaie.logicalobj
 // -----
 
 // Verify that source and target of `amdaie.dma_cpy_nd` is still correct after canonicalization.
-//
-// CHECK-LABEL: func.func @dma_cpy_nd_source_target
-// CHECK-SAME:  %[[ARG0:.+]]: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
-// CHECK-SAME:  %[[ARG1:.+]]: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
-// CHECK:       amdaie.dma_cpy_nd
-// CHECK-SAME:  %[[ARG0]]
-// CHECK-SAME:  %[[ARG1]]
+
+// CHECK-LABEL:             func.func @dma_cpy_nd_source_target
+// CHECK-SAME:              %[[ARG0:.+]]: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+// CHECK-SAME:              %[[ARG1:.+]]: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+// CHECK-DAG:               %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:               %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:               %[[C64:.+]] = arith.constant 64 : index
+// CHECK-DAG:               %[[C128:.+]] = arith.constant 128 : index
+// CHECK:                   amdaie.dma_cpy_nd(%[[ARG0]][%[[C0]]] [%[[C128]]] [%[[C1]]], %[[ARG1]][%[[C0]]] [%[[C64]]] [%[[C1]]])
+
+// FOLD-SINGLE-DIMS-LABEL:  func.func @dma_cpy_nd_source_target
+// FOLD-SINGLE-DIMS-SAME:   %[[ARG0:.+]]: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+// FOLD-SINGLE-DIMS-SAME:   %[[ARG1:.+]]: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+// FOLD-SINGLE-DIMS:        amdaie.dma_cpy_nd(%[[ARG0]][] [] [], %[[ARG1]][] [] [])
 func.func @dma_cpy_nd_source_target(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.dma_cpy_nd(%arg0[0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[0, 0, 0, 0] [1, 4, 2, 8] [64, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   amdaie.logicalobjectfifo.consume(%0)
@@ -131,10 +161,13 @@ func.func @dma_cpy_nd_source_target(%arg0: !amdaie.logicalobjectfifo<memref<1x1x
 
 // -----
 
-// CHECK-LABEL: func.func @dma_cpy_nd_linear_implicit
-// CHECK:       amdaie.dma_cpy_nd
-// CHECK-SAME:  [] [] []
-// CHECK-SAME:  [] [] []
+// CHECK-LABEL:       func.func @dma_cpy_nd_linear_implicit
+// CHECK-DAG:         %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:         %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:         %[[C64:.+]] = arith.constant 64 : index
+// CHECK-DAG:         %[[C128:.+]] = arith.constant 128 : index
+// CHECK:             amdaie.dma_cpy_nd(%{{.+}}[%[[C0]]] [%[[C128]]] [%[[C1]]], %{{.+}}[%[[C0]]] [%[[C64]]] [%[[C1]]])
+// FOLD-SINGLE-DIMS:  amdaie.dma_cpy_nd(%{{.+}}[] [] [], %{{.+}}[] [] [])
 func.func @dma_cpy_nd_linear_implicit(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.dma_cpy_nd(%arg0[0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[0, 0, 0, 0] [1, 4, 2, 8] [64, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   amdaie.logicalobjectfifo.consume(%0)
@@ -143,16 +176,21 @@ func.func @dma_cpy_nd_linear_implicit(%arg0: !amdaie.logicalobjectfifo<memref<1x
 
 // -----
 
-// CHECK-LABEL: func.func @dma_cpy_nd_linear
-// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:   %[[C8:.+]] = arith.constant 8 : index
-// CHECK-DAG:   %[[C16:.+]] = arith.constant 16 : index
-// CHECK-DAG:   %[[C64:.+]] = arith.constant 64 : index
-// CHECK-DAG:   %[[C128:.+]] = arith.constant 128 : index
-// CHECK:       amdaie.dma_cpy_nd
-// CHECK-SAME:  [%[[C0]], %[[C0]]] [%[[C16]], %[[C8]]] [%[[C16]], %[[C1]]]
-// CHECK-SAME:  [%[[C0]], %[[C0]], %[[C0]]] [%[[C64]], %[[C16]], %[[C128]]] [%[[C128]], %[[C16]], %[[C1]]]
+// CHECK-LABEL:           func.func @dma_cpy_nd_linear
+// CHECK-DAG:             %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:             %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:             %[[C8:.+]] = arith.constant 8 : index
+// CHECK-DAG:             %[[C16:.+]] = arith.constant 16 : index
+// CHECK-DAG:             %[[C64:.+]] = arith.constant 64 : index
+// CHECK-DAG:             %[[C128:.+]] = arith.constant 128 : index
+// CHECK:                 amdaie.dma_cpy_nd(%{{.+}}[%[[C0]], %[[C0]]] [%[[C16]], %[[C8]]] [%[[C16]], %[[C1]]], %{{.+}}[%[[C0]], %[[C0]], %[[C0]]] [%[[C64]], %[[C16]], %[[C128]]] [%[[C128]], %[[C16]], %[[C1]]])
+// FOLD-SINGLE-DIMS-DAG:  %[[C0:.+]] = arith.constant 0 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C1:.+]] = arith.constant 1 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C8:.+]] = arith.constant 8 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C16:.+]] = arith.constant 16 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C64:.+]] = arith.constant 64 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C128:.+]] = arith.constant 128 : index
+// FOLD-SINGLE-DIMS:      amdaie.dma_cpy_nd(%{{.+}}[%[[C0]], %[[C0]]] [%[[C16]], %[[C8]]] [%[[C16]], %[[C1]]], %{{.+}}[%[[C0]], %[[C0]], %[[C0]]] [%[[C64]], %[[C16]], %[[C128]]] [%[[C128]], %[[C16]], %[[C1]]])
 func.func @dma_cpy_nd_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %c16 = arith.constant 16 : index
   %0 = amdaie.dma_cpy_nd(%arg0[0, 0, 0, 0] [1, 2, 8, 8] [256, 128, %c16, 1], %arg1[0, 0, 0, 0] [64, 16, 8, %c16] [128, %c16, %c16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
@@ -162,10 +200,9 @@ func.func @dma_cpy_nd_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi3
 
 // -----
 
-// CHECK-LABEL: func.func @dma_cpy_nd_no_linear
-// CHECK:       amdaie.dma_cpy_nd
-// CHECK-SAME:  [0, 0, 0, 0] [2, 2, 8, 8] [256, 64, 16, 1]
-// CHECK-SAME:  [0, 0, 0, 0] [2, 2, 8, 16] [128, 16, 8, 1]
+// CHECK-LABEL:       func.func @dma_cpy_nd_no_linear
+// CHECK:             amdaie.dma_cpy_nd(%{{.+}}[0, 0, 0, 0] [2, 2, 8, 8] [256, 64, 16, 1], %{{.+}}[0, 0, 0, 0] [2, 2, 8, 16] [128, 16, 8, 1])
+// FOLD-SINGLE-DIMS:  amdaie.dma_cpy_nd(%{{.+}}[0, 0, 0, 0] [2, 2, 8, 8] [256, 64, 16, 1], %{{.+}}[0, 0, 0, 0] [2, 2, 8, 16] [128, 16, 8, 1])
 func.func @dma_cpy_nd_no_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.dma_cpy_nd(%arg0[0, 0, 0, 0] [2, 2, 8, 8] [256, 64, 16, 1], %arg1[0, 0, 0, 0] [2, 2, 8, 16] [128, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   amdaie.logicalobjectfifo.consume(%0)
@@ -174,15 +211,20 @@ func.func @dma_cpy_nd_no_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16
 
 // -----
 
-// CHECK-LABEL: func.func @dma_cpy_nd_unit
-// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
-// CHECK-DAG:   %[[C8:.+]] = arith.constant 8 : index
-// CHECK-DAG:   %[[C16:.+]] = arith.constant 16 : index
-// CHECK:       amdaie.dma_cpy_nd
-// CHECK-SAME:  [] [] []
-// CHECK-SAME:  [%[[C0]], %[[C0]], %[[C0]]] [%[[C2]], %[[C8]], %[[C8]]] [%[[C8]], %[[C16]], %[[C1]]]
+// CHECK-LABEL:           func.func @dma_cpy_nd_unit
+// CHECK-DAG:             %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:             %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:             %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG:             %[[C8:.+]] = arith.constant 8 : index
+// CHECK-DAG:             %[[C16:.+]] = arith.constant 16 : index
+// CHECK-DAG:             %[[C128:.+]] = arith.constant 128 : index
+// CHECK:                 amdaie.dma_cpy_nd(%{{.+}}[%[[C0]]] [%[[C128]]] [%[[C1]]], %{{.+}}[%[[C0]], %[[C0]], %[[C0]]] [%[[C2]], %[[C8]], %[[C8]]] [%[[C8]], %[[C16]], %[[C1]]])
+// FOLD-SINGLE-DIMS-DAG:  %[[C0:.+]] = arith.constant 0 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C1:.+]] = arith.constant 1 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C2:.+]] = arith.constant 2 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C8:.+]] = arith.constant 8 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C16:.+]] = arith.constant 16 : index
+// FOLD-SINGLE-DIMS:      amdaie.dma_cpy_nd(%{{.+}}[] [] [], %{{.+}}[%[[C0]], %[[C0]], %[[C0]]] [%[[C2]], %[[C8]], %[[C8]]] [%[[C8]], %[[C16]], %[[C1]]])
 func.func @dma_cpy_nd_unit(%arg0: !amdaie.logicalobjectfifo<memref<1x1x2x2x4x8xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>) {
   %0 = amdaie.dma_cpy_nd(%arg0[0, 0, 0, 0, 0, 0] [1, 1, 2, 2, 4, 8] [128, 128, 64, 32, 8, 1], %arg1[0, 0, 0, 0, 0, 0] [1, 1, 2, 2, 4, 8] [128, 128, 8, 64, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x2x2x4x8xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>)
   amdaie.logicalobjectfifo.consume(%0)
@@ -191,10 +233,12 @@ func.func @dma_cpy_nd_unit(%arg0: !amdaie.logicalobjectfifo<memref<1x1x2x2x4x8xi
 
 // -----
 
-// CHECK-LABEL: func.func @dma_cpy_nd_unit_between_linear
-// CHECK:       amdaie.dma_cpy_nd
-// CHECK-SAME:  [] [] []
-// CHECK-SAME:  [] [] []
+// CHECK-LABEL:       func.func @dma_cpy_nd_unit_between_linear
+// CHECK-DAG:         %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:         %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:         %[[C128:.+]] = arith.constant 128 : index
+// CHECK:             amdaie.dma_cpy_nd(%{{.+}}[%[[C0]]] [%[[C128]]] [%[[C1]]], %{{.+}}[%[[C0]]] [%[[C128]]] [%[[C1]]])
+// FOLD-SINGLE-DIMS:  amdaie.dma_cpy_nd(%{{.+}}[] [] [], %{{.+}}[] [] [])
 func.func @dma_cpy_nd_unit_between_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x2x2x4x8xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>) {
   %0 = amdaie.dma_cpy_nd(%arg0[0, 0, 0, 0, 0, 0] [2, 2, 1, 1, 4, 8] [64, 32, 32, 32, 8, 1], %arg1[0, 0, 0, 0, 0, 0] [2, 1, 2, 1, 4, 8] [64, 64, 32, 32, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x2x2x4x8xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>)
   amdaie.logicalobjectfifo.consume(%0)
@@ -203,10 +247,9 @@ func.func @dma_cpy_nd_unit_between_linear(%arg0: !amdaie.logicalobjectfifo<memre
 
 // -----
 
-// CHECK-LABEL: func.func @dma_cpy_nd_non_zero_offset
-// CHECK:       amdaie.dma_cpy_nd
-// CHECK-SAME:  [1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1]
-// CHECK-SAME:  [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1]
+// CHECK-LABEL:       func.func @dma_cpy_nd_non_zero_offset
+// CHECK:             amdaie.dma_cpy_nd(%{{.+}}[1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], %{{.+}}[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
+// FOLD-SINGLE-DIMS:  amdaie.dma_cpy_nd(%{{.+}}[1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], %{{.+}}[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
 func.func @dma_cpy_nd_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.dma_cpy_nd(%arg0[1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   amdaie.logicalobjectfifo.consume(%0)
@@ -215,13 +258,15 @@ func.func @dma_cpy_nd_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x
 
 // -----
 
-// CHECK-LABEL: func.func @dma_cpy_nd_partial_non_zero_offset
-// CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:   %[[C64:.+]] = arith.constant 64 : index
-// CHECK-DAG:   %[[C128:.+]] = arith.constant 128 : index
-// CHECK:       amdaie.dma_cpy_nd
-// CHECK-SAME:  [%[[C1]]] [%[[C128]]] [%[[C1]]]
-// CHECK-SAME:  [%[[C1]]] [%[[C64]]] [%[[C1]]]
+// CHECK-LABEL:           func.func @dma_cpy_nd_partial_non_zero_offset
+// CHECK-DAG:             %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:             %[[C64:.+]] = arith.constant 64 : index
+// CHECK-DAG:             %[[C128:.+]] = arith.constant 128 : index
+// CHECK:                 amdaie.dma_cpy_nd(%{{.+}}[%[[C1]]] [%[[C128]]] [%[[C1]]], %{{.+}}[%[[C1]]] [%[[C64]]] [%[[C1]]])
+// FOLD-SINGLE-DIMS-DAG:  %[[C1:.+]] = arith.constant 1 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C64:.+]] = arith.constant 64 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C128:.+]] = arith.constant 128 : index
+// FOLD-SINGLE-DIMS:      amdaie.dma_cpy_nd(%{{.+}}[%[[C1]]] [%[[C128]]] [%[[C1]]], %{{.+}}[%[[C1]]] [%[[C64]]] [%[[C1]]])
 func.func @dma_cpy_nd_partial_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.dma_cpy_nd(%arg0[0, 0, 0, 1] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[0, 0, 0, 1] [1, 4, 2, 8] [64, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   amdaie.logicalobjectfifo.consume(%0)
@@ -231,13 +276,22 @@ func.func @dma_cpy_nd_partial_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<m
 // -----
 
 // Verify that the input DMA of `amdaie.npu.dma_cpy_nd` is still correct after canonicalization.
-//
-// CHECK-LABEL: func.func @npu_dma_cpy_nd_source
-// CHECK-SAME:  %[[ARG0:.+]]: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
-// CHECK-SAME:  %[[ARG1:.+]]: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
-// CHECK:       %[[DMA0:.+]] = amdaie.circular_dma_cpy_nd
-// CHECK:       amdaie.npu.dma_cpy_nd
-// CHECK-SAME:  %[[DMA0]]
+
+// CHECK-LABEL:             func.func @npu_dma_cpy_nd_source
+// CHECK-SAME:              %[[ARG0:.+]]: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+// CHECK-SAME:              %[[ARG1:.+]]: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+// CHECK-DAG:               %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:               %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:               %[[C64:.+]] = arith.constant 64 : index
+// CHECK-DAG:               %[[C128:.+]] = arith.constant 128 : index
+// CHECK:                   %[[DMA0:.+]] = amdaie.circular_dma_cpy_nd(%[[ARG0]][] [] [], %[[ARG1]][] [] [])
+// CHECK:                   amdaie.npu.dma_cpy_nd %[[DMA0]]([%[[C0]]] [%[[C128]]] [%[[C1]]], [%[[C0]]] [%[[C64]]] [%[[C1]]])
+
+// FOLD-SINGLE-DIMS-LABEL:  func.func @npu_dma_cpy_nd_source
+// FOLD-SINGLE-DIMS-SAME:   %[[ARG0:.+]]: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+// FOLD-SINGLE-DIMS-SAME:   %[[ARG1:.+]]: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+// FOLD-SINGLE-DIMS:        %[[DMA0:.+]] = amdaie.circular_dma_cpy_nd(%[[ARG0]][] [] [], %[[ARG1]][] [] [])
+// FOLD-SINGLE-DIMS:        amdaie.npu.dma_cpy_nd %[[DMA0]]([] [] [], [] [] [])
 func.func @npu_dma_cpy_nd_source(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 4, 2, 8] [64, 16, 8, 1])
@@ -246,10 +300,13 @@ func.func @npu_dma_cpy_nd_source(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x1
 
 // -----
 
-// CHECK-LABEL: func.func @npu_dma_cpy_nd_linear_implicit
-// CHECK:       amdaie.npu.dma_cpy_nd
-// CHECK-SAME:  [] [] []
-// CHECK-SAME:  [] [] []
+// CHECK-LABEL:       func.func @npu_dma_cpy_nd_linear_implicit
+// CHECK-DAG:         %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:         %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:         %[[C64:.+]] = arith.constant 64 : index
+// CHECK-DAG:         %[[C128:.+]] = arith.constant 128 : index
+// CHECK:             amdaie.npu.dma_cpy_nd %{{.+}}([%[[C0]]] [%[[C128]]] [%[[C1]]], [%[[C0]]] [%[[C64]]] [%[[C1]]])
+// FOLD-SINGLE-DIMS:  amdaie.npu.dma_cpy_nd %{{.+}}([] [] [], [] [] [])
 func.func @npu_dma_cpy_nd_linear_implicit(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 4, 2, 8] [64, 16, 8, 1])
@@ -258,16 +315,21 @@ func.func @npu_dma_cpy_nd_linear_implicit(%arg0: !amdaie.logicalobjectfifo<memre
 
 // -----
 
-// CHECK-LABEL: func.func @npu_dma_cpy_nd_linear
-// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:   %[[C8:.+]] = arith.constant 8 : index
-// CHECK-DAG:   %[[C16:.+]] = arith.constant 16 : index
-// CHECK-DAG:   %[[C64:.+]] = arith.constant 64 : index
-// CHECK-DAG:   %[[C128:.+]] = arith.constant 128 : index
-// CHECK:       amdaie.npu.dma_cpy_nd
-// CHECK-SAME:  [%[[C0]], %[[C0]]] [%[[C16]], %[[C8]]] [%[[C16]], %[[C1]]]
-// CHECK-SAME:  [%[[C0]], %[[C0]], %[[C0]]] [%[[C64]], %[[C16]], %[[C128]]] [%[[C128]], %[[C16]], %[[C1]]]
+// CHECK-LABEL:           func.func @npu_dma_cpy_nd_linear
+// CHECK-DAG:             %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:             %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:             %[[C8:.+]] = arith.constant 8 : index
+// CHECK-DAG:             %[[C16:.+]] = arith.constant 16 : index
+// CHECK-DAG:             %[[C64:.+]] = arith.constant 64 : index
+// CHECK-DAG:             %[[C128:.+]] = arith.constant 128 : index
+// CHECK:                 amdaie.npu.dma_cpy_nd %{{.+}}([%[[C0]], %[[C0]]] [%[[C16]], %[[C8]]] [%[[C16]], %[[C1]]], [%[[C0]], %[[C0]], %[[C0]]] [%[[C64]], %[[C16]], %[[C128]]] [%[[C128]], %[[C16]], %[[C1]]])
+// FOLD-SINGLE-DIMS-DAG:  %[[C0:.+]] = arith.constant 0 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C1:.+]] = arith.constant 1 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C8:.+]] = arith.constant 8 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C16:.+]] = arith.constant 16 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C64:.+]] = arith.constant 64 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C128:.+]] = arith.constant 128 : index
+// FOLD-SINGLE-DIMS:      amdaie.npu.dma_cpy_nd %{{.+}}([%[[C0]], %[[C0]]] [%[[C16]], %[[C8]]] [%[[C16]], %[[C1]]], [%[[C0]], %[[C0]], %[[C0]]] [%[[C64]], %[[C16]], %[[C128]]] [%[[C128]], %[[C16]], %[[C1]]])
 func.func @npu_dma_cpy_nd_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %c16 = arith.constant 16 : index
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
@@ -277,10 +339,9 @@ func.func @npu_dma_cpy_nd_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x1
 
 // -----
 
-// CHECK-LABEL: func.func @npu_dma_cpy_nd_no_linear
-// CHECK:       amdaie.npu.dma_cpy_nd
-// CHECK-SAME:  [0, 0, 0, 0] [2, 2, 8, 8] [256, 64, 16, 1]
-// CHECK-SAME:  [0, 0, 0, 0] [2, 2, 8, 16] [128, 16, 8, 1]
+// CHECK-LABEL:       func.func @npu_dma_cpy_nd_no_linear
+// CHECK:             amdaie.npu.dma_cpy_nd %{{.+}}([0, 0, 0, 0] [2, 2, 8, 8] [256, 64, 16, 1], [0, 0, 0, 0] [2, 2, 8, 16] [128, 16, 8, 1])
+// FOLD-SINGLE-DIMS:  amdaie.npu.dma_cpy_nd %{{.+}}([0, 0, 0, 0] [2, 2, 8, 8] [256, 64, 16, 1], [0, 0, 0, 0] [2, 2, 8, 16] [128, 16, 8, 1])
 func.func @npu_dma_cpy_nd_no_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [2, 2, 8, 8] [256, 64, 16, 1], [0, 0, 0, 0] [2, 2, 8, 16] [128, 16, 8, 1])
@@ -289,15 +350,20 @@ func.func @npu_dma_cpy_nd_no_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x
 
 // -----
 
-// CHECK-LABEL: func.func @npu_dma_cpy_nd_unit
-// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
-// CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
-// CHECK-DAG:   %[[C8:.+]] = arith.constant 8 : index
-// CHECK-DAG:   %[[C16:.+]] = arith.constant 16 : index
-// CHECK:       amdaie.npu.dma_cpy_nd
-// CHECK-SAME:  [] [] []
-// CHECK-SAME:  [%[[C0]], %[[C0]], %[[C0]]] [%[[C2]], %[[C8]], %[[C8]]] [%[[C8]], %[[C16]], %[[C1]]]
+// CHECK-LABEL:           func.func @npu_dma_cpy_nd_unit
+// CHECK-DAG:             %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:             %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:             %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG:             %[[C8:.+]] = arith.constant 8 : index
+// CHECK-DAG:             %[[C16:.+]] = arith.constant 16 : index
+// CHECK-DAG:             %[[C128:.+]] = arith.constant 128 : index
+// CHECK:                 amdaie.npu.dma_cpy_nd %{{.+}}([%[[C0]]] [%[[C128]]] [%[[C1]]], [%[[C0]], %[[C0]], %[[C0]]] [%[[C2]], %[[C8]], %[[C8]]] [%[[C8]], %[[C16]], %[[C1]]])
+// FOLD-SINGLE-DIMS-DAG:  %[[C0:.+]] = arith.constant 0 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C1:.+]] = arith.constant 1 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C2:.+]] = arith.constant 2 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C8:.+]] = arith.constant 8 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C16:.+]] = arith.constant 16 : index
+// FOLD-SINGLE-DIMS:      amdaie.npu.dma_cpy_nd %{{.+}}([] [] [], [%[[C0]], %[[C0]], %[[C0]]] [%[[C2]], %[[C8]], %[[C8]]] [%[[C8]], %[[C16]], %[[C1]]])
 func.func @npu_dma_cpy_nd_unit(%arg0: !amdaie.logicalobjectfifo<memref<1x1x2x2x4x8xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x2x2x4x8xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>)
   %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0, 0, 0] [1, 1, 2, 2, 4, 8] [128, 128, 64, 32, 8, 1], [0, 0, 0, 0, 0, 0] [1, 1, 2, 2, 4, 8] [128, 128, 8, 64, 16, 1])
@@ -306,10 +372,13 @@ func.func @npu_dma_cpy_nd_unit(%arg0: !amdaie.logicalobjectfifo<memref<1x1x2x2x4
 
 // -----
 
-// CHECK-LABEL: func.func @npu_dma_cpy_nd_unit_between_linear
-// CHECK:       amdaie.npu.dma_cpy_nd
-// CHECK-SAME:  [] [] []
-// CHECK-SAME:  [] [] []
+// CHECK-LABEL:       func.func @npu_dma_cpy_nd_unit_between_linear
+// CHECK-DAG:         %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:         %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:         %[[C128:.+]] = arith.constant 128 : index
+// CHECK-DAG:         %[[C8192:.+]] = arith.constant 8192 : index
+// CHECK:             amdaie.npu.dma_cpy_nd %{{.+}}([%[[C0]]] [%[[C8192]]] [%[[C1]]], [%[[C0]]] [%[[C128]]] [%[[C1]]])
+// FOLD-SINGLE-DIMS:  amdaie.npu.dma_cpy_nd %{{.+}}([] [] [], [] [] [])
 func.func @npu_dma_cpy_nd_unit_between_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [2, 1, 64, 64] [4096, 64, 64, 1], [0, 0, 0, 0] [2, 1, 1, 64] [64, 64, 64, 1])
@@ -318,10 +387,9 @@ func.func @npu_dma_cpy_nd_unit_between_linear(%arg0: !amdaie.logicalobjectfifo<m
 
 // -----
 
-// CHECK-LABEL: func.func @npu_dma_cpy_nd_non_zero_offset
-// CHECK:       amdaie.npu.dma_cpy_nd
-// CHECK-SAME:  [1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1]
-// CHECK-SAME:  [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1]
+// CHECK-LABEL:       func.func @npu_dma_cpy_nd_non_zero_offset
+// CHECK:             amdaie.npu.dma_cpy_nd %{{.+}}([1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
+// FOLD-SINGLE-DIMS:  amdaie.npu.dma_cpy_nd %{{.+}}([1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
 func.func @npu_dma_cpy_nd_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   %1 = amdaie.npu.dma_cpy_nd %0([1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
@@ -330,13 +398,15 @@ func.func @npu_dma_cpy_nd_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memre
 
 // -----
 
-// CHECK-LABEL: func.func @npu_dma_cpy_nd_partial_non_zero_offset
-// CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-// CHECK-DAG:   %[[C64:.+]] = arith.constant 64 : index
-// CHECK-DAG:   %[[C128:.+]] = arith.constant 128 : index
-// CHECK:       amdaie.npu.dma_cpy_nd
-// CHECK-SAME:  [%[[C1]]] [%[[C128]]] [%[[C1]]]
-// CHECK-SAME:  [%[[C1]]] [%[[C64]]] [%[[C1]]]
+// CHECK-LABEL:           func.func @npu_dma_cpy_nd_partial_non_zero_offset
+// CHECK-DAG:             %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:             %[[C64:.+]] = arith.constant 64 : index
+// CHECK-DAG:             %[[C128:.+]] = arith.constant 128 : index
+// CHECK:                 amdaie.npu.dma_cpy_nd %{{.+}}([%[[C1]]] [%[[C128]]] [%[[C1]]], [%[[C1]]] [%[[C64]]] [%[[C1]]])
+// FOLD-SINGLE-DIMS-DAG:  %[[C1:.+]] = arith.constant 1 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C64:.+]] = arith.constant 64 : index
+// FOLD-SINGLE-DIMS-DAG:  %[[C128:.+]] = arith.constant 128 : index
+// FOLD-SINGLE-DIMS:      amdaie.npu.dma_cpy_nd %{{.+}}([%[[C1]]] [%[[C128]]] [%[[C1]]], [%[[C1]]] [%[[C64]]] [%[[C1]]])
 func.func @npu_dma_cpy_nd_partial_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 1] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 1] [1, 4, 2, 8] [64, 16, 8, 1])


### PR DESCRIPTION
Fixes incorrect results issues exposed by a 128x32x128 and 256x32x256 matmuls: https://github.com/nod-ai/iree-amd-aie/issues/556.

NPU DMA operations with implicit addressing on L3 side behave incorrectly on some cases and while the correct strides and sizes can be derived from other places, this is quite indirect and easily leads to bugs. For example, in the following case it can be derived from the input `%circ_dma` that the explicit source access pattern is `[0] [1024] [1]` or `[0, 0] [32, 32] [32, 1]` by inspecting at the **target** side of that operation:

```
%circ_dma = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<32x32xi32, 1>>, !amdaie.logicalobjectfifo<memref<1024x1024xi32>>)
...
%npu_dma = amdaie.npu.dma_cpy_nd %circ_dma ([] [] [], [] [] [] bd_id = %bd_id_0)
```

However, it would be more clear and simple to just keep the access patterns explicit (when there is one) like this:

```
%circ_dma = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<32x32xi32, 1>>, !amdaie.logicalobjectfifo<memref<1024x1024xi32>>)
...
%npu_dma = amdaie.npu.dma_cpy_nd %circ_dma ([] [] [], [0] [1024] [1] bd_id = %bd_id_0)
```


