### PR TITLE
Support chess and peano crt

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -140,19 +140,6 @@ source $XRT_DIR/setup.sh
 export XRT_HACK_UNSECURE_LOADING_XCLBIN=1
 
 MM_KERNEL_URL=https://github.com/nod-ai/iree-amd-aie/releases/download/ukernels/mm.o
-ME_BASIC_URL=https://github.com/nod-ai/iree-amd-aie/releases/download/ukernels/me_basic.o
-
-if [ -d "$PEANO" ]; then
-  PEANO_ME_BASIC_FP="$PEANO/lib/aie2-none-unknown-elf/me_basic.o"
-  if [ -f "$PEANO_ME_BASIC_FP" ]; then
-    echo "File 'me_basic.o' already exists at $PEANO_ME_BASIC_FP"
-  else
-    echo "Downloading 'me_basic.o' to $PEANO_ME_BASIC_FP"
-    wget $ME_BASIC_URL -O "$PEANO_ME_BASIC_FP"
-  fi
-else
-  echo "Peano install not found at $PEANO; not downloading me_basic."
-fi
 
 # The flag '--iree-amdaie-path-to-ukernels' currently does not work,
 # see for example https://github.com/nod-ai/iree-amd-aie/issues/340.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AMDAIETargetBCF.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AMDAIETargetBCF.cpp
@@ -119,6 +119,8 @@ LogicalResult AIETranslateToBCF(ModuleOp module, raw_ostream &output,
       if (tile.getCoreOp() && tile.getCoreOp().getLinkWith())
         output << "_include _file "
                << tile.getCoreOp().getLinkWith().value().str() << "\n";
+      // chess's libc expects a _main not a main (despite what me_basic.c looks
+      // like...)
       output << "_resolve _main core_" << tile.getCol() << "_" << tile.getRow()
              << "\n";
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AMDAIETargetLdScript.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AMDAIETargetLdScript.cpp
@@ -158,7 +158,7 @@ SECTIONS
         if (auto fileAttr = coreOp.getLinkWith())
           output << "INPUT(" << fileAttr.value().str() << ")\n";
 
-        output << "PROVIDE(_main = core_" << tile.getCol() << "_"
+        output << "PROVIDE(main = core_" << tile.getCol() << "_"
                << tile.getRow() << ");\n";
       }
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
@@ -83,7 +83,7 @@ void applyConfigToPassManager(PassManager &pm, bool printIRBeforeAll,
 }
 }  // namespace
 
-FailureOr<std::string> findVitis(std::optional<std::string> &vitisDir) {
+FailureOr<Path> findVitis(std::optional<Path> &vitisDir) {
   if (!vitisDir) {
     const char *envVitis = ::getenv("VITIS");
     if (!envVitis) {
@@ -102,82 +102,65 @@ FailureOr<std::string> findVitis(std::optional<std::string> &vitisDir) {
   if (!vitisDir) {
     llvm::errs() << "ERROR: couldn't find vitis directory\n";
     return failure();
-  };
+  }
 
-  SmallString<64> aieToolsPath(*vitisDir);
-  sys::path::append(aieToolsPath, "aietools");
-  if (!sys::fs::exists(aieToolsPath)) {
+  Path aieToolsPath = *vitisDir / "aietools";
+  if (!std::filesystem::exists(aieToolsPath)) {
     llvm::errs() << "ERROR: couldn't find aietools directory\n";
     return failure();
   }
 
-  SmallString<64> chessccPath(aieToolsPath);
-  sys::path::append(chessccPath, "tps", "lnx64", "target_aie_ml");
-  sys::path::append(chessccPath, "bin", "LNa64bin");
+  Path chessccPath =
+      aieToolsPath / "tps" / "lnx64" / "target_aie_ml" / "bin" / "LNa64bin";
 
-  SmallString<64> path(::getenv("PATH"));
-  ::setenv(
-      "PATH",
-      (chessccPath + std::string{sys::EnvPathSeparator} + path).str().c_str(),
-      1);
+  Path path(::getenv("PATH"));
+  ::setenv("PATH",
+           (chessccPath.string() + std::string{sys::EnvPathSeparator} +
+            path.string())
+               .c_str(),
+           1);
 
-  SmallString<64> chessClangExe(chessccPath);
-  sys::path::append(chessClangExe, "chess-clang");
-  SmallString<64> chessLLVMLinkExe(chessccPath);
-  sys::path::append(chessLLVMLinkExe, "chess-llvm-link");
-  if (!sys::fs::exists(chessClangExe)) {
+  if (!std::filesystem::exists(chessccPath / "chess-clang")) {
     llvm::errs() << "ERROR: couldn't find chess-clang\n";
     return failure();
   }
-  if (!sys::fs::exists(chessLLVMLinkExe)) {
+  if (!std::filesystem::exists(chessccPath / "chess-llvm-link")) {
     llvm::errs() << "ERROR: couldn't find chess-llvm-link\n";
     return failure();
   }
 
-  SmallString<64> lnx64o(aieToolsPath);
-  sys::path::append(lnx64o, "lib", "lnx64.o");
-  SmallString<64> dotLib(aieToolsPath);
-  sys::path::append(dotLib, "lnx64", "tools", "dot", "lib");
-  SmallString<64> ldLibraryPath(::getenv("LD_LIBRARY_PATH"));
-  ::setenv("LD_LIBRARY_PATH",
-           (lnx64o + std::string{sys::EnvPathSeparator} + dotLib +
-            std::string{sys::EnvPathSeparator} + ldLibraryPath)
-               .str()
-               .c_str(),
-           1);
+  Path lnx64o = aieToolsPath / "lib" / "lnx64.o";
+  Path dotLib = aieToolsPath / "lnx64" / "tools" / "dot" / "lib";
+  Path ldLibraryPath(::getenv("LD_LIBRARY_PATH"));
+  ::setenv(
+      "LD_LIBRARY_PATH",
+      (lnx64o.string() + std::string{sys::EnvPathSeparator} + dotLib.string() +
+       std::string{sys::EnvPathSeparator} + ldLibraryPath.string())
+          .c_str(),
+      1);
 
-  SmallString<64> rdiDataDir(aieToolsPath);
-  sys::path::append(rdiDataDir, "data");
-  ::setenv("RDI_DATADIR", rdiDataDir.c_str(), 1);
+  ::setenv("RDI_DATADIR", (aieToolsPath / "data").c_str(), 1);
 
   return *vitisDir;
 }
 
-std::pair<std::string, std::vector<std::string>> makeChessArgs(
-    const std::string &vitisDir, const std::string &tempDir, bool verbose) {
-  SmallString<64> aieToolsDir(vitisDir);
-  sys::path::append(aieToolsDir, "aietools");
-  SmallString<64> chessworkDir(tempDir);
-  sys::path::append(chessworkDir, "chesswork");
-  SmallString<64> xChessCCExe(aieToolsDir);
-  sys::path::append(xChessCCExe, "bin", "unwrapped", "lnx64.o", "xchesscc");
-
-  SmallString<64> procModelLib(aieToolsDir);
-  sys::path::append(procModelLib, "data", "aie_ml", "lib");
-
+std::pair<std::string, std::vector<std::string>> makeChessArgs(Path &vitisDir,
+                                                               Path &tempDir,
+                                                               bool verbose) {
+  Path aieToolsDir = vitisDir / "aietools";
   std::vector<std::string> flags{
       // -j <threads> : parallel compilation (function + file level)
       "-j4",
       // -p <name> : processor
       "-pme",
       // -P <dir> : processor model directory
-      "-P" + procModelLib.str().str(),
+      "-P" + (aieToolsDir / "data" / "aie_ml" / "lib").string(),
       // -f : use LLVM frontend (chess-clang)
       "-f",
       // -C <cfg> : configuration (for chess-clang)
       "-CRelease_LLVM",
       // +w <dir> : work directory
-      "+w" + tempDir,
+      "+w" + tempDir.string(),
       // for adf headers
       "-D__AIENGINE__",
       // for aie_api headers
@@ -185,7 +168,7 @@ std::pair<std::string, std::vector<std::string>> makeChessArgs(
   };
   // disassemble output
   if (verbose) flags.emplace_back("-d");
-  return {xChessCCExe.str().str(), flags};
+  return {aieToolsDir / "bin" / "unwrapped" / "lnx64.o" / "xchesscc", flags};
 }
 
 std::optional<std::string> dumpStrToDisk(const std::string &payload,
@@ -226,8 +209,8 @@ static std::string getUUIDString() {
 //  -- the output of running the tool, if run without failure, or
 //  -- an empty optional, if the tool fails to run.
 static std::optional<std::string> runTool(
-    StringRef program, ArrayRef<std::string> args, bool verbose,
-    std::optional<ArrayRef<StringRef>> env = std::nullopt) {
+    const std::string &program, const std::vector<std::string> &args,
+    bool verbose, std::optional<ArrayRef<StringRef>> env = std::nullopt) {
   if (verbose) {
     llvm::outs() << "Run: ";
     if (env)
@@ -238,7 +221,7 @@ static std::optional<std::string> runTool(
   }
 
   // Check that 'program' is a valid path, if not, fail immediately.
-  if (!sys::fs::exists(program)) {
+  if (!std::filesystem::exists(program)) {
     llvm::errs() << "Program " << program << " does not exist\n";
     return {};
   }
@@ -267,9 +250,9 @@ static std::optional<std::string> runTool(
       std::string(temporaryPath.begin(), temporaryPath.size());
   StringRef temporaryPathRef(temporaryPathStr);
   auto tp = std::optional<StringRef>(temporaryPathRef);
-  int result =
-      sys::ExecuteAndWait(program, pArgs, env, /* redirects */ {tp, tp, tp}, 0,
-                          0, &errMsg, nullptr, &optStats);
+  int result = sys::ExecuteAndWait(program, pArgs, env,
+                                   /* redirects */ {tp, tp, tp}, 0, 0, &errMsg,
+                                   nullptr, &optStats);
 
   auto maybeOutputFromFile = [&]() -> std::optional<std::string> {
     std::ifstream t(temporaryPathRef.str());
@@ -310,8 +293,8 @@ static std::optional<std::string> runTool(
 
 static LogicalResult assembleFileUsingChess(
     const std::string &inputFile, const std::string &outputFile,
-    const std::vector<std::string> &extraArgs, const std::string &tempDir,
-    const std::string &vitisDir, bool verbose) {
+    const std::vector<std::string> &extraArgs, Path &tempDir, Path &vitisDir,
+    bool verbose) {
   auto [xChessCCExe, args] = makeChessArgs(vitisDir, tempDir, verbose);
   args.reserve(args.size() + std::distance(extraArgs.begin(), extraArgs.end()));
   args.insert(args.end(), extraArgs.begin(), extraArgs.end());
@@ -326,13 +309,11 @@ static LogicalResult assembleFileUsingChess(
   return success();
 }
 
-bool buildCRT(const std::string &peanoDir, bool verbose) {
+bool buildCRT(Path &peanoDir, bool verbose) {
   if (verbose)
     llvm::outs() << "Checking if we should use me_basic, based on "
                     "the version of peano\n";
-  SmallString<64> peanoOptBin(peanoDir);
-  sys::path::append(peanoOptBin, "bin", "opt");
-  auto maybeVersion = runTool(peanoOptBin, {"--version"}, verbose);
+  auto maybeVersion = runTool(peanoDir / "bin" / "opt", {"--version"}, verbose);
   // default to "yes do use"
   if (!maybeVersion) return true;
   const auto &version = maybeVersion.value();
@@ -342,21 +323,19 @@ bool buildCRT(const std::string &peanoDir, bool verbose) {
 
 static LogicalResult assembleFileUsingPeano(
     const std::string &inputFile, const std::string &outputFile,
-    const std::vector<std::string> &extraArgs, const std::string &_tempDir,
-    const std::string &peanoDir, bool verbose) {
-  SmallString<64> peanoClangExe(peanoDir);
-  sys::path::append(peanoClangExe, "bin", "clang");
-
-  SmallVector<std::string, 10> args;
+    const std::vector<std::string> &extraArgs, Path &_tempDir, Path &peanoDir,
+    bool verbose) {
+  std::vector<std::string> args;
   args.reserve(args.size() + std::distance(extraArgs.begin(), extraArgs.end()));
   args.insert(args.end(), extraArgs.begin(), extraArgs.end());
   args.push_back("-O2");
+  // TODO(max): pipe target arch in somehow
   args.push_back("--target=aie2-none-elf");
   args.push_back("-c");
   args.emplace_back(inputFile);
   args.push_back("-o");
   args.emplace_back(outputFile);
-  if (!runTool(peanoClangExe, args, verbose)) {
+  if (!runTool(peanoDir / "bin" / "clang", args, verbose)) {
     llvm::errs() << "Failed to assemble " << outputFile << ".o with peano";
     return failure();
   }
@@ -370,31 +349,28 @@ using FileAssemblerT = std::function<decltype(assembleFileUsingPeano)>;
 static FailureOr<std::string> assembleStringUsing(
     const FileAssemblerT &assembler, const std::string &inputFileStr,
     const std::string &inputFileName, const std::string &outputFileName,
-    const std::string &outputDir, const std::vector<std::string> &extraArgs,
-    const std::string &workDir, const std::string &toolDir,
-    bool verbose = false) {
-  SmallString<64> inputFile(workDir);
-  sys::path::append(inputFile, inputFileName);
-  if (auto maybeErr = dumpStrToDisk(inputFileStr, inputFile.str().str());
+    Path &outputDir, const std::vector<std::string> &extraArgs, Path &workDir,
+    Path &toolDir, bool verbose = false) {
+  Path inputFile = workDir / inputFileName;
+  if (auto maybeErr = dumpStrToDisk(inputFileStr, inputFile);
       maybeErr.has_value()) {
     llvm::errs() << "Failed to dump to disk " << inputFile
                  << " because: " << maybeErr;
     return failure();
   }
 
-  SmallString<64> outputFile;
+  Path outputFile;
   if (!sys::path::is_absolute(outputFileName)) {
-    outputFile = outputDir;
-    sys::path::append(outputFile, outputFileName);
+    outputFile = Path(outputDir) / outputFileName;
   } else {
     outputFile = outputFileName;
   }
-  if (failed(assembler(inputFile.str().str(), outputFile.str().str(), extraArgs,
-                       workDir, toolDir, verbose))) {
+  if (failed(assembler(inputFile, outputFile, extraArgs, workDir, toolDir,
+                       verbose))) {
     llvm::errs() << "Failed to assemble " << outputFileName << ".o";
     return failure();
   }
-  return outputFile.str().str();
+  return outputFile.string();
 }
 
 static auto assembleStringUsingChess =
@@ -405,10 +381,12 @@ static auto assembleStringUsingPeano =
               _6, _7, _8);
 
 // Generate the elf files for the core
-static LogicalResult generateCoreElfFiles(
-    ModuleOp moduleOp, const StringRef objFile, const std::string &tempDir,
-    bool useChess, std::optional<std::string> &vitisDir,
-    const std::string &targetArch, bool verbose, const std::string &peanoDir) {
+static LogicalResult generateCoreElfFiles(ModuleOp moduleOp,
+                                          const std::string &objFile,
+                                          Path tempDir, bool useChess,
+                                          std::optional<Path> vitisDir,
+                                          const std::string &targetArch,
+                                          bool verbose, Path peanoDir) {
   auto deviceOps = moduleOp.getOps<AIE::DeviceOp>();
   if (!llvm::hasSingleElement(deviceOps))
     return moduleOp.emitOpError("expected a single device op");
@@ -433,11 +411,10 @@ static LogicalResult generateCoreElfFiles(
       coreOp.setElfFile(elfFileName);
     }
 
-    SmallString<64> elfFile(tempDir);
-    sys::path::append(elfFile, elfFileName);
+    Path elfFile = tempDir / elfFileName;
 
     if (useChess) {
-      FailureOr<std::string> maybeVitisDir = findVitis(vitisDir);
+      FailureOr<Path> maybeVitisDir = findVitis(vitisDir);
       if (failed(maybeVitisDir)) return failure();
       auto chessIntrinsicsObjFile = assembleStringUsingChess(
           /*inputFileStr=*/_CHESS_INTRINSIC_WRAPPER_CPP,
@@ -450,11 +427,10 @@ static LogicalResult generateCoreElfFiles(
       if (failed(chessIntrinsicsObjFile)) return failure();
 
       // Use xbridge (to remove any peano dependency with use-chess option)
-      SmallString<64> bcfPath(tempDir);
-      sys::path::append(bcfPath, elfFileName + ".bcf");
+      Path bcfPath = tempDir / (elfFileName + ".bcf");
 
       {
-        auto bcfOutput = openOutputFile(bcfPath, &errorMessage);
+        auto bcfOutput = openOutputFile(bcfPath.string(), &errorMessage);
         if (!bcfOutput) {
           llvm::errs() << "failed to open bcf file because: " << errorMessage;
           return failure();
@@ -471,7 +447,7 @@ static LogicalResult generateCoreElfFiles(
 
       std::vector<std::string> extractedIncludes{*chessIntrinsicsObjFile};
       {
-        auto bcfFileIn = openInputFile(bcfPath, &errorMessage);
+        auto bcfFileIn = openInputFile(bcfPath.string(), &errorMessage);
         if (!bcfFileIn) {
           llvm::errs() << "failed to open bcf because: " << errorMessage;
           return failure();
@@ -500,10 +476,10 @@ static LogicalResult generateCoreElfFiles(
         return failure();
       }
     } else {
-      SmallString<64> ldscriptPath(tempDir);
-      sys::path::append(ldscriptPath, elfFileName + ".ld");
+      Path ldscriptPath = tempDir / (elfFileName + ".ld");
       {
-        auto ldscriptOutput = openOutputFile(ldscriptPath, &errorMessage);
+        auto ldscriptOutput =
+            openOutputFile(ldscriptPath.string(), &errorMessage);
         if (!ldscriptOutput) {
           llvm::errs() << "Failed to open ldscript file because: "
                        << errorMessage;
@@ -521,11 +497,8 @@ static LogicalResult generateCoreElfFiles(
       // We are running a clang command for now, but really this is an lld
       // command.
       {
-        SmallString<64> peanoClangExe(peanoDir);
-        sys::path::append(peanoClangExe, "bin", "clang");
-
         std::string targetLower = StringRef(targetArch).lower();
-        SmallVector<std::string, 10> flags;
+        std::vector<std::string> flags;
         flags.push_back("-O2");
         std::string targetFlag = "--target=" + targetLower + "-none-elf";
         flags.push_back(targetFlag);
@@ -543,11 +516,11 @@ static LogicalResult generateCoreElfFiles(
 
         flags.emplace_back(objFile);
         flags.push_back("-Wl,--gc-sections");
-        std::string ldScriptFlag = "-Wl,-T," + std::string(ldscriptPath);
+        std::string ldScriptFlag = "-Wl,-T," + ldscriptPath.string();
         flags.push_back(ldScriptFlag);
         flags.push_back("-o");
         flags.emplace_back(elfFile);
-        if (!runTool(peanoClangExe, flags, verbose)) {
+        if (!runTool(peanoDir / "bin" / "clang", flags, verbose)) {
           llvm::errs() << "failed to link elf file for core(" << col << ","
                        << row << ")";
           return failure();
@@ -561,7 +534,7 @@ static LogicalResult generateCoreElfFiles(
 static LogicalResult generateCDO(MLIRContext *context, ModuleOp moduleOp,
                                  bool printIRBeforeAll, bool printIRAfterAll,
                                  bool printIRModuleScope, bool timing,
-                                 const std::string &tempDir) {
+                                 const Path &tempDir) {
   ModuleOp copy = moduleOp.clone();
   std::string errorMessage;
   PassManager passManager(context, ModuleOp::getOperationName());
@@ -574,8 +547,8 @@ static LogicalResult generateCDO(MLIRContext *context, ModuleOp moduleOp,
     return failure();
   }
 
-  if (failed(mlir::iree_compiler::AMDAIE::AIETranslateToCDODirect(copy,
-                                                                  tempDir))) {
+  if (failed(mlir::iree_compiler::AMDAIE::AIETranslateToCDODirect(
+          copy, tempDir.string()))) {
     llvm::errs() << "failed to emit CDO";
     return failure();
   }
@@ -639,15 +612,15 @@ static json::Object makeKernelJSON(const std::string &name,
       {"instances", json::Array{json::Object{{"name", instance}}}}};
 }
 
-static LogicalResult generateXCLBin(
-    const std::string &Output, const std::string &tempDir,
-    const std::string &xclBinKernelID, const std::string &xclBinKernelName,
-    const std::string &xclBinInstanceName, const std::string &amdAIEInstallDir,
-    bool verbose, const std::string &inputXclbin = "") {
+static LogicalResult generateXCLBin(const std::string &Output, Path tempDir,
+                                    const std::string &xclBinKernelID,
+                                    const std::string &xclBinKernelName,
+                                    const std::string &xclBinInstanceName,
+                                    Path amdAIEInstallDir, bool verbose,
+                                    const std::string &inputXclbin = "") {
   std::string errorMessage;
   // Create mem_topology.json.
-  SmallString<64> memTopologyJsonFile(tempDir);
-  sys::path::append(memTopologyJsonFile, "mem_topology.json");
+  Path memTopologyJsonFile = tempDir / "mem_topology.json";
   {
     std::string memTopologyData = R"({
       "mem_topology": {
@@ -670,8 +643,7 @@ static LogicalResult generateXCLBin(
           ]
       }
     })";
-    if (auto maybeErr =
-            dumpStrToDisk(memTopologyData, memTopologyJsonFile.str().str());
+    if (auto maybeErr = dumpStrToDisk(memTopologyData, memTopologyJsonFile);
         maybeErr.has_value()) {
       llvm::errs() << "failed to dump to disk mem_topology.json because: "
                    << *maybeErr;
@@ -680,8 +652,7 @@ static LogicalResult generateXCLBin(
   }
 
   // Create aie_partition.json.
-  SmallString<64> aiePartitionJsonFile(tempDir);
-  sys::path::append(aiePartitionJsonFile, "aie_partition.json");
+  Path aiePartitionJsonFile = tempDir / "aie_partition.json";
   {
     std::string uuidStr = getUUIDString();
     std::string aiePartitionJsonData = R"(
@@ -720,8 +691,8 @@ static LogicalResult generateXCLBin(
         }
       }
     )";
-    if (auto maybeErr = dumpStrToDisk(aiePartitionJsonData,
-                                      aiePartitionJsonFile.str().str());
+    if (auto maybeErr =
+            dumpStrToDisk(aiePartitionJsonData, aiePartitionJsonFile);
         maybeErr.has_value()) {
       llvm::errs() << "failed to dump to disk aie_partition.json because: "
                    << *maybeErr;
@@ -729,20 +700,18 @@ static LogicalResult generateXCLBin(
     }
   }
 
-  // Create kernels.json.
-  SmallString<64> kernelsJsonFile(tempDir);
-  sys::path::append(kernelsJsonFile, "kernels.json");
+  Path kernelsJsonFile = tempDir / "kernels.json";
   {
     // TODO: Support for multiple kernels
-    json::Object kernels_data{
+    json::Object kernelsData{
         {"ps-kernels",
          json::Object{{"kernels", json::Array{makeKernelJSON(
                                       xclBinKernelName, xclBinKernelID,
                                       xclBinInstanceName)}}}}};
 
     auto kernelStr =
-        llvm::formatv("{0:2}", json::Value(std::move(kernels_data)));
-    if (auto maybeErr = dumpStrToDisk(kernelStr, kernelsJsonFile.str().str());
+        llvm::formatv("{0:2}", json::Value(std::move(kernelsData)));
+    if (auto maybeErr = dumpStrToDisk(kernelStr, kernelsJsonFile);
         maybeErr.has_value()) {
       llvm::errs() << "failed to dump to disk kernels.json because: "
                    << *maybeErr;
@@ -750,10 +719,9 @@ static LogicalResult generateXCLBin(
     }
   }
   // Create design.bif.
-  SmallString<64> designBifFile(tempDir);
-  sys::path::append(designBifFile, "design.bif");
+  Path designBifFile = tempDir / "design.bif";
   {
-    auto designBifOut = openOutputFile(designBifFile, &errorMessage);
+    auto designBifOut = openOutputFile(designBifFile.string(), &errorMessage);
     if (!designBifOut) {
       llvm::errs() << "failed to open design.bif because: " << errorMessage;
       return failure();
@@ -777,54 +745,45 @@ static LogicalResult generateXCLBin(
   }
 
   // Execute the bootgen command.
-  SmallString<64> designPdiFile(tempDir);
-  sys::path::append(designPdiFile, "design.pdi");
   {
-    SmallVector<std::string, 7> flags{"-arch",  "versal",
-                                      "-image", std::string(designBifFile),
-                                      "-o",     std::string(designPdiFile),
-                                      "-w"};
+    std::vector<std::string> flags{"-arch",  "versal",
+                                   "-image", designBifFile,
+                                   "-o",     tempDir / "design.pdi",
+                                   "-w"};
 
-    SmallString<64> bootgenBin(amdAIEInstallDir);
-    sys::path::append(bootgenBin, "bin", "amdaie_bootgen");
-    if (!sys::fs::exists(bootgenBin)) {
-      bootgenBin = amdAIEInstallDir;
-      sys::path::append(bootgenBin, "tools", "amdaie_bootgen");
+    Path bootgenBin = amdAIEInstallDir / "bin" / "amdaie_bootgen";
+    if (!std::filesystem::exists(bootgenBin)) {
+      bootgenBin = amdAIEInstallDir / "tools" / "amdaie_bootgen";
     }
     if (!runTool(bootgenBin, flags, verbose)) {
       llvm::errs() << "failed to execute bootgen";
       return failure();
     }
   }
-  SmallVector<std::string, 20> flags;
+  std::vector<std::string> flags;
   // Execute the xclbinutil command.
-  std::string memArg = "MEM_TOPOLOGY:JSON:" + std::string(memTopologyJsonFile);
-  std::string partArg =
-      "AIE_PARTITION:JSON:" + std::string(aiePartitionJsonFile);
-  SmallString<64> xclbinutilBin(amdAIEInstallDir);
-  sys::path::append(xclbinutilBin, "bin", "amdaie_xclbinutil");
-  if (!sys::fs::exists(xclbinutilBin)) {
-    xclbinutilBin = amdAIEInstallDir;
-    sys::path::append(xclbinutilBin, "tools", "amdaie_xclbinutil");
+  std::string memArg = "MEM_TOPOLOGY:JSON:" + memTopologyJsonFile.string();
+  std::string partArg = "AIE_PARTITION:JSON:" + aiePartitionJsonFile.string();
+  Path xclbinutilBin = amdAIEInstallDir / "bin" / "amdaie_xclbinutil";
+  if (!std::filesystem::exists(xclbinutilBin)) {
+    xclbinutilBin = amdAIEInstallDir / "tools" / "amdaie_xclbinutil";
   }
   {
     if (!inputXclbin.empty()) {
       // Create aie_partition.json.
-      SmallString<64> aieInputPartitionJsonFile(tempDir);
-      sys::path::append(aieInputPartitionJsonFile, "aie_input_partition.json");
-
+      Path aieInputPartitionJsonFile = tempDir / "aie_input_partition.json";
       std::string inputPartArg =
-          "AIE_PARTITION:JSON:" + std::string(aieInputPartitionJsonFile);
-      SmallVector<std::string, 20> inputFlags{"--dump-section", inputPartArg,
-                                              "--force", "--input",
-                                              std::string(inputXclbin)};
+          "AIE_PARTITION:JSON:" + aieInputPartitionJsonFile.string();
+      std::vector<std::string> inputFlags{"--dump-section", inputPartArg,
+                                          "--force", "--input",
+                                          std::string(inputXclbin)};
 
       if (!runTool(xclbinutilBin, inputFlags, verbose)) {
         llvm::errs() << "failed to execute xclbinutil";
         return failure();
       }
       auto aieInputPartitionOut =
-          openInputFile(aieInputPartitionJsonFile, &errorMessage);
+          openInputFile(aieInputPartitionJsonFile.string(), &errorMessage);
       if (!aieInputPartitionOut) {
         llvm::errs() << "failed to open aie_input_partition.json because: "
                      << errorMessage;
@@ -836,7 +795,8 @@ static LogicalResult generateXCLBin(
       aieInputPartionPDIs = aieInputPartitionOutValue->getAsObject()
                                 ->getObject("aie_partition")
                                 ->getArray("PDIs");
-      auto aiePartitionOut = openInputFile(aiePartitionJsonFile, &errorMessage);
+      auto aiePartitionOut =
+          openInputFile(aiePartitionJsonFile.string(), &errorMessage);
       if (!aiePartitionOut) {
         llvm::errs() << "failed to open aie aie_input_partition.json for "
                         "output because: "
@@ -855,7 +815,7 @@ static LogicalResult generateXCLBin(
       // rewrite aie partion json file
       if (auto maybeErr =
               dumpStrToDisk(formatv("{0:2}", *aieInputPartitionOutValue),
-                            aiePartitionJsonFile.str().str());
+                            aiePartitionJsonFile);
           maybeErr.has_value()) {
         llvm::errs()
             << "failed to dump to disk aie_input_partition.json because: "
@@ -866,9 +826,9 @@ static LogicalResult generateXCLBin(
     } else {
       flags.insert(flags.end(), {"--add-replace-section", memArg});
     }
-    flags.insert(flags.end(), {"--add-kernel", std::string(kernelsJsonFile),
-                               "--add-replace-section", partArg, "--force",
-                               "--output", std::string(Output)});
+    flags.insert(flags.end(),
+                 {"--add-kernel", kernelsJsonFile, "--add-replace-section",
+                  partArg, "--force", "--output", std::string(Output)});
 
     if (!runTool(xclbinutilBin, flags, verbose)) {
       llvm::errs() << "failed to execute xclbinutil";
@@ -948,9 +908,9 @@ struct RemoveAlignment2FromLLVMLoadPass
 static LogicalResult generateUnifiedObject(
     MLIRContext *context, ModuleOp moduleOp, const std::string &outputFile,
     bool printIRBeforeAll, bool printIRAfterAll, bool printIRModuleScope,
-    bool timing, bool useChess, bool verbose, const std::string &tempDir,
-    std::optional<std::string> &vitisDir, const std::string &targetArch,
-    const std::string &peanoDir) {
+    bool timing, bool useChess, bool verbose, Path tempDir,
+    std::optional<Path> vitisDir, const std::string &targetArch,
+    Path peanoDir) {
   PassManager pm(context, moduleOp.getOperationName());
   applyConfigToPassManager(pm, printIRBeforeAll, printIRAfterAll,
                            printIRModuleScope, timing);
@@ -985,10 +945,9 @@ static LogicalResult generateUnifiedObject(
 
   std::string errorMessage;
   if (useChess) {
-    SmallString<64> inputLLChessHackedFile(tempDir);
-    sys::path::append(inputLLChessHackedFile, "input.chesshacked.ll");
+    Path inputLLChessHackedFile = tempDir / "input.chesshacked.ll";
     std::string inputLLChessHackedStr = chesshack(inputLLStr);
-    FailureOr<std::string> maybeVitisDir = findVitis(vitisDir);
+    FailureOr<Path> maybeVitisDir = findVitis(vitisDir);
     if (failed(maybeVitisDir)) return failure();
     FailureOr<std::string> chessIntrinsicsObjFile = assembleStringUsingChess(
         /*inputFileStr=*/inputLLChessHackedStr,
@@ -1001,21 +960,17 @@ static LogicalResult generateUnifiedObject(
         /*verbose=*/verbose);
     if (failed(chessIntrinsicsObjFile)) return failure();
   } else {
-    SmallString<64> LLVMIRFile(tempDir);
-    sys::path::append(LLVMIRFile, "input.ll");
-    if (auto maybeErr = dumpStrToDisk(inputLLStr, LLVMIRFile.str().str());
+    Path LLVMIRFile = tempDir / "input.ll";
+    if (auto maybeErr = dumpStrToDisk(inputLLStr, LLVMIRFile);
         maybeErr.has_value()) {
       llvm::errs() << "Failed to dump to disk input.ll"
                    << " because: " << maybeErr;
       return failure();
     }
-    SmallString<64> peanoOptBin(peanoDir);
-    sys::path::append(peanoOptBin, "bin", "opt");
-    SmallString<64> peanoLLCBin(peanoDir);
-    sys::path::append(peanoLLCBin, "bin", "llc");
+    Path peanoOptBin = peanoDir / "bin" / "opt";
+    Path peanoLLCBin = peanoDir / "bin" / "llc";
 
-    SmallString<64> OptLLVMIRFile(tempDir);
-    sys::path::append(OptLLVMIRFile, "input.opt.ll");
+    Path OptLLVMIRFile = tempDir / "input.opt.ll";
     if (!runTool(peanoOptBin,
                  {"-O2", "--inline-threshold=10", "-S", std::string(LLVMIRFile),
                   "--disable-builtin=memset", "-o", std::string(OptLLVMIRFile)},
@@ -1076,12 +1031,11 @@ LogicalResult aie2xclbin(
     output->os() << llvm::format("%08X\n", w);
   output->keep();
 
-  SmallString<64> unifiedObj(tempDir);
-  sys::path::append(unifiedObj, "input.o");
-  if (failed(generateUnifiedObject(
-          ctx, moduleOp, std::string(unifiedObj), printIRBeforeAll,
-          printIRAfterAll, printIRModuleScope, timing, useChess, verbose,
-          tempDir, vitisDir, targetArch, peanoDir)))
+  Path unifiedObj = Path(tempDir) / "input.o";
+  if (failed(generateUnifiedObject(ctx, moduleOp, unifiedObj, printIRBeforeAll,
+                                   printIRAfterAll, printIRModuleScope, timing,
+                                   useChess, verbose, tempDir, vitisDir,
+                                   targetArch, peanoDir)))
     return moduleOp.emitOpError("Failed to generate unified object");
 
   if (failed(generateCoreElfFiles(moduleOp, unifiedObj, tempDir, useChess,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/chess_intrinsic_wrapper.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/chess_intrinsic_wrapper.cpp
@@ -25,6 +25,4 @@ extern "C" void llvm___aie2___acquire(unsigned id, unsigned val) {
 extern "C" void llvm___aie2___release(unsigned id, unsigned val) {
   release(id, val);
 }
-extern "C" void llvm___aie___event0() { event0(); }
-extern "C" void llvm___aie___event1() { event1(); }
 )chess"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/crt.c
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/crt.c
@@ -1,0 +1,43 @@
+/// This is ported from llvm-aie's libc/startup/baremetal/aie2/crt0.S and
+/// libc/startup/baremetal/aie2/crt1.cc. The purpose is to have a "baremetal"
+/// crt for peano. Tip peano (currently) automatically links their own crt but
+/// older peano (eg what we have in CI as of 7/23/204) does not.
+/// Note, this has nothing to do with chess (which also automatically links its
+/// crt).
+R"crt(
+__asm(
+    ".global __start\n"
+    ".type __start, STT_FUNC\n"
+    ".global _sp_start_value_DM_stack\n"
+    ".global _main_init\n"
+    "__start:\n"
+    "JL  #_main_init\n"
+    "MOVXM sp, #_sp_start_value_DM_stack\n"
+    "NOP\n"
+    "NOP\n"
+    "NOP\n"
+    "NOP\n");
+
+_Noreturn void done (void) {
+  __builtin_aiev2_sched_barrier();
+  __builtin_aiev2_done();
+  __builtin_aiev2_sched_barrier();
+}
+
+extern int main(int, char**);
+_Noreturn void _Exit (int val) {
+  (void)val;
+  done();
+}
+
+#define NULL ((void*)0)
+
+void _main_init() {
+
+  _Exit(main(0, NULL));
+}
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+)crt"


### PR DESCRIPTION
Turns out we never needed `me_basic.o` for chess (which automatically links its own) nor do we need it for peano tip (which also automatically links its own libc/crt). So really this PR just ports crt from tip peano for old peano.

Note, this PR doesn't do anything to resolve NA issues we've been having. It merely makes us forward compatible ie we can now generate elfs using both old peano and tip peano (just in the latter case, we don't have NA).