### PR TITLE
[AccessToAcquireRelease] Ensure deterministic acquire/release order

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/access_to_acquire_release.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/access_to_acquire_release.mlir
@@ -88,10 +88,10 @@ func.func @any_access(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>)
 // CHECK:       %[[DMA0:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:       %[[DMA1:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:       amdaie.core
-// CHECK:         %[[ACQUIRE_0:.+]] = amdaie.logicalobjectfifo.acquire(%[[DMA1]], Produce)
-// CHECK:         %[[ACCESS_0:.+]] = amdaie.logicalobjectfifo.access(%[[ACQUIRE_0]], Write)
 // CHECK:         %[[ACQUIRE_1:.+]] = amdaie.logicalobjectfifo.acquire(%[[DMA0]], Consume)
 // CHECK:         %[[ACCESS_1:.+]] = amdaie.logicalobjectfifo.access(%[[ACQUIRE_1]], Read)
+// CHECK:         %[[ACQUIRE_0:.+]] = amdaie.logicalobjectfifo.acquire(%[[DMA1]], Produce)
+// CHECK:         %[[ACCESS_0:.+]] = amdaie.logicalobjectfifo.access(%[[ACQUIRE_0]], Write)
 // CHECK:         linalg.fill ins(%{{.+}} : i32) outs(%[[ACCESS_1]]
 // CHECK:         linalg.fill ins(%{{.+}} : i32) outs(%[[ACCESS_0]]
 // CHECK:         amdaie.logicalobjectfifo.release(%[[DMA0]], Consume)
@@ -120,8 +120,6 @@ func.func @read_and_write(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 
 // CHECK:       %[[DMA0:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:       %[[DMA1:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:       amdaie.core
-// CHECK:         %[[ACQUIRE_0:.+]] = amdaie.logicalobjectfifo.acquire(%[[DMA1]], Produce)
-// CHECK:         %[[ACCESS_0:.+]] = amdaie.logicalobjectfifo.access(%[[ACQUIRE_0]], Write)
 // CHECK:         %[[ACQUIRE_1:.+]] = amdaie.logicalobjectfifo.acquire(%[[DMA0]], Consume)
 // CHECK:         %[[ACCESS_1:.+]] = amdaie.logicalobjectfifo.access(%[[ACQUIRE_1]], Read)
 // CHECK:         linalg.fill ins(%{{.+}} : i32) outs(%[[ACCESS_1]]
@@ -134,6 +132,8 @@ func.func @read_and_write(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 
 // CHECK:         amdaie.logicalobjectfifo.release(%[[DMA0]], Consume)
 // CHECK:         %[[ACQUIRE_1:.+]] = amdaie.logicalobjectfifo.acquire(%[[DMA0]], Consume)
 // CHECK:         %[[ACCESS_1:.+]] = amdaie.logicalobjectfifo.access(%[[ACQUIRE_1]], Read)
+// CHECK:         %[[ACQUIRE_0:.+]] = amdaie.logicalobjectfifo.acquire(%[[DMA1]], Produce)
+// CHECK:         %[[ACCESS_0:.+]] = amdaie.logicalobjectfifo.access(%[[ACQUIRE_0]], Write)
 // CHECK:         linalg.fill ins(%{{.+}} : i32) outs(%[[ACCESS_1]]
 // CHECK:         linalg.fill ins(%{{.+}} : i32) outs(%[[ACCESS_0]]
 // CHECK:         amdaie.logicalobjectfifo.release(%[[DMA0]], Consume)
@@ -160,6 +160,72 @@ func.func @read_write_multiple_blocks(%arg0: !amdaie.logicalobjectfifo<memref<1x
     amdaie.logicalobjectfifo.consume(%2)    
     linalg.fill ins(%c0_i32 : i32) outs(%6 : memref<1x1x8x16xi32, 2>)
     linalg.fill ins(%c0_i32 : i32) outs(%7 : memref<1x1x8x16xi32, 2>)
+    amdaie.logicalobjectfifo.produce(%3)
+    amdaie.end
+  }
+  return
+}
+
+// -----
+
+// Check deterministic order of multiple reads.
+// CHECK-LABEL: @multiple_reads_deterministic_order
+// CHECK:       %[[DMA0:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK:       %[[DMA1:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK:       amdaie.core
+// CHECK:         %[[ACQUIRE_0:.+]] = amdaie.logicalobjectfifo.acquire(%[[DMA0]], Consume)
+// CHECK:         %[[ACCESS_0:.+]] = amdaie.logicalobjectfifo.access(%[[ACQUIRE_0]], Read)
+// CHECK:         %[[ACQUIRE_1:.+]] = amdaie.logicalobjectfifo.acquire(%[[DMA1]], Consume)
+// CHECK:         %[[ACCESS_1:.+]] = amdaie.logicalobjectfifo.access(%[[ACQUIRE_1]], Read)
+// CHECK:         linalg.fill ins(%{{.+}} : i32) outs(%[[ACCESS_0]]
+// CHECK:         linalg.fill ins(%{{.+}} : i32) outs(%[[ACCESS_1]]
+// CHECK:         amdaie.logicalobjectfifo.release(%[[DMA0]], Consume)
+// CHECK:         amdaie.logicalobjectfifo.release(%[[DMA1]], Consume)
+func.func @multiple_reads_deterministic_order(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, %arg2: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, %arg3: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+  %c0 = arith.constant 0 : index
+  %c0_i32 = arith.constant 0 : i32
+  %tile = amdaie.tile(%c0, %c0)
+  %2 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  %3 = amdaie.circular_dma_cpy_nd(%arg2[] [] [], %arg3[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  %core = amdaie.core(%tile) {
+    %4 = amdaie.logicalobjectfifo.access(%arg0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
+    %5 = amdaie.logicalobjectfifo.access(%arg2, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
+    amdaie.logicalobjectfifo.consume(%2)
+    amdaie.logicalobjectfifo.consume(%3)
+    linalg.fill ins(%c0_i32 : i32) outs(%4 : memref<1x1x8x16xi32, 2>)
+    linalg.fill ins(%c0_i32 : i32) outs(%5 : memref<1x1x8x16xi32, 2>)
+    amdaie.end
+  }
+  return
+}
+
+// -----
+
+// Check deterministic order of multiple writes.
+// CHECK-LABEL: @multiple_writes_deterministic_order
+// CHECK:       %[[DMA0:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK:       %[[DMA1:.+]] = amdaie.circular_dma_cpy_nd
+// CHECK:       amdaie.core
+// CHECK:         %[[ACQUIRE_0:.+]] = amdaie.logicalobjectfifo.acquire(%[[DMA0]], Produce)
+// CHECK:         %[[ACCESS_0:.+]] = amdaie.logicalobjectfifo.access(%[[ACQUIRE_0]], Write)
+// CHECK:         %[[ACQUIRE_1:.+]] = amdaie.logicalobjectfifo.acquire(%[[DMA1]], Produce)
+// CHECK:         %[[ACCESS_1:.+]] = amdaie.logicalobjectfifo.access(%[[ACQUIRE_1]], Write)
+// CHECK:         linalg.fill ins(%{{.+}} : i32) outs(%[[ACCESS_0]]
+// CHECK:         linalg.fill ins(%{{.+}} : i32) outs(%[[ACCESS_1]]
+// CHECK:         amdaie.logicalobjectfifo.release(%[[DMA0]], Produce)
+// CHECK:         amdaie.logicalobjectfifo.release(%[[DMA1]], Produce)
+func.func @multiple_writes_deterministic_order(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, %arg2: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, %arg3: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+  %c0 = arith.constant 0 : index
+  %c0_i32 = arith.constant 0 : i32
+  %tile = amdaie.tile(%c0, %c0)
+  %2 = amdaie.circular_dma_cpy_nd(%arg1[] [] [], %arg0[] [] []) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>)
+  %3 = amdaie.circular_dma_cpy_nd(%arg3[] [] [], %arg2[] [] []) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>)
+  %core = amdaie.core(%tile) {
+    %4 = amdaie.logicalobjectfifo.access(%arg0, Write) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
+    %5 = amdaie.logicalobjectfifo.access(%arg2, Write) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
+    linalg.fill ins(%c0_i32 : i32) outs(%4 : memref<1x1x8x16xi32, 2>)
+    linalg.fill ins(%c0_i32 : i32) outs(%5 : memref<1x1x8x16xi32, 2>)
+    amdaie.logicalobjectfifo.produce(%2)
     amdaie.logicalobjectfifo.produce(%3)
     amdaie.end
   }


### PR DESCRIPTION
Fix for: https://github.com/nod-ai/iree-amd-aie/issues/582. Ensures deterministic acquire/release order inside AIE cores, which should help with tests and debugging.