### PR TITLE
[AMD-AIE][Objectfifo] Update KernelDispatch for targeting larger bf16 and i8 Matmul on Objectfifo

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -860,6 +860,14 @@ run_matmul_test \
     --acc_type "i32" \
     --m "64" --k "64" --n "64"
 
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "i8" \
+    --acc_type "i32" \
+    --m "128" --k "256" --n "128"
+
 ###################################################################
 # Chess tests
 ###################################################################

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -848,6 +848,14 @@ run_matmul_test \
     --name_prefix "small" \
     --lower_to_aie_pipeline "objectFifo" \
     --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "bf16" \
+    --acc_type "f32" \
+    --m "128" --k "256" --n "128"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
     --lhs_rhs_type "i8" \
     --acc_type "i32" \
     --m "64" --k "64" --n "64"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAddLoweringStrategy.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAddLoweringStrategy.cpp
@@ -54,7 +54,8 @@ void AMDAIELoweringStrategyPass::runOnOperation() {
   struct AIEConfig cfg = {numCores};
   for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
     // Set the strategy with default heuristics.
-    if (failed(initAIELaunchConfig(funcOp, usePassPipeline, cfg))) {
+    if (failed(initAIELaunchConfig(funcOp, usePassPipeline,
+                                   useLowerToAIEPipeline, cfg))) {
       funcOp.emitOpError("failed to have a lowering configuration set for it.");
       return signalPassFailure();
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -94,7 +94,7 @@ class ParameterSetting {
   }
 
   static FailureOr<ParameterSetting> create(linalg::LinalgOp linalgOp,
-                                            bool isPackPeel);
+                                            bool isPackPeel, bool isObjectFifo);
 
   uint32_t getM0() const { return M0; }
   uint32_t getN0() const { return N0; }
@@ -142,7 +142,8 @@ class ParameterSetting {
 };
 
 FailureOr<ParameterSetting> ParameterSetting::create(linalg::LinalgOp linalgOp,
-                                                     bool isPackPeel) {
+                                                     bool isPackPeel,
+                                                     bool isObjectFifo) {
   auto initType =
       llvm::cast<ShapedType>(linalgOp.getDpsInitOperand(0)->get().getType());
   auto initShape = initType.getShape();
@@ -204,7 +205,12 @@ FailureOr<ParameterSetting> ParameterSetting::create(linalg::LinalgOp linalgOp,
 
     auto maxL0Size = 32 * scaleFactor;
     uint32_t M0 = findLargestFactor(M, maxL0Size, m1Pack * M1);
-    uint32_t N0 = findLargestFactor(N, maxL0Size, n1Pack * N1);
+    uint32_t N0 = 0;
+    if (isObjectFifo && scaleFactor > 2) {
+      N0 = findLargestFactor(N, 64, n1Pack * N1);
+    } else {
+      N0 = findLargestFactor(N, maxL0Size, n1Pack * N1);
+    }
 
     // In pack-peel pipeline there is only one level of tiling for K dimension,
     // so set K1 = 0. The packed outer K dimension needs to be 1, so set K0 = 1.
@@ -308,8 +314,12 @@ static SmallVector<int64_t> setInnerPermB(bool isMatmulTransposeB) {
 
 static LogicalResult setRootConfigForPackPeelPipeline(
     mlir::FunctionOpInterface entryPointFn, linalg::LinalgOp linalgOp,
-    AIEConfig cfg, bool isMatmulTransposeB) {
-  auto maybePackPeelTiling = ParameterSetting::create(linalgOp, true);
+    LowerToAIEPassPipeline useLowerToAIEPipeline, AIEConfig cfg,
+    bool isMatmulTransposeB) {
+  bool isObjectFifo =
+      useLowerToAIEPipeline == LowerToAIEPassPipeline::ObjectFifo;
+  auto maybePackPeelTiling =
+      ParameterSetting::create(linalgOp, true, isObjectFifo);
   if (failed(maybePackPeelTiling)) return failure();
   auto packPeelTiling = maybePackPeelTiling.value();
 
@@ -382,7 +392,7 @@ static LogicalResult setRootConfigForPackPeelPipeline(
 static LogicalResult setRootConfigForPadPackPipeline(
     mlir::FunctionOpInterface entryPointFn, linalg::LinalgOp linalgOp,
     AIEConfig cfg, bool isMatmulTransposeB) {
-  auto maybePadPackTiling = ParameterSetting::create(linalgOp, false);
+  auto maybePadPackTiling = ParameterSetting::create(linalgOp, false, false);
   if (failed(maybePadPackTiling)) return failure();
   auto padPackTiling = maybePadPackTiling.value();
 
@@ -549,9 +559,11 @@ static bool isMatmulTransposeB(linalg::GenericOp genericOp) {
 /// transposition.
 static LogicalResult setTransposeLikeOpRootConfig(
     mlir::FunctionOpInterface entryPointFn, linalg::LinalgOp linalgOp,
-    TilePassPipeline passPipeline, AIEConfig cfg) {
+    TilePassPipeline passPipeline, LowerToAIEPassPipeline useLowerToAIEPipeline,
+    AIEConfig cfg) {
   if (passPipeline == TilePassPipeline::PackPeelPipeline)
-    return setRootConfigForPackPeelPipeline(entryPointFn, linalgOp, cfg, true);
+    return setRootConfigForPackPeelPipeline(entryPointFn, linalgOp,
+                                            useLowerToAIEPipeline, cfg, true);
   else if (passPipeline == TilePassPipeline::PadPackPipeline)
     return setRootConfigForPadPackPipeline(entryPointFn, linalgOp, cfg, true);
   return linalgOp.emitError(
@@ -565,13 +577,14 @@ static LogicalResult setTransposeLikeOpRootConfig(
 static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
                                    linalg::GenericOp genericOp,
                                    TilePassPipeline passPipeline,
+                                   LowerToAIEPassPipeline useLowerToAIEPipeline,
                                    AIEConfig cfg) {
   assert(!getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(genericOp) &&
          "expected lowering_config is not set");
 
   if (isMatmulTransposeB(genericOp) &&
-      succeeded(setTransposeLikeOpRootConfig(entryPointFn, genericOp,
-                                             passPipeline, cfg))) {
+      succeeded(setTransposeLikeOpRootConfig(
+          entryPointFn, genericOp, passPipeline, useLowerToAIEPipeline, cfg))) {
     return success();
   }
 
@@ -583,13 +596,15 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
 static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
                                    linalg::ContractionOpInterface contractionOp,
                                    TilePassPipeline passPipeline,
+                                   LowerToAIEPassPipeline useLowerToAIEPipeline,
                                    AIEConfig cfg) {
   assert(!getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(contractionOp) &&
          "expected lowering_config is not set");
   auto linalgOp = cast<linalg::LinalgOp>(contractionOp.getOperation());
   if (isa<linalg::MatmulTransposeBOp>(linalgOp)) {
     if (succeeded(setTransposeLikeOpRootConfig(entryPointFn, linalgOp,
-                                               passPipeline, cfg))) {
+                                               passPipeline,
+                                               useLowerToAIEPipeline, cfg))) {
       return success();
     }
     return failure();
@@ -609,7 +624,8 @@ static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
   // logic. Also, need a flag to experiment between pad based and pack based
   // approach which will have different tile sizes and pass pipelines
   if (passPipeline == TilePassPipeline::PackPeelPipeline)
-    return setRootConfigForPackPeelPipeline(entryPointFn, linalgOp, cfg, false);
+    return setRootConfigForPackPeelPipeline(entryPointFn, linalgOp,
+                                            useLowerToAIEPipeline, cfg, false);
   if (passPipeline == TilePassPipeline::PadPackPipeline)
     return setRootConfigForPadPackPipeline(entryPointFn, linalgOp, cfg, false);
   return linalgOp.emitError("Unhandled pass pipeline in setRootConfig.");
@@ -630,10 +646,10 @@ static LogicalResult setConvRootConfig(mlir::FunctionOpInterface entryPointFn,
 }
 
 /// Redirects to methods that set the configuration based on operation type.
-static LogicalResult setRootConfigImpl(mlir::FunctionOpInterface entryPointFn,
-                                       Operation *op,
-                                       TilePassPipeline passPipeline,
-                                       AIEConfig cfg) {
+static LogicalResult setRootConfigImpl(
+    mlir::FunctionOpInterface entryPointFn, Operation *op,
+    TilePassPipeline passPipeline, LowerToAIEPassPipeline useLowerToAIEPipeline,
+    AIEConfig cfg) {
   auto setRootConfigFn = [&](Operation *op) -> LogicalResult {
     return TypeSwitch<Operation *, LogicalResult>(op)
         // TODO (nmeshram): This is very limited for now, plan is to
@@ -645,10 +661,12 @@ static LogicalResult setRootConfigImpl(mlir::FunctionOpInterface entryPointFn,
           return setConvRootConfig(entryPointFn, op, passPipeline, cfg);
         })
         .Case<linalg::GenericOp>([&](auto op) {
-          return setRootConfig(entryPointFn, op, passPipeline, cfg);
+          return setRootConfig(entryPointFn, op, passPipeline,
+                               useLowerToAIEPipeline, cfg);
         })
         .Case<linalg::ContractionOpInterface>([&](auto op) {
-          return setRootConfig(entryPointFn, op, passPipeline, cfg);
+          return setRootConfig(entryPointFn, op, passPipeline,
+                               useLowerToAIEPipeline, cfg);
         })
         .Default([&](Operation *op) { return success(); });
   };
@@ -658,7 +676,8 @@ static LogicalResult setRootConfigImpl(mlir::FunctionOpInterface entryPointFn,
 /// Sets the translation information to use for a dispatch region.
 static LogicalResult setTranslationInfoAndRootConfig(
     mlir::FunctionOpInterface entryPointFn, ArrayRef<Operation *> computeOps,
-    TilePassPipeline passPipeline, AIEConfig cfg) {
+    TilePassPipeline passPipeline, LowerToAIEPassPipeline useLowerToAIEPipeline,
+    AIEConfig cfg) {
   // Make sure that lowering_config is not preset on any compute ops.
   for (auto computeOp : computeOps) {
     if (getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(computeOp))
@@ -673,7 +692,8 @@ static LogicalResult setTranslationInfoAndRootConfig(
   if (!rootOperation)
     return entryPointFn.emitError("Case with no root ops not yet supported.");
 
-  if (failed(setRootConfigImpl(entryPointFn, rootOperation, passPipeline, cfg)))
+  if (failed(setRootConfigImpl(entryPointFn, rootOperation, passPipeline,
+                               useLowerToAIEPipeline, cfg)))
     return failure();
   return success();
 }
@@ -684,6 +704,7 @@ static LogicalResult setTranslationInfoAndRootConfig(
 
 LogicalResult initAIELaunchConfig(FunctionOpInterface funcOp,
                                   TilePassPipeline passPipeline,
+                                  LowerToAIEPassPipeline useLowerToAIEPipeline,
                                   AIEConfig cfg) {
   if (getTranslationInfo(funcOp)) return success();
 
@@ -693,7 +714,7 @@ LogicalResult initAIELaunchConfig(FunctionOpInterface funcOp,
 
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
   if (failed(setTranslationInfoAndRootConfig(funcOp, computeOps, passPipeline,
-                                             cfg)))
+                                             useLowerToAIEPipeline, cfg)))
     return failure();
 
   // The root configuration setting introduces `tensor.dim` operations.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -315,7 +315,7 @@ static LogicalResult setRootConfigForPackPeelPipeline(
   bool isObjectFifo =
       useLowerToAIEPipeline == LowerToAIEPassPipeline::ObjectFifo;
   auto maybePackPeelTiling =
-      ParameterSetting::create(linalgOp, true, isObjectFifo);
+      ParameterSetting::create(linalgOp, /*isPackPeel=*/true, isObjectFifo);
   if (failed(maybePackPeelTiling)) return failure();
   auto packPeelTiling = maybePackPeelTiling.value();
 
@@ -388,7 +388,8 @@ static LogicalResult setRootConfigForPackPeelPipeline(
 static LogicalResult setRootConfigForPadPackPipeline(
     mlir::FunctionOpInterface entryPointFn, linalg::LinalgOp linalgOp,
     AIEConfig cfg, bool isMatmulTransposeB) {
-  auto maybePadPackTiling = ParameterSetting::create(linalgOp, false, false);
+  auto maybePadPackTiling = ParameterSetting::create(
+      linalgOp, /*isPackPeel=*/false, /*isObjectFifo=*/false);
   if (failed(maybePadPackTiling)) return failure();
   auto padPackTiling = maybePadPackTiling.value();
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
@@ -43,6 +43,7 @@ struct AIEConfig {
 
 LogicalResult initAIELaunchConfig(FunctionOpInterface funcOp,
                                   TilePassPipeline usePassPipeline,
+                                  LowerToAIEPassPipeline useLowerToAIEPipeline,
                                   AIEConfig cfg);
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -531,6 +531,7 @@ void buildAMDAIETransformPassPipeline(OpPassManager &variantPassManager) {
   {
     AMDAIELoweringStrategyOptions options;
     options.usePassPipeline = clUseTilePipeline;
+    options.useLowerToAIEPipeline = clUseLowerToAIEPipeline;
     options.numCores = clNumCores;
     modulePassManager.addPass(createAMDAIELoweringStrategyPass(options));
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -263,7 +263,17 @@ def AMDAIELoweringStrategy :
                    "Use the conv-decompose based lowering strategy for convolution interface ops.")
       )}]>,
     Option<"numCores", "num-cores", "int32_t", /*default=*/"1",
-      "Choose the number of cores to use">
+      "Choose the number of cores to use">,
+    Option<"useLowerToAIEPipeline", "use-lower-to-aie-pipeline",
+      "mlir::iree_compiler::AMDAIE::LowerToAIEPassPipeline",
+      /*default=*/"mlir::iree_compiler::AMDAIE::LowerToAIEPassPipeline::AIR",
+      "Lowering pass pipeline to use",
+      [{::llvm::cl::values(
+        clEnumValN(mlir::iree_compiler::AMDAIE::LowerToAIEPassPipeline::ObjectFifo, "objectFifo",
+                   "Use the IREE lowering to objectFifos"),
+        clEnumValN(mlir::iree_compiler::AMDAIE::LowerToAIEPassPipeline::AIR, "air",
+                   "Use the IREE lowering through AIR")
+      )}]>
   ];
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_lit_test_suite(
     "lowering_strategy.mlir"
     "lowering_strategy_conv.mlir"
     "lowering_strategy_failures.mlir"
+    "lowering_strategy_objectfifo.mlir"
     "map_forall_to_cores.mlir"
     "normalize_loop_bounds.mlir"
     "pack_and_transpose_level1.mlir"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo.mlir
@@ -1,0 +1,65 @@
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-amdaie-lowering-strategy{use-pass-pipeline=pack-peel use-lower-to-aie-pipeline=objectFifo})' %s | FileCheck %s
+
+// CHECK-{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
+// CHECK-{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+module {
+  func.func @matmul_i32_dispatch_0_matmul_128x128x256_bf16xbf16xf32() {
+    %cst = arith.constant 0.000000e+00 : f32
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<128x256xbf16>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<256x128xbf16>>
+    %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<128x128xf32>>
+    %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<128x256xbf16>> -> tensor<128x256xbf16>
+    %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 128], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<256x128xbf16>> -> tensor<256x128xbf16>
+    %5 = tensor.empty() : tensor<128x128xf32>
+    %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<128x128xf32>) -> tensor<128x128xf32>
+    // CHECK:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig}
+    %7 = linalg.matmul ins(%3, %4 : tensor<128x256xbf16>, tensor<256x128xbf16>) outs(%6 : tensor<128x128xf32>) -> tensor<128x128xf32>
+    flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [128, 128], strides = [1, 1] : tensor<128x128xf32> -> !flow.dispatch.tensor<writeonly:tensor<128x128xf32>>
+    return
+  }
+}
+
+// -----
+
+// CHECK-{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
+// CHECK-{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+module {
+  func.func @matmul_i32_dispatch_0_matmul_128x128x256_i32() {
+    %c0_i32 = arith.constant 0 : i32
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<128x256xi32>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<256x128xi32>>
+    %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<128x128xi32>>
+    %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<128x256xi32>> -> tensor<128x256xi32>
+    %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 128], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<256x128xi32>> -> tensor<256x128xi32>
+    %5 = tensor.empty() : tensor<128x128xi32>
+    %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<128x128xi32>) -> tensor<128x128xi32>
+    // CHECK:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig}
+    %7 = linalg.matmul ins(%3, %4 : tensor<128x256xi32>, tensor<256x128xi32>) outs(%6 : tensor<128x128xi32>) -> tensor<128x128xi32>
+    flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [128, 128], strides = [1, 1] : tensor<128x128xi32> -> !flow.dispatch.tensor<writeonly:tensor<128x128xi32>>
+    return
+  }
+}
+
+// -----
+
+// CHECK-{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
+// CHECK-{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+module {
+  func.func @matmul_i32_dispatch_0_matmul_128x128x256_i8xi8xi32() {
+    %c0_i32 = arith.constant 0 : i32
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<128x256xi8>>
+    %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<256x128xi8>>
+    %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<128x128xi32>>
+    %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<128x256xi8>> -> tensor<128x256xi8>
+    %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 128], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<256x128xi8>> -> tensor<256x128xi8>
+    %5 = tensor.empty() : tensor<128x128xi32>
+    %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<128x128xi32>) -> tensor<128x128xi32>
+    // CHECK:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig}
+    %7 = linalg.matmul ins(%3, %4 : tensor<128x256xi8>, tensor<256x128xi8>) outs(%6 : tensor<128x128xi32>) -> tensor<128x128xi32>
+    flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [128, 128], strides = [1, 1] : tensor<128x128xi32> -> !flow.dispatch.tensor<writeonly:tensor<128x128xi32>>
+    return
+  }
+}


### PR DESCRIPTION
In this PR I've updated the KernelDispatch logic to target `ObjectFifo` backend.

Currently we extract `scalingFactor` based on `LHS` type, but a better way is to use the accumulator's element type to do the same. And even better way is to see how to use element types of all the operands. This has already been acknowledged as [a comment in KernelDispatch.cpp](https://github.com/nod-ai/iree-amd-aie/blob/main/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp#L159-L169).

In order to not hamper `AIR` backend, this PR therefore uses accumulator's element type to decide the `scalingFactor` for `objectFifo`.

e2e CI test for larger shaped `bf16` as well as `i8` has been added.