### PR TITLE
Depthwise convolution (part i)

### DIFF
--- a/build_tools/ci/cpu_comparison/run_test.py
+++ b/build_tools/ci/cpu_comparison/run_test.py
@@ -451,6 +451,7 @@ def run_all(
         "conv2d_nhwc_bf16",
         "conv2d_nhwc_int8",
         "conv2d_nhwc_q",
+        "depthwise_convolution_i32",
     ]:
         n_conv_repeats = 4
 

--- a/build_tools/ci/cpu_comparison/test_files/depthwise_convolution_i32.mlir
+++ b/build_tools/ci/cpu_comparison/test_files/depthwise_convolution_i32.mlir
@@ -1,0 +1,12 @@
+// These 2 lines are required by the script which generates input data:
+// input 1x14x14x64xi32
+// input 3x3x64xi32
+
+func.func @depthwise_conv_2d_nhwc_hwc(%arg0: tensor<1x14x14x64xi32>, %arg1: tensor<3x3x64xi32>) -> tensor<1x12x12x64xi32> {
+  %cst = arith.constant 0 : i32
+  %0 = tensor.empty() : tensor<1x12x12x64xi32>
+  %1 = linalg.fill ins(%cst : i32) outs(%0 : tensor<1x12x12x64xi32>) -> tensor<1x12x12x64xi32>
+  %2 = linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%arg0, %arg1 : tensor<1x14x14x64xi32>, tensor<3x3x64xi32>) outs(%1 : tensor<1x12x12x64xi32>) -> tensor<1x12x12x64xi32>
+  return %2 : tensor<1x12x12x64xi32>
+}
+

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
@@ -166,7 +166,6 @@ void AMDAIETileAndFusePass::runOnOperation() {
     // loops, and the first level of tiling is always using scf.forall and
     // mapped to blocks. Currently we are not using mapping attributes for
     // Conv2d ops, because there could be four parallel tiling dimensions.
-    // Somehow `linalg::isaConvolutionOpInterface()` doesn't work properly.
     // TODO (vivian): create AIE specific mapping attributes.
     if (!isa<linalg::ConvolutionOpInterface>(consumerOp.getOperation())) {
       if (tilingLevel == 0) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Linalg/Transforms/TilingInterfaceImpl.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -167,8 +168,7 @@ void AMDAIETileAndFusePass::runOnOperation() {
     // Conv2d ops, because there could be four parallel tiling dimensions.
     // Somehow `linalg::isaConvolutionOpInterface()` doesn't work properly.
     // TODO (vivian): create AIE specific mapping attributes.
-    if (!isa<linalg::Conv2DNhwcHwcfOp, linalg::Conv2DNchwFchwOp,
-             linalg::Conv2DNhwcHwcfQOp>(consumerOp)) {
+    if (!isa<linalg::ConvolutionOpInterface>(consumerOp.getOperation())) {
       if (tilingLevel == 0) {
         options.setMapping(
             {gpu::GPUBlockMappingAttr::get(context, gpu::MappingId::DimY),

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
@@ -85,6 +85,17 @@ FailureOr<std::array<uint32_t, 3>> getAIEIntegerMatmulInstructionSize(
   return it->second;
 }
 
+// The number of elements in a vector instruction for a given element type.
+FailureOr<uint32_t> getAIEMacWidth(Type inputType, Type outputType) {
+  // inputType = i8, outputType = i32:
+  if (inputType.isInteger(8) && outputType.isInteger(32)) return 32;
+  // inputType = i16, outputType = i32:
+  if (inputType.isInteger(16) && outputType.isInteger(32)) return 32;
+  // inputType = bf16, outputType = f32:
+  if (inputType.isBF16() && outputType.isF32()) return 16;
+  return failure();
+}
+
 FailureOr<std::array<uint32_t, 3>> getAIEMatmulInstructionSize(Type elTypeLhs,
                                                                Type elTypeRhs,
                                                                Type elTypeAcc) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
@@ -86,12 +86,11 @@ FailureOr<std::array<uint32_t, 3>> getAIEIntegerMatmulInstructionSize(
 }
 
 // The number of elements in a vector instruction for a given element type.
-FailureOr<uint32_t> getAIEMacWidth(Type inputType, Type outputType) {
-  // inputType = i8, outputType = i32:
+// Reference:
+// https://www.xilinx.com/htmldocs/xilinx2023_2/aiengine_ml_intrinsics/intrinsics/group__intr__gpvectorop__mul__bf16xbf16.html
+FailureOr<uint32_t> getAIEMacNumElements(Type inputType, Type outputType) {
   if (inputType.isInteger(8) && outputType.isInteger(32)) return 32;
-  // inputType = i16, outputType = i32:
   if (inputType.isInteger(16) && outputType.isInteger(32)) return 32;
-  // inputType = bf16, outputType = f32:
   if (inputType.isBF16() && outputType.isF32()) return 16;
   return failure();
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
@@ -62,8 +62,9 @@ FailureOr<std::array<uint32_t, 3>> getAIEMatmulInstructionSize(Type elTypeLhs,
 FailureOr<std::array<uint32_t, 3>> getAIEIntegerMatmulInstructionSize(
     uint32_t nBitsLhs, uint32_t nBitsRhs, uint32_t nBitsAcc);
 
-// Return the number of elements in a vector fma/mul/add instruction that AIE supports. TODO(newling) reference to source of truth.
-FailureOr<uint32_t> getAIEMacWidth(Type inputType, Type outputType);
+// Return the number of elements in a vector fma/mul/add instruction that AIE
+// supports.
+FailureOr<uint32_t> getAIEMacNumElements(Type inputType, Type outputType);
 
 /// Utility function that, given an element type, computes tiling scaling factor
 /// as : 64/bitWidth.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
@@ -24,8 +24,6 @@ std::optional<AMDAIEDevice> getConfigAMDAIEDevice(
 /// attr in the AST.
 std::optional<AMDAIEDevice> getConfigAMDAIEDevice(Operation *op);
 
-
-
 // This function is based on the following table pulled from the
 // AIEVec_MatMulOp documentation in
 // mlir-aie/include/aie/Dialect/AIEVec/IR/AIEVecOps.td

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
@@ -24,6 +24,8 @@ std::optional<AMDAIEDevice> getConfigAMDAIEDevice(
 /// attr in the AST.
 std::optional<AMDAIEDevice> getConfigAMDAIEDevice(Operation *op);
 
+
+
 // This function is based on the following table pulled from the
 // AIEVec_MatMulOp documentation in
 // mlir-aie/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
@@ -59,6 +61,9 @@ FailureOr<std::array<uint32_t, 3>> getAIEMatmulInstructionSize(Type elTypeLhs,
 // bitwidths nBitsLhs, nBitsRhs, and nBitsAcc. Based on the table above.
 FailureOr<std::array<uint32_t, 3>> getAIEIntegerMatmulInstructionSize(
     uint32_t nBitsLhs, uint32_t nBitsRhs, uint32_t nBitsAcc);
+
+// Return the number of elements in a vector fma/mul/add instruction that AIE supports. TODO(newling) reference to source of truth.
+FailureOr<uint32_t> getAIEMacWidth(Type inputType, Type outputType);
 
 /// Utility function that, given an element type, computes tiling scaling factor
 /// as : 64/bitWidth.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -498,11 +498,11 @@ static LogicalResult setRootConfigForConvDecomposePipeline(
     const uint16_t OH_1 = 1;
 
     auto operandType = getElementType(linalgOp->getOperand(0));
-    auto maybeMacWidth =
-        getAIEMacWidth(operandType, getElementType(linalgOp->getResult(0)));
+    auto maybeMacNumElements =
+        getAIEMacNumElements(operandType, getElementType(linalgOp->getResult(0)));
     uint16_t OC_0 = 16;
-    if (!failed(maybeMacWidth)) {
-      OC_0 = maybeMacWidth.value();
+    if (!failed(maybeMacNumElements)) {
+      OC_0 = maybeMacNumElements.value();
     }
     // If the operand type has fewer than 32-bits, we really should be able to
     // get a mac-width for it Bail because we didn't, and there's probably just

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -488,7 +488,6 @@ static LogicalResult setRootConfigForConvDecomposePipeline(
     // dimensions are perfectly tiled by the hard-coded tile dimensions below.
     // These will be done as a follow-up task.
     //
-    // depthwise_conv2d_nhwc_hwc tiling dims: [N, OH, OW, OC, KH, KW]
     //
     // Below we target a 4x4 array of AIE cores.
     auto getElementType = [](Value v) {
@@ -516,9 +515,11 @@ static LogicalResult setRootConfigForConvDecomposePipeline(
 
     const uint16_t OC_1 = OC_0 / 4;
 
+    // depthwise_conv2d_nhwc_hwc tiling dims:
+    //               [N, OH,   OW,   OC,   KH,KW]
     tileSizeLevel0 = {1, OH_0, OW_0, OC_0, 0, 0};
     tileSizeLevel1 = {1, OH_1, OW_0, OC_1, 0, 0};
-    tileSizeLevel2 = {1, OH_1, OW_0, OC_1, 1, 1};
+    tileSizeLevel2 = {0, 0, 0, 0, 1, 1};
   } else {
     assert(false && "Support must be added for this convolution op");
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -503,7 +503,7 @@ static LogicalResult setRootConfigForConvDecomposePipeline(
         getAIEMacWidth(operandType, getElementType(linalgOp->getResult(0)));
     uint16_t OC_0 = 16;
     if (!failed(maybeMacWidth)) {
-      OC_0 = maybeMacWidth.value() / 4;
+      OC_0 = maybeMacWidth.value();
     }
     // If the operand type has fewer than 32-bits, we really should be able to
     // get a mac-width for it Bail because we didn't, and there's probably just

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_conv.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_conv.mlir
@@ -40,7 +40,7 @@ func.func @conv_static_dispatch_0_conv_2d_nhwc_hwcf_2x12x12x64x3x3x32_bf16xbf16x
 
 // -----
 
-// CHECK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[1, 4, 4, 16, 0, 0], [1, 1, 4, 4, 0, 0], [1, 1, 4, 4, 1, 1]]>
+// CHECK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[1, 4, 4, 16, 0, 0], [1, 1, 4, 4, 0, 0], [0, 0, 0, 0, 1, 1]]>
 func.func @conv_depthwise_channel_last_bf16(){
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_conv.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_conv.mlir
@@ -60,7 +60,7 @@ func.func @conv_depthwise_channel_last_bf16(){
 // -----
 // Same test as above, but where the operand type is i8. In this case we expect OC tile size of 32 (not 16) at level 0, and 8 at levels 1 and 2. This is because of the instruction size of AIE. 
 
-// CHECK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[1, 4, 4, 32, 0, 0], [1, 1, 4, 8, 0, 0], [1, 1, 4, 8, 1, 1]]>
+// CHECK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[1, 4, 4, 32, 0, 0], [1, 1, 4, 8, 0, 0], [0, 0, 0, 0, 1, 1]]>
 func.func @conv_depthwise_channel_last_i8(){
   %cst = arith.constant 0 : i32
   %c0 = arith.constant 0 : index

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_conv.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_conv.mlir
@@ -37,3 +37,42 @@ func.func @conv_static_dispatch_0_conv_2d_nhwc_hwcf_2x12x12x64x3x3x32_bf16xbf16x
   flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 12, 12, 64], strides = [1, 1, 1, 1] : tensor<2x12x12x64xf32> -> !flow.dispatch.tensor<writeonly:tensor<2x12x12x64xf32>>
   return
 }
+
+// -----
+
+// CHECK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[1, 4, 4, 16, 0, 0], [1, 1, 4, 4, 0, 0], [1, 1, 4, 4, 1, 1]]>
+func.func @conv_depthwise_channel_last_bf16(){
+  %cst = arith.constant 0.000000e+00 : f32
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2x14x14x64xbf16>>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<3x3x64xbf16>>
+  %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x12x12x64xf32>>
+  %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 14, 14, 64], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x14x14x64xbf16>> -> tensor<2x14x14x64xbf16>
+  %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [3, 3, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x64xbf16>> -> tensor<3x3x64xbf16>
+  %5 = tensor.empty() : tensor<2x12x12x64xf32>
+  %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<2x12x12x64xf32>) -> tensor<2x12x12x64xf32>
+  %7 = linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%3, %4 : tensor<2x14x14x64xbf16>, tensor<3x3x64xbf16>) outs(%6 : tensor<2x12x12x64xf32>) -> tensor<2x12x12x64xf32>
+  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : vector<2xi64>, lowering_config = #config, strides = dense<1> : vector<2xi64>}
+  flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 12, 12, 64], strides = [1, 1, 1, 1] : tensor<2x12x12x64xf32> -> !flow.dispatch.tensor<writeonly:tensor<2x12x12x64xf32>>
+  return
+}
+
+// -----
+// Same test as above, but where the operand type is i8. In this case we expect OC tile size of 32 (not 16) at level 0, and 8 at levels 1 and 2. This is because of the instruction size of AIE. 
+
+// CHECK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[1, 4, 4, 32, 0, 0], [1, 1, 4, 8, 0, 0], [1, 1, 4, 8, 1, 1]]>
+func.func @conv_depthwise_channel_last_i8(){
+  %cst = arith.constant 0 : i32
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<2x14x14x64xi8>>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<3x3x64xi8>>
+  %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x12x12x64xi32>>
+  %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 14, 14, 64], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x14x14x64xi8>> -> tensor<2x14x14x64xi8>
+  %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [3, 3, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x64xi8>> -> tensor<3x3x64xi8>
+  %5 = tensor.empty() : tensor<2x12x12x64xi32>
+  %6 = linalg.fill ins(%cst : i32) outs(%5 : tensor<2x12x12x64xi32>) -> tensor<2x12x12x64xi32>
+  %7 = linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>} ins(%3, %4 : tensor<2x14x14x64xi8>, tensor<3x3x64xi8>) outs(%6 : tensor<2x12x12x64xi32>) -> tensor<2x12x12x64xi32>
+  // CHECK: linalg.depthwise_conv_2d_nhwc_hwc {dilations = dense<1> : vector<2xi64>, lowering_config = #config, strides = dense<1> : vector<2xi64>}
+  flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [2, 12, 12, 64], strides = [1, 1, 1, 1] : tensor<2x12x12x64xi32> -> !flow.dispatch.tensor<writeonly:tensor<2x12x12x64xi32>>
+  return
+}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Utils/test/UtilsTest.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Utils/test/UtilsTest.cpp
@@ -6,7 +6,6 @@
 
 #include "gtest/gtest.h"
 #include "iree-amd-aie/Utils/Utils.h"
-#include "mlir/IR/PatternMatch.h"
 
 namespace {
 


### PR DESCRIPTION
This PR adds e2d support for i32 convolution, and partial support for i8 and bf16 (we cannot do e2e for types which need vectorization at the moment). 