### PR TITLE
Compile chess ukernels at test time (rather than downloading)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,16 @@ jobs:
           source .venv/bin/activate
           pip install -r tests/matmul/requirements.txt
 
+
+      - name : E2E comparison of AIE to llvm-cpu
+        run: |
+          source .venv/bin/activate
+          # install requirements
+          # TODO(newling) make requirements.txt file
+          pip install numpy
+          source /opt/xilinx/xrt/setup.sh
+          python3 build_tools/ci/cpu_comparison/run_test.py test_aie_vs_cpu iree-install $PWD/llvm-aie
+
       - name: E2E correctness matmul test
         run: |
           source .venv/bin/activate
@@ -149,15 +159,6 @@ jobs:
           sudo prlimit -lunlimited --pid $$
 
           bash build_tools/ci/run_matmul_test.sh test_matmuls iree-install $PWD/llvm-aie
-
-      - name : E2E comparison of AIE to llvm-cpu
-        run: |
-          source .venv/bin/activate
-          # install requirements
-          # TODO(newling) make requirements.txt file
-          pip install numpy
-          source /opt/xilinx/xrt/setup.sh
-          python3 build_tools/ci/cpu_comparison/run_test.py test_aie_vs_cpu iree-install $PWD/llvm-aie
 
       - name: Printing IR from aie2xclbin
         run: |

--- a/build_tools/ci/ukernels/chess-clang
+++ b/build_tools/ci/ukernels/chess-clang
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# =============================================================
+# THIS FILE COPIED FROM /mlir-aie/tools/chess-clang/chess-clang
+# =============================================================
+
+declare -a ArgsArr
+for var in "$@"
+do
+  if [ $var = "-xc++" ]; then
+    echo ""
+    echo "chess-clang script: removed '-xc++' argument from chess-clang
+          invocation";
+    echo ""
+  # Force using C++2a instead of C++11, it should be irrelevant when passing
+  # LLVM IR but it will remain for now so that if someone wishes to compile some
+  # modern C++ with xchescc for AI Engine they can do so. It also helps to show
+  # how you can manipulate the chess-clang arguments at the moment.
+  elif [ $var = "-std=c++11" ]; then
+    ArgsArr+=( "-std=c++2a" )
+  else
+    ArgsArr+=( "$var" )
+  fi
+done
+
+# aie_api.h spews tons of warnings here.
+ArgsArr+=( "-Wno-deprecated-declarations" )
+
+# Has to be invoked with exec, which means it never returns to this script
+# so this has to be the final invocation.
+exec $CHESSROOT/target/bin/LNa64bin/chess-clang "${ArgsArr[@]}"

--- a/build_tools/ci/ukernels/mm.cc
+++ b/build_tools/ci/ukernels/mm.cc
@@ -1,0 +1,311 @@
+//===- mm.cc ----------------------------------------------000---*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#define __AIENGINE__ 2
+#define NOCPP
+#define __AIEARCH__ 20
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <type_traits>
+
+#define REL_WRITE 0
+#define REL_READ 1
+
+#include <aie_api/aie.hpp>
+
+#include "zero.cc"
+
+// Suppose A is a 64x64 tensor and B is a 64x64 tensor, and r=4, s=8, t=4.
+//
+// Let A[i,j] be the element at row i and column j of A, and
+//     B[i,j] be the element at row i and column j of B.
+//
+// The expectations of this function on the points pA, pB, and pC are:
+//
+// 1) all elements of A are contiguous in memory, starting from pA + offsetA
+// 2) all elements of B are contiguous in memory, starting from pB + offsetB
+// 3) all elements of C are contiguous in memory, starting from pC + offsetC
+// 4) element A[i,j] is at pA[offsetA + i*8 + (64*8)*(j/8) + j%8]
+// 5) element B[i,j] is at pB[offsetB + i*4 + (64*4)*(j/4) + j%4]
+//
+// 4) and 5) describe vertical stripes of A and B that are stored contiguously,
+// with a row-major order within each stripe. i.e. elements starting at ptrA +
+// offsetA are:
+//
+// [A[0,0], ..., A[0,7], A[1,0], ..., A[1,7], A[2,0], ..., A[2,7], ... A[63,0],
+// ..., A[63,7], A[0,8], ..., A[0,15], ..., A[63, 64]]
+//
+
+template <typename T_in, typename T_out, unsigned rowA, unsigned colA,
+          unsigned colB, unsigned r, unsigned s, unsigned t>
+void matmul_vectorized(const T_in *__restrict pA, unsigned offsetA,
+                       const T_in *__restrict pB, unsigned offsetB,
+                       T_out *__restrict pC, unsigned offsetC) {
+  using MMUL = aie::mmul<r, s, t, T_in, T_in, accfloat>;
+
+  event0();
+
+  for (unsigned z = 0; z < rowA; z += 4)
+    chess_loop_range(2, ) {
+      T_out *__restrict pC1 = pC + offsetC + (z)*MMUL::size_C;
+      T_out *__restrict pC2 = pC + offsetC + ((z + 1)) * MMUL::size_C;
+      T_out *__restrict pC3 = pC + offsetC + ((z + 2)) * MMUL::size_C;
+      T_out *__restrict pC4 = pC + offsetC + ((z + 3)) * MMUL::size_C;
+
+      for (unsigned j = 0; j < colB; j += 4)
+        chess_prepare_for_pipelining chess_loop_range(8, ) {
+          const T_in *__restrict pA1 = pA + offsetA + (z)*MMUL::size_A;
+          const T_in *__restrict pA2 = pA + offsetA + ((z + 1)) * MMUL::size_A;
+          const T_in *__restrict pA3 = pA + offsetA + ((z + 2)) * MMUL::size_A;
+          const T_in *__restrict pA4 = pA + offsetA + ((z + 3)) * MMUL::size_A;
+
+          const T_in *__restrict pB1 =
+              pB + offsetB + ((j + 0)) * colA * MMUL::size_B;
+          const T_in *__restrict pB2 =
+              pB + offsetB + ((j + 1)) * colA * MMUL::size_B;
+          const T_in *__restrict pB3 =
+              pB + offsetB + ((j + 2)) * colA * MMUL::size_B;
+          const T_in *__restrict pB4 =
+              pB + offsetB + ((j + 3)) * colA * MMUL::size_B;
+
+          aie::vector<T_in, MMUL::size_A> A0 = aie::load_v<MMUL::size_A>(pA1);
+          pA1 += rowA * MMUL::size_A;
+          aie::vector<T_in, MMUL::size_A> A1 = aie::load_v<MMUL::size_A>(pA2);
+          pA2 += rowA * MMUL::size_A;
+          aie::vector<T_in, MMUL::size_A> A2 = aie::load_v<MMUL::size_A>(pA3);
+          pA3 += rowA * MMUL::size_A;
+          aie::vector<T_in, MMUL::size_A> A3 = aie::load_v<MMUL::size_A>(pA4);
+          pA4 += rowA * MMUL::size_A;
+          aie::vector<T_in, MMUL::size_B> B0 = aie::load_v<MMUL::size_B>(pB1);
+          pB1 += MMUL::size_B;
+          aie::vector<T_in, MMUL::size_B> B1 = aie::load_v<MMUL::size_B>(pB2);
+          pB2 += MMUL::size_B;
+          aie::vector<T_in, MMUL::size_B> B2 = aie::load_v<MMUL::size_B>(pB3);
+          pB3 += MMUL::size_B;
+          aie::vector<T_in, MMUL::size_B> B3 = aie::load_v<MMUL::size_B>(pB4);
+          pB4 += MMUL::size_B;
+
+          aie::vector<T_out, MMUL::size_C> acc_C00 =
+              aie::load_v<MMUL::size_C>(pC1);
+          aie::vector<T_out, MMUL::size_C> acc_C01 =
+              aie::load_v<MMUL::size_C>(pC1 + MMUL::size_C * rowA);
+          aie::vector<T_out, MMUL::size_C> acc_C02 =
+              aie::load_v<MMUL::size_C>(pC1 + 2 * MMUL::size_C * rowA);
+          aie::vector<T_out, MMUL::size_C> acc_C03 =
+              aie::load_v<MMUL::size_C>(pC1 + 3 * MMUL::size_C * rowA);
+
+          aie::vector<T_out, MMUL::size_C> acc_C10 =
+              aie::load_v<MMUL::size_C>(pC2);
+          aie::vector<T_out, MMUL::size_C> acc_C11 =
+              aie::load_v<MMUL::size_C>(pC2 + MMUL::size_C * rowA);
+          aie::vector<T_out, MMUL::size_C> acc_C12 =
+              aie::load_v<MMUL::size_C>(pC2 + 2 * MMUL::size_C * rowA);
+          aie::vector<T_out, MMUL::size_C> acc_C13 =
+              aie::load_v<MMUL::size_C>(pC2 + 3 * MMUL::size_C * rowA);
+
+          aie::vector<T_out, MMUL::size_C> acc_C20 =
+              aie::load_v<MMUL::size_C>(pC3);
+          aie::vector<T_out, MMUL::size_C> acc_C21 =
+              aie::load_v<MMUL::size_C>(pC3 + MMUL::size_C * rowA);
+          aie::vector<T_out, MMUL::size_C> acc_C22 =
+              aie::load_v<MMUL::size_C>(pC3 + 2 * MMUL::size_C * rowA);
+          aie::vector<T_out, MMUL::size_C> acc_C23 =
+              aie::load_v<MMUL::size_C>(pC3 + 3 * MMUL::size_C * rowA);
+
+          aie::vector<T_out, MMUL::size_C> acc_C30 =
+              aie::load_v<MMUL::size_C>(pC4);
+          aie::vector<T_out, MMUL::size_C> acc_C31 =
+              aie::load_v<MMUL::size_C>(pC4 + MMUL::size_C * rowA);
+          aie::vector<T_out, MMUL::size_C> acc_C32 =
+              aie::load_v<MMUL::size_C>(pC4 + 2 * MMUL::size_C * rowA);
+          aie::vector<T_out, MMUL::size_C> acc_C33 =
+              aie::load_v<MMUL::size_C>(pC4 + 3 * MMUL::size_C * rowA);
+
+          MMUL C00(acc_C00);
+          MMUL C01(acc_C01);
+          MMUL C02(acc_C02);
+          MMUL C03(acc_C03);
+
+          MMUL C10(acc_C10);
+          MMUL C11(acc_C11);
+          MMUL C12(acc_C12);
+          MMUL C13(acc_C13);
+
+          MMUL C20(acc_C20);
+          MMUL C21(acc_C21);
+          MMUL C22(acc_C22);
+          MMUL C23(acc_C23);
+
+          MMUL C30(acc_C30);
+          MMUL C31(acc_C31);
+          MMUL C32(acc_C32);
+          MMUL C33(acc_C33);
+
+          C00.mac(A0, B0);
+          C01.mac(A0, B1);
+          C10.mac(A1, B0);
+          C11.mac(A1, B1);
+
+          C02.mac(A0, B2);
+          C03.mac(A0, B3);
+          C12.mac(A1, B2);
+          C13.mac(A1, B3);
+
+          C20.mac(A2, B0);
+          C21.mac(A2, B1);
+          C30.mac(A3, B0);
+          C31.mac(A3, B1);
+
+          C22.mac(A2, B2);
+          C23.mac(A2, B3);
+          C32.mac(A3, B2);
+          C33.mac(A3, B3);
+
+          for (unsigned i = 1; i < colA; ++i)
+            chess_prepare_for_pipelining chess_loop_range(7, ) {
+              A0 = aie::load_v<MMUL::size_A>(pA1);
+              pA1 += rowA * MMUL::size_A;
+              A1 = aie::load_v<MMUL::size_A>(pA2);
+              pA2 += rowA * MMUL::size_A;
+              A2 = aie::load_v<MMUL::size_A>(pA3);
+              pA3 += rowA * MMUL::size_A;
+              A3 = aie::load_v<MMUL::size_A>(pA4);
+              pA4 += rowA * MMUL::size_A;
+
+              B0 = aie::load_v<MMUL::size_B>(pB1);
+              pB1 += MMUL::size_B;
+              B1 = aie::load_v<MMUL::size_B>(pB2);
+              pB2 += MMUL::size_B;
+              B2 = aie::load_v<MMUL::size_B>(pB3);
+              pB3 += MMUL::size_B;
+              B3 = aie::load_v<MMUL::size_B>(pB4);
+              pB4 += MMUL::size_B;
+
+              C00.mac(A0, B0);
+              C01.mac(A0, B1);
+              C10.mac(A1, B0);
+              C11.mac(A1, B1);
+
+              C02.mac(A0, B2);
+              C03.mac(A0, B3);
+              C12.mac(A1, B2);
+              C13.mac(A1, B3);
+
+              C20.mac(A2, B0);
+              C21.mac(A2, B1);
+              C30.mac(A3, B0);
+              C31.mac(A3, B1);
+
+              C22.mac(A2, B2);
+              C23.mac(A2, B3);
+              C32.mac(A3, B2);
+              C33.mac(A3, B3);
+            }
+
+          aie::store_v(pC1, C00.template to_vector<T_out>());
+          pC1 += MMUL::size_C * rowA;
+          aie::store_v(pC1, C01.template to_vector<T_out>());
+          pC1 += MMUL::size_C * rowA;
+          aie::store_v(pC1, C02.template to_vector<T_out>());
+          pC1 += MMUL::size_C * rowA;
+          aie::store_v(pC1, C03.template to_vector<T_out>());
+          pC1 += MMUL::size_C * rowA;
+
+          aie::store_v(pC2, C10.template to_vector<T_out>());
+          pC2 += MMUL::size_C * rowA;
+          aie::store_v(pC2, C11.template to_vector<T_out>());
+          pC2 += MMUL::size_C * rowA;
+          aie::store_v(pC2, C12.template to_vector<T_out>());
+          pC2 += MMUL::size_C * rowA;
+          aie::store_v(pC2, C13.template to_vector<T_out>());
+          pC2 += MMUL::size_C * rowA;
+
+          aie::store_v(pC3, C20.template to_vector<T_out>());
+          pC3 += MMUL::size_C * rowA;
+          aie::store_v(pC3, C21.template to_vector<T_out>());
+          pC3 += MMUL::size_C * rowA;
+          aie::store_v(pC3, C22.template to_vector<T_out>());
+          pC3 += MMUL::size_C * rowA;
+          aie::store_v(pC3, C23.template to_vector<T_out>());
+          pC3 += MMUL::size_C * rowA;
+
+          aie::store_v(pC4, C30.template to_vector<T_out>());
+          pC4 += MMUL::size_C * rowA;
+          aie::store_v(pC4, C31.template to_vector<T_out>());
+          pC4 += MMUL::size_C * rowA;
+          aie::store_v(pC4, C32.template to_vector<T_out>());
+          pC4 += MMUL::size_C * rowA;
+          aie::store_v(pC4, C33.template to_vector<T_out>());
+          pC4 += MMUL::size_C * rowA;
+        }
+    }
+
+  event1();
+}
+
+template <unsigned m, unsigned k, unsigned n>
+void matmul_vectorized_4x8x4_bf16_bf16(const bfloat16 *__restrict pA,
+                                       unsigned offsetA,
+                                       const bfloat16 *__restrict pB,
+                                       unsigned offsetB,
+                                       bfloat16 *__restrict pC,
+                                       unsigned offsetC) {
+  constexpr int r = 4;
+  constexpr int s = 8;
+  constexpr int t = 4;
+  static_assert(m % (2 * r) == 0 && m / (2 * r) > 0);
+  static_assert(k % (2 * s) == 0 && k / (2 * s) > 0);
+  static_assert(n % (2 * t) == 0 && n / (2 * t) > 0);
+  return matmul_vectorized<bfloat16, bfloat16, m / r, k / s, n / t, r, s, t>(
+      pA, offsetA, pB, offsetB, pC, offsetC);
+}
+
+template <unsigned m, unsigned k, unsigned n>
+void matmul_vectorized_4x8x4_bf16_f32(const bfloat16 *__restrict pA,
+                                      unsigned offsetA,
+                                      const bfloat16 *__restrict pB,
+                                      unsigned offsetB, float *__restrict pC,
+                                      unsigned offsetC) {
+  constexpr int r = 4;
+  constexpr int s = 8;
+  constexpr int t = 4;
+  static_assert(m % (2 * r) == 0 && m / (2 * r) > 0);
+  static_assert(k % (2 * s) == 0 && k / (2 * s) > 0);
+  static_assert(n % (2 * t) == 0 && n / (2 * t) > 0);
+  return matmul_vectorized<bfloat16, float, m / r, k / s, n / t, r, s, t>(
+      pA, offsetA, pB, offsetB, pC, offsetC);
+}
+
+extern "C" {
+
+#define combos(X)                                                              \
+  X(bfloat16, bf16, bfloat16, bf16, 4, 8, 4)                                   \
+  X(bfloat16, bf16, float, f32, 4, 8, 4)
+
+#define matmul_vectorized_c_func(ctype_in, mlir_type_in, ctype_out,            \
+                                 mlir_type_out, r, s, t)                       \
+  void matmul_##mlir_type_in##_##mlir_type_out(                                \
+      ctype_in *a_in, unsigned offsetA, ctype_in *b_in, unsigned offsetB,      \
+      ctype_out *c_out, unsigned offsetC) {                                    \
+    matmul_vectorized_##r##x##s##x##t##_##mlir_type_in##_##mlir_type_out<      \
+        64, 64, 64>(a_in, offsetA, b_in, offsetB, c_out, offsetC);             \
+  }
+
+#define zero_vectorized_c_func(ctype_in, mlir_type_in, ctype_out,              \
+                               mlir_type_out, r, s, t)                         \
+  void zero_##mlir_type_out(ctype_out *c_out, unsigned offsetC) {              \
+    zero_vectorized<ctype_out, 64, 64, 32>(c_out, offsetC);                    \
+  }
+
+combos(matmul_vectorized_c_func) combos(zero_vectorized_c_func)
+
+} // extern "C"

--- a/build_tools/ci/ukernels/xchesscc_wrapper
+++ b/build_tools/ci/ukernels/xchesscc_wrapper
@@ -1,0 +1,84 @@
+#!/bin/bash
+#
+# ==================================================================
+# THIS FILE IS BASED ON /mlir-aie/tools/chess-clang/xchesscc_wrapper
+# ==================================================================
+
+if [ "$#" -ne 3 ]; then
+    echo "Usage: ./xchesscc_wrapper /vitis/root/directory /path/to/src.c /path/to/src.o"
+    exit 1
+fi
+
+# Set vitis root directory (make complete path)
+vitis_root_dir=$1 #(realpath $1)
+if [ ! -d $vitis_root_dir ]; then
+    echo "Error: vitis root directory ${vitis_root_dir} does not exist"
+    exit 1
+fi
+
+# The file to compile:
+src_file=$(realpath $2)
+if [ ! -f $src_file ]; then
+    echo "Error: source file ${src_file} does not exist"
+    exit 1
+fi
+
+object_file=$(realpath $3)
+
+aietools_dir=$vitis_root_dir/aietools
+if [ ! -d $aietools_dir ]; then
+    echo "Error: aietools directory ${aietools_dir} does not exist"
+    exit 1
+fi
+
+aietools_include_dir=$aietools_dir/include
+if [ ! -d $aietools_include_dir ]; then
+    echo "Error: aietools include directory ${aietools_include_dir} does not exist"
+    exit 1
+fi
+
+rdi_datadir=$aietools_dir/data
+if [ ! -d $rdi_datadir ]; then
+    echo "Error: rdi data directory ${rdi_datadir} does not exist"
+    exit 1
+fi
+
+libdir=$rdi_datadir/aie_ml/lib
+if [ ! -d $libdir ]; then
+    echo "Error: target aie2 lib directory ${libdir} does not exist"
+    exit 1
+fi
+
+
+unwrapped_xchesscc=$aietools_dir/bin/unwrapped/lnx64.o/xchesscc
+if [ ! -f $unwrapped_xchesscc ]; then
+    echo "Error: unwrapped_xchesscc ${unwrapped_xchesscc} does not exist"
+    exit 1
+fi
+
+this_dir="$(cd $(dirname $0) && pwd)"
+chess_clang=$this_dir/chess-clang
+if [ ! -f $chess_clang ]; then
+    echo "Error: chess-clang ${chess_clang} does not exist"
+    exit 1
+fi
+
+# Print all the directories set thus far:
+echo "vitis_root_dir:        $vitis_root_dir"
+echo "aietools_dir:          $aietools_dir"
+echo "aietools_include_dir:  $aietools_include_dir"
+echo "rdi_datadir:           $rdi_datadir"
+echo "libdir:                $libdir"
+echo "unwrapped_xchesscc:    $unwrapped_xchesscc"
+echo "src_file:              $src_file"
+echo "object_file:           $object_file"
+echo "this_dir:              $this_dir"
+echo "chess_clang:           $chess_clang"
+
+export RDI_DATADIR=$rdi_datadir
+export LD_LIBRARY_PATH=$aietools_dir/lib/lnx64.o:$aietools_dir/lnx64/tools/dot/lib:$LD_LIBRARY_PATH
+
+export PATH=$this_dir:$aietools_dir/bin/unwrapped/lnx64.o:$aietools_dir/tps/lnx64/target/bin/LNa64bin
+# extra_defs="-D__AIENGINE__ -D__AIE_ARCH__=20 -D__AIEARCH__=20"
+extra_defs="-D__AIE_ARCH__=20 -D__AIEARCH__=20"
+$unwrapped_xchesscc -p me -C Release_LLVM $extra_defs -Y clang=$chess_clang -P $libdir -d -f -I$aietools_include_dir -c ${src_file} -o ${object_file}

--- a/build_tools/ci/ukernels/zero.cc
+++ b/build_tools/ci/ukernels/zero.cc
@@ -1,0 +1,34 @@
+//===- zero.cc --------------------------------------------000---*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ZERO_CC
+#define ZERO_CC
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <type_traits>
+
+template <typename T, int M, int N, int r>
+void zero_vectorized(T *__restrict pC, unsigned offsetC) {
+  const aie::vector<T, r> zeros = aie::zeros<T, r>();
+  T *__restrict pC1 = pC + offsetC;
+  const T *__restrict c_end = pC1 + M * N;
+  for (; pC1 + r < c_end; pC1 += r) {
+    aie::store_v(pC1, zeros);
+  }
+  // Do a scalar write for any remainder not divisible by vector instruction
+  // size r
+  for (; pC1 < c_end; pC1++) {
+    *pC1 = 0;
+  }
+}
+
+#endif


### PR DESCRIPTION
Copy code from mlir-aie for generating ukernels with chess. Currently placed it in the build_tools/ci, we can consider making it part of core iree-amd-aie (with cmake) at later point (or now if people prefer). 

Files copies:
chess-clang : copied directly (except from removal of commented out code)
mm.cc : copied directly
zero.cc : copied directly (I'm not sure we need this though)
xchesscc_wrapper: simplified to only support AIE2, and reduce compile time warnings 

This PR also removes ukernels from run_matmul_test.sh, so that ukernels are only tested in cpu_comparison/run_test.sh. This is to reduce code complexity 

The one risk I see with this PR is that we become more dependent on chess -- downloading the ukernel meant that we could use ukernels without needing the heavy vitis machinery to start with 