### PR TITLE
[AMD-AIE][ObjectFifo] Add more e2e CI test for bf16 and i8 Matmul on ObjectFifo

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -836,13 +836,15 @@ run_matmul_test \
     --m "1536" --k "2048" --n "1536" \
     --num_repeat_runs "10"
 
+# bf16 Matmul tests.
 run_matmul_test \
     --name_prefix "small" \
     --lower_to_aie_pipeline "objectFifo" \
     --tile_pipeline "pack-peel" \
     --lhs_rhs_type "bf16" \
     --acc_type "f32" \
-    --m "64" --k "64" --n "64"
+    --m "32" --k "32" --n "32" \
+    --num_repeat_runs "10"
 
 run_matmul_test \
     --name_prefix "small" \
@@ -850,7 +852,90 @@ run_matmul_test \
     --tile_pipeline "pack-peel" \
     --lhs_rhs_type "bf16" \
     --acc_type "f32" \
-    --m "128" --k "256" --n "128"
+    --m "64" --k "32" --n "128" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "bf16" \
+    --acc_type "f32" \
+    --m "128" --k "32" --n "64" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "bf16" \
+    --acc_type "f32" \
+    --m "128" --k "32" --n "128" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "bf16" \
+    --acc_type "f32" \
+    --m "256" --k "32" --n "256" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "bf16" \
+    --acc_type "f32" \
+    --m "32" --k "64" --n "32" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "bf16" \
+    --acc_type "f32" \
+    --m "64" --k "64" --n "64" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "bf16" \
+    --acc_type "f32" \
+    --m "128" --k "256" --n "128" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "medium" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "bf16" \
+    --acc_type "f32" \
+    --m "1024" --k "1024" --n "1024" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "medium" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "bf16" \
+    --acc_type "f32" \
+    --m "1536" --k "2048" --n "1536" \
+    --num_repeat_runs "10"
+
+# i8 Matmul tests.
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "i8" \
+    --acc_type "i32" \
+    --m "32" --k "32" --n "32" \
+    --num_repeat_runs "10"
 
 run_matmul_test \
     --name_prefix "small" \
@@ -858,7 +943,8 @@ run_matmul_test \
     --tile_pipeline "pack-peel" \
     --lhs_rhs_type "i8" \
     --acc_type "i32" \
-    --m "64" --k "64" --n "64"
+    --m "64" --k "32" --n "128" \
+    --num_repeat_runs "10"
 
 run_matmul_test \
     --name_prefix "small" \
@@ -866,7 +952,71 @@ run_matmul_test \
     --tile_pipeline "pack-peel" \
     --lhs_rhs_type "i8" \
     --acc_type "i32" \
-    --m "128" --k "256" --n "128"
+    --m "128" --k "32" --n "64" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "i8" \
+    --acc_type "i32" \
+    --m "128" --k "32" --n "128" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "i8" \
+    --acc_type "i32" \
+    --m "256" --k "32" --n "256" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "i8" \
+    --acc_type "i32" \
+    --m "32" --k "64" --n "32" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "i8" \
+    --acc_type "i32" \
+    --m "64" --k "64" --n "64" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "i8" \
+    --acc_type "i32" \
+    --m "128" --k "256" --n "128" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "medium" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "i8" \
+    --acc_type "i32" \
+    --m "1024" --k "1024" --n "1024" \
+    --num_repeat_runs "10"
+
+run_matmul_test \
+    --name_prefix "medium" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "i8" \
+    --acc_type "i32" \
+    --m "1536" --k "2048" --n "1536" \
+    --num_repeat_runs "10"
 
 ###################################################################
 # Chess tests

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -843,60 +843,6 @@ run_matmul_test \
     --tile_pipeline "pack-peel" \
     --lhs_rhs_type "bf16" \
     --acc_type "f32" \
-    --m "32" --k "32" --n "32" \
-    --num_repeat_runs "10"
-
-run_matmul_test \
-    --name_prefix "small" \
-    --lower_to_aie_pipeline "objectFifo" \
-    --tile_pipeline "pack-peel" \
-    --lhs_rhs_type "bf16" \
-    --acc_type "f32" \
-    --m "64" --k "32" --n "128" \
-    --num_repeat_runs "10"
-
-run_matmul_test \
-    --name_prefix "small" \
-    --lower_to_aie_pipeline "objectFifo" \
-    --tile_pipeline "pack-peel" \
-    --lhs_rhs_type "bf16" \
-    --acc_type "f32" \
-    --m "128" --k "32" --n "64" \
-    --num_repeat_runs "10"
-
-run_matmul_test \
-    --name_prefix "small" \
-    --lower_to_aie_pipeline "objectFifo" \
-    --tile_pipeline "pack-peel" \
-    --lhs_rhs_type "bf16" \
-    --acc_type "f32" \
-    --m "128" --k "32" --n "128" \
-    --num_repeat_runs "10"
-
-run_matmul_test \
-    --name_prefix "small" \
-    --lower_to_aie_pipeline "objectFifo" \
-    --tile_pipeline "pack-peel" \
-    --lhs_rhs_type "bf16" \
-    --acc_type "f32" \
-    --m "256" --k "32" --n "256" \
-    --num_repeat_runs "10"
-
-run_matmul_test \
-    --name_prefix "small" \
-    --lower_to_aie_pipeline "objectFifo" \
-    --tile_pipeline "pack-peel" \
-    --lhs_rhs_type "bf16" \
-    --acc_type "f32" \
-    --m "32" --k "64" --n "32" \
-    --num_repeat_runs "10"
-
-run_matmul_test \
-    --name_prefix "small" \
-    --lower_to_aie_pipeline "objectFifo" \
-    --tile_pipeline "pack-peel" \
-    --lhs_rhs_type "bf16" \
-    --acc_type "f32" \
     --m "64" --k "64" --n "64" \
     --num_repeat_runs "10"
 
@@ -916,7 +862,7 @@ run_matmul_test \
     --lhs_rhs_type "bf16" \
     --acc_type "f32" \
     --m "1024" --k "1024" --n "1024" \
-    --num_repeat_runs "10"
+    --num_repeat_runs "5"
 
 run_matmul_test \
     --name_prefix "medium" \
@@ -925,7 +871,7 @@ run_matmul_test \
     --lhs_rhs_type "bf16" \
     --acc_type "f32" \
     --m "1536" --k "2048" --n "1536" \
-    --num_repeat_runs "10"
+    --num_repeat_runs "5"
 
 # i8 Matmul tests.
 run_matmul_test \
@@ -934,60 +880,6 @@ run_matmul_test \
     --tile_pipeline "pack-peel" \
     --lhs_rhs_type "i8" \
     --acc_type "i32" \
-    --m "32" --k "32" --n "32" \
-    --num_repeat_runs "10"
-
-run_matmul_test \
-    --name_prefix "small" \
-    --lower_to_aie_pipeline "objectFifo" \
-    --tile_pipeline "pack-peel" \
-    --lhs_rhs_type "i8" \
-    --acc_type "i32" \
-    --m "64" --k "32" --n "128" \
-    --num_repeat_runs "10"
-
-run_matmul_test \
-    --name_prefix "small" \
-    --lower_to_aie_pipeline "objectFifo" \
-    --tile_pipeline "pack-peel" \
-    --lhs_rhs_type "i8" \
-    --acc_type "i32" \
-    --m "128" --k "32" --n "64" \
-    --num_repeat_runs "10"
-
-run_matmul_test \
-    --name_prefix "small" \
-    --lower_to_aie_pipeline "objectFifo" \
-    --tile_pipeline "pack-peel" \
-    --lhs_rhs_type "i8" \
-    --acc_type "i32" \
-    --m "128" --k "32" --n "128" \
-    --num_repeat_runs "10"
-
-run_matmul_test \
-    --name_prefix "small" \
-    --lower_to_aie_pipeline "objectFifo" \
-    --tile_pipeline "pack-peel" \
-    --lhs_rhs_type "i8" \
-    --acc_type "i32" \
-    --m "256" --k "32" --n "256" \
-    --num_repeat_runs "10"
-
-run_matmul_test \
-    --name_prefix "small" \
-    --lower_to_aie_pipeline "objectFifo" \
-    --tile_pipeline "pack-peel" \
-    --lhs_rhs_type "i8" \
-    --acc_type "i32" \
-    --m "32" --k "64" --n "32" \
-    --num_repeat_runs "10"
-
-run_matmul_test \
-    --name_prefix "small" \
-    --lower_to_aie_pipeline "objectFifo" \
-    --tile_pipeline "pack-peel" \
-    --lhs_rhs_type "i8" \
-    --acc_type "i32" \
     --m "64" --k "64" --n "64" \
     --num_repeat_runs "10"
 
@@ -1007,7 +899,7 @@ run_matmul_test \
     --lhs_rhs_type "i8" \
     --acc_type "i32" \
     --m "1024" --k "1024" --n "1024" \
-    --num_repeat_runs "10"
+    --num_repeat_runs "5"
 
 run_matmul_test \
     --name_prefix "medium" \
@@ -1016,7 +908,7 @@ run_matmul_test \
     --lhs_rhs_type "i8" \
     --acc_type "i32" \
     --m "1536" --k "2048" --n "1536" \
-    --num_repeat_runs "10"
+    --num_repeat_runs "5"
 
 ###################################################################
 # Chess tests


### PR DESCRIPTION
-- This commit adds more bf16 and i8 Matmul on ObjectFifio to e2e CI test.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>