### PR TITLE
[ObjectFifo][AMDAIEInsertCores] Fail gracefully when there is no thread mapping

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertCores.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertCores.cpp
@@ -44,7 +44,7 @@ DenseMap<Attribute, Value> getAttributeMapping(
   return attrMapping;
 }
 
-/// Partition of all scf.forall operations in the module into 3 sets: 
+/// Partition of all scf.forall operations in the module into 3 sets:
 ///
 /// 1. parents: scf.forall operations that have a child with a thread mapping
 /// 2. innerMostThreadMapped: scf.forall operations that have a thread mapping,
@@ -52,7 +52,6 @@ DenseMap<Attribute, Value> getAttributeMapping(
 /// 3. notThreadMapped: scf.forall operations that have no thread mapping, and
 ///    have no child with a thread mapping
 struct ForallsPartition {
-
   DenseSet<scf::ForallOp> parents;
   SmallVector<scf::ForallOp> innerMostThreadMapped;
   SmallVector<scf::ForallOp> notThreadMapped;
@@ -62,7 +61,7 @@ struct ForallsPartition {
     numForalls = 0;
 
     // Visit all scf.forall operations in the module in post order (most nested
-    // to least nested). 
+    // to least nested).
     moduleOp->walk<WalkOrder::PostOrder>([&](scf::ForallOp forallOp) {
       ++numForalls;
 
@@ -93,8 +92,7 @@ struct ForallsPartition {
       return WalkResult::advance();
     });
 
-    assert(numForalls == innerMostThreadMapped.size() +
-                             notThreadMapped.size() +
+    assert(numForalls == innerMostThreadMapped.size() + notThreadMapped.size() +
                              parents.size() &&
            "Expected complete partition of foralls");
   }
@@ -103,8 +101,7 @@ struct ForallsPartition {
 /// Insert core ops inside innermost forall ops around computational ops and
 /// add synchronization ops along the way to synchronize with surrounding
 /// dma ops.
-LogicalResult
-insertCoreOps(mlir::ModuleOp moduleOp) {
+LogicalResult insertCoreOps(mlir::ModuleOp moduleOp) {
   IRRewriter rewriter(moduleOp.getContext());
 
   ForallsPartition foralls(moduleOp);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEOpUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEOpUtils.h
@@ -7,14 +7,12 @@
 #ifndef IREE_AMD_AIE_TRANSFORMS_AMDAIEOPUTILS_H_
 #define IREE_AMD_AIE_TRANSFORMS_AMDAIEOPUTILS_H_
 
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/IR/Block.h"
 #include "mlir/IR/Operation.h"
 
 namespace mlir::iree_compiler::AMDAIE {
 
 /// Return a vector of the parent operations that are of type 'OpTy', including
-/// this op if it has type 'OpTy'
+/// argument 'op' if it has type 'OpTy'
 template <typename OpTy>
 SmallVector<OpTy> getInclusiveParentsOfType(Operation *op) {
   SmallVector<OpTy> res;
@@ -25,6 +23,15 @@ SmallVector<OpTy> getInclusiveParentsOfType(Operation *op) {
     }
   } while ((current = current->getParentOp()));
   return res;
+}
+
+/// Return a vector of the parent operations that are of type 'OpTy', not
+/// including 'op'
+template <typename OpTy>
+SmallVector<OpTy> getParentsOfType(Operation *op) {
+  auto parent = op->getParentOp();
+  if (!parent) return {};
+  return getInclusiveParentsOfType<OpTy>(parent);
 }
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_cores.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_cores.mlir
@@ -17,10 +17,10 @@ module{
 func.func @insert_cores_with_non_normalized_forall() {
   scf.forall (%arg0, %arg1) in (1, 1) {
     scf.forall (%arg2, %arg3) = (0, 0) to (4, 4) step (1, 1) {
-    } 
+    }
     scf.forall (%arg2, %arg3) = (0, 0) to (2, 2) step (1, 1) {
-    } 
-  } 
+    }
+  }
   return
 }
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_cores.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_cores.mlir
@@ -12,6 +12,21 @@ func.func @insert_cores_with_non_normalized_forall() {
 
 // -----
 
+// expected-error @+1 {{has 3 scf.forall operations, but 0 scf.forall operations with a thread mapping. Conservatively bailing, as running this pass on such a module is probably a mistake}}
+module{
+func.func @insert_cores_with_non_normalized_forall() {
+  scf.forall (%arg0, %arg1) in (1, 1) {
+    scf.forall (%arg2, %arg3) = (0, 0) to (4, 4) step (1, 1) {
+    } 
+    scf.forall (%arg2, %arg3) = (0, 0) to (2, 2) step (1, 1) {
+    } 
+  } 
+  return
+}
+}
+
+// -----
+
 // CHECK-LABEL: @insert_cores
 // CHECK:       scf.forall (%[[ARG0:.*]], %[[ARG1:.*]]) in (1, 1) {
 // CHECK:         scf.forall (%[[ARG2:.*]], %[[ARG3:.*]]) in (1, 2) {


### PR DESCRIPTION
This PR
1) improves failure mode encountered in https://github.com/nod-ai/iree-amd-aie/issues/619
2) changes logic to only process the inner-most forall loop(s) with thread mappings 