### PR TITLE
[DistributeCoresAndObjectFifos] Fix access op ordering in cores

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDistributeCoresAndObjectFifos.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDistributeCoresAndObjectFifos.cpp
@@ -566,10 +566,11 @@ LogicalResult insertLogicalObjectFifoAccess(ModuleOp moduleOp) {
         // We want to insert amdaie.logicalobjectfifo.access ops right before
         // the first usage. But for vectorized ops this would mean they'd get
         // inserted within the vectorized scf.for ops. We therefore would want
-        // to traverse to the outermost scf.for op whose immediate parent is
-        // amdaie.core op.
+        // to traverse to the outermost scf.for op in that case. Currently we
+        // bubble up this traversal till that operation whose parent is not a
+        // scf.for op. TODO: Generalize this later.
         Operation *opToInsertRewriterPoint = op;
-        while (!isa<AMDAIE::CoreOp>(opToInsertRewriterPoint->getParentOp())) {
+        while (isa<scf::ForOp>(opToInsertRewriterPoint->getParentOp())) {
           opToInsertRewriterPoint = opToInsertRewriterPoint->getParentOp();
         }
         for (auto &&[idx, operand] : llvm::enumerate(op->getOpOperands())) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDistributeCoresAndObjectFifos.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDistributeCoresAndObjectFifos.cpp
@@ -563,11 +563,20 @@ LogicalResult insertLogicalObjectFifoAccess(ModuleOp moduleOp) {
     WalkResult res = coreOp->walk([&](Operation *op) {
       if (isa<linalg::LinalgOp, vector::TransferReadOp, vector::TransferWriteOp,
               memref::ExtractStridedMetadataOp>(op)) {
+        // We want to insert amdaie.logicalobjectfifo.access ops right before
+        // the first usage. But for vectorized ops this would mean they'd get
+        // inserted within the vectorized scf.for ops. We therefore would want
+        // to traverse to the outermost scf.for op whose immediate parent is
+        // amdaie.core op.
+        Operation *opToInsertRewriterPoint = op;
+        while (!isa<AMDAIE::CoreOp>(opToInsertRewriterPoint->getParentOp())) {
+          opToInsertRewriterPoint = opToInsertRewriterPoint->getParentOp();
+        }
         for (auto &&[idx, operand] : llvm::enumerate(op->getOpOperands())) {
           if (memrefToLogicalObjectFifoAccess.contains(operand.get())) {
             op->setOperand(idx, memrefToLogicalObjectFifoAccess[operand.get()]);
           } else if (memrefToLogicalObjectFifo.contains(operand.get())) {
-            rewriter.setInsertionPoint(op);
+            rewriter.setInsertionPoint(opToInsertRewriterPoint);
             std::tuple<AMDAIE::LogicalObjectFifoFromMemrefOp,
                        AMDAIE::MemoryAccess>
                 value = memrefToLogicalObjectFifo[operand.get()];
@@ -584,7 +593,7 @@ LogicalResult insertLogicalObjectFifoAccess(ModuleOp moduleOp) {
                 rewriter.create<AMDAIE::LogicalObjectFifoFromMemrefOp>(
                     rewriter.getUnknownLoc(), LogicalObjectFifoType::get(type),
                     memref);
-            rewriter.setInsertionPoint(op);
+            rewriter.setInsertionPoint(opToInsertRewriterPoint);
 
             AMDAIE::LogicalObjectFifoAccessOp accessOp;
             if (memrefToLogicalObjectFifo.contains(memref)) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDistributeCoresAndObjectFifos.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDistributeCoresAndObjectFifos.cpp
@@ -567,7 +567,7 @@ LogicalResult insertLogicalObjectFifoAccess(ModuleOp moduleOp) {
           if (memrefToLogicalObjectFifoAccess.contains(operand.get())) {
             op->setOperand(idx, memrefToLogicalObjectFifoAccess[operand.get()]);
           } else if (memrefToLogicalObjectFifo.contains(operand.get())) {
-            rewriter.setInsertionPointToStart(coreOp.getBody());
+            rewriter.setInsertionPoint(op);
             std::tuple<AMDAIE::LogicalObjectFifoFromMemrefOp,
                        AMDAIE::MemoryAccess>
                 value = memrefToLogicalObjectFifo[operand.get()];
@@ -584,7 +584,7 @@ LogicalResult insertLogicalObjectFifoAccess(ModuleOp moduleOp) {
                 rewriter.create<AMDAIE::LogicalObjectFifoFromMemrefOp>(
                     rewriter.getUnknownLoc(), LogicalObjectFifoType::get(type),
                     memref);
-            rewriter.setInsertionPointToStart(coreOp.getBody());
+            rewriter.setInsertionPoint(op);
 
             AMDAIE::LogicalObjectFifoAccessOp accessOp;
             if (memrefToLogicalObjectFifo.contains(memref)) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/distribute_cores_and_objectfifos.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/distribute_cores_and_objectfifos.mlir
@@ -86,14 +86,14 @@ module {
 // CHECK-DAG:     %[[DMA_0:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_2]]
 // CHECK-SAME:    %[[FROM_MEMREF_0]]
 // CHECK-DAG:     %[[CORE_0:.*]] = amdaie.core(%[[TILE_0_2]])
-// CHECK:           %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_2]], Read)
 // CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA_0]])
+// CHECK:           %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_2]], Read)
 // CHECK:           linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_0]] : memref<32x64xi32, 2>)
 // CHECK-DAG:     %[[DMA_1:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_1]]
 // CHECK-SAME:    %[[FROM_MEMREF_0]]
 // CHECK-DAG:     %[[CORE_1:.*]] = amdaie.core(%[[TILE_1_2]])
-// CHECK:           %[[VAL_1:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_1]], Read)
 // CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA_1]])
+// CHECK:           %[[VAL_1:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_1]], Read)
 // CHECK:           linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_1]] : memref<32x64xi32, 2>)
 module {
   func.func @unroll_dma() {
@@ -141,12 +141,12 @@ module {
 // CHECK-DAG:     %[[DMA_0:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_1]]
 // CHECK-SAME:    %[[FROM_MEMREF_0]]
 // CHECK-DAG:     %[[CORE_0:.*]] = amdaie.core(%[[TILE_0_2]])
-// CHECK:           %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_1]], Read)
 // CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA_0]])
+// CHECK:           %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_1]], Read)
 // CHECK:           linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_0]] : memref<32x64xi32, 2>)
 // CHECK-DAG:     %[[CORE_1:.*]] = amdaie.core(%[[TILE_1_2]])
-// CHECK:           %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_1]], Read)
 // CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA_0]])
+// CHECK:           %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_1]], Read)
 // CHECK:           linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_0]] : memref<32x64xi32, 2>)
 module {
   func.func @hoist_dma_single_loop() {
@@ -526,35 +526,35 @@ module {
 // CHECK-DAG:     %[[DMA_0:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_1]][] [] [], %[[FROM_MEMREF_0]][%[[ARG1]]]
 // CHECK-DAG:     %[[DMA_1:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_3]][] [] [], %[[FROM_MEMREF_1]]
 // CHECK-DAG:     %[[DMA_2:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_8]][%c0, %c0] [%c1, %c1] [%c1, %c1], %[[FROM_MEMREF_4]]
-// CHECK-DAG:     %[[CORE_0_2:.*]] = amdaie.core(%[[TILE_0_2]])
-// CHECK-DAG:       %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_4]], Write)
-// CHECK-DAG:       %[[VAL_1:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_3]], Read)
-// CHECK-DAG:       amdaie.logicalobjectfifo.consume(%[[DMA_1]])
-// CHECK-DAG:       linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_1]] : memref<32x64xi32, 2>)
-// CHECK-DAG:       linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_0]] : memref<32x32xi32, 2>)
-// CHECK-DAG:     %[[DMA_3:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_8]][%c0, %c1] [%c1, %c1] [%c1, %c1], %[[FROM_MEMREF_5]]
-// CHECK-DAG:     %[[CORE_1_2:.*]] = amdaie.core(%[[TILE_1_2]])
-// CHECK-DAG:       %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_5]], Write)
-// CHECK-DAG:       %[[VAL_1:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_3]], Read)
-// CHECK-DAG:       amdaie.logicalobjectfifo.consume(%[[DMA_1]])
-// CHECK-DAG:       linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_1]] : memref<32x64xi32, 2>)
-// CHECK-DAG:       linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_0]] : memref<32x32xi32, 2>)
+// CHECK:         %[[CORE_0_2:.*]] = amdaie.core(%[[TILE_0_2]])
+// CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA_1]])
+// CHECK:           %[[VAL_1:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_3]], Read)
+// CHECK:           linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_1]] : memref<32x64xi32, 2>)
+// CHECK:           %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_4]], Write)
+// CHECK:           linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_0]] : memref<32x32xi32, 2>)
+// CHECK:         %[[DMA_3:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_8]][%c0, %c1] [%c1, %c1] [%c1, %c1], %[[FROM_MEMREF_5]]
+// CHECK:         %[[CORE_1_2:.*]] = amdaie.core(%[[TILE_1_2]])
+// CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA_1]])
+// CHECK:           %[[VAL_1:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_3]], Read)
+// CHECK:           linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_1]] : memref<32x64xi32, 2>)
+// CHECK:           %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_5]], Write)
+// CHECK:           linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_0]] : memref<32x32xi32, 2>)
 // CHECK-DAG:     %[[DMA_4:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_2]][] [] [], %[[FROM_MEMREF_1]]
 // CHECK-DAG:     %[[DMA_5:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_8]][%c1, %c0] [%c1, %c1] [%c1, %c1], %[[FROM_MEMREF_6]]
-// CHECK-DAG:     %[[CORE_0_3:.*]] = amdaie.core(%[[TILE_0_3]])
-// CHECK-DAG:       %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_6]], Write)
-// CHECK-DAG:       %[[VAL_1:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_2]], Read)
-// CHECK-DAG:       amdaie.logicalobjectfifo.consume(%[[DMA_4]])
-// CHECK-DAG:       linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_1]] : memref<32x64xi32, 2>)
-// CHECK-DAG:       linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_0]] : memref<32x32xi32, 2>)
-// CHECK-DAG:     %[[DMA_6:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_8]][%c1, %c1] [%c1, %c1] [%c1, %c1], %[[FROM_MEMREF_7]]
-// CHECK-DAG:     %[[CORE_1_3:.*]] = amdaie.core(%[[TILE_1_3]])
-// CHECK-DAG:       %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_7]], Write)
-// CHECK-DAG:       %[[VAL_1:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_2]], Read)
-// CHECK-DAG:       amdaie.logicalobjectfifo.consume(%[[DMA_4]])
-// CHECK-DAG:       linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_1]] : memref<32x64xi32, 2>)
-// CHECK-DAG:       linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_0]] : memref<32x32xi32, 2>)
-// CHECK-DAG:     %[[DMA_7:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_9]][%[[ARG1]]] [%c1] [%c1], %[[FROM_MEMREF_8]]
+// CHECK:         %[[CORE_0_3:.*]] = amdaie.core(%[[TILE_0_3]])
+// CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA_4]])
+// CHECK:           %[[VAL_1:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_2]], Read)
+// CHECK:           linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_1]] : memref<32x64xi32, 2>)
+// CHECK:           %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_6]], Write)
+// CHECK:           linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_0]] : memref<32x32xi32, 2>)
+// CHECK:         %[[DMA_6:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_8]][%c1, %c1] [%c1, %c1] [%c1, %c1], %[[FROM_MEMREF_7]]
+// CHECK:         %[[CORE_1_3:.*]] = amdaie.core(%[[TILE_1_3]])
+// CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA_4]])
+// CHECK:           %[[VAL_1:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_2]], Read)
+// CHECK:           linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_1]] : memref<32x64xi32, 2>)
+// CHECK:           %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_7]], Write)
+// CHECK:           linalg.fill ins(%{{.+}} : i32) outs(%[[VAL_0]] : memref<32x32xi32, 2>)
+// CHECK:         %[[DMA_7:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_9]][%[[ARG1]]] [%c1] [%c1], %[[FROM_MEMREF_8]]
 module {
   func.func @nested_dma_dependencies() {
     %c0_i32 = arith.constant 0 : i32

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/distribute_cores_and_objectfifos.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/distribute_cores_and_objectfifos.mlir
@@ -881,12 +881,12 @@ module {
 // CHECK-DAG:         %[[DMA_2:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_2]]
 // CHECK-SAME:        %[[FROM_MEMREF_5]]
 // CHECK-DAG:         %[[CORE_0:.*]] = amdaie.core(%[[TILE_0_2]])
-// CHECK-DAG:           %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_3]], Read)
-// CHECK-DAG:           %[[VAL_1:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_4]], Read)
-// CHECK-DAG:           %[[VAL_2:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_5]], Write)
 // CHECK-DAG:           amdaie.logicalobjectfifo.consume(%[[DMA_0]])
 // CHECK-DAG:           amdaie.logicalobjectfifo.consume(%[[DMA_1]])
 // CHECK-DAG:           amdaie.logicalobjectfifo.produce(%[[DMA_2]])
+// CHECK-DAG:           %[[VAL_0:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_3]], Read)
+// CHECK-DAG:           %[[VAL_1:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_4]], Read)
+// CHECK-DAG:           %[[VAL_2:.+]] = amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_5]], Write)
 // CHECK-DAG:           scf.for %[[ARG2:.*]] = %[[C0]] to %[[C16]] step %[[C1]] {
 // CHECK-DAG:             scf.for %[[ARG3:.*]] = %[[C0]] to %[[C16]] step %[[C1]] {
 // CHECK-DAG:               scf.for %[[ARG4:.*]] = %[[C0]] to %[[C8]] step %[[C1]] {


### PR DESCRIPTION
The `amdaie.logicalobjectfifo.access` ops should be ordered right before the first usage, instead of at the beginning of the block. This issue comes up for matmul + elementwise. Existing tests are updated to check for this more carefully.