### PR TITLE
Port new mlir-aie pattern to iree-amd-aie

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aievec/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/aievec/Passes.h
@@ -14,22 +14,65 @@
 #ifndef AIE_DIALECT_AIEVEC_PIPELINES_PASSES_H
 #define AIE_DIALECT_AIEVEC_PIPELINES_PASSES_H
 
+#include <memory>
+
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassOptions.h"
 
 namespace mlir::iree_compiler::aievec {
 
-/// Adds the "convert-vector-to-aievec" pipeline to the `OpPassManager`. This
-/// pipeline takes `Vector` code, transforms it to make it compatible with the
-/// selected `AIE` target, lowers it to `AIEVec` dialect, and performs some
-/// optimizations based on the target AIE architecture.
-void buildConvertVectorToAIEVec(mlir::OpPassManager &pm);
+/**
+ * Append pass(es) for canonicalizing operations in the vector dialect to a form
+ * that can be lowered to the AIEVec dialect.
+ */
+void buildCanonicalizeVectorForAIEVec(mlir::OpPassManager &);
 
-void buildCanonicalizeVectorForAIEVec(mlir::OpPassManager &pm);
+/**
+ * A pass containing patterns for canonicalizing operations in the vector
+ * dialect to a form that can be lowered to the AIEVec dialect. This pass is
+ * named `canonicalize-vector-for-aievec`.
+ */
+std::unique_ptr<mlir::Pass> createCanonicalizeVectorForAIEVecPass();
 
+/**
+ * Expose the pass `canonicalize-vector-for-aievec` to the command line.
+ */
+void registerCanonicalizeVectorForAIEVecPass();
+
+/**
+ * Append pass(es) for lowering operations in the vector dialect to the AIEVec
+ * dialect. Vector dialect ops are expected to be in a canonical form
+ * before entering this pass pipeline.
+ */
 void buildLowerVectorToAIEVec(mlir::OpPassManager &pm);
 
+/**
+ * A pass containing patterns for lowering operations in the vector dialect to
+ * the AIEVec dialect. The pass is currently named `test-lower-vector-to-aievec`.
+ */
+static std::unique_ptr<mlir::Pass> createLowerVectorToAIEVec();
+
+/**
+ * Expose the pass `test-lower-vector-to-aievec` to the command line.
+ */
+void registerLowerVectorToAIEVecPass();
+
+/**
+ * This appends a combination of canonicalization and lowering passes to
+ * a pass pipline. It takes vector dialect code, transforms it to make it
+ * compatible with the AIE, and then lowers it to the AIEVec dialect.
+ */
+void buildConvertVectorToAIEVec(mlir::OpPassManager &);
+
+/**
+ * Lower from the vector dialect to the AIEVec dialect. The pass is called
+ * `convert-aievec-to-llvm`.
+ * */
 std::unique_ptr<mlir::Pass> createConvertAIEVecToLLVMPass();
+
+/**
+ * Expose the pass `convert-aievec-to-llvm` to the command line.
+ */
 void registerConvertAIEVecToLLVMPass();
 
 /// Register the AIEVec dialect and the translation from it to the LLVM dialect

--- a/compiler/plugins/target/AMD-AIE/aievec/VectorToAIEVecConversions.cpp
+++ b/compiler/plugins/target/AMD-AIE/aievec/VectorToAIEVecConversions.cpp
@@ -13,14 +13,12 @@
 //===----------------------------------------------------------------------===//
 
 #include <optional>
-#include <tuple>
 
 #include "AIEVecOps.h"
 #include "AIEVecUtils.h"
 #include "Passes.h"
 #include "Utils.h"
 #include "llvm/ADT/SmallSet.h"
-#include "llvm/ADT/TypeSwitch.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/Dialect/Math/IR/Math.h"
@@ -1082,18 +1080,26 @@ struct LowerVectorToAIEVec : PassWrapper<LowerVectorToAIEVec, OperationPass<>> {
   }
 };
 
-static std::unique_ptr<Pass> createLowerVectorToAIEVec() {
-  return std::make_unique<LowerVectorToAIEVec>();
-}
-
 //============================================================================//
 //=============== Main Vector2AIEVec Pipeline Configuration ==================//
 //============================================================================//
 
-void mlir::iree_compiler::aievec::buildLowerVectorToAIEVec(OpPassManager &pm) {
+namespace mlir::iree_compiler::aievec {
+static std::unique_ptr<Pass> createLowerVectorToAIEVec() {
+  return std::make_unique<LowerVectorToAIEVec>();
+}
+
+void registerLowerVectorToAIEVecPass() {
+  ::mlir::registerPass([]() -> std::unique_ptr<mlir::Pass> {
+    return createLowerVectorToAIEVec();
+  });
+}
+
+void buildLowerVectorToAIEVec(mlir::OpPassManager &pm) {
   // Add lowering from `Vector` to `AIEVec`
   pm.addPass(createLowerVectorToAIEVec());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
   pm.addPass(createCanonicalizerPass());
 }
+}  // namespace mlir::iree_compiler::aievec

--- a/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
+++ b/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
@@ -90,25 +90,24 @@ static bool isGemmBTransposedContractionOp(vector::ContractionOp op) {
 // `vector.extract_strided_slice` selecting the subvector matching the
 // original `vector.transfer_read`.
 struct SplitUnalignedTransferReadPattern
-    : public OpConversionPattern<vector::TransferReadOp> {
-  using OpConversionPattern<vector::TransferReadOp>::OpConversionPattern;
+    : public OpRewritePattern<vector::TransferReadOp> {
+  using OpRewritePattern<vector::TransferReadOp>::OpRewritePattern;
 
   SplitUnalignedTransferReadPattern(MLIRContext *context, int64_t maxVectorSize,
                                     int64_t alignment)
-      : OpConversionPattern<vector::TransferReadOp>(context),
+      : OpRewritePattern<vector::TransferReadOp>(context),
         maxVectorSize(maxVectorSize),
         vectorAlignment(alignment) {}
 
-  LogicalResult matchAndRewrite(
-      vector::TransferReadOp readOp, OpAdaptor adaptor,
-      ConversionPatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(vector::TransferReadOp readOp,
+                                PatternRewriter &rewriter) const override {
     // Check that it's not a splat transfer read.
-    if (adaptor.getPermutationMap().isConstant()) return failure();
+    if (readOp.getPermutationMap().isConstant()) return failure();
 
     // Check if the transfer is unaligned.
     auto vType = readOp.getVectorType();
     int64_t offset =
-        getTransferReadAlignmentOffset(adaptor, vType, vectorAlignment)
+        getTransferReadAlignmentOffset(readOp, vType, vectorAlignment)
             .value_or(0);
     if (offset == 0) return failure();
 
@@ -122,7 +121,7 @@ struct SplitUnalignedTransferReadPattern
     // TODO: Add support for cases where the offset is greater than the
     // TODO: vector length.
     auto loc = readOp.getLoc();
-    Value oldInnerMostIdx = adaptor.getIndices().back();
+    Value oldInnerMostIdx = readOp.getIndices().back();
     auto offsetCorrectionMap =
         AffineMap::get(1, 0, getAffineDimExpr(0, readOp.getContext()) - offset);
     Value newInnerMostIdx = rewriter
@@ -131,13 +130,13 @@ struct SplitUnalignedTransferReadPattern
                                     SmallVector<Value, 1>({oldInnerMostIdx}))
                                 .getResult();
     SmallVector<Value, 8> alignedIdx;
-    alignedIdx.append(adaptor.getIndices().begin(), adaptor.getIndices().end());
+    alignedIdx.append(readOp.getIndices().begin(), readOp.getIndices().end());
     alignedIdx[alignedIdx.size() - 1] = newInnerMostIdx;
 
     // Create the aligned transfer read for a vector 2x as long that covers the
     // elements of the unaligned vector.
     auto newReadOp = rewriter.create<vector::TransferReadOp>(
-        loc, longVecTy, adaptor.getSource(), alignedIdx, adaptor.getPadding());
+        loc, longVecTy, readOp.getSource(), alignedIdx, readOp.getPadding());
 
     // Create a `vector.extract_strided_slice` to extract the unaligned vector.
     rewriter.replaceOpWithNewOp<vector::ExtractStridedSliceOp>(
@@ -155,19 +154,18 @@ struct SplitUnalignedTransferReadPattern
 // obtain the splat value and a `vector.broadcast` to broadcast it into a
 // vector of the right size.
 struct ConvertSplatTransferReadToBroadcastPattern
-    : public OpConversionPattern<vector::TransferReadOp> {
-  using OpConversionPattern<vector::TransferReadOp>::OpConversionPattern;
+    : public OpRewritePattern<vector::TransferReadOp> {
+  using OpRewritePattern<vector::TransferReadOp>::OpRewritePattern;
 
   ConvertSplatTransferReadToBroadcastPattern(MLIRContext *context)
-      : OpConversionPattern<vector::TransferReadOp>(context) {}
+      : OpRewritePattern<vector::TransferReadOp>(context) {}
 
-  LogicalResult matchAndRewrite(
-      vector::TransferReadOp readOp, OpAdaptor adaptor,
-      ConversionPatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(vector::TransferReadOp readOp,
+                                PatternRewriter &rewriter) const override {
     AffineMap map = readOp.getPermutationMap();
     if (!map.isConstant()) return failure();
 
-    Value srcMemRef = adaptor.getSource();
+    Value srcMemRef = readOp.getSource();
     SmallVector<Value, 8> indices;
     Value newIdx;
     int64_t offset = 0;
@@ -182,7 +180,7 @@ struct ConvertSplatTransferReadToBroadcastPattern
                                                   rewriter.getIndexAttr(0L));
       indices.push_back(newIdx);
     } else {
-      indices.append(adaptor.getIndices().begin(), adaptor.getIndices().end());
+      indices.append(readOp.getIndices().begin(), readOp.getIndices().end());
       newIdx = indices[indices.size() - 1];
       // If the innermost index comes from an `affine.apply` op, take the base
       // as the new innermost index for the new `vector.transfer_read`, and the
@@ -211,7 +209,7 @@ struct ConvertSplatTransferReadToBroadcastPattern
     indices[indices.size() - 1] = newIdx;
     auto newReadOp = rewriter.create<vector::TransferReadOp>(
         readOp.getLoc(), readOp.getVector().getType(), srcMemRef, indices,
-        adaptor.getPadding());
+        readOp.getPadding());
     auto extractOp = rewriter.create<vector::ExtractOp>(
         readOp.getLoc(), newReadOp.getResult(), ArrayRef<int64_t>{offset});
     rewriter.replaceOpWithNewOp<vector::BroadcastOp>(
@@ -311,20 +309,19 @@ static Value collapseInnerMostShapeDims(PatternRewriter &b, Location loc,
 // replacing them with a `memref.collapse_shape`, a 1D `vector.transfer_read`,
 // and a `vector.shape_cast`.
 struct FlattenMultDimTransferReadPattern
-    : public OpConversionPattern<vector::TransferReadOp> {
-  using OpConversionPattern<vector::TransferReadOp>::OpConversionPattern;
+    : public OpRewritePattern<vector::TransferReadOp> {
+  using OpRewritePattern<vector::TransferReadOp>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(
-      vector::TransferReadOp readOp, OpAdaptor adaptor,
-      ConversionPatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(vector::TransferReadOp readOp,
+                                PatternRewriter &rewriter) const override {
     // We can only deal with unmasked transfer ops with an identity permutation
     // map.
-    if (!adaptor.getPermutationMap().isMinorIdentity() || adaptor.getMask())
+    if (!readOp.getPermutationMap().isMinorIdentity() || readOp.getMask())
       return failure();
     VectorType vectorTy = readOp.getVector().getType();
     if (vectorTy.getRank() < 2) return failure();
     // Work only on bufferized reads
-    MemRefType memRefTy = dyn_cast<MemRefType>(adaptor.getSource().getType());
+    MemRefType memRefTy = dyn_cast<MemRefType>(readOp.getSource().getType());
     if (!memRefTy) return failure();
     auto memRefShape = memRefTy.getShape();
     auto vecShape = vectorTy.getShape();
@@ -336,13 +333,13 @@ struct FlattenMultDimTransferReadPattern
     AffineMap layout = memRefTy.getLayout().getAffineMap();
     auto newIndices =
         collapseInnerMostDimIndices(rewriter, readOp.getLoc(), vecShape.size(),
-                                    adaptor.getIndices(), memRefShape, layout);
+                                    readOp.getIndices(), memRefShape, layout);
     auto newSource = collapseInnerMostShapeDims(
-        rewriter, readOp.getLoc(), vecShape.size(), adaptor.getSource());
+        rewriter, readOp.getLoc(), vecShape.size(), readOp.getSource());
     auto newVector = rewriter.create<vector::TransferReadOp>(
         readOp.getLoc(), newVectorTy, newSource, newIndices);
 
-    auto inBoundsArrayAttrOpt = adaptor.getInBounds();
+    auto inBoundsArrayAttrOpt = readOp.getInBounds();
     if (inBoundsArrayAttrOpt) {
       SmallVector<bool> inBounds =
           llvm::to_vector(inBoundsArrayAttrOpt.getAsValueRange<BoolAttr>());
@@ -364,20 +361,19 @@ struct FlattenMultDimTransferReadPattern
 // replacing them with a `memref.collapse_shape`, a `vector.shape_cast`, and a
 // 1D `vector.transfer_write`,
 struct FlattenMultDimTransferWritePattern
-    : public OpConversionPattern<vector::TransferWriteOp> {
-  using OpConversionPattern<vector::TransferWriteOp>::OpConversionPattern;
+    : public OpRewritePattern<vector::TransferWriteOp> {
+  using OpRewritePattern<vector::TransferWriteOp>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(
-      vector::TransferWriteOp writeOp, OpAdaptor adaptor,
-      ConversionPatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(vector::TransferWriteOp writeOp,
+                                PatternRewriter &rewriter) const override {
     // We can only deal with unmasked transfer ops with an identity permutation
     // map.
-    if (!adaptor.getPermutationMap().isMinorIdentity() || adaptor.getMask())
+    if (!writeOp.getPermutationMap().isMinorIdentity() || writeOp.getMask())
       return failure();
-    VectorType vectorTy = cast<VectorType>(adaptor.getVector().getType());
+    VectorType vectorTy = cast<VectorType>(writeOp.getVector().getType());
     if (vectorTy.getRank() < 2) return failure();
     // Work only on bufferized reads
-    MemRefType memRefTy = dyn_cast<MemRefType>(adaptor.getSource().getType());
+    MemRefType memRefTy = dyn_cast<MemRefType>(writeOp.getSource().getType());
     if (!memRefTy) return failure();
     auto memRefShape = memRefTy.getShape();
     auto vecShape = vectorTy.getShape();
@@ -389,18 +385,18 @@ struct FlattenMultDimTransferWritePattern
     AffineMap layout = memRefTy.getLayout().getAffineMap();
     auto newVector = rewriter
                          .create<vector::ShapeCastOp>(
-                             writeOp.getLoc(), newVectorTy, adaptor.getVector())
+                             writeOp.getLoc(), newVectorTy, writeOp.getVector())
                          .getResult();
     auto newIndices =
         collapseInnerMostDimIndices(rewriter, writeOp.getLoc(), vecShape.size(),
-                                    adaptor.getIndices(), memRefShape, layout);
+                                    writeOp.getIndices(), memRefShape, layout);
     auto newSource = collapseInnerMostShapeDims(
-        rewriter, writeOp.getLoc(), vecShape.size(), adaptor.getSource());
+        rewriter, writeOp.getLoc(), vecShape.size(), writeOp.getSource());
 
     auto newOp = rewriter.replaceOpWithNewOp<vector::TransferWriteOp>(
         writeOp, newVector, newSource, newIndices);
 
-    auto inBoundsArrayAttrOpt = adaptor.getInBounds();
+    auto inBoundsArrayAttrOpt = writeOp.getInBounds();
     if (inBoundsArrayAttrOpt) {
       SmallVector<bool> inBounds =
           llvm::to_vector(inBoundsArrayAttrOpt.getAsValueRange<BoolAttr>());
@@ -420,8 +416,8 @@ struct FlattenMultDimTransferWritePattern
 // If `rhs` is coming from a widening op (`extf`/`extsi`/`extui`), the
 // transposition will be hoisted above the widening op.
 struct ExtractTransposeFromContractionOp
-    : public OpConversionPattern<vector::ContractionOp> {
-  using OpConversionPattern<vector::ContractionOp>::OpConversionPattern;
+    : public OpRewritePattern<vector::ContractionOp> {
+  using OpRewritePattern<vector::ContractionOp>::OpRewritePattern;
 
   static VectorType getTransposedVectorType(VectorType vecTy) {
     SmallVector<int64_t> shape{vecTy.getShape()};
@@ -433,15 +429,14 @@ struct ExtractTransposeFromContractionOp
     return VectorType::get(shape, elemTy);
   }
 
-  LogicalResult matchAndRewrite(
-      vector::ContractionOp contractOp, OpAdaptor adaptor,
-      ConversionPatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(vector::ContractionOp contractOp,
+                                PatternRewriter &rewriter) const override {
     if (!isGemmBTransposedContractionOp(contractOp)) return failure();
 
     Location loc = contractOp.getLoc();
     auto ctx = rewriter.getContext();
 
-    Value rhsVal = adaptor.getRhs();
+    Value rhsVal = contractOp.getRhs();
     VectorType rhsVecTy = contractOp.getRhsType();
     Type rhsElemTy = rhsVecTy.getElementType();
 
@@ -506,8 +501,8 @@ struct ExtractTransposeFromContractionOp
         {oldIdxMaps[0], oldIdxMaps[1].compose(transpPermMap), oldIdxMaps[2]});
 
     rewriter.replaceOpWithNewOp<vector::ContractionOp>(
-        contractOp, contractOp.getResult().getType(), adaptor.getLhs(), rhsVal,
-        adaptor.getAcc(), newIdxMaps, contractOp.getIteratorTypes());
+        contractOp, contractOp.getResult().getType(), contractOp.getLhs(),
+        rhsVal, contractOp.getAcc(), newIdxMaps, contractOp.getIteratorTypes());
 
     return success();
   }

--- a/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
@@ -1,0 +1,23 @@
+// RUN: iree-opt %s --canonicalize-vector-for-aievec -split-input-file | FileCheck %s
+
+// CHECK-LABEL: @extsi_to_broadcast_swap(
+// CHECK-SAME: %[[VIN:.*]]: vector<8xi8>
+func.func @extsi_to_broadcast_swap(%v: vector<8xi8>) -> vector<4x8xi32> {
+    // CHECK: %[[BCAST:.*]] = vector.broadcast %[[VIN]] : vector<8xi8> to vector<4x8xi8>
+    // CHECK: %[[EXT:.*]] = arith.extsi %[[BCAST]] : vector<4x8xi8> to vector<4x8xi32>
+    %0 = arith.extsi %v : vector<8xi8> to vector<8xi32>
+    %1 = vector.broadcast %0 : vector<8xi32> to vector<4x8xi32>
+    return %1 : vector<4x8xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @scalar_extsi_to_broadcast_swap(
+// CHECK-SAME: %[[SIN:.*]]: i8
+func.func @scalar_extsi_to_broadcast_swap(%s: i8) -> vector<32xi32> {
+    // CHECK: %[[BCAST:.*]] = vector.broadcast %[[SIN]] : i8 to vector<32xi8>
+    // CHECK: %[[EXT:.*]] = arith.extsi %[[BCAST]] : vector<32xi8> to vector<32xi32>
+    %0 = arith.extsi %s : i8 to i32
+    %1 = vector.broadcast %0 : i32 to vector<32xi32>
+    return %1 : vector<32xi32>
+}

--- a/compiler/plugins/target/AMD-AIE/aievec/test/test-ups.mlir
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/test-ups.mlir
@@ -182,3 +182,21 @@ func.func @v32f32_ups_v32bf16(%arg0 : vector<32xbf16>) {
 // CHECK-SAME: %[[BITCAST4]], %[[BITCAST5]]) :
 // CHECK-SAME: (vector<16xi32>, vector<16xi32>) -> vector<32xi32>
 // CHECK-NEXT: %[[RES:.*]] = llvm.bitcast %[[CONCAT]] : vector<32xi32> to vector<32xf32>
+
+
+// -----
+
+// CHECK-LABEL: @multidim_ups_i8_to_i32
+// CHECK-SAME: %[[V:.*]]: vector<4x8xi8>
+// CHECK: %[[FV:.*]] = vector.shape_cast %[[V]]
+// CHECK-SAME:                     : vector<4x8xi8> to vector<32xi8>
+// CHECK: %[[FUPS:.*]] = "xllvm.intr.aie2.acc32.v32.I256.ups"(%[[FV]],
+// CHECK-SAME:                             %{{[a-zA-Z0-9]+}}, %{{[a-zA-Z0-9]+}})
+// CHECK-SAME:                     : (vector<32xi8>, i32, i32) -> vector<16xi64>
+// CHECK: %[[FR:.*]] = llvm.bitcast %3 : vector<16xi64> to vector<32xi32>
+// CHECK: %[[UPS:.*]] = vector.shape_cast %[[FR]]
+// CHECK-sAME:                     : vector<32xi32> to vector<4x8xi32>
+func.func @multidim_ups_i8_to_i32(%arg0 : vector<4x8xi8>) -> vector<4x8xi32> {
+  %0 = aievec.ups %arg0 {shift = 0 : i8} : vector<4x8xi8>, vector<4x8xi32>
+  return %0 : vector<4x8xi32>
+}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/PluginRegistration.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/PluginRegistration.cpp
@@ -13,7 +13,6 @@
 #include "air/Passes.h"
 #include "iree-amd-aie/IR/AMDAIEDialect.h"
 #include "iree-amd-aie/Target/AIETarget.h"
-#include "iree-amd-aie/Target/AIETargetDirect.h"
 #include "iree-amd-aie/Transforms/Passes.h"
 #include "iree/compiler/Dialect/HAL/Target/TargetRegistry.h"
 #include "iree/compiler/PluginAPI/Client.h"
@@ -39,6 +38,8 @@ struct AMDAIESession
     AMDAIE::registerAIRConversionPasses();
     AMDAIE::registerAIRTransformPasses();
     aievec::registerConvertAIEVecToLLVMPass();
+    aievec::registerCanonicalizeVectorForAIEVecPass();
+    aievec::registerLowerVectorToAIEVecPass();
   }
 
   void onRegisterDialects(DialectRegistry &registry) override {


### PR DESCRIPTION
Pulls in 2 PRs from mlir-aie for the AIEVec dialect:

1) https://github.com/Xilinx/mlir-aie/pull/1655
2) https://github.com/Xilinx/mlir-aie/pull/1665


Required some changes to pass registration to get the testing working. 
I also did some refactoring specific to our simpler requirements (no AIE1 support, etc)