### PR TITLE
Enable workflow dispatch for CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,9 @@ name: CI
 
 on:
   workflow_call:
-
+  workflow_dispatch:
   pull_request:
-
   merge_group:
-
   push:
     branches:
       - main


### PR DESCRIPTION
It's useful to people to start these arbitrarily - it works like this: 
![Screenshot from 2024-08-02 16-25-32](https://github.com/user-attachments/assets/0f0c0d90-a2cb-460e-9a81-1c53b6669b4c)
