### PR TITLE
Fix XRT bindings hangs and numerics issues

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -209,6 +209,7 @@ function run_matmul_test() {
   # intermittently. It is also useful if a test is know to fail at runtime but
   # should still be checked to compile (set num_repeat_runs=0 in this case).
   local num_repeat_runs="1"
+  local num_corruption_repeat_runs="1"
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -218,6 +219,10 @@ function run_matmul_test() {
         ;;
       --num_repeat_runs)
         num_repeat_runs="$2"
+        shift 2
+        ;;
+      --num_corruption_repeat_runs)
+        num_corruption_repeat_runs="$2"
         shift 2
         ;;
       --max_elements_to_check)
@@ -436,20 +441,24 @@ function run_matmul_test() {
 
   set +e
 
-  echo "**** Running '${name}' matmul test ${num_repeat_runs} times (command ${COMMAND}) ****"
+  total_num_runs=$(( num_repeat_runs * num_corruption_repeat_runs))
+  echo "**** Running '${name}' matmul test ${total_num_runs} times (command ${COMMAND}) ****"
   for i in $(seq 1 $num_repeat_runs); do
     # Only reset NPU in CI to facilitate easier local testing without sudo access.
     if [ "${GITHUB_ACTIONS}" = true ]; then
       echo "Reset NPU"
       bash $THIS_DIR/reset_npu.sh
     fi
-    echo "Run number ${i} / ${num_repeat_runs}"
-    eval "${COMMAND}"
-    return_status=$?
-    if [ $return_status -ne 0 ]; then
-      echo "'${name}' matmul test failed!"
-      export MATMUL_TESTS_FAILS=$(( $MATMUL_TESTS_FAILS+1 ))
-    fi
+    for j in $(seq 1 $num_corruption_repeat_runs); do
+      run_number=$(( (i - 1) * num_corruption_repeat_runs + j))
+      echo "Run number ${run_number} / ${total_num_runs}"
+      eval "${COMMAND}"
+      return_status=$?
+      if [ $return_status -ne 0 ]; then
+        echo "'${name}' matmul test failed!"
+        export MATMUL_TESTS_FAILS=$(( $MATMUL_TESTS_FAILS+1 ))
+      fi
+    done
   done
   set -e
 
@@ -748,6 +757,20 @@ run_matmul_test \
 # ObjectFifo Matmul tests
 ###################################################################
 
+# Run repeatedly to check for non-deterministic hangs and numerical 
+# issues.
+repeat_shapes=(
+  '32x32x32'
+)
+
+run_matmul_test_on_shapes ${repeat_shapes[@]} \
+    --name_prefix "small" \
+    --lower_to_aie_pipeline "objectFifo" \
+    --tile_pipeline "pack-peel" \
+    --lhs_rhs_type "i32" \
+    --acc_type "i32" \
+    --num_corruption_repeat_runs "1000"
+
 i32_shapes_small=(
   '32x32x32'
   '64x32x128'
@@ -760,9 +783,10 @@ i32_shapes_small=(
   '128x256x128'
 )
 
+# TODO(jornt): Debug and re-enable 1536x2048x1536
 i32_shapes_medium=(
   '1024x1024x1024' 
-  '1536x2048x1536'
+  # '1536x2048x1536' 
 )
 
 run_matmul_test_on_shapes ${i32_shapes_small[@]} \
@@ -771,7 +795,7 @@ run_matmul_test_on_shapes ${i32_shapes_small[@]} \
     --tile_pipeline "pack-peel" \
     --lhs_rhs_type "i32" \
     --acc_type "i32" \
-    --num_repeat_runs "2"
+    --num_repeat_runs "10"
 
 run_matmul_test_on_shapes ${i32_shapes_medium[@]} \
     --name_prefix "medium" \

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -209,6 +209,11 @@ function run_matmul_test() {
   # intermittently. It is also useful if a test is know to fail at runtime but
   # should still be checked to compile (set num_repeat_runs=0 in this case).
   local num_repeat_runs="1"
+
+  # Run the test 'num_corruption_repeat_runs' times without an NPU reset in 
+  # between. This can be used to check for corruption, i.e. the AIE might be
+  # left in a bad state in between runs. Additionally, this increases the speed
+  # of the repeated test
   local num_corruption_repeat_runs="1"
 
   while [ "$#" -gt 0 ]; do

--- a/runtime/src/iree-amd-aie/driver/xrt/direct_allocator.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/direct_allocator.cc
@@ -28,7 +28,7 @@ typedef struct iree_hal_xrt_allocator_t {
   // The device that this allocator is attached to.
   iree_hal_device_t* base_device;
 
-  xrt::device device;
+  xrt::device *device;
 
   iree_allocator_t host_allocator;
 
@@ -46,7 +46,7 @@ static iree_hal_xrt_allocator_t* iree_hal_xrt_allocator_cast(
 }
 
 iree_status_t iree_hal_xrt_allocator_create(
-    iree_hal_device_t* base_device, xrt::device device,
+    iree_hal_device_t* base_device, xrt::device *device,
     iree_allocator_t host_allocator, iree_hal_allocator_t** out_allocator) {
   IREE_ASSERT_ARGUMENT(base_device);
   IREE_ASSERT_ARGUMENT(out_allocator);
@@ -171,7 +171,7 @@ static iree_status_t iree_hal_xrt_allocator_allocate_buffer(
   std::unique_ptr<xrt::bo> xrt_buffer;
 
   try {
-    xrt_buffer = std::make_unique<xrt::bo>(allocator->device, allocation_size,
+    xrt_buffer = std::make_unique<xrt::bo>(*allocator->device, allocation_size,
                                            XRT_BO_FLAGS_HOST_ONLY, group_id);
   } catch (...) {
     IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree-amd-aie/driver/xrt/direct_allocator.h
+++ b/runtime/src/iree-amd-aie/driver/xrt/direct_allocator.h
@@ -17,7 +17,7 @@ extern "C" {
 
 // Creates an XRT memory allocator.
 iree_status_t iree_hal_xrt_allocator_create(
-    iree_hal_device_t* base_device, xrt::device device,
+    iree_hal_device_t* base_device, xrt::device* device,
     iree_allocator_t host_allocator, iree_hal_allocator_t** out_allocator);
 
 #ifdef __cplusplus

--- a/runtime/src/iree-amd-aie/driver/xrt/direct_command_buffer.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/direct_command_buffer.cc
@@ -324,12 +324,9 @@ static iree_status_t iree_hal_xrt_direct_command_buffer_dispatch(
       z0, iree_hal_resource_set_insert(command_buffer->resource_set, 1,
                                        &executable));
 
-  xrt::device device = *kernel_params.device;
   xrt::kernel kernel = *kernel_params.kernel;
   xrt::bo instr = *kernel_params.instr;
   uint32_t num_instr = kernel_params.num_instr;
-  instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-
   xrt::run run = xrt::run(kernel);
 
   // set opcode for transaction binary execution

--- a/runtime/src/iree-amd-aie/driver/xrt/native_executable.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/native_executable.cc
@@ -99,7 +99,7 @@ static iree_status_t iree_amd_aie_hal_xrt_native_executable_flatbuffer_verify(
 }
 
 iree_status_t iree_hal_xrt_native_executable_create(
-    xrt::device device, const iree_hal_executable_params_t* executable_params,
+    xrt::device *device, const iree_hal_executable_params_t* executable_params,
     iree_allocator_t host_allocator, iree_hal_executable_t** out_executable) {
   IREE_ASSERT_ARGUMENT(executable_params);
   IREE_ASSERT_ARGUMENT(out_executable);
@@ -177,15 +177,15 @@ iree_status_t iree_hal_xrt_native_executable_create(
     // XRT API needs this vector and cant actually read a void*.
     std::vector<char> xclbinVector(
         xclbin_fb, xclbin_fb + flatbuffers_string_len(xclbin_fb));
-    xrt::xclbin xclbin;
+    std::unique_ptr<xrt::xclbin> xclbin;
     try {
-      xclbin = xrt::xclbin(xclbinVector);
+      xclbin = std::make_unique<xrt::xclbin>(xclbinVector);
     } catch (std::runtime_error& e) {
       return iree_make_status(IREE_STATUS_INTERNAL, "XCLBIN load error: %s",
                               e.what());
     }
-    device.register_xclbin(xclbin);
-    xrt::hw_context context(device, xclbin.get_uuid());
+    device->register_xclbin(*xclbin);
+    xrt::hw_context context(*device, xclbin->get_uuid());
     uint32_t asm_instr_index =
         flatbuffers_uint32_vec_at(asm_instr_indices_vec, entry_ordinal);
     iree_amd_aie_hal_xrt_AsmInstDef_table_t asminst_def =
@@ -199,11 +199,11 @@ iree_status_t iree_hal_xrt_native_executable_create(
       kernel = std::make_unique<xrt::kernel>(context, entry_name);
       // XCL_BO_FLAGS_CACHEABLE is used to indicate that this is an instruction
       // buffer that resides in instr_memory. This buffer is always passed as
-      // the second argument to the kernel and we can use the
-      // kernel.group_id(/*index of second argument*/=1) to get the group_id.
-      instr = std::make_unique<xrt::bo>(device, num_instr * sizeof(uint32_t),
+      // the second argument to the kernel and we can use group id 1.
+      int group_id = 1;
+      instr = std::make_unique<xrt::bo>(*device, num_instr * sizeof(uint32_t),
                                         XCL_BO_FLAGS_CACHEABLE,
-                                        kernel.get()->group_id(1));
+                                        group_id);
     } catch (...) {
       iree_hal_executable_destroy((iree_hal_executable_t*)executable);
       IREE_TRACE_ZONE_END(z0);
@@ -219,6 +219,8 @@ iree_status_t iree_hal_xrt_native_executable_create(
     instr->sync(XCL_BO_SYNC_BO_TO_DEVICE);
     iree_hal_xrt_kernel_params_t* params =
         &executable->entry_points[entry_ordinal];
+    params->xclbin = xclbin.release();
+    params->device = device;
     params->kernel = kernel.release();
     params->instr = instr.release();
     params->num_instr = num_instr;

--- a/runtime/src/iree-amd-aie/driver/xrt/native_executable.h
+++ b/runtime/src/iree-amd-aie/driver/xrt/native_executable.h
@@ -22,7 +22,6 @@ extern "C" {
 // Object and launch parameters for a compute kernel.
 typedef struct iree_hal_xrt_kernel_params_t {
   xrt::xclbin *xclbin;
-  xrt::device* device;
   // The kernel code object.
   xrt::kernel* kernel;
   // Instruction buffer argument to the kernel.

--- a/runtime/src/iree-amd-aie/driver/xrt/native_executable.h
+++ b/runtime/src/iree-amd-aie/driver/xrt/native_executable.h
@@ -21,6 +21,8 @@ extern "C" {
 
 // Object and launch parameters for a compute kernel.
 typedef struct iree_hal_xrt_kernel_params_t {
+  xrt::xclbin *xclbin;
+  xrt::device* device;
   // The kernel code object.
   xrt::kernel* kernel;
   // Instruction buffer argument to the kernel.
@@ -36,7 +38,7 @@ typedef struct iree_hal_xrt_kernel_params_t {
 // |out_executable| must be released by the caller (see
 // iree_hal_executable_release).
 iree_status_t iree_hal_xrt_native_executable_create(
-    xrt::device device, const iree_hal_executable_params_t* executable_params,
+    xrt::device *device, const iree_hal_executable_params_t* executable_params,
     iree_allocator_t host_allocator, iree_hal_executable_t** out_executable);
 
 // Returns the kernel launch parameters for the given |entry_point|.

--- a/runtime/src/iree-amd-aie/driver/xrt/nop_executable_cache.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/nop_executable_cache.cc
@@ -18,7 +18,7 @@ typedef struct iree_hal_xrt_nop_executable_cache_t {
   // at offset 0.
   iree_hal_resource_t resource;
 
-  xrt::device device;
+  xrt::device *device;
 
   iree_allocator_t host_allocator;
 } iree_hal_xrt_nop_executable_cache_t;
@@ -36,7 +36,7 @@ iree_hal_xrt_nop_executable_cache_cast(
 }
 
 iree_status_t iree_hal_xrt_nop_executable_cache_create(
-    xrt::device device, iree_string_view_t identifier,
+    xrt::device *device, iree_string_view_t identifier,
     iree_allocator_t host_allocator,
     iree_hal_executable_cache_t** out_executable_cache) {
   IREE_ASSERT_ARGUMENT(out_executable_cache);

--- a/runtime/src/iree-amd-aie/driver/xrt/nop_executable_cache.h
+++ b/runtime/src/iree-amd-aie/driver/xrt/nop_executable_cache.h
@@ -22,7 +22,7 @@ extern "C" {
 // |out_executable_cache| must be released by the caller (see
 // iree_hal_executable_cache_release).
 iree_status_t iree_hal_xrt_nop_executable_cache_create(
-    xrt::device device, iree_string_view_t identifier,
+    xrt::device *device, iree_string_view_t identifier,
     iree_allocator_t host_allocator,
     iree_hal_executable_cache_t** out_executable_cache);
 

--- a/runtime/src/iree-amd-aie/driver/xrt/xrt_device.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/xrt_device.cc
@@ -33,7 +33,7 @@ typedef struct iree_hal_xrt_device_t {
   iree_allocator_t host_allocator;
   iree_hal_allocator_t* device_allocator;
 
-  xrt::device device;
+  xrt::device *device;
 } iree_hal_xrt_device_t;
 
 namespace {
@@ -66,7 +66,7 @@ const iree_hal_xrt_device_params_t* iree_hal_xrt_device_params(
 }
 
 static iree_status_t iree_hal_xrt_device_create_internal(
-    iree_string_view_t identifier, xrt::device xrt_device,
+    iree_string_view_t identifier, xrt::device *xrt_device,
     const iree_hal_xrt_device_params_t* params, iree_allocator_t host_allocator,
     iree_hal_device_t** out_device) {
   iree_hal_xrt_device_t* device = NULL;
@@ -100,7 +100,7 @@ static iree_status_t iree_hal_xrt_device_create_internal(
 
 iree_status_t iree_hal_xrt_device_create(
     iree_string_view_t identifier, const iree_hal_xrt_device_params_t* params,
-    xrt::device device, iree_allocator_t host_allocator,
+    xrt::device *device, iree_allocator_t host_allocator,
     iree_hal_device_t** out_device) {
   IREE_ASSERT_ARGUMENT(out_device);
   IREE_TRACE_ZONE_BEGIN(z0);

--- a/runtime/src/iree-amd-aie/driver/xrt/xrt_device.h
+++ b/runtime/src/iree-amd-aie/driver/xrt/xrt_device.h
@@ -16,13 +16,19 @@
 extern "C" {
 #endif  // __cplusplus
 
+/// P0 TODO(jornt): get rid of the global variable.
+/// Using a global variable is currently the only 'reliable' approach that will
+/// not result in occasional hangs. Creating a unique pointer and releasing it
+/// doesn't work for some reason. Needs further debugging.
+static xrt::device global_device;
+
 // Creates a XRT device by wrapping |device| from the given |driver| with the
 // specific |params|.
 //
 // |out_device| must be released by the caller (see iree_hal_device_release).
 iree_status_t iree_hal_xrt_device_create(
     iree_string_view_t identifier, const iree_hal_xrt_device_params_t* params,
-    xrt::device device, iree_allocator_t host_allocator,
+    xrt::device* device, iree_allocator_t host_allocator,
     iree_hal_device_t** out_device);
 
 // Returns the parameters used for creating the device.


### PR DESCRIPTION
Temporary fix as it seems to work reliably, but needs some follow ups to get rid of the global variable and output buffer sync inside the dispatch function.

Currently, I think there are two separate issues, which are fixed by this PR:

- Hangs, caused by the xrt::device getting destroyed while in use.
- Numerical issues, presumably caused by a missing sync on the output.

Locally, I can do 5000 runs without any issue on my debug shape 32x32x32. 