### PR TITLE
[Convolution tiling] change strategy

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -470,7 +470,7 @@ void addConvDecomposePassPipeline(OpPassManager &funcPassManager,
   // Pad the linalg operation
   {
     AMDAIEPadOptions padOptions;
-    padOptions.paddingLevel = 1;
+    padOptions.paddingLevel = 0;
     funcPassManager.addPass(createAMDAIEPadPass(padOptions));
   }
 
@@ -478,7 +478,7 @@ void addConvDecomposePassPipeline(OpPassManager &funcPassManager,
   {
     AMDAIEBufferizeToAllocationOptions bufferizeOptions;
     bufferizeOptions.memorySpace = 2;
-    bufferizeOptions.bufferizeOperand = BufferizeOperand::Output;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::InputOutput;
     funcPassManager.addPass(
         createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
   }
@@ -493,22 +493,6 @@ void addConvDecomposePassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createAMDAIECleanupPass());
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
-
-  // Pad the linalg operation
-  {
-    AMDAIEPadOptions padOptions;
-    padOptions.paddingLevel = 2;
-    funcPassManager.addPass(createAMDAIEPadPass(padOptions));
-  }
-
-  // Promote the inputs to local memory
-  {
-    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
-    bufferizeOptions.memorySpace = 2;
-    bufferizeOptions.bufferizeOperand = BufferizeOperand::Input;
-    funcPassManager.addPass(
-        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
-  }
 
   // Decompose Conv2d ops to Conv1d ops
   funcPassManager.addPass(createDecomposeConvolutionToLowerDimOpsPass());


### PR DESCRIPTION
Use larger L1 operand tile sizes. Do not interleave small copies from L2 to L1 with compute, rather copy large blocks of data across. 