### PR TITLE
Adding conditional statement to remove target_include_directories when tests are not enabled

### DIFF
--- a/runtime/src/iree-amd-aie/aie_runtime/CMakeLists.txt
+++ b/runtime/src/iree-amd-aie/aie_runtime/CMakeLists.txt
@@ -500,7 +500,11 @@ endif()
 # iree-aie-runtime-static
 # ##############################################################################
 
-iree_add_all_subdirs()
+add_subdirectory(Utils)
+
+if (IREE_BUILD_TESTS)
+  add_subdirectory(test)
+endif()
 
 iree_tablegen_library(
   NAME


### PR DESCRIPTION
When building iree-amd-aie with IREE_BUILD_TESTS=OFF, this line generates an error because the target is not being built:

```
CMake Error at /opt/iree/installers/AARInternal/iree-amd-aie/runtime/src/iree-amd-aie/aie_runtime/test/CMakeLists.txt:109 (target_include_directories):
  Cannot specify include directories for target
  "iree-amd-aie_aie_runtime_test_DeviceModelTestCppTest" which is not built
  by this project.
```