### PR TITLE
Replace logical objectfifo produce/consume with core in/out DMA operands

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.cpp
@@ -52,16 +52,27 @@ LogicalResult ControlCodeOp::verify() {
 // AMDAIE_CoreOp
 //===----------------------------------------------------------------------===//
 
+
+void CoreOp::build(OpBuilder &b, OperationState &result, AMDAIE::TileOp tileOp,
+                   ValueRange inputDmas, ValueRange outputDmas) {
+  build(b, result, b.getIndexType(), tileOp, inputDmas, outputDmas, nullptr);
+}
+
 /// Hardcoded row_offset == 2 -> AIE core rows start from 2
 /// TODO(jornt): avoid hardcoding here. Add a device model/identifier to loop up
 /// core offset. This will be handled in a follow-up.
 void CoreOp::build(OpBuilder &b, OperationState &result, Value coreCol,
-                   Value coreRow) {
+                   Value coreRow, ValueRange inputDmas, ValueRange outputDmas) {
   auto rowOffset = b.create<arith::ConstantIndexOp>(b.getUnknownLoc(), 2);
   auto row =
       b.createOrFold<arith::AddIOp>(b.getUnknownLoc(), rowOffset, coreRow);
   auto tileOp = b.create<AMDAIE::TileOp>(b.getUnknownLoc(), coreCol, row);
-  build(b, result, b.getIndexType(), tileOp, nullptr);
+  build(b, result, tileOp, inputDmas, outputDmas, nullptr);
+}
+
+void CoreOp::build(OpBuilder &b, OperationState &result, Value coreCol,
+                   Value coreRow) {
+  build(b, result, coreCol, coreRow, {}, {});
 }
 
 LogicalResult CoreOp::verify() {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -47,7 +47,7 @@ def AMDAIE_ControlCodeOp : AMDAIE_Op<"controlcode", [HasParent<"WorkgroupOp">,
   let hasVerifier = 1;
 }
 
-def AMDAIE_CoreOp: AMDAIE_Op<"core", [SingleBlock]>, Results<(outs Index)> {
+def AMDAIE_CoreOp: AMDAIE_Op<"core", [SingleBlock, AttrSizedOperandSegments]>, Results<(outs Index)> {
   let summary = "The AIE core operator";
   let description = [{
     This operation represents an AIE core op, containing a sequence of operations
@@ -62,15 +62,20 @@ def AMDAIE_CoreOp: AMDAIE_Op<"core", [SingleBlock]>, Results<(outs Index)> {
 
   let arguments = (
     ins Index:$tile,
-    OptionalAttr<StrAttr>:$link_with
+        Variadic<Index>:$input_dmas,
+        Variadic<Index>:$output_dmas,
+        OptionalAttr<StrAttr>:$link_with
   );
 
   let regions = (region SizedRegion<1>:$region);
   
-  let assemblyFormat = [{ `(` $tile `)` regions attr-dict }];
+  let assemblyFormat = [{ `(` $tile `,` `in` `:` `[` $input_dmas `]` `,` `out` `:` `[` $output_dmas `]` `)` regions attr-dict }];
   
   let builders = [
     OpBuilder<(ins "mlir::Value":$coreCol, "mlir::Value":$coreRow)>,
+    OpBuilder<(ins "mlir::Value":$coreCol, "mlir::Value":$coreRow,
+      "ValueRange":$input_dmas, "ValueRange":$output_dmas)>,
+    OpBuilder<(ins "TileOp":$tile, "ValueRange":$input_dmas, "ValueRange":$output_dmas)>
   ];
 
   let extraClassDeclaration = [{
@@ -438,7 +443,7 @@ def AMDAIE_LogicalObjectFifoAccessOp : AMDAIE_Op<"logicalobjectfifo.access"> {
       %alloc = memref.alloc() : memref<8x16xi32, 2>
       %0 = amdaie.logicalobjectfifo.from_memref %alloc, {%tile} : memref<8x16xi32, 2>
         -> !amdaie.logicalobjectfifo<memref<8x16xi32, 2>>
-      %core = amdaie.core(%tile) {
+      %core = amdaie.core(%tile, in : [], out : []) {
         %1 = amdaie.logicalobjectfifo.access(%0, Read) : 
           !amdaie.logicalobjectfifo<memref<8x16xi32, 2>> ->  memref<8x16xi32, 2>
     ```
@@ -509,47 +514,6 @@ def AMDAIE_LogicalObjectFifoAcquire:
   let builders = [
     OpBuilder<(ins "mlir::TypeRange":$resultTypes, "mlir::Value":$dma, "LogicalObjectFifoPort":$port)>,
   ];
-}
-
-def AMDAIE_LogicalObjectFifoConsume: AMDAIE_Op<"logicalobjectfifo.consume", []> {
-  let summary = "Consume a DMA logical objectFifo result.";
-  let description = [{
-    Consumes the result of a DMA operation. This is a blocking operation,
-    waiting for the DMA to produce data. Typically, this operation will reside
-    inside a `CoreOp` to synchronize with external DMA operations producing data
-    into the respective core's local memory.
-
-    Example:
-    ```mlir
-    %2 = amdaie.dma_cpy_nd(
-      %1[%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16, %c1],
-      %0[%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c16, %c16, %c1])
-      : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>,
-      !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-    %3 = amdaie.logicalobjectfifo.consume(%2)
-    ```
-  }];
-
-  let arguments = (
-    ins Index:$dma
-  );
-
-  let assemblyFormat = [{
-    `(` $dma `)`  attr-dict
-  }];
-
-  let extraClassDeclaration = [{
-    DmaCpyNdOp getDmaCpyNdOp() {
-      return dyn_cast<DmaCpyNdOp>(getDma().getDefiningOp());
-    }
-    Value getLogicalObjectfifo() {
-      return dyn_cast<DmaCpyNdOp>(getDma().getDefiningOp()).getTarget();
-    }
-    // Return the port of this operation.
-    LogicalObjectFifoPort getPort() {
-      return LogicalObjectFifoPort::Consume;
-    }
-  }];
 }
 
 def AMDAIE_LogicalObjectFifoFromMemrefOp
@@ -651,48 +615,6 @@ def AMDAIE_LogicalObjectFifoLink
 
   let assemblyFormat = [{
     `[` ($ins^)? `]` `->` `[` ($outs^)? `]` `(` `)` attr-dict
-  }];
-}
-
-def AMDAIE_LogicalObjectFifoProduce: AMDAIE_Op<"logicalobjectfifo.produce", []> {
-  let summary = "Produce a DMA logicalobjectfifo input.";
-  let description = [{
-    Produces the input of a DMA operation. This is a release-type operation,
-    where the DMA will be waiting for the data to be produced. Typically, this
-    operation will reside inside a `CoreOp` to synchronize with external DMA
-    operations waiting for data from the respective core's local memory to be
-    released.
-
-    Example:
-    ```mlir
-    %2 = amdaie.dma_cpy_nd(
-      %1[%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16, %c1],
-      %0[%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c16, %c16, %c1])
-      : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>,
-      !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-    %3 = amdaie.logicalobjectfifo.produce(%2)
-    ```
-  }];
-
-  let arguments = (
-    ins Index:$dma
-  );
-  
-  let assemblyFormat = [{
-    `(` $dma `)`  attr-dict
-  }];
-  
-  let extraClassDeclaration = [{
-    DmaCpyNdOp getDmaCpyNdOp() {
-      return dyn_cast<DmaCpyNdOp>(getDma().getDefiningOp());
-    }
-    Value getLogicalObjectfifo() {
-      return dyn_cast<DmaCpyNdOp>(getDma().getDefiningOp()).getSource();
-    }
-    // Return the port of this operation.
-    LogicalObjectFifoPort getPort() {
-      return LogicalObjectFifoPort::Produce;
-    }
   }];
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/invalid.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/invalid.mlir
@@ -6,7 +6,7 @@ func.func @core_invalid_terminator() {
   %tile = amdaie.tile(%c0, %c0)
   // expected-note @+2 {{in custom textual format, the absence of terminator implies 'amdaie.end'}}
   // expected-error @+1 {{'amdaie.core' op expects regions to end with 'amdaie.end', found 'arith.constant'}}
-  %core = amdaie.core(%tile) {
+  %core = amdaie.core(%tile, in : [], out : []) {
     %c1 = arith.constant 0 : index
   }
   return

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/roundtrip.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/roundtrip.mlir
@@ -16,12 +16,12 @@ func.func @bd_id() {
 // CHECK-LABEL: func.func @core
 // CHECK: %[[C0:.*]] = arith.constant 0 : index
 // CHECK: %[[TILE_0:.*]] = amdaie.tile(%[[C0]], %[[C0]])
-// CHECK: %[[CORE_0:.*]] = amdaie.core(%[[TILE_0]])
+// CHECK: %[[CORE_0:.*]] = amdaie.core(%[[TILE_0]], in : [], out : [])
 // CHECK: amdaie.end
 func.func @core() {
   %c0 = arith.constant 0 : index
   %tile = amdaie.tile(%c0, %c0)
-  %core = amdaie.core(%tile) {
+  %core = amdaie.core(%tile, in : [], out : []) {
     amdaie.end
   }
   return
@@ -150,17 +150,6 @@ func.func @logicalobjectfifo_acquire(%arg0: !amdaie.logicalobjectfifo<memref<1x1
 
 // -----
 
-// CHECK-LABEL: func.func @logicalobjectfifo_consume
-// CHECK: amdaie.dma_cpy_nd
-// CHECK: amdaie.logicalobjectfifo.consume
-func.func @logicalobjectfifo_consume(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
-  %0 = amdaie.dma_cpy_nd(%arg0[0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-  amdaie.logicalobjectfifo.consume(%0)
-  return
-}
-
-// -----
-
 // CHECK-LABEL: func.func @logicalobjectfifo_link
 // CHECK:       %[[DMA0:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:       %[[DMA1:.+]] = amdaie.circular_dma_cpy_nd
@@ -171,17 +160,6 @@ func.func @logicalobjectfifo_link(%arg0: !amdaie.logicalobjectfifo<memref<32x102
   %0 = amdaie.circular_dma_cpy_nd(%arg1[] [] [], %arg0[] [] []) : (!amdaie.logicalobjectfifo<memref<32x64xi32, 1>>, !amdaie.logicalobjectfifo<memref<32x1024xi32>>)
   %1 = amdaie.circular_dma_cpy_nd(%arg2[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<8x8x4x8xi32, 2>>, !amdaie.logicalobjectfifo<memref<32x64xi32, 1>>)
   amdaie.logicalobjectfifo.link[%0] -> [%1] ()
-  return
-}
-
-// -----
-
-// CHECK-LABEL: func.func @logicalobjectfifo_produce
-// CHECK: amdaie.dma_cpy_nd
-// CHECK: amdaie.logicalobjectfifo.produce
-func.func @logicalobjectfifo_produce(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
-  %0 = amdaie.dma_cpy_nd(%arg0[0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-  amdaie.logicalobjectfifo.produce(%0)
   return
 }
 
@@ -300,11 +278,11 @@ func.func @workgroup() {
   %c1 = arith.constant 1 : index
   amdaie.workgroup {
     %tile_0_0 = amdaie.tile(%c0, %c0)
-    %core_0 = amdaie.core(%tile_0_0) {
+    %core_0 = amdaie.core(%tile_0_0, in : [], out : []) {
       amdaie.end
     }
     %tile_0_1 = amdaie.tile(%c0, %c1)
-    %core_1 = amdaie.core(%tile_0_1) {
+    %core_1 = amdaie.core(%tile_0_1, in : [], out : []) {
       amdaie.end
     }
     amdaie.controlcode {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.h
@@ -168,7 +168,7 @@ class CoreContext {
     if (!existingCoreOp) {
       coreMap[coordinate] = coreOp;
     } else {
-      mergeCoreOps(coreOp, existingCoreOp);
+      coreMap[coordinate] = mergeCoreOps(coreOp, existingCoreOp);
     }
   }
 
@@ -179,9 +179,8 @@ class CoreContext {
   }
 
  private:
-  /// Merge the 'source' core operations in the end of the 'dest' core
-  /// operation.
-  void mergeCoreOps(AMDAIE::CoreOp source, AMDAIE::CoreOp dest);
+  /// Merge the 'source' and 'dest' core operations into a new one.
+  AMDAIE::CoreOp mergeCoreOps(AMDAIE::CoreOp source, AMDAIE::CoreOp dest);
 
   /// The rewriter to be used.
   IRRewriterAndMapper &rewriter;

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
@@ -363,16 +363,6 @@ LogicalResult coreToAIE(IRRewriter &rewriter, AMDAIE::CoreOp coreOp,
             .Case<AMDAIE::LogicalObjectFifoAcquire>([&](auto acquireOp) {
               return acquireOpToAIE(rewriter, acquireOp, mapper, toBeErased);
             })
-            .Case<AMDAIE::LogicalObjectFifoConsume>([&](auto consumeOp) {
-              // TODO(jornt): get rid of LogicalObjectFifoConsume before this
-              rewriter.eraseOp(consumeOp);
-              return success();
-            })
-            .Case<AMDAIE::LogicalObjectFifoProduce>([&](auto produceOp) {
-              // TODO(jornt): get rid of LogicalObjectFifoProduce before this
-              rewriter.eraseOp(produceOp);
-              return success();
-            })
             .Case<AMDAIE::LogicalObjectFifoRelease>([&](auto releaseOp) {
               return coreReleaseOpToAIE(rewriter, releaseOp, mapper,
                                         toBeErased);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/access_to_acquire_release.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/access_to_acquire_release.mlir
@@ -12,9 +12,8 @@ func.func @read_access(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
   %c0 = arith.constant 0 : index
   %tile = amdaie.tile(%c0, %c0)
   %2 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-  %core = amdaie.core(%tile) {
+  %core = amdaie.core(%tile, in : [%2], out : []) {
     %3 = amdaie.logicalobjectfifo.access(%arg0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
-    amdaie.logicalobjectfifo.consume(%2)
     linalg.fill ins(%c0_i32 : i32) outs(%3 : memref<1x1x8x16xi32, 2>)
     amdaie.end
   }
@@ -35,10 +34,9 @@ func.func @write_access(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>
   %c0_i32 = arith.constant 0 : i32
   %tile = amdaie.tile(%c0, %c0)
   %2 = amdaie.circular_dma_cpy_nd(%arg1[] [] [], %arg0[] [] []) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>)
-  %core = amdaie.core(%tile) {
+  %core = amdaie.core(%tile, in : [], out : [%2]) {
     %3 = amdaie.logicalobjectfifo.access(%arg0, Write) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
     linalg.fill ins(%c0_i32 : i32) outs(%3 : memref<1x1x8x16xi32, 2>)
-    amdaie.logicalobjectfifo.produce(%2)
     amdaie.end
   }
   return
@@ -55,7 +53,7 @@ func.func @none_access(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
   %c0_i32 = arith.constant 0 : i32
   %c0 = arith.constant 0 : index
   %tile = amdaie.tile(%c0, %c0)
-  %core = amdaie.core(%tile) {
+  %core = amdaie.core(%tile, in : [], out : []) {
     %3 = amdaie.logicalobjectfifo.access(%arg0, None) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
     linalg.fill ins(%c0_i32 : i32) outs(%3 : memref<1x1x8x16xi32, 2>)
     amdaie.end
@@ -74,7 +72,7 @@ func.func @any_access(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>)
   %c0_i32 = arith.constant 0 : i32
   %c0 = arith.constant 0 : index
   %tile = amdaie.tile(%c0, %c0)
-  %core = amdaie.core(%tile) {
+  %core = amdaie.core(%tile, in : [], out : []) {
     %3 = amdaie.logicalobjectfifo.access(%arg0, Any) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
     linalg.fill ins(%c0_i32 : i32) outs(%3 : memref<1x1x8x16xi32, 2>)
     amdaie.end
@@ -102,13 +100,11 @@ func.func @read_and_write(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 
   %tile = amdaie.tile(%c0, %c0)
   %2 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   %3 = amdaie.circular_dma_cpy_nd(%arg3[] [] [], %arg2[] [] []) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>)
-  %core = amdaie.core(%tile) {
+  %core = amdaie.core(%tile, in : [%2], out : [%3]) {
     %4 = amdaie.logicalobjectfifo.access(%arg0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
     %5 = amdaie.logicalobjectfifo.access(%arg2, Write) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
-    amdaie.logicalobjectfifo.consume(%2)
     linalg.fill ins(%c0_i32 : i32) outs(%4 : memref<1x1x8x16xi32, 2>)
     linalg.fill ins(%c0_i32 : i32) outs(%5 : memref<1x1x8x16xi32, 2>)
-    amdaie.logicalobjectfifo.produce(%3)
     amdaie.end
   }
   return
@@ -146,21 +142,17 @@ func.func @read_write_multiple_blocks(%arg0: !amdaie.logicalobjectfifo<memref<1x
   %tile = amdaie.tile(%c0, %c0)
   %2 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   %3 = amdaie.circular_dma_cpy_nd(%arg3[] [] [], %arg2[] [] []) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>)
-  %core = amdaie.core(%tile) {
+  %core = amdaie.core(%tile, in : [%2], out : [%3]) {
     %4 = amdaie.logicalobjectfifo.access(%arg0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
-    amdaie.logicalobjectfifo.consume(%2)
     linalg.fill ins(%c0_i32 : i32) outs(%4 : memref<1x1x8x16xi32, 2>)
     scf.for %arg = %c0 to %c8 step %c1  {
       %5 = amdaie.logicalobjectfifo.access(%arg0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
-      amdaie.logicalobjectfifo.consume(%2)
       linalg.fill ins(%c0_i32 : i32) outs(%5 : memref<1x1x8x16xi32, 2>)
     }
     %6 = amdaie.logicalobjectfifo.access(%arg0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
     %7 = amdaie.logicalobjectfifo.access(%arg2, Write) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
-    amdaie.logicalobjectfifo.consume(%2)    
     linalg.fill ins(%c0_i32 : i32) outs(%6 : memref<1x1x8x16xi32, 2>)
     linalg.fill ins(%c0_i32 : i32) outs(%7 : memref<1x1x8x16xi32, 2>)
-    amdaie.logicalobjectfifo.produce(%3)
     amdaie.end
   }
   return
@@ -187,11 +179,9 @@ func.func @multiple_reads_deterministic_order(%arg0: !amdaie.logicalobjectfifo<m
   %tile = amdaie.tile(%c0, %c0)
   %2 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   %3 = amdaie.circular_dma_cpy_nd(%arg2[] [] [], %arg3[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-  %core = amdaie.core(%tile) {
+  %core = amdaie.core(%tile, in : [%2, %3], out : []) {
     %4 = amdaie.logicalobjectfifo.access(%arg0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
     %5 = amdaie.logicalobjectfifo.access(%arg2, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
-    amdaie.logicalobjectfifo.consume(%2)
-    amdaie.logicalobjectfifo.consume(%3)
     linalg.fill ins(%c0_i32 : i32) outs(%4 : memref<1x1x8x16xi32, 2>)
     linalg.fill ins(%c0_i32 : i32) outs(%5 : memref<1x1x8x16xi32, 2>)
     amdaie.end
@@ -220,13 +210,11 @@ func.func @multiple_writes_deterministic_order(%arg0: !amdaie.logicalobjectfifo<
   %tile = amdaie.tile(%c0, %c0)
   %2 = amdaie.circular_dma_cpy_nd(%arg1[] [] [], %arg0[] [] []) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>)
   %3 = amdaie.circular_dma_cpy_nd(%arg3[] [] [], %arg2[] [] []) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>)
-  %core = amdaie.core(%tile) {
+  %core = amdaie.core(%tile, in : [], out : [%2, %3]) {
     %4 = amdaie.logicalobjectfifo.access(%arg0, Write) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
     %5 = amdaie.logicalobjectfifo.access(%arg2, Write) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
     linalg.fill ins(%c0_i32 : i32) outs(%4 : memref<1x1x8x16xi32, 2>)
     linalg.fill ins(%c0_i32 : i32) outs(%5 : memref<1x1x8x16xi32, 2>)
-    amdaie.logicalobjectfifo.produce(%2)
-    amdaie.logicalobjectfifo.produce(%3)
     amdaie.end
   }
   return

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
@@ -40,18 +40,18 @@ func.func @circular_dma_cpy_nd(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16x
 // CHECK:       amdaie.workgroup
 // CHECK:         %[[TILE_0:.+]] = amdaie.tile
 // CHECK:         %[[TILE_1:.+]] = amdaie.tile
-// CHECK:         %{{.+}} = amdaie.core(%[[TILE_0]])
-// CHECK:         %{{.+}} = amdaie.core(%[[TILE_1]])
+// CHECK:         %{{.+}} = amdaie.core(%[[TILE_0]], in : [], out : [])
+// CHECK:         %{{.+}} = amdaie.core(%[[TILE_1]], in : [], out : [])
 // CHECK:         amdaie.controlcode
 func.func @core() {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %tile_0_0 = amdaie.tile(%c0, %c0)
   %tile_0_1 = amdaie.tile(%c0, %c1)
-  %core_0_0 = amdaie.core(%tile_0_0) {
+  %core_0_0 = amdaie.core(%tile_0_0, in : [], out : []) {
     amdaie.end
   }
-  %core_0_1 = amdaie.core(%tile_0_1) {
+  %core_0_1 = amdaie.core(%tile_0_1, in : [], out : []) {
     amdaie.end
   }
   return
@@ -195,9 +195,9 @@ func.func @for() {
 // CHECK-DAG:     %[[C8:.+]] = arith.constant 8 : index
 // CHECK-DAG:     %[[TILE_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
 // CHECK-DAG:     %[[TILE_1:.+]] = amdaie.tile(%[[C0]], %[[C1]])
-// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_0]])
+// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_0]], in : [], out : [])
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
-// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_1]])
+// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_1]], in : [], out : [])
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
 // CHECK:         amdaie.controlcode
 // CHECK-DAG:       %[[C0_1:.+]] = arith.constant 0 : index
@@ -211,10 +211,10 @@ func.func @for_cores() {
   scf.for %arg2 = %c0 to %c8 step %c1  {
     %tile_0_0 = amdaie.tile(%c0, %c0)
     %tile_0_1 = amdaie.tile(%c0, %c1)
-    %core_0_0 = amdaie.core(%tile_0_0) {
+    %core_0_0 = amdaie.core(%tile_0_0, in : [], out : []) {
       amdaie.end
     }
-    %core_0_1 = amdaie.core(%tile_0_1) {
+    %core_0_1 = amdaie.core(%tile_0_1, in : [], out : []) {
       amdaie.end
     }
   }
@@ -281,9 +281,9 @@ func.func @forall() {
 // CHECK:       amdaie.workgroup
 // CHECK:         %[[TILE_0:.+]] = amdaie.tile
 // CHECK:         %[[TILE_1:.+]] = amdaie.tile
-// CHECK:         %{{.+}} = amdaie.core(%[[TILE_0]])
+// CHECK:         %{{.+}} = amdaie.core(%[[TILE_0]], in : [], out : [])
 // CHECK:           scf.forall (%{{.*}}, %{{.*}}) in (1, 2)
-// CHECK:         %{{.+}} = amdaie.core(%[[TILE_1]])
+// CHECK:         %{{.+}} = amdaie.core(%[[TILE_1]], in : [], out : [])
 // CHECK:           scf.forall (%{{.*}}, %{{.*}}) in (1, 2)
 // CHECK:         amdaie.controlcode
 // CHECK:           scf.forall (%{{.*}}, %{{.*}}) in (1, 2)
@@ -293,10 +293,10 @@ func.func @forall_cores() {
   scf.forall (%arg2, %arg3) in (1, 2) {
     %tile_0_0 = amdaie.tile(%c0, %c0)
     %tile_0_1 = amdaie.tile(%c0, %c1)
-    %core_0_0 = amdaie.core(%tile_0_0) {
+    %core_0_0 = amdaie.core(%tile_0_0, in : [], out : []) {
       amdaie.end
     }
-    %core_0_1 = amdaie.core(%tile_0_1) {
+    %core_0_1 = amdaie.core(%tile_0_1, in : [], out : []) {
       amdaie.end
     }
   }
@@ -351,11 +351,11 @@ func.func @forall_dmas(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) 
 // CHECK-SAME:    %[[FROMMEMREF0]][] [] []
 // CHECK-SAME:    %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
 // CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_0]])
-// CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA]])
+// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_0]], in : [], out : [])
+// CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF0]], Read)
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
-// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_1]])
-// CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA]])
+// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_1]], in : [], out : [])
+// CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF0]], Read)
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
 // CHECK:         amdaie.controlcode
 // CHECK-DAG:       %[[C0_1:.+]] = arith.constant 0 : index
@@ -375,19 +375,19 @@ func.func @merge_cores(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) 
   %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
   %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
   %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-  %core_0_0_0 = amdaie.core(%tile_0_0) {
-    amdaie.logicalobjectfifo.consume(%2)
+  %core_0_0_0 = amdaie.core(%tile_0_0, in : [], out : []) {
+    amdaie.logicalobjectfifo.access(%0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>> -> memref<1x1x8x16xi32>
     amdaie.end
   }
-  %core_0_1_0 = amdaie.core(%tile_0_1) {
-    amdaie.logicalobjectfifo.consume(%2)
+  %core_0_1_0 = amdaie.core(%tile_0_1, in : [], out : []) {
+    amdaie.logicalobjectfifo.access(%0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>> -> memref<1x1x8x16xi32>
     amdaie.end
   }
   scf.for %arg2 = %c0 to %c8 step %c1  {
-    %core_0_0_1 = amdaie.core(%tile_0_0) {
+    %core_0_0_1 = amdaie.core(%tile_0_0, in : [], out : []) {
       amdaie.end
     }
-    %core_0_1_1 = amdaie.core(%tile_0_1) {
+    %core_0_1_1 = amdaie.core(%tile_0_1, in : [], out : []) {
       amdaie.end
     }
   }
@@ -427,15 +427,15 @@ func.func @merge_cores(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) 
 // CHECK-SAME:    %[[FROMMEMREF4]][] [] []
 // CHECK-SAME:    %[[FROMMEMREF5]][0, 0, 0, 0] [1, 1, 32, 16] [128, 16, 8, 1]
 // CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x32x16xi32>>, !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>)
-// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_0]])
-// CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA0]])
+// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_0]], in : [], out : [])
+// CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF0]], Read)
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
-// CHECK:             amdaie.logicalobjectfifo.consume(%[[DMA1]])
+// CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF2]], Read)
 // CHECK:             linalg.fill
-// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_1]])
-// CHECK:           amdaie.logicalobjectfifo.consume(%[[DMA0]])
+// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_1]], in : [], out : [])
+// CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF0]], Read)
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
-// CHECK:             amdaie.logicalobjectfifo.consume(%[[DMA2]])
+// CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF4]], Read)
 // CHECK:             linalg.fill
 // CHECK:         amdaie.controlcode
 // CHECK-DAG:       %[[C0_1:.+]] = arith.constant 0 : index
@@ -468,24 +468,24 @@ func.func @complex_example(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 
   %4 = amdaie.logicalobjectfifo.from_memref %arg4, {} : memref<1x1x32x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x32x16xi32>>
   %5 = amdaie.logicalobjectfifo.from_memref %arg5, {} : memref<32x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>
   %dma_0 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-  %core_0_0_0 = amdaie.core(%tile_0_0) {
-    amdaie.logicalobjectfifo.consume(%dma_0)
+  %core_0_0_0 = amdaie.core(%tile_0_0, in : [], out : []) {
+    amdaie.logicalobjectfifo.access(%0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>> -> memref<1x1x8x16xi32>
     amdaie.end
   }
-  %core_0_1_0 = amdaie.core(%tile_0_1) {
-    amdaie.logicalobjectfifo.consume(%dma_0)
+  %core_0_1_0 = amdaie.core(%tile_0_1, in : [], out : []) {
+    amdaie.logicalobjectfifo.access(%0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>> -> memref<1x1x8x16xi32>
     amdaie.end
   }
   scf.for %iv0 = %c0 to %c8 step %c1  {
     %dma_1 = amdaie.dma_cpy_nd(%2[] [] [], %3[0, 0, 0, 0] [1, 1, 16, 16] [128, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x16x16xi32>>, !amdaie.logicalobjectfifo<memref<16x16xi32, 1>>)
     %dma_2 = amdaie.dma_cpy_nd(%4[] [] [], %5[0, 0, 0, 0] [1, 1, 32, 16] [128, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x32x16xi32>>, !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>)
-    %core_0_0_1 = amdaie.core(%tile_0_0) {
-      amdaie.logicalobjectfifo.consume(%dma_1)
+    %core_0_0_1 = amdaie.core(%tile_0_0, in : [], out : []) {
+      amdaie.logicalobjectfifo.access(%2, Read) : !amdaie.logicalobjectfifo<memref<1x1x16x16xi32>> -> memref<1x1x16x16xi32>
       linalg.fill ins(%c0_i32 : i32) outs(%arg2 : memref<1x1x16x16xi32>)
       amdaie.end
     }
-    %core_0_1_1 = amdaie.core(%tile_0_1) {
-      amdaie.logicalobjectfifo.consume(%dma_2)
+    %core_0_1_1 = amdaie.core(%tile_0_1, in : [], out : []) {
+      amdaie.logicalobjectfifo.access(%4, Read) : !amdaie.logicalobjectfifo<memref<1x1x32x16xi32>> -> memref<1x1x32x16xi32>
       linalg.fill ins(%c0_i32 : i32) outs(%arg4 : memref<1x1x32x16xi32>)
       amdaie.end
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/flatten_logical_objectfifo.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/flatten_logical_objectfifo.mlir
@@ -37,7 +37,7 @@ module {
       %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {%tile} : memref<1x2x32x32xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1x2x32x32xi32, 1 : i32>>
       %2 = amdaie.circular_dma_cpy_nd(%0[%c0] [%c1024] [%c1], %1[%c0, %c0, %c0] [%c8, %c32, %c4] [%c4, %c32, %c1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x4x8x4xi32, 2 : i32>>, !amdaie.logicalobjectfifo<memref<1x2x32x32xi32, 1 : i32>>)
       %3 = amdaie.logicalobjectfifo.from_memref %alloc_1, {%tile_2} : memref<1x1x8x8x4x4xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<1x1x8x8x4x4xi32, 2 : i32>>
-      %4 = amdaie.core(%tile_2) {
+      %4 = amdaie.core(%tile_2, in : [%2], out : []) {
         scf.forall (%arg0, %arg1) in (2, 2) {
           %5 = amdaie.logicalobjectfifo.access(%0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x4x8x4xi32, 2 : i32>> -> memref<1x1x8x4x8x4xi32, 2 : i32>
           %6 = amdaie.logicalobjectfifo.access(%3, None) : !amdaie.logicalobjectfifo<memref<1x1x8x8x4x4xi32, 2 : i32>> -> memref<1x1x8x8x4x4xi32, 2 : i32>

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_cores.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_cores.mlir
@@ -22,10 +22,8 @@ func.func @insert_cores_with_non_normalized_forall() {
 // CHECK:           %[[C2:.*]] = arith.constant 2 : index
 // CHECK:           %[[ADD:.*]] = arith.addi %[[ARG2]], %[[C2]] : index
 // CHECK:           %[[TILE0:.*]] = amdaie.tile(%[[ARG3]], %[[ADD]])
-// CHECK:           %[[CORE0:.*]] = amdaie.core(%[[TILE0]]) {
+// CHECK:           %[[CORE0:.*]] = amdaie.core(%[[TILE0]], in : [%[[DMA_CPY2]], %[[DMA_CPY3]]], out : []) {
 // CHECK:             linalg.fill
-// CHECK:             amdaie.logicalobjectfifo.consume(%[[DMA_CPY2]])
-// CHECK:             amdaie.logicalobjectfifo.consume(%[[DMA_CPY3]])
 // CHECK:             linalg.generic
 // CHECK:             amdaie.end
 // CHECK:           }
@@ -40,12 +38,9 @@ func.func @insert_cores_with_non_normalized_forall() {
 // CHECK:           %[[C2:.*]] = arith.constant 2 : index
 // CHECK:           %[[ADD:.*]] = arith.addi %[[ARG2]], %[[C2]] : index
 // CHECK:           %[[TILE1:.*]] = amdaie.tile(%[[ARG3]], %[[ADD]])
-// CHECK:           %[[CORE1:.*]] = amdaie.core(%[[TILE1]]) {
+// CHECK:           %[[CORE1:.*]] = amdaie.core(%[[TILE1]], in : [%[[DMA_CPY2]], %[[DMA_CPY3]]], out : [%[[DMA_CPY4]]]) {
 // CHECK:             linalg.fill ins(%c0_i32 : i32) outs(%alloc_1 : memref<4x8x4x8xi32, 2>)
-// CHECK:             amdaie.logicalobjectfifo.consume(%[[DMA_CPY2]])
-// CHECK:             amdaie.logicalobjectfifo.consume(%[[DMA_CPY3]])
 // CHECK:             linalg.generic
-// CHECK:             amdaie.logicalobjectfifo.produce(%[[DMA_CPY4]])
 // CHECK:             amdaie.end
 // CHECK:           }
 // CHECK:         } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
@@ -142,9 +137,7 @@ module {
 // CHECK:           %[[C2:.*]] = arith.constant 2 : index
 // CHECK:           %[[ADD:.*]] = arith.addi %[[ARG2]], %[[C2]] : index
 // CHECK:           %[[TILE0:.*]] = amdaie.tile(%[[ARG3]], %[[ADD]])
-// CHECK:           amdaie.core(%[[TILE0]]) {
-// CHECK:             amdaie.logicalobjectfifo.consume(%[[DMA_CPY0]])
-// CHECK:             amdaie.logicalobjectfifo.consume(%[[DMA_CPY1]])
+// CHECK:           amdaie.core(%[[TILE0]], in : [%[[DMA_CPY0]], %[[DMA_CPY1]]], out : []) {
 // CHECK:             linalg.fill
 // CHECK:             scf.for
 // CHECK:               scf.for
@@ -226,9 +219,7 @@ module {
 // CHECK:           %[[C2:.*]] = arith.constant 2 : index
 // CHECK:           %[[ADD:.*]] = arith.addi %[[ARG2]], %[[C2]] : index
 // CHECK:           %[[TILE0:.*]] = amdaie.tile(%[[ARG3]], %[[ADD]])
-// CHECK:           amdaie.core(%[[TILE0]]) {
-// CHECK:             amdaie.logicalobjectfifo.consume(%[[DMA_CPY0]])
-// CHECK:             amdaie.logicalobjectfifo.consume(%[[DMA_CPY1]])
+// CHECK:           amdaie.core(%[[TILE0]], in : [%[[DMA_CPY0]], %[[DMA_CPY1]]], out : []) {
 // CHECK:             linalg.fill
 // CHECK:             memref.extract_strided_metadata
 // CHECK:             memref.extract_strided_metadata

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
@@ -192,7 +192,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %obj2 = amdaie.logicalobjectfifo.from_memref %alloc_2, {%tile_0_2} : memref<4x8x4x8xi32, 2> -> !amdaie.logicalobjectfifo<memref<4x8x4x8xi32, 2>>
       %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj2[] [] []) : (!amdaie.logicalobjectfifo<memref<32x32xi32, 1>>, !amdaie.logicalobjectfifo<memref<4x8x4x8xi32, 2>>)
       %dma1 = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<32x64xi32>>, !amdaie.logicalobjectfifo<memref<32x32xi32, 1>>)
-      %core_0_0 = amdaie.core(%tile_0_2) {
+      %core_0_0 = amdaie.core(%tile_0_2, in : [], out : [%dma0]) {
         %0 = amdaie.logicalobjectfifo.acquire(%dma0, Produce) {size = 1 : i32} -> !amdaie.logicalobjectfifo<memref<32x32xi32, 1>>
         %1 = amdaie.logicalobjectfifo.access(%0, Write) : !amdaie.logicalobjectfifo<memref<32x32xi32, 1>> -> memref<32x32xi32, 1>
         linalg.fill ins(%c0_i32 : i32) outs(%1 : memref<32x32xi32, 1>)
@@ -258,7 +258,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %obj4 = amdaie.logicalobjectfifo.from_memref %alloc_4, {%tile_0_2} : memref<4x8x4x8xf32, 1> -> !amdaie.logicalobjectfifo<memref<4x8x4x8xf32, 1>>
       %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj2[] [] []) : (!amdaie.logicalobjectfifo<memref<32x32xi32, 2>>, !amdaie.logicalobjectfifo<memref<4x8x4x8xi32, 1>>)
       %dma1 = amdaie.circular_dma_cpy_nd(%obj3[] [] [], %obj4[] [] []) : (!amdaie.logicalobjectfifo<memref<32x32xf32, 2>>, !amdaie.logicalobjectfifo<memref<4x8x4x8xf32, 1>>)
-      %core_0_0 = amdaie.core(%tile_0_2) {
+      %core_0_0 = amdaie.core(%tile_0_2, in : [], out : [%dma0, %dma1]) {
         %0 = amdaie.logicalobjectfifo.acquire(%dma0, Produce) {size = 1 : i32} -> !amdaie.logicalobjectfifo<memref<32x32xi32, 2>>
         %1 = amdaie.logicalobjectfifo.access(%0, Write) : !amdaie.logicalobjectfifo<memref<32x32xi32, 2>> -> memref<32x32xi32, 2>
         %2 = amdaie.logicalobjectfifo.acquire(%dma1, Produce) {size = 1 : i32} -> !amdaie.logicalobjectfifo<memref<32x32xf32, 2>>
@@ -323,11 +323,11 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %obj2 = amdaie.logicalobjectfifo.from_memref %alloc_2, {%tile_0_2, %tile_1_2} : memref<4x8x4x8xi32, 2> -> !amdaie.logicalobjectfifo<memref<4x8x4x8xi32, 2>>
       %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj0[] [] []) : (!amdaie.logicalobjectfifo<memref<32x32xi32, 1>>, !amdaie.logicalobjectfifo<memref<32x64xi32>>)
       %dma1 = amdaie.circular_dma_cpy_nd(%obj2[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<4x8x4x8xi32, 2>>, !amdaie.logicalobjectfifo<memref<32x32xi32, 1>>)
-      %core_0_2 = amdaie.core(%tile_0_2) {
+      %core_0_2 = amdaie.core(%tile_0_2, in : [%dma1], out : []) {
         %0 = amdaie.logicalobjectfifo.acquire(%dma1, Consume) {size = 1 : i32} -> !amdaie.logicalobjectfifo<memref<32x32xi32, 1>>
         amdaie.end
       }
-      %core_1_2 = amdaie.core(%tile_1_2) {
+      %core_1_2 = amdaie.core(%tile_1_2, in : [%dma1], out : []) {
         %0 = amdaie.logicalobjectfifo.acquire(%dma1, Consume) {size = 1 : i32} -> !amdaie.logicalobjectfifo<memref<32x32xi32, 1>>
         amdaie.end
       }
@@ -372,7 +372,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %obj2 = amdaie.logicalobjectfifo.from_memref %alloc_2, {%tile_0_2} : memref<4x8x4x8xi32, 2> -> !amdaie.logicalobjectfifo<memref<4x8x4x8xi32, 2>>
       %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj2[] [] []) : (!amdaie.logicalobjectfifo<memref<32x32xi32, 1>>, !amdaie.logicalobjectfifo<memref<4x8x4x8xi32, 2>>)
       %dma1 = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<32x64xi32>>, !amdaie.logicalobjectfifo<memref<32x32xi32, 1>>)
-      %core_0_0 = amdaie.core(%tile_0_2) {
+      %core_0_0 = amdaie.core(%tile_0_2, in : [], out : [%dma0]) {
         amdaie.logicalobjectfifo.release(%dma0, Produce) {size = 1 : i32}
         amdaie.end
       }
@@ -875,7 +875,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj0[] [] []) : (!amdaie.logicalobjectfifo<memref<32x32xi32, 1>>, !amdaie.logicalobjectfifo<memref<32x64xi32>>)
       %dma1 = amdaie.circular_dma_cpy_nd(%obj2[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<4x8x4x8xi32, 2>>, !amdaie.logicalobjectfifo<memref<32x32xi32, 1>>)
       amdaie.logicalobjectfifo.link[%dma0] -> [%dma1] ()
-      %core_0_2 = amdaie.core(%tile_0_2) {
+      %core_0_2 = amdaie.core(%tile_0_2, in : [%dma1], out : []) {
         %1 = amdaie.logicalobjectfifo.acquire(%dma1, Consume) {size = 1 : i32} -> !amdaie.logicalobjectfifo<memref<4x8x4x8xi32, 2>>
         %2 = amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<4x8x4x8xi32, 2>> -> memref<4x8x4x8xi32, 2>
         scf.for %arg2 = %c0 to %c8 step %c1  {
@@ -884,7 +884,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
         amdaie.logicalobjectfifo.release(%dma1, Consume) {size = 1 : i32}
         amdaie.end
       }
-      %core_1_2 = amdaie.core(%tile_1_2) {
+      %core_1_2 = amdaie.core(%tile_1_2, in : [%dma1], out : []) {
         %1 = amdaie.logicalobjectfifo.acquire(%dma1, Consume) {size = 1 : i32} -> !amdaie.logicalobjectfifo<memref<4x8x4x8xi32, 2>>
         %2 = amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<4x8x4x8xi32, 2>> -> memref<4x8x4x8xi32, 2>
         scf.for %arg2 = %c0 to %c8 step %c1  {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/none_access_to_temporary_buffer.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/none_access_to_temporary_buffer.mlir
@@ -11,7 +11,7 @@ func.func @none_access_to_buffer(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x1
   %c0_i32 = arith.constant 0 : i32
   %c0 = arith.constant 0 : index
   %tile = amdaie.tile(%c0, %c0)
-  %core = amdaie.core(%tile) {
+  %core = amdaie.core(%tile, in : [], out : []) {
     %3 = amdaie.logicalobjectfifo.access(%arg0, None) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
     linalg.fill ins(%c0_i32 : i32) outs(%3 : memref<1x1x8x16xi32, 2>)
     amdaie.end
@@ -43,20 +43,18 @@ func.func @single_none_access_multiple_users(%arg0: !amdaie.logicalobjectfifo<me
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   %1 = amdaie.circular_dma_cpy_nd(%arg3[] [] [], %arg2[] [] []) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>)
   %2 = amdaie.logicalobjectfifo.from_memref %arg4, {%tile} : memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
-  %3 = amdaie.core(%tile) {
+  %3 = amdaie.core(%tile, in : [%0], out : [%1]) {
     %4 = amdaie.logicalobjectfifo.acquire(%0, Consume) {size = 1 : i32} -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
     %5 = amdaie.logicalobjectfifo.access(%4, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
     %6 = amdaie.logicalobjectfifo.access(%2, None) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
     %7 = amdaie.logicalobjectfifo.acquire(%1, Produce) {size = 1 : i32} -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
     %8 = amdaie.logicalobjectfifo.access(%7, Write) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
-    amdaie.logicalobjectfifo.consume(%0)
     linalg.fill ins(%c0_i32 : i32) outs(%5 : memref<1x1x8x16xi32, 2>)
     linalg.fill ins(%c0_i32 : i32) outs(%6 : memref<1x1x8x16xi32, 2>)
     linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%6 : memref<1x1x8x16xi32, 2>) outs(%8 : memref<1x1x8x16xi32, 2>) {
     ^bb0(%in: i32, %out: i32):
       linalg.yield %in : i32
     }
-    amdaie.logicalobjectfifo.produce(%1)
     amdaie.logicalobjectfifo.release(%0, Consume) {size = 1 : i32}
     amdaie.logicalobjectfifo.release(%1, Produce) {size = 1 : i32}
     amdaie.end
@@ -97,31 +95,27 @@ func.func @multiple_none_access_multiple_users(%arg0: !amdaie.logicalobjectfifo<
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   %1 = amdaie.circular_dma_cpy_nd(%arg3[] [] [], %arg2[] [] []) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>)
   %2 = amdaie.logicalobjectfifo.from_memref %arg4, {%tile} : memref<1x1x8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
-  %3 = amdaie.core(%tile) {
+  %3 = amdaie.core(%tile, in : [%0], out : [%1]) {
     %4 = amdaie.logicalobjectfifo.acquire(%0, Consume) {size = 1 : i32} -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
     %5 = amdaie.logicalobjectfifo.access(%4, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
     %6 = amdaie.logicalobjectfifo.access(%2, None) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
-    amdaie.logicalobjectfifo.consume(%0)
     linalg.fill ins(%c0_i32 : i32) outs(%5 : memref<1x1x8x16xi32, 2>)
     linalg.fill ins(%c0_i32 : i32) outs(%6 : memref<1x1x8x16xi32, 2>)
     scf.for %arg5 = %c0 to %c8 step %c1 {
       amdaie.logicalobjectfifo.release(%0, Consume) {size = 1 : i32}
       %10 = amdaie.logicalobjectfifo.acquire(%0, Consume) {size = 1 : i32} -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
       %11 = amdaie.logicalobjectfifo.access(%10, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
-      amdaie.logicalobjectfifo.consume(%0)
       linalg.fill ins(%c0_i32 : i32) outs(%11 : memref<1x1x8x16xi32, 2>)
     }
     amdaie.logicalobjectfifo.release(%0, Consume) {size = 1 : i32}
     %7 = amdaie.logicalobjectfifo.access(%2, None) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
     %8 = amdaie.logicalobjectfifo.acquire(%1, Produce) {size = 1 : i32} -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>>
     %9 = amdaie.logicalobjectfifo.access(%8, Write) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 2>> -> memref<1x1x8x16xi32, 2>
-    amdaie.logicalobjectfifo.consume(%0)
     linalg.fill ins(%c0_i32 : i32) outs(%7 : memref<1x1x8x16xi32, 2>)
     linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%7 : memref<1x1x8x16xi32, 2>) outs(%9 : memref<1x1x8x16xi32, 2>) {
     ^bb0(%in: i32, %out: i32):
       linalg.yield %in : i32
     }
-    amdaie.logicalobjectfifo.produce(%1)
     amdaie.logicalobjectfifo.release(%1, Produce) {size = 1 : i32}
     amdaie.end
   }


### PR DESCRIPTION
Remove the partially redundant produce/consume ops as they have been largely replaced already with the `logicalobjectfifo.access` ops. The main use for them is to provide information on which cores are using which DMAs which can be handled by adding input and output DMA operands to the `amdaie.core` ops.