### PR TITLE
[Testing] Don't pollute source tree with artifacts 

### DIFF
--- a/runtime/src/iree-amd-aie/aie_runtime/test/cdo/add_12_i8_using_2d_dma_op_with_padding.mlir
+++ b/runtime/src/iree-amd-aie/aie_runtime/test/cdo/add_12_i8_using_2d_dma_op_with_padding.mlir
@@ -1,4 +1,4 @@
-// RUN: (aie_cdo_gen_test %s %S) 2>&1 | FileCheck %s
+// RUN: (aie_cdo_gen_test %s %T) 2>&1 | FileCheck %s
 
 module {
   aie.device(npu1_1col) {

--- a/runtime/src/iree-amd-aie/aie_runtime/test/cdo/add_21_i8_using_dma_op_with_padding.mlir
+++ b/runtime/src/iree-amd-aie/aie_runtime/test/cdo/add_21_i8_using_dma_op_with_padding.mlir
@@ -1,4 +1,4 @@
-// RUN: (aie_cdo_gen_test %s %S) 2>&1 | FileCheck %s
+// RUN: (aie_cdo_gen_test %s %T) 2>&1 | FileCheck %s
 
 module {
   aie.device(npu1_1col) {

--- a/runtime/src/iree-amd-aie/aie_runtime/test/cdo/add_378_i32_using_dma_op_with_padding.mlir
+++ b/runtime/src/iree-amd-aie/aie_runtime/test/cdo/add_378_i32_using_dma_op_with_padding.mlir
@@ -1,4 +1,4 @@
-// RUN: (aie_cdo_gen_test %s %S) 2>&1 | FileCheck %s
+// RUN: (aie_cdo_gen_test %s %T) 2>&1 | FileCheck %s
 
 module {
   aie.device(npu1_1col) {

--- a/runtime/src/iree-amd-aie/aie_runtime/test/cdo/matmul_16x16_8xi32__dispatch_0_matmul_16x1_0.aiecc.mlir
+++ b/runtime/src/iree-amd-aie/aie_runtime/test/cdo/matmul_16x16_8xi32__dispatch_0_matmul_16x1_0.aiecc.mlir
@@ -1,4 +1,4 @@
-// RUN: (aie_cdo_gen_test %s %S) 2>&1 | FileCheck %s
+// RUN: (aie_cdo_gen_test %s %T) 2>&1 | FileCheck %s
 
 module {
 aie.device(npu1_4col) {

--- a/runtime/src/iree-amd-aie/aie_runtime/test/cdo/matmul_16x64_32xi8__dispatch_0_matmul_tran_0.aiecc.mlir
+++ b/runtime/src/iree-amd-aie/aie_runtime/test/cdo/matmul_16x64_32xi8__dispatch_0_matmul_tran_0.aiecc.mlir
@@ -1,4 +1,4 @@
-// RUN: (aie_cdo_gen_test %s %S) 2>&1 | FileCheck %s
+// RUN: (aie_cdo_gen_test %s %T) 2>&1 | FileCheck %s
 
 module {
 aie.device(npu1_4col) {

--- a/runtime/src/iree-amd-aie/aie_runtime/test/cdo/matmul_512x512_512xi32__dispatch_0_matmul__0.aiecc.mlir
+++ b/runtime/src/iree-amd-aie/aie_runtime/test/cdo/matmul_512x512_512xi32__dispatch_0_matmul__0.aiecc.mlir
@@ -1,4 +1,4 @@
-// RUN: (aie_cdo_gen_test %s %S) 2>&1 | FileCheck %s
+// RUN: (aie_cdo_gen_test %s %T) 2>&1 | FileCheck %s
 
 module {
 aie.device(npu1_4col) {

--- a/runtime/src/iree-amd-aie/aie_runtime/test/cdo/matmul_64x64_64xbf16__dispatch_0_matmul_64_0.aiecc.mlir
+++ b/runtime/src/iree-amd-aie/aie_runtime/test/cdo/matmul_64x64_64xbf16__dispatch_0_matmul_64_0.aiecc.mlir
@@ -1,4 +1,4 @@
-// RUN: (aie_cdo_gen_test %s %S) 2>&1 | FileCheck %s
+// RUN: (aie_cdo_gen_test %s %T) 2>&1 | FileCheck %s
 
 module {
 aie.device(npu1_4col) {

--- a/runtime/src/iree-amd-aie/aie_runtime/test/cdo/matmul_64x64_64xi8__dispatch_0_matmul_64x6_0.aiecc.mlir
+++ b/runtime/src/iree-amd-aie/aie_runtime/test/cdo/matmul_64x64_64xi8__dispatch_0_matmul_64x6_0.aiecc.mlir
@@ -1,4 +1,4 @@
-// RUN: (aie_cdo_gen_test %s %S) 2>&1 | FileCheck %s
+// RUN: (aie_cdo_gen_test %s %T) 2>&1 | FileCheck %s
 
 module {
 aie.device(npu1_4col) {

--- a/runtime/src/iree-amd-aie/aie_runtime/test/cdo/matmul_8x32_16xi32__dispatch_0_matmul_8x32_0.aiecc.mlir
+++ b/runtime/src/iree-amd-aie/aie_runtime/test/cdo/matmul_8x32_16xi32__dispatch_0_matmul_8x32_0.aiecc.mlir
@@ -1,4 +1,4 @@
-// RUN: (aie_cdo_gen_test %s %S) 2>&1 | FileCheck %s
+// RUN: (aie_cdo_gen_test %s %T) 2>&1 | FileCheck %s
 
 module {
 aie.device(npu1_4col) {


### PR DESCRIPTION
Use %T (temporary dir) instead of %S (source dir) https://llvm.org/docs/CommandGuide/lit.html

This prevents the 2 .bin files being left in the source tree after testing 