### PR TITLE
[AMDAIEInsertCore] Handle convolution case 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertCores.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertCores.cpp
@@ -134,7 +134,7 @@ LogicalResult insertCoreOps(mlir::ModuleOp moduleOp) {
       // loop nest inside the amdaie.core op here. Currently look for a
       // subset of ops which we know should be in the core.
       // TODO(newling) improve this design.
-      auto insertInCore =
+      bool insertInCore =
           isa<linalg::LinalgOp>(op) || isa<vector::ContractionOp>(op) ||
           isa<memref::ExtractStridedMetadataOp>(op) || isa<func::CallOp>(op);
       if (insertInCore) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertCores.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertCores.cpp
@@ -18,8 +18,9 @@
 #include "iree-amd-aie/IR/AMDAIEOps.h"
 #include "iree-amd-aie/Transforms/AMDAIEOpUtils.h"
 #include "iree-amd-aie/Transforms/Passes.h"
-#include "iree-amd-aie/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/TransformStrategies/GPU/Common.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 
 #define DEBUG_TYPE "iree-amdaie-insert-cores"
@@ -50,6 +51,7 @@ LogicalResult insertCoreOps(mlir::ModuleOp moduleOp) {
     // Currently, innermost `scf.forall` operations are expected to have thread
     // mapping and are therefore selected for insertion of cores. Advance if no
     // thread mapping.
+    if (!forallOp.getMapping().has_value()) return WalkResult::advance();
     SmallVector<Attribute> mapping =
         llvm::to_vector(forallOp.getMapping()->getValue());
     if (!isa<mlir::gpu::GPUThreadMappingAttr>(*mapping.begin()))
@@ -107,20 +109,10 @@ LogicalResult insertCoreOps(mlir::ModuleOp moduleOp) {
     WalkResult forallRes = forallOp->walk([&](Operation *op) {
       // Skip operations already inside core ops
       if (op->getParentOfType<AMDAIE::CoreOp>()) return WalkResult::advance();
-      if (auto linalgOp = dyn_cast<linalg::LinalgOp>(op)) {
-        rewriter.setInsertionPoint(endOp);
-        rewriter.moveOpBefore(linalgOp, endOp);
-      } else if (isa<vector::ContractionOp>(op)) {
-        // Because vector.contract op is surrounded by vectorized loop nest, we
-        // need to traverse to the outermost loop to move the entire vectorized
-        // computation within amdaie.core op.
-        Operation *currOp = op;
-        while (currOp->getParentOp() != forallOp) {
-          currOp = currOp->getParentOp();
-        }
-        rewriter.setInsertionPoint(endOp);
-        rewriter.moveOpBefore(currOp, endOp);
-      } else if (auto callOp = dyn_cast<func::CallOp>(op)) {
+
+      if (op == forallOp) return WalkResult::advance();
+
+      if (auto callOp = dyn_cast<func::CallOp>(op)) {
         // Fetch name of the ukernel function to look up its declaration in the
         // Symbol table.
         StringRef fnName = callOp.getCallee();
@@ -136,14 +128,29 @@ LogicalResult insertCoreOps(mlir::ModuleOp moduleOp) {
         //               As of now this hasn't turned up yet, so will table this
         //               for now.
         coreOp.setLinkWith(fnDecl->getAttrOfType<StringAttr>("link_with"));
-        rewriter.setInsertionPoint(endOp);
-        rewriter.moveOpBefore(op, endOp);
-      } else if (isa<memref::ExtractStridedMetadataOp>(op)) {
-        rewriter.setInsertionPoint(endOp);
-        rewriter.moveOpBefore(op, endOp);
       }
+
+      // Some ops are surrrounded by scf.for loop nests. Place the entire
+      // loop nest inside the amdaie.core op here. Currently look for a
+      // subset of ops which we know should be in the core.
+      // TODO(newling) improve this design.
+      auto insertInCore =
+          isa<linalg::LinalgOp>(op) || isa<vector::ContractionOp>(op) ||
+          isa<memref::ExtractStridedMetadataOp>(op) || isa<func::CallOp>(op);
+      if (insertInCore) {
+        // Most distant ancestor of 'op' that's a strict descendant of
+        // 'forallOp'.
+        Operation *ancestor = op;
+        while (ancestor->getParentOp() != forallOp) {
+          ancestor = ancestor->getParentOp();
+        }
+        rewriter.setInsertionPoint(endOp);
+        rewriter.moveOpBefore(ancestor, endOp);
+      }
+
       return WalkResult::advance();
     });
+
     if (forallRes.wasInterrupted()) return WalkResult::interrupt();
     return WalkResult::advance();
   });

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_cores.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_cores.mlir
@@ -282,7 +282,7 @@ module {
 
 // -----
 
-// This is the starting IR currently generated for tiling a convd op.
+// This is the starting IR currently generated for tiling a conv2d op.
 
 // CHECK-LABEL:   @conv_2d_nhwc_hwcf_dispatch_0_conv_2d_nhwc_hwcf_2x12x12x64x3x3x32_i32
 // CHECK:         scf.forall

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_cores.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_cores.mlir
@@ -146,18 +146,15 @@ module {
 // CHECK:             amdaie.end
 // CHECK:           }
 // CHECK:         } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
-#map = affine_map<(d0) -> (d0 * 128)>
-#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d2, d5, d3, d6, d8)>
-#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d2, d1, d4, d5, d8, d7)>
-#map3 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d4, d3, d6, d7)>
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d2, d5, d3, d6, d8)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d2, d1, d4, d5, d8, d7)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d4, d3, d6, d7)>
 module {
   func.func @insert_cores_with_vectorized_matmul() {
     %c8192 = arith.constant 8192 : index
     %c4096 = arith.constant 4096 : index
-    %c1024 = arith.constant 1024 : index
     %c512 = arith.constant 512 : index
     %c256 = arith.constant 256 : index
-    %c128 = arith.constant 128 : index
     %c64 = arith.constant 64 : index
     %c32 = arith.constant 32 : index
     %c16 = arith.constant 16 : index
@@ -177,23 +174,21 @@ module {
     %2 = amdaie.logicalobjectfifo.from_memref %alloc_2, {} : memref<1x2x64x64xbf16, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1x2x64x64xbf16, 1 : i32>>
     %3 = amdaie.logicalobjectfifo.from_memref %alloc_3, {} : memref<2x1x64x64xbf16, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2x1x64x64xbf16, 1 : i32>>
     scf.forall (%arg0, %arg1) in (1, 1) {
-      %4 = affine.apply #map(%arg1)
-      %5 = affine.apply #map(%arg0)
       scf.forall (%arg2, %arg3) in (2, 2) {
-        %6 = amdaie.dma_cpy_nd(%1[%c0, %c0, %c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16, %c4, %c8] [%c4096, %c4096, %c512, %c32, %c8, %c1], %3[%arg2, %c0, %c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16, %c4, %c8] [%c4096, %c4096, %c8, %c256, %c64, %c1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16x4x8xbf16, 2 : i32>>, !amdaie.logicalobjectfifo<memref<2x1x64x64xbf16, 1 : i32>>)
-        %7 = amdaie.dma_cpy_nd(%0[%c0, %c0, %c0, %c0, %c0, %c0] [%c1, %c1, %c16, %c8, %c8, %c4] [%c4096, %c4096, %c256, %c32, %c4, %c1], %2[%c0, %arg3, %c0, %c0, %c0, %c0] [%c1, %c1, %c16, %c8, %c8, %c4] [%c8192, %c4096, %c4, %c512, %c64, %c1]) : (!amdaie.logicalobjectfifo<memref<1x1x16x8x8x4xbf16, 2 : i32>>, !amdaie.logicalobjectfifo<memref<1x2x64x64xbf16, 1 : i32>>)
+        %4 = amdaie.dma_cpy_nd(%1[%c0, %c0, %c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16, %c4, %c8] [%c4096, %c4096, %c512, %c32, %c8, %c1], %3[%arg2, %c0, %c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16, %c4, %c8] [%c4096, %c4096, %c8, %c256, %c64, %c1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16x4x8xbf16, 2 : i32>>, !amdaie.logicalobjectfifo<memref<2x1x64x64xbf16, 1 : i32>>)
+        %5 = amdaie.dma_cpy_nd(%0[%c0, %c0, %c0, %c0, %c0, %c0] [%c1, %c1, %c16, %c8, %c8, %c4] [%c4096, %c4096, %c256, %c32, %c4, %c1], %2[%c0, %arg3, %c0, %c0, %c0, %c0] [%c1, %c1, %c16, %c8, %c8, %c4] [%c8192, %c4096, %c4, %c512, %c64, %c1]) : (!amdaie.logicalobjectfifo<memref<1x1x16x8x8x4xbf16, 2 : i32>>, !amdaie.logicalobjectfifo<memref<1x2x64x64xbf16, 1 : i32>>)
         %subview = memref.subview %alloc_4[%arg2, %arg3, 0, 0, 0, 0] [1, 1, 16, 16, 4, 4] [1, 1, 1, 1, 1, 1] : memref<2x2x16x16x4x4xf32, 2 : i32> to memref<1x1x16x16x4x4xf32, strided<[8192, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>
         linalg.fill ins(%cst_0 : f32) outs(%subview : memref<1x1x16x16x4x4xf32, strided<[8192, 4096, 256, 16, 4, 1], offset: ?>, 2 : i32>)
         scf.for %arg4 = %c0 to %c16 step %c1 {
           scf.for %arg5 = %c0 to %c16 step %c1 {
             scf.for %arg6 = %c0 to %c8 step %c1 {
-              %8 = vector.transfer_read %alloc_1[%c0, %c0, %arg6, %arg4, %c0, %c0], %cst {in_bounds = [true, true, true, true, true, true]} : memref<1x1x8x16x4x8xbf16, 2 : i32>, vector<1x1x1x1x4x8xbf16>
-              %9 = vector.transfer_read %alloc[%c0, %c0, %arg5, %arg6, %c0, %c0], %cst {in_bounds = [true, true, true, true, true, true]} : memref<1x1x16x8x8x4xbf16, 2 : i32>, vector<1x1x1x1x8x4xbf16>
-              %10 = vector.transfer_read %alloc_4[%arg2, %arg3, %arg5, %arg4, %c0, %c0], %cst_0 {in_bounds = [true, true, true, true, true, true]} : memref<2x2x16x16x4x4xf32, 2 : i32>, vector<1x1x1x1x4x4xf32>
-              %11 = arith.extf %8 : vector<1x1x1x1x4x8xbf16> to vector<1x1x1x1x4x8xf32>
-              %12 = arith.extf %9 : vector<1x1x1x1x8x4xbf16> to vector<1x1x1x1x8x4xf32>
-              %13 = vector.contract {indexing_maps = [#map1, #map2, #map3], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction", "parallel", "parallel", "reduction"], kind = #vector.kind<add>} %11, %12, %10 : vector<1x1x1x1x4x8xf32>, vector<1x1x1x1x8x4xf32> into vector<1x1x1x1x4x4xf32>
-              vector.transfer_write %13, %alloc_4[%arg2, %arg3, %arg5, %arg4, %c0, %c0] {in_bounds = [true, true, true, true, true, true]} : vector<1x1x1x1x4x4xf32>, memref<2x2x16x16x4x4xf32, 2 : i32>
+              %6 = vector.transfer_read %alloc_1[%c0, %c0, %arg6, %arg4, %c0, %c0], %cst {in_bounds = [true, true, true, true, true, true]} : memref<1x1x8x16x4x8xbf16, 2 : i32>, vector<1x1x1x1x4x8xbf16>
+              %7 = vector.transfer_read %alloc[%c0, %c0, %arg5, %arg6, %c0, %c0], %cst {in_bounds = [true, true, true, true, true, true]} : memref<1x1x16x8x8x4xbf16, 2 : i32>, vector<1x1x1x1x8x4xbf16>
+              %8 = vector.transfer_read %alloc_4[%arg2, %arg3, %arg5, %arg4, %c0, %c0], %cst_0 {in_bounds = [true, true, true, true, true, true]} : memref<2x2x16x16x4x4xf32, 2 : i32>, vector<1x1x1x1x4x4xf32>
+              %9 = arith.extf %6 : vector<1x1x1x1x4x8xbf16> to vector<1x1x1x1x4x8xf32>
+              %10 = arith.extf %7 : vector<1x1x1x1x8x4xbf16> to vector<1x1x1x1x8x4xf32>
+              %11 = vector.contract {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction", "parallel", "parallel", "reduction"], kind = #vector.kind<add>} %9, %10, %8 : vector<1x1x1x1x4x8xf32>, vector<1x1x1x1x8x4xf32> into vector<1x1x1x1x4x4xf32>
+              vector.transfer_write %11, %alloc_4[%arg2, %arg3, %arg5, %arg4, %c0, %c0] {in_bounds = [true, true, true, true, true, true]} : vector<1x1x1x1x4x4xf32>, memref<2x2x16x16x4x4xf32, 2 : i32>
             }
           }
         }
@@ -231,44 +226,35 @@ module {
 module {
   func.func private @matmul_i32_i32(memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index) attributes {link_with = "/path/to/ukernel/mm.o", llvm.bareptr = true}
   func.func @insert_cores_with_ukernel_linking() {
-    %c64 = arith.constant 64 : index
-    %c16 = arith.constant 16 : index
-    %c224 = arith.constant 224 : index
     %c8 = arith.constant 8 : index
     %c4 = arith.constant 4 : index
     %c128 = arith.constant 128 : index
-    %c4096 = arith.constant 4096 : index
     %c2048 = arith.constant 2048 : index
     %c256 = arith.constant 256 : index
-    %c8192 = arith.constant 8192 : index
     %c1024 = arith.constant 1024 : index
     %c32 = arith.constant 32 : index
-    %c2 = arith.constant 2 : index
-    %c7 = arith.constant 7 : index
     %c0 = arith.constant 0 : index
     %c0_i32 = arith.constant 0 : i32
     %c1 = arith.constant 1 : index
     %alloc = memref.alloc() : memref<1x1x8x4x8x4xi32, 2 : i32>
     %0 = amdaie.logicalobjectfifo.from_memref %alloc, {} : memref<1x1x8x4x8x4xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<1x1x8x4x8x4xi32, 2 : i32>>
     %alloc_0 = memref.alloc() : memref<1x1x4x8x4x8xi32, 2 : i32>
-    %3 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<1x1x4x8x4x8xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<1x1x4x8x4x8xi32, 2 : i32>>
+    %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<1x1x4x8x4x8xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<1x1x4x8x4x8xi32, 2 : i32>>
     %alloc_1 = memref.alloc() : memref<1x2x32x32xi32, 1 : i32>
-    %7 = amdaie.logicalobjectfifo.from_memref %alloc_1, {} : memref<1x2x32x32xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1x2x32x32xi32, 1 : i32>>
+    %2 = amdaie.logicalobjectfifo.from_memref %alloc_1, {} : memref<1x2x32x32xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1x2x32x32xi32, 1 : i32>>
     %alloc_2 = memref.alloc() : memref<2x1x32x32xi32, 1 : i32>
-    %13 = amdaie.logicalobjectfifo.from_memref %alloc_2, {} : memref<2x1x32x32xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2x1x32x32xi32, 1 : i32>>
+    %3 = amdaie.logicalobjectfifo.from_memref %alloc_2, {} : memref<2x1x32x32xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2x1x32x32xi32, 1 : i32>>
     %alloc_3 = memref.alloc() : memref<2x2x8x8x4x4xi32, 2 : i32>
     scf.forall (%arg0, %arg1) in (1, 1) {
-      %31 = affine.apply affine_map<(d0) -> (d0 * 64)>(%arg1)
-      %32 = affine.apply affine_map<(d0) -> (d0 * 64)>(%arg0)
       scf.forall (%arg2, %arg3) in (2, 2) {
-        %38 = amdaie.dma_cpy_nd(%3[%c0, %c0, %c0, %c0, %c0, %c0] [%c1, %c1, %c4, %c8, %c4, %c8] [%c1024, %c1024, %c256, %c32, %c8, %c1], %13[%arg2, %c0, %c0, %c0, %c0, %c0] [%c1, %c1, %c4, %c8, %c4, %c8] [%c1024, %c1024, %c8, %c128, %c32, %c1]) : (!amdaie.logicalobjectfifo<memref<1x1x4x8x4x8xi32, 2 : i32>>, !amdaie.logicalobjectfifo<memref<2x1x32x32xi32, 1 : i32>>)
-        %39 = amdaie.dma_cpy_nd(%0[%c0, %c0, %c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c4, %c8, %c4] [%c1024, %c1024, %c128, %c32, %c4, %c1], %7[%c0, %arg3, %c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c4, %c8, %c4] [%c2048, %c1024, %c4, %c256, %c32, %c1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x4x8x4xi32, 2 : i32>>, !amdaie.logicalobjectfifo<memref<1x2x32x32xi32, 1 : i32>>)
+        %4 = amdaie.dma_cpy_nd(%1[%c0, %c0, %c0, %c0, %c0, %c0] [%c1, %c1, %c4, %c8, %c4, %c8] [%c1024, %c1024, %c256, %c32, %c8, %c1], %3[%arg2, %c0, %c0, %c0, %c0, %c0] [%c1, %c1, %c4, %c8, %c4, %c8] [%c1024, %c1024, %c8, %c128, %c32, %c1]) : (!amdaie.logicalobjectfifo<memref<1x1x4x8x4x8xi32, 2 : i32>>, !amdaie.logicalobjectfifo<memref<2x1x32x32xi32, 1 : i32>>)
+        %5 = amdaie.dma_cpy_nd(%0[%c0, %c0, %c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c4, %c8, %c4] [%c1024, %c1024, %c128, %c32, %c4, %c1], %2[%c0, %arg3, %c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c4, %c8, %c4] [%c2048, %c1024, %c4, %c256, %c32, %c1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x4x8x4xi32, 2 : i32>>, !amdaie.logicalobjectfifo<memref<1x2x32x32xi32, 1 : i32>>)
         %subview = memref.subview %alloc_3[%arg2, %arg3, 0, 0, 0, 0] [1, 1, 8, 8, 4, 4] [1, 1, 1, 1, 1, 1] : memref<2x2x8x8x4x4xi32, 2 : i32> to memref<1x1x8x8x4x4xi32, strided<[2048, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32>
         linalg.fill ins(%c0_i32 : i32) outs(%subview : memref<1x1x8x8x4x4xi32, strided<[2048, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32>)
         %base_buffer, %offset, %sizes:6, %strides:6 = memref.extract_strided_metadata %alloc_0 : memref<1x1x4x8x4x8xi32, 2 : i32> -> memref<i32, 2 : i32>, index, index, index, index, index, index, index, index, index, index, index, index, index
-        %base_buffer_10, %offset_11, %sizes_12:6, %strides_13:6 = memref.extract_strided_metadata %alloc : memref<1x1x8x4x8x4xi32, 2 : i32> -> memref<i32, 2 : i32>, index, index, index, index, index, index, index, index, index, index, index, index, index
-        %base_buffer_14, %offset_15, %sizes_16:6, %strides_17:6 = memref.extract_strided_metadata %subview : memref<1x1x8x8x4x4xi32, strided<[2048, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32> -> memref<i32, 2 : i32>, index, index, index, index, index, index, index, index, index, index, index, index, index
-        func.call @matmul_i32_i32(%base_buffer, %c0, %base_buffer_10, %c0, %base_buffer_14, %offset_15) : (memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index) -> ()
+        %base_buffer_4, %offset_5, %sizes_6:6, %strides_7:6 = memref.extract_strided_metadata %alloc : memref<1x1x8x4x8x4xi32, 2 : i32> -> memref<i32, 2 : i32>, index, index, index, index, index, index, index, index, index, index, index, index, index
+        %base_buffer_8, %offset_9, %sizes_10:6, %strides_11:6 = memref.extract_strided_metadata %subview : memref<1x1x8x8x4x4xi32, strided<[2048, 1024, 128, 16, 4, 1], offset: ?>, 2 : i32> -> memref<i32, 2 : i32>, index, index, index, index, index, index, index, index, index, index, index, index, index
+        func.call @matmul_i32_i32(%base_buffer, %c0, %base_buffer_4, %c0, %base_buffer_8, %offset_9) : (memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index, memref<i32, 2 : i32>, index) -> ()
       } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
     } {mapping = [#gpu.block<y>, #gpu.block<x>]}
     memref.dealloc %alloc_3 : memref<2x2x8x8x4x4xi32, 2 : i32>
@@ -282,101 +268,35 @@ module {
 
 // -----
 
-// This is the starting IR currently generated for tiling a conv2d op.
-
-// CHECK-LABEL:   @conv_2d_nhwc_hwcf_dispatch_0_conv_2d_nhwc_hwcf_2x12x12x64x3x3x32_i32
-// CHECK:         scf.forall
-// CHECK-SAME:    (3, 3, 16)
+// This is based on the starting IR currently generated for tiling a convd2d op.
+// The IR has been stripped down, for example the outer scf.forall denoting the
+// block dimensions has been removed, as has all the data movement to L2.
+// This test checks  that the linalg.conv_1d_nwc_wcf op is handled correctly
+// (inserted into a core).
+// CHECK-LABEL:   @stripped_down_conv2d
 // CHECK:         scf.forall
 // CHECK-SAME:    (2, 4)
 // CHECK:         amdaie.tile
 // CHECK:         amdaie.core
-// CHECK-COUNT-3: scf.for
+// CHECK-COUNT-2: scf.for
 // CHECK-NOT:     scf.for
 // CHECK:         linalg.conv_1d_nwc_wcf
 // CHECK:         amdaie.end
-#map = affine_map<(d0) -> (d0 * 4)>
-#map1 = affine_map<(d0) -> (d0 * 8)>
-#translation = #iree_codegen.translation_info<Custom>
-builtin.module {
-  func.func @conv_2d_nhwc_hwcf_dispatch_0_conv_2d_nhwc_hwcf_2x12x12x64x3x3x32_i32() attributes {translation_info = #translation} {
-    %c768 = arith.constant 768 : index
-    %c9216 = arith.constant 9216 : index
-    %c16 = arith.constant 16 : index
-    %c128 = arith.constant 128 : index
-    %c384 = arith.constant 384 : index
-    %c192 = arith.constant 192 : index
-    %c1152 = arith.constant 1152 : index
-    %c64 = arith.constant 64 : index
-    %c2048 = arith.constant 2048 : index
-    %c6144 = arith.constant 6144 : index
-    %c4 = arith.constant 4 : index
-    %c448 = arith.constant 448 : index
-    %c6272 = arith.constant 6272 : index
-    %c6 = arith.constant 6 : index
-    %c2 = arith.constant 2 : index
+module {
+  func.func @stripped_down_conv2d(%arg0: memref<1x3x6x32xi32, 2 : i32>, %arg1: memref<3x3x32x4xi32, 2 : i32>, %arg2: memref<1x1x4x4xi32, 2 : i32>) {
     %c1 = arith.constant 1 : index
-    %c32 = arith.constant 32 : index
     %c3 = arith.constant 3 : index
-    %c0_i32 = arith.constant 0 : i32
     %c0 = arith.constant 0 : index
-    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<2x14x14x32xi32>
-    %1 = amdaie.logicalobjectfifo.from_memref %0, {} : memref<2x14x14x32xi32> -> !amdaie.logicalobjectfifo<memref<2x14x14x32xi32>>
-    memref.assume_alignment %0, 64 : memref<2x14x14x32xi32>
-    %2 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<3x3x32x64xi32>
-    %3 = amdaie.logicalobjectfifo.from_memref %2, {} : memref<3x3x32x64xi32> -> !amdaie.logicalobjectfifo<memref<3x3x32x64xi32>>
-    memref.assume_alignment %2, 64 : memref<3x3x32x64xi32>
-    %4 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : memref<2x12x12x64xi32>
-    %5 = amdaie.logicalobjectfifo.from_memref %4, {} : memref<2x12x12x64xi32> -> !amdaie.logicalobjectfifo<memref<2x12x12x64xi32>>
-    memref.assume_alignment %4, 64 : memref<2x12x12x64xi32>
-    scf.forall (%arg0, %arg1, %arg2) in (3, 3, 16) {
-      %6 = affine.apply #map(%arg2)
-      %7 = affine.apply #map(%arg1)
-      %8 = affine.apply #map(%arg0)
-      %alloc = memref.alloc() : memref<2x6x6x32xi32, 1 : i32>
-      %9 = amdaie.logicalobjectfifo.from_memref %alloc, {} : memref<2x6x6x32xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2x6x6x32xi32, 1 : i32>>
-      %10 = amdaie.logicalobjectfifo.from_memref %alloc, {} : memref<2x6x6x32xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2x6x6x32xi32, 1 : i32>>
-      %11 = amdaie.dma_cpy_nd(%9[] [] [], %1[%c0, %8, %7, %c0] [%c2, %c6, %c6, %c32] [%c6272, %c448, %c32, %c1]) : (!amdaie.logicalobjectfifo<memref<2x6x6x32xi32, 1 : i32>>, !amdaie.logicalobjectfifo<memref<2x14x14x32xi32>>)
-      %alloc_0 = memref.alloc() : memref<3x3x32x4xi32, 1 : i32>
-      %12 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<3x3x32x4xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<3x3x32x4xi32, 1 : i32>>
-      %13 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<3x3x32x4xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<3x3x32x4xi32, 1 : i32>>
-      %14 = amdaie.dma_cpy_nd(%12[] [] [], %3[%c0, %c0, %c0, %6] [%c3, %c3, %c32, %c4] [%c6144, %c2048, %c64, %c1]) : (!amdaie.logicalobjectfifo<memref<3x3x32x4xi32, 1 : i32>>, !amdaie.logicalobjectfifo<memref<3x3x32x64xi32>>)
-      %alloc_1 = memref.alloc() : memref<2x4x4x4xi32, 1 : i32>
-      %15 = amdaie.logicalobjectfifo.from_memref %alloc_1, {} : memref<2x4x4x4xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2x4x4x4xi32, 1 : i32>>
-      %16 = amdaie.logicalobjectfifo.from_memref %alloc_1, {} : memref<2x4x4x4xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2x4x4x4xi32, 1 : i32>>
-      %alloc_2 = memref.alloc() : memref<1x3x6x32xi32, 2 : i32>
-      %alloc_3 = memref.alloc() : memref<3x3x32x4xi32, 2 : i32>
-      %alloc_4 = memref.alloc() : memref<1x1x4x4xi32, 2 : i32>
-      scf.forall (%arg3, %arg4) in (2, 4) {
-        %18 = affine.apply #map(%arg4)
-        %19 = affine.apply #map(%arg3)
-        %20 = amdaie.logicalobjectfifo.from_memref %alloc_2, {} : memref<1x3x6x32xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<1x3x6x32xi32, 2 : i32>>
-        %21 = amdaie.dma_cpy_nd(%20[] [] [], %10[%arg3, %arg4, %19, %c0] [%c1, %c3, %c6, %c32] [%c1152, %c192, %c32, %c1]) : (!amdaie.logicalobjectfifo<memref<1x3x6x32xi32, 2 : i32>>, !amdaie.logicalobjectfifo<memref<2x6x6x32xi32, 1 : i32>>)
-        %22 = amdaie.logicalobjectfifo.from_memref %alloc_3, {} : memref<3x3x32x4xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<3x3x32x4xi32, 2 : i32>>
-        %23 = amdaie.dma_cpy_nd(%22[] [] [], %13[%c0, %c0, %c0, %18] [%c3, %c3, %c32, %c4] [%c384, %c128, %c4, %c1]) : (!amdaie.logicalobjectfifo<memref<3x3x32x4xi32, 2 : i32>>, !amdaie.logicalobjectfifo<memref<3x3x32x4xi32, 1 : i32>>)
-        %24 = amdaie.logicalobjectfifo.from_memref %alloc_4, {} : memref<1x1x4x4xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<1x1x4x4xi32, 2 : i32>>
-        linalg.fill ins(%c0_i32 : i32) outs(%alloc_4 : memref<1x1x4x4xi32, 2 : i32>)
-        scf.for %arg5 = %c0 to %c3 step %c1 {
-          scf.for %arg6 = %c0 to %c3 step %c1 {
-            scf.for %arg7 = %c0 to %c4 step %c1 {
-              %26 = affine.apply #map1(%arg7)
-              %subview = memref.subview %alloc_2[0, %arg5, %arg6, %26] [1, 1, 4, 8] [1, 1, 1, 1] : memref<1x3x6x32xi32, 2 : i32> to memref<1x4x8xi32, strided<[576, 32, 1], offset: ?>, 2 : i32>
-              %subview_5 = memref.subview %alloc_3[%arg5, %arg6, %26, 0] [1, 1, 8, 4] [1, 1, 1, 1] : memref<3x3x32x4xi32, 2 : i32> to memref<1x8x4xi32, strided<[384, 4, 1], offset: ?>, 2 : i32>
-              %subview_6 = memref.subview %alloc_4[0, 0, 0, 0] [1, 1, 4, 4] [1, 1, 1, 1] : memref<1x1x4x4xi32, 2 : i32> to memref<1x4x4xi32, strided<[16, 4, 1]>, 2 : i32>
-              linalg.conv_1d_nwc_wcf {dilations = dense<1> : vector<1xi64>, strides = dense<1> : vector<1xi64>} ins(%subview, %subview_5 : memref<1x4x8xi32, strided<[576, 32, 1], offset: ?>, 2 : i32>, memref<1x8x4xi32, strided<[384, 4, 1], offset: ?>, 2 : i32>) outs(%subview_6 : memref<1x4x4xi32, strided<[16, 4, 1]>, 2 : i32>)
-            }
-          }
+    scf.forall (%arg3, %arg4) in (2, 4) {
+      scf.for %arg5 = %c0 to %c3 step %c1 {
+        scf.for %arg6 = %c0 to %c3 step %c1 {
+          %subview = memref.subview %arg0[0, %arg5, %arg6, 0] [1, 1, 4, 8] [1, 1, 1, 1] : memref<1x3x6x32xi32, 2 : i32> to memref<1x4x8xi32, strided<[576, 32, 1], offset: ?>, 2 : i32>
+          %subview_0 = memref.subview %arg1[%arg5, %arg6, 0, 0] [1, 1, 8, 4] [1, 1, 1, 1] : memref<3x3x32x4xi32, 2 : i32> to memref<1x8x4xi32, strided<[384, 4, 1], offset: ?>, 2 : i32>
+          %subview_1 = memref.subview %arg2[0, 0, 0, 0] [1, 1, 4, 4] [1, 1, 1, 1] : memref<1x1x4x4xi32, 2 : i32> to memref<1x4x4xi32, strided<[16, 4, 1]>, 2 : i32>
+          linalg.conv_1d_nwc_wcf {dilations = dense<1> : vector<1xi64>, strides = dense<1> : vector<1xi64>} ins(%subview, %subview_0 : memref<1x4x8xi32, strided<[576, 32, 1], offset: ?>, 2 : i32>, memref<1x8x4xi32, strided<[384, 4, 1], offset: ?>, 2 : i32>) outs(%subview_1 : memref<1x4x4xi32, strided<[16, 4, 1]>, 2 : i32>)
         }
-        %25 = amdaie.dma_cpy_nd(%15[%arg3, %arg4, %19, %18] [%c1, %c1, %c4, %c4] [%c64, %c16, %c4, %c1], %24[] [] []) : (!amdaie.logicalobjectfifo<memref<2x4x4x4xi32, 1 : i32>>, !amdaie.logicalobjectfifo<memref<1x1x4x4xi32, 2 : i32>>)
-      } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
-      %17 = amdaie.dma_cpy_nd(%5[%c0, %8, %7, %6] [%c2, %c4, %c4, %c4] [%c9216, %c768, %c64, %c1], %16[] [] []) : (!amdaie.logicalobjectfifo<memref<2x12x12x64xi32>>, !amdaie.logicalobjectfifo<memref<2x4x4x4xi32, 1 : i32>>)
-      memref.dealloc %alloc : memref<2x6x6x32xi32, 1 : i32>
-      memref.dealloc %alloc_0 : memref<3x3x32x4xi32, 1 : i32>
-      memref.dealloc %alloc_1 : memref<2x4x4x4xi32, 1 : i32>
-      memref.dealloc %alloc_2 : memref<1x3x6x32xi32, 2 : i32>
-      memref.dealloc %alloc_3 : memref<3x3x32x4xi32, 2 : i32>
-      memref.dealloc %alloc_4 : memref<1x1x4x4xi32, 2 : i32>
-    }
+      }
+    } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
     return
   }
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_cores.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_cores.mlir
@@ -279,3 +279,104 @@ module {
     return
   }
 }
+
+// -----
+
+// This is the starting IR currently generated for tiling a convd op.
+
+// CHECK-LABEL:   @conv_2d_nhwc_hwcf_dispatch_0_conv_2d_nhwc_hwcf_2x12x12x64x3x3x32_i32
+// CHECK:         scf.forall
+// CHECK-SAME:    (3, 3, 16)
+// CHECK:         scf.forall
+// CHECK-SAME:    (2, 4)
+// CHECK:         amdaie.tile
+// CHECK:         amdaie.core
+// CHECK-COUNT-3: scf.for
+// CHECK-NOT:     scf.for
+// CHECK:         linalg.conv_1d_nwc_wcf
+// CHECK:         amdaie.end
+#map = affine_map<(d0) -> (d0 * 4)>
+#map1 = affine_map<(d0) -> (d0 * 8)>
+#translation = #iree_codegen.translation_info<Custom>
+builtin.module {
+  func.func @conv_2d_nhwc_hwcf_dispatch_0_conv_2d_nhwc_hwcf_2x12x12x64x3x3x32_i32() attributes {translation_info = #translation} {
+    %c768 = arith.constant 768 : index
+    %c9216 = arith.constant 9216 : index
+    %c16 = arith.constant 16 : index
+    %c128 = arith.constant 128 : index
+    %c384 = arith.constant 384 : index
+    %c192 = arith.constant 192 : index
+    %c1152 = arith.constant 1152 : index
+    %c64 = arith.constant 64 : index
+    %c2048 = arith.constant 2048 : index
+    %c6144 = arith.constant 6144 : index
+    %c4 = arith.constant 4 : index
+    %c448 = arith.constant 448 : index
+    %c6272 = arith.constant 6272 : index
+    %c6 = arith.constant 6 : index
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %c3 = arith.constant 3 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c0 = arith.constant 0 : index
+    %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<2x14x14x32xi32>
+    %1 = amdaie.logicalobjectfifo.from_memref %0, {} : memref<2x14x14x32xi32> -> !amdaie.logicalobjectfifo<memref<2x14x14x32xi32>>
+    memref.assume_alignment %0, 64 : memref<2x14x14x32xi32>
+    %2 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : memref<3x3x32x64xi32>
+    %3 = amdaie.logicalobjectfifo.from_memref %2, {} : memref<3x3x32x64xi32> -> !amdaie.logicalobjectfifo<memref<3x3x32x64xi32>>
+    memref.assume_alignment %2, 64 : memref<3x3x32x64xi32>
+    %4 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : memref<2x12x12x64xi32>
+    %5 = amdaie.logicalobjectfifo.from_memref %4, {} : memref<2x12x12x64xi32> -> !amdaie.logicalobjectfifo<memref<2x12x12x64xi32>>
+    memref.assume_alignment %4, 64 : memref<2x12x12x64xi32>
+    scf.forall (%arg0, %arg1, %arg2) in (3, 3, 16) {
+      %6 = affine.apply #map(%arg2)
+      %7 = affine.apply #map(%arg1)
+      %8 = affine.apply #map(%arg0)
+      %alloc = memref.alloc() : memref<2x6x6x32xi32, 1 : i32>
+      %9 = amdaie.logicalobjectfifo.from_memref %alloc, {} : memref<2x6x6x32xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2x6x6x32xi32, 1 : i32>>
+      %10 = amdaie.logicalobjectfifo.from_memref %alloc, {} : memref<2x6x6x32xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2x6x6x32xi32, 1 : i32>>
+      %11 = amdaie.dma_cpy_nd(%9[] [] [], %1[%c0, %8, %7, %c0] [%c2, %c6, %c6, %c32] [%c6272, %c448, %c32, %c1]) : (!amdaie.logicalobjectfifo<memref<2x6x6x32xi32, 1 : i32>>, !amdaie.logicalobjectfifo<memref<2x14x14x32xi32>>)
+      %alloc_0 = memref.alloc() : memref<3x3x32x4xi32, 1 : i32>
+      %12 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<3x3x32x4xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<3x3x32x4xi32, 1 : i32>>
+      %13 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<3x3x32x4xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<3x3x32x4xi32, 1 : i32>>
+      %14 = amdaie.dma_cpy_nd(%12[] [] [], %3[%c0, %c0, %c0, %6] [%c3, %c3, %c32, %c4] [%c6144, %c2048, %c64, %c1]) : (!amdaie.logicalobjectfifo<memref<3x3x32x4xi32, 1 : i32>>, !amdaie.logicalobjectfifo<memref<3x3x32x64xi32>>)
+      %alloc_1 = memref.alloc() : memref<2x4x4x4xi32, 1 : i32>
+      %15 = amdaie.logicalobjectfifo.from_memref %alloc_1, {} : memref<2x4x4x4xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2x4x4x4xi32, 1 : i32>>
+      %16 = amdaie.logicalobjectfifo.from_memref %alloc_1, {} : memref<2x4x4x4xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2x4x4x4xi32, 1 : i32>>
+      %alloc_2 = memref.alloc() : memref<1x3x6x32xi32, 2 : i32>
+      %alloc_3 = memref.alloc() : memref<3x3x32x4xi32, 2 : i32>
+      %alloc_4 = memref.alloc() : memref<1x1x4x4xi32, 2 : i32>
+      scf.forall (%arg3, %arg4) in (2, 4) {
+        %18 = affine.apply #map(%arg4)
+        %19 = affine.apply #map(%arg3)
+        %20 = amdaie.logicalobjectfifo.from_memref %alloc_2, {} : memref<1x3x6x32xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<1x3x6x32xi32, 2 : i32>>
+        %21 = amdaie.dma_cpy_nd(%20[] [] [], %10[%arg3, %arg4, %19, %c0] [%c1, %c3, %c6, %c32] [%c1152, %c192, %c32, %c1]) : (!amdaie.logicalobjectfifo<memref<1x3x6x32xi32, 2 : i32>>, !amdaie.logicalobjectfifo<memref<2x6x6x32xi32, 1 : i32>>)
+        %22 = amdaie.logicalobjectfifo.from_memref %alloc_3, {} : memref<3x3x32x4xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<3x3x32x4xi32, 2 : i32>>
+        %23 = amdaie.dma_cpy_nd(%22[] [] [], %13[%c0, %c0, %c0, %18] [%c3, %c3, %c32, %c4] [%c384, %c128, %c4, %c1]) : (!amdaie.logicalobjectfifo<memref<3x3x32x4xi32, 2 : i32>>, !amdaie.logicalobjectfifo<memref<3x3x32x4xi32, 1 : i32>>)
+        %24 = amdaie.logicalobjectfifo.from_memref %alloc_4, {} : memref<1x1x4x4xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<1x1x4x4xi32, 2 : i32>>
+        linalg.fill ins(%c0_i32 : i32) outs(%alloc_4 : memref<1x1x4x4xi32, 2 : i32>)
+        scf.for %arg5 = %c0 to %c3 step %c1 {
+          scf.for %arg6 = %c0 to %c3 step %c1 {
+            scf.for %arg7 = %c0 to %c4 step %c1 {
+              %26 = affine.apply #map1(%arg7)
+              %subview = memref.subview %alloc_2[0, %arg5, %arg6, %26] [1, 1, 4, 8] [1, 1, 1, 1] : memref<1x3x6x32xi32, 2 : i32> to memref<1x4x8xi32, strided<[576, 32, 1], offset: ?>, 2 : i32>
+              %subview_5 = memref.subview %alloc_3[%arg5, %arg6, %26, 0] [1, 1, 8, 4] [1, 1, 1, 1] : memref<3x3x32x4xi32, 2 : i32> to memref<1x8x4xi32, strided<[384, 4, 1], offset: ?>, 2 : i32>
+              %subview_6 = memref.subview %alloc_4[0, 0, 0, 0] [1, 1, 4, 4] [1, 1, 1, 1] : memref<1x1x4x4xi32, 2 : i32> to memref<1x4x4xi32, strided<[16, 4, 1]>, 2 : i32>
+              linalg.conv_1d_nwc_wcf {dilations = dense<1> : vector<1xi64>, strides = dense<1> : vector<1xi64>} ins(%subview, %subview_5 : memref<1x4x8xi32, strided<[576, 32, 1], offset: ?>, 2 : i32>, memref<1x8x4xi32, strided<[384, 4, 1], offset: ?>, 2 : i32>) outs(%subview_6 : memref<1x4x4xi32, strided<[16, 4, 1]>, 2 : i32>)
+            }
+          }
+        }
+        %25 = amdaie.dma_cpy_nd(%15[%arg3, %arg4, %19, %18] [%c1, %c1, %c4, %c4] [%c64, %c16, %c4, %c1], %24[] [] []) : (!amdaie.logicalobjectfifo<memref<2x4x4x4xi32, 1 : i32>>, !amdaie.logicalobjectfifo<memref<1x1x4x4xi32, 2 : i32>>)
+      } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
+      %17 = amdaie.dma_cpy_nd(%5[%c0, %8, %7, %6] [%c2, %c4, %c4, %c4] [%c9216, %c768, %c64, %c1], %16[] [] []) : (!amdaie.logicalobjectfifo<memref<2x12x12x64xi32>>, !amdaie.logicalobjectfifo<memref<2x4x4x4xi32, 1 : i32>>)
+      memref.dealloc %alloc : memref<2x6x6x32xi32, 1 : i32>
+      memref.dealloc %alloc_0 : memref<3x3x32x4xi32, 1 : i32>
+      memref.dealloc %alloc_1 : memref<2x4x4x4xi32, 1 : i32>
+      memref.dealloc %alloc_2 : memref<1x3x6x32xi32, 2 : i32>
+      memref.dealloc %alloc_3 : memref<3x3x32x4xi32, 2 : i32>
+      memref.dealloc %alloc_4 : memref<1x1x4x4xi32, 2 : i32>
+    }
+    return
+  }
+}


### PR DESCRIPTION
This is a small change to get convolution lowering through the insert core pass. Specifically, it makes sure that linalg::ConvolutionInterfaceOps are handled correctly (in the same way as vector::ContractionOp). I think the pass can be improved further at a later point (we should be able to lift only a subset of the nested loop into the core I think). 