### PR TITLE
[Localize ObjectFifo] Don't crash when scf.forall has no mapping

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELocalizeLogicalObjectFifo.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELocalizeLogicalObjectFifo.cpp
@@ -29,7 +29,7 @@ namespace mlir::iree_compiler::AMDAIE {
 namespace {
 
 template <class... T>
-scf::ForallOp getThreadMappedForallAncestor(Operation *op) {
+scf::ForallOp getMappedForallAncestor(Operation *op) {
   auto forall = op->getParentOfType<scf::ForallOp>();
   while (forall) {
     bool isMapped = [&forall]() {
@@ -49,12 +49,12 @@ scf::ForallOp getThreadMappedForallAncestor(Operation *op) {
 }
 
 scf::ForallOp getThreadMappedForallAncestor(Operation *op) {
-  return getThreadMappedForallAncestor<mlir::gpu::GPUThreadMappingAttr>(op);
+  return getMappedForallAncestor<mlir::gpu::GPUThreadMappingAttr>(op);
 }
 
 scf::ForallOp getThreadOrBlockMappedForallAncestor(Operation *op) {
-  return getThreadMappedForallAncestor<mlir::gpu::GPUThreadMappingAttr,
-                                       mlir::gpu::GPUBlockMappingAttr>(op);
+  return getMappedForallAncestor<mlir::gpu::GPUThreadMappingAttr,
+                                 mlir::gpu::GPUBlockMappingAttr>(op);
 }
 
 class AMDAIELocalizeLogicalObjectfifoPass

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELocalizeLogicalObjectFifo.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELocalizeLogicalObjectFifo.cpp
@@ -19,7 +19,7 @@
 #include "iree-amd-aie/IR/AMDAIEDialect.h"
 #include "iree-amd-aie/IR/AMDAIEOps.h"
 #include "iree-amd-aie/Transforms/Passes.h"
-#include "iree/compiler/Codegen/TransformStrategies/GPU/Common.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 
 #define DEBUG_TYPE "iree-amdaie-localize-logicalobjectfifo"
@@ -28,17 +28,33 @@ namespace mlir::iree_compiler::AMDAIE {
 
 namespace {
 
-// Recursively find and return a parent scf.forall op chosen for parallel
-// distribution across cores. For now, this looks for thread mapping, but this
-// will probably be changed to include block mapping as well in the future.
-scf::ForallOp getParentForallWithParallelMapping(Operation *op) {
-  scf::ForallOp forallOp = op->getParentOfType<scf::ForallOp>();
-  if (!forallOp) return scf::ForallOp();
-  if (isa<mlir::gpu::GPUThreadMappingAttr>(
-          *forallOp.getMapping()->getValue().begin())) {
-    return forallOp;
+template <class... T>
+scf::ForallOp getThreadMappedForallAncestor(Operation *op) {
+  auto forall = op->getParentOfType<scf::ForallOp>();
+  while (forall) {
+    bool isMapped = [&forall]() {
+      auto maybeMapping = forall.getMapping();
+      auto hasMapping = maybeMapping.has_value();
+      if (!hasMapping) return false;
+      auto mapping = maybeMapping->getValue();
+      if (mapping.size() == 0) return false;
+      auto mappingAttr0 = *mapping.begin();
+      if (isa<T...>(mappingAttr0)) return true;
+      return false;
+    }();
+    if (isMapped) return forall;
+    forall = forall->getParentOfType<scf::ForallOp>();
   }
-  return getParentForallWithParallelMapping(forallOp);
+  return scf::ForallOp();
+}
+
+scf::ForallOp getThreadMappedForallAncestor(Operation *op) {
+  return getThreadMappedForallAncestor<mlir::gpu::GPUThreadMappingAttr>(op);
+}
+
+scf::ForallOp getThreadOrBlockMappedForallAncestor(Operation *op) {
+  return getThreadMappedForallAncestor<mlir::gpu::GPUThreadMappingAttr,
+                                       mlir::gpu::GPUBlockMappingAttr>(op);
 }
 
 class AMDAIELocalizeLogicalObjectfifoPass
@@ -62,9 +78,9 @@ void AMDAIELocalizeLogicalObjectfifoPass::runOnOperation() {
 
   SmallVector<AMDAIE::LogicalObjectFifoFromMemrefOp> logicalObjectFifos;
   moduleOp->walk([&](AMDAIE::LogicalObjectFifoFromMemrefOp op) {
-    // The op is already within the parallel mapped forall, so doesn't need
+    // The op is already within the thread mapped forall, so doesn't need
     // any change.
-    if (getParentForallWithParallelMapping(op)) {
+    if (getThreadMappedForallAncestor(op)) {
       return WalkResult::advance();
     }
     logicalObjectFifos.push_back(op);
@@ -72,11 +88,11 @@ void AMDAIELocalizeLogicalObjectfifoPass::runOnOperation() {
   });
 
   for (AMDAIE::LogicalObjectFifoFromMemrefOp op : logicalObjectFifos) {
-    // Get all parallel scf.forall operations containing users of this logical
-    // objectFifo.
+    // Get all thread mapped scf.forall operations containing users of this
+    // logical objectFifo.
     llvm::SmallSetVector<scf::ForallOp, 4> localUsers;
     for (Operation *userOp : op->getUsers()) {
-      if (scf::ForallOp forallOp = getParentForallWithParallelMapping(userOp)) {
+      if (scf::ForallOp forallOp = getThreadMappedForallAncestor(userOp)) {
         localUsers.insert(forallOp);
       }
     }
@@ -90,7 +106,7 @@ void AMDAIELocalizeLogicalObjectfifoPass::runOnOperation() {
       auto clone = rewriter.clone(*(op.getOperation()));
       op->replaceUsesWithIf(clone, [&](OpOperand &use) {
         scf::ForallOp localParentForall =
-            getParentForallWithParallelMapping(use.getOwner());
+            getThreadMappedForallAncestor(use.getOwner());
         return localParentForall && localParentForall == forallOp;
       });
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/localize_logical_objectfifo.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/localize_logical_objectfifo.mlir
@@ -17,16 +17,17 @@
 module {
   func.func @localize_logical_objectfifo() {
     %alloc = memref.alloc() : memref<32x1024xi32>
-    %alloc_1 = memref.alloc() : memref<32x64xi32, 1>
-    %1 = amdaie.logicalobjectfifo.from_memref %alloc, {} : memref<32x1024xi32> -> !amdaie.logicalobjectfifo<memref<32x1024xi32>>
-    %3 = amdaie.logicalobjectfifo.from_memref %alloc_1, {} : memref<32x64xi32, 1> -> !amdaie.logicalobjectfifo<memref<32x64xi32, 1>>
+    %alloc_0 = memref.alloc() : memref<32x64xi32, 1>
+    %0 = amdaie.logicalobjectfifo.from_memref %alloc, {} : memref<32x1024xi32> -> !amdaie.logicalobjectfifo<memref<32x1024xi32>>
+    %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<32x64xi32, 1> -> !amdaie.logicalobjectfifo<memref<32x64xi32, 1>>
     scf.forall (%arg0, %arg1) in (2, 2) {
       scf.forall (%arg2, %arg3) in (1, 1) {
-        %11 = amdaie.dma_cpy_nd(%3[] [] [], %1[] [] []) : (!amdaie.logicalobjectfifo<memref<32x64xi32, 1>>, !amdaie.logicalobjectfifo<memref<32x1024xi32>>)
+        %2 = amdaie.dma_cpy_nd(%1[] [] [], %0[] [] []) : (!amdaie.logicalobjectfifo<memref<32x64xi32, 1>>, !amdaie.logicalobjectfifo<memref<32x1024xi32>>)
       } {mapping = [#gpu.thread<y>, #gpu.thread<x>]}
     } {mapping = [#gpu.block<y>, #gpu.block<x>]}
-    memref.dealloc %alloc_1 : memref<32x64xi32, 1>
+    memref.dealloc %alloc_0 : memref<32x64xi32, 1>
     memref.dealloc %alloc : memref<32x1024xi32>
     return
   }
 }
+


### PR DESCRIPTION
While we probably don't expect an scf.forall without _either_ a thread or block mapping, it's better if this pass can handle the case. 