### PR TITLE
[LogicalObjectFifoType] Prefer retrieving memory space from type

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDmaOpInterface.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDmaOpInterface.td
@@ -362,6 +362,51 @@ def DoublyStridedCopyOpInterface : OpInterface<"DoublyStridedCopyOpInterface",
     specifies source and target indirectly via a referenced DMA operation.
   }];
   let cppNamespace = "mlir::iree_compiler::AMDAIE";
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/"Return the source memory space attribute.",
+      /*retTy=*/"::mlir::Attribute",
+      /*methodName=*/"getSourceMemorySpace",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return $_op.getSourceMemorySpace();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/"Return the source memory space as an integer (0 for global "
+               "memory).",
+      /*retTy=*/"uint8_t",
+      /*methodName=*/"getSourceMemorySpaceAsUInt",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return $_op.getSourceMemorySpaceAsUInt();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/"Return the target memory space attribute.",
+      /*retTy=*/"::mlir::Attribute",
+      /*methodName=*/"getTargetMemorySpace",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return $_op.getTargetMemorySpace();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/"Return the target memory space as an integer (0 for global "
+               "memory).",
+      /*retTy=*/"uint8_t",
+      /*methodName=*/"getTargetMemorySpaceAsUInt",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return $_op.getTargetMemorySpaceAsUInt();
+      }]
+    >,
+  ];
 }
 
 #endif // IREE_AMDAIE_DIALECT_DMAOPINTERFACE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -322,7 +322,8 @@ def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd",
 
     // Return the source memory space as an attribute.
     Attribute getSourceMemorySpace() {
-      return getSourceMemrefType().getMemorySpace();
+      return cast<LogicalObjectFifoType>(getDmaCpyNdOp().getSourceType())
+        .getMemorySpace();
     }
 
     // Helper method to return the source memory space as an integer. If no 
@@ -342,7 +343,8 @@ def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd",
 
     // Return the target memory space as an attribute.
     Attribute getTargetMemorySpace() {
-      return getTargetMemrefType().getMemorySpace();
+      return cast<LogicalObjectFifoType>(getDmaCpyNdOp().getTargetType())
+        .getMemorySpace();
     }
 
     // Helper method to return the target memory space as an integer. If no
@@ -562,7 +564,8 @@ def AMDAIE_LogicalObjectFifoFromMemrefOp
 
     // Return the memory space as an attribute.
     Attribute getMemorySpace() {
-      return getMemrefType().getMemorySpace();
+      return cast<LogicalObjectFifoType>(getOutput().getType())
+        .getMemorySpace();
     }
 
     // Helper method to return the memory space as an integer. If no memory
@@ -575,7 +578,8 @@ def AMDAIE_LogicalObjectFifoFromMemrefOp
 
     // Return the source memref type.
     MemRefType getMemrefType() { 
-      return cast<LogicalObjectFifoType>(getOutput().getType()).getElementType();
+      return cast<LogicalObjectFifoType>(getOutput().getType())
+        .getElementType();
     }
   }];
 
@@ -744,6 +748,31 @@ class AMDAIE_DmaCpyNdBaseOp<string mnemonic, list<Trait> traits = []> :
     Type getTargetType() { return getTarget().getType(); }
     LogicalObjectFifoFromMemrefOp getSourceObjectFifo();
     LogicalObjectFifoFromMemrefOp getTargetObjectFifo();
+
+    Attribute getSourceMemorySpace() {
+      return cast<LogicalObjectFifoType>(getSourceType()).getMemorySpace();
+    }
+
+    /// Helper method to return the source memory space as an integer. If no 
+    /// memory space attribute exists, this indicates a global memory space and
+    /// we return 0. Else we cast the memory space attribute to an integer. 
+    uint8_t getSourceMemorySpaceAsUInt() {
+      Attribute memSpace = getSourceMemorySpace();
+      return memSpace ? cast<IntegerAttr>(memSpace).getInt() : 0;
+    }
+
+    Attribute getTargetMemorySpace() {
+      return cast<LogicalObjectFifoType>(getTargetType()).getMemorySpace();
+    }
+
+    /// Helper method to return the target memory space as an integer. If no
+    /// memory space attribute exists, this indicates a global memory space and
+    /// we return 0. Else we cast the memory space attribute to an integer.
+    uint8_t getTargetMemorySpaceAsUInt() {
+      Attribute memSpace = getTargetMemorySpace();
+      return memSpace ? cast<IntegerAttr>(memSpace).getInt() : 0;
+    }
+    
     // A utility to create a new doubly strided operation from this one with a
     // new set of source and target offsets, sizes and strides.
     DoublyStridedOpInterface createDoublyStridedOp(

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIETypes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIETypes.td
@@ -44,6 +44,20 @@ def AMDAIE_LogicalObjectFifoType :
       return $_get(elementType.getContext(), elementType, depth);
     }]>
   ];
+
+  let extraClassDeclaration = [{
+    Attribute getMemorySpace() {
+      return getElementType().getMemorySpace();
+    }
+
+    /// Helper method to return the memory space as an integer. If no memory 
+    /// space attribute exists, this indicates a global memory space and we 
+    /// return 0. Else we cast the memory space attribute to an integer. 
+    uint8_t getMemorySpaceAsUInt() {
+      Attribute memSpace = getMemorySpace();
+      return memSpace ? llvm::cast<IntegerAttr>(memSpace).getInt() : 0;
+    }
+  }];
 }
 
 def AnyAMDAIELogicalObjectFifoType : AnyTypeOf<[AMDAIE_LogicalObjectFifoType]>;

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertCores.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertCores.cpp
@@ -78,10 +78,8 @@ LogicalResult insertCoreOps(mlir::ModuleOp moduleOp) {
     SmallVector<Value> inputDmas;
     SmallVector<Value> outputDmas;
     WalkResult dmaRes = forallOp->walk([&](AMDAIE::DmaCpyNdOp dmaOp) {
-      uint8_t sourceMemspace =
-          dmaOp.getSourceObjectFifo().getMemorySpaceAsUInt();
-      uint8_t targetMemspace =
-          dmaOp.getTargetObjectFifo().getMemorySpaceAsUInt();
+      uint8_t sourceMemspace = dmaOp.getSourceMemorySpaceAsUInt();
+      uint8_t targetMemspace = dmaOp.getTargetMemorySpaceAsUInt();
       if (sourceMemspace == 2 && targetMemspace == 2) {
         dmaOp->emitOpError()
             << "dma op with both source and target on L1 is not supported";
@@ -166,7 +164,7 @@ class AMDAIEInsertCoresPass
   }
 
   AMDAIEInsertCoresPass() = default;
-  AMDAIEInsertCoresPass(const AMDAIEInsertCoresPass &pass){};
+  AMDAIEInsertCoresPass(const AMDAIEInsertCoresPass &pass) {};
   void runOnOperation() override;
 };
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
@@ -82,11 +82,15 @@ AIE::BDDimLayoutArrayAttr convertSizeStrideToBDDimLayoutArrayAttr(
 FailureOr<AIE::ObjectFifoCreateOp> createObjectFifo(
     IRRewriter &rewriter, AMDAIE::CircularDmaCpyNdOp dmaOp, Value srcTile,
     ValueRange dstTiles, StringAttr &symName) {
-  uint8_t sourceMemSpace = dmaOp.getSourceObjectFifo().getMemorySpaceAsUInt();
-  uint8_t targetMemSpace = dmaOp.getTargetObjectFifo().getMemorySpaceAsUInt();
+  auto sourceType =
+      cast<AMDAIE::LogicalObjectFifoType>(dmaOp.getSource().getType());
+  auto targetType =
+      cast<AMDAIE::LogicalObjectFifoType>(dmaOp.getTarget().getType());
+  uint8_t sourceMemSpace = sourceType.getMemorySpaceAsUInt();
+  uint8_t targetMemSpace = targetType.getMemorySpaceAsUInt();
   unsigned depth;
-  unsigned sourceDepth = dmaOp.getSourceObjectFifo().getDepth();
-  unsigned targetDepth = dmaOp.getTargetObjectFifo().getDepth();
+  unsigned sourceDepth = sourceType.getDepth();
+  unsigned targetDepth = targetType.getDepth();
   if (sourceMemSpace == 0 && targetMemSpace == 0) {
     return dmaOp.emitOpError()
            << "both source and target on main memory not supported";
@@ -992,7 +996,7 @@ class AMDAIELowerToAIEPass
   }
 
   AMDAIELowerToAIEPass() = default;
-  AMDAIELowerToAIEPass(const AMDAIELowerToAIEPass &pass){};
+  AMDAIELowerToAIEPass(const AMDAIELowerToAIEPass &pass) {};
   void runOnOperation() override;
 };
 


### PR DESCRIPTION
Small utility PR to add memory space retrieval to `LogicalObjectFifoType` and prefers using it as it is more general as it would work with any value of this type. Needed for a follow-up in which a new `LogicalObjectFifoPlaceholderOp` will be added, making it unnecessary to distinguish between this new op and `LogicalObjectFifoFromMemrefOp` in a lot of cases.