### PR TITLE
[LowerToAIE] Fix for non-deterministic error (observed with convolution)

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
@@ -42,16 +42,10 @@ void remapOperands(Operation *op, IRMapping &mapper) {
   }
 }
 
-//===----------------------------------------------------------------------===//
-// Convert amdaie.core operation to aie.core
-//===----------------------------------------------------------------------===//
-
-namespace {
-
-// It is dangerous to erase ops with `rewriter` without erasing them from
-// `mapper` too, as addresses of Operations/Values can be reused, resulting in
-// unexpected key-value pairs in `mapper`. Use this utility if `mapper` might be
-// used after `op` is erased.
+/// It is dangerous to erase ops with `rewriter` without erasing them from
+/// `mapper` too, as addresses of Operations/Values can be reused, resulting in
+/// unexpected key-value pairs in `mapper`. Use this utility if `mapper` might
+/// be used after `op` is erased.
 void eraseOp(IRRewriter &rewriter, IRMapping &mapper, Operation *op) {
   for (Value result : op->getResults()) {
     mapper.erase(result);
@@ -60,6 +54,13 @@ void eraseOp(IRRewriter &rewriter, IRMapping &mapper, Operation *op) {
   op->dropAllUses();
   rewriter.eraseOp(op);
 }
+
+//===----------------------------------------------------------------------===//
+// Convert amdaie.core operation to aie.core
+//===----------------------------------------------------------------------===//
+
+namespace {
+
 
 /// Utility to convert vectors of `size` and `stride` into an
 /// `AIE::BDDimLayoutArrayAttr`.


### PR DESCRIPTION
What was happening was 

1) Value/Operation inserted into IRMapping
2) IRRewriter erased Value/Op
3) New Value/Op created with same address as erased Value/Op
4) Bad state: new Value/Op is a key in IRMapping, even though it was never added. 

That's my analysis, at least. Either way, this change makes my failure rate go from 10/20 to 0/20. 

An alternative to this PR might be to postpone erasing of ops even longer, so that only after all CoreOps have been processed are the ops erased.