### PR TITLE
[TileAndFuse] Add thread groups for convolution ops 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
@@ -289,7 +289,7 @@ void AMDAIETileAndFusePass::runOnOperation() {
     // So for now we're keeping the block group dimension here, but should
     // be able to compile without any block group dimensions TODO(newling)
     auto groupType =
-        tilingLevel == 1 ? GPUGroupType::Block : GPUGroupType::Thread;
+        tilingLevel == 0 ? GPUGroupType::Block : GPUGroupType::Thread;
 
     auto maybeMapping =
         getGPUMappingAttributes(tileSizesVal, groupType, consumerOp);


### PR DESCRIPTION
This works for now because the sizes of dimensions `DimZ` and `LinearDim0` are 1 with our tiling strategy, and so `DimY` and `DimX` map to the rows and columns of the AIE array. Follow-up work: pass to collapse scf.forall's with more than 2 induction variables to just 2. So instead of 

`(i,j,k) in (2,3,5)` 

for example, could be

`(i,l) in (2,15)` and then j=l/5 k=l%5. 