### PR TITLE
Add logical objFifo placeholder op for connection reuse

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.cpp
@@ -1,0 +1,10 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.h"
+
+/// Include the definitions of the logical-objFifo-like interfaces.
+#include "iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.cpp.inc"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.h
@@ -1,0 +1,16 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_AMDAIE_LOGICALOBJFIFOOPINTERFACE_H_
+#define IREE_COMPILER_AMDAIE_LOGICALOBJFIFOOPINTERFACE_H_
+
+#include "mlir/IR/OpImplementation.h"
+
+// clang-format off
+#include "iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.h.inc"
+// clang-format on
+
+#endif  // IREE_COMPILER_AMDAIE_LOGICALOBJFIFOOPINTERFACE_H_

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.td
@@ -1,0 +1,37 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_AMDAIE_DIALECT_LOGICALOBJFIFOOPINTERFACE
+#define IREE_AMDAIE_DIALECT_LOGICALOBJFIFOOPINTERFACE
+
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/CopyOpInterface.td"
+
+//===----------------------------------------------------------------------===//
+// Defines the interface for logical objectFifo operations.
+//===----------------------------------------------------------------------===//
+
+def LogicalObjFifoOpInterface : OpInterface<"LogicalObjFifoOpInterface"> {
+  let description = [{
+    Interface for operations creating a logical objectFifo.
+  }];
+  let cppNamespace = "mlir::iree_compiler::AMDAIE";
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/"Return the assigned tiles.",
+      /*retTy=*/"::mlir::OperandRange",
+      /*methodName=*/"getTiles",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return $_op.getTiles();
+      }]
+    >
+  ];
+}
+
+#endif // IREE_AMDAIE_DIALECT_LOGICALOBJFIFOOPINTERFACE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.h
@@ -9,6 +9,7 @@
 
 #include "iree-amd-aie/IR/AMDAIEAttrs.h"
 #include "iree-amd-aie/IR/AMDAIEDmaOpInterface.h"
+#include "iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.h"
 #include "iree-amd-aie/IR/AMDAIETypes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -18,6 +18,7 @@ include "iree-amd-aie/IR/AMDAIEAttrs.td"
 include "iree-amd-aie/aie_runtime/AMDAIEEnums.td"
 include "iree-amd-aie/IR/AMDAIEDialect.td"
 include "iree-amd-aie/IR/AMDAIEDmaOpInterface.td"
+include "iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.td"
 include "iree-amd-aie/IR/AMDAIETypes.td"
 
 //===----------------------------------------------------------------------===//
@@ -208,8 +209,8 @@ def AMDAIE_BdIdOp: AMDAIE_Op<"bd_id", [
 // IREE AMDAIE Npu Ops
 //===----------------------------------------------------------------------===//
 
-def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd",
-    [AttrSizedOperandSegments, DoublyStridedOpInterface]>,
+def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd", [
+      AttrSizedOperandSegments, DoublyStridedOpInterface]>,
     Results<(outs Index)> {
   let summary = "The Npu uController's dma operator";
   let description = [{
@@ -239,58 +240,50 @@ def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd",
 
   let arguments = (
     ins Index:$dma,
+        Optional<AnyAMDAIELogicalObjectFifoType>:$target,
         Variadic<Index>:$target_offsets,
         Variadic<Index>:$target_sizes,
         Variadic<Index>:$target_strides,
         DenseI64ArrayAttr:$target_static_offsets,
         DenseI64ArrayAttr:$target_static_sizes,
         DenseI64ArrayAttr:$target_static_strides,
+        Optional<Index>:$target_bd_id,
+        Optional<AnyAMDAIELogicalObjectFifoType>:$source,
         Variadic<Index>:$source_offsets,
         Variadic<Index>:$source_sizes,
         Variadic<Index>:$source_strides,
         DenseI64ArrayAttr:$source_static_offsets,
         DenseI64ArrayAttr:$source_static_sizes,
         DenseI64ArrayAttr:$source_static_strides,
-        Optional<Index>:$target_bd_id,
         Optional<Index>:$source_bd_id
   );
 
-  let assemblyFormat = [{
-    $dma
-    `(`
-    custom<DynamicIndexList>($target_offsets, $target_static_offsets)
-    custom<DynamicIndexList>($target_sizes, $target_static_sizes)
-    custom<DynamicIndexList>($target_strides, $target_static_strides)
-    (`bd_id` `=` $target_bd_id^)?
-    `,`
-    custom<DynamicIndexList>($source_offsets, $source_static_offsets)
-    custom<DynamicIndexList>($source_sizes, $source_static_sizes)
-    custom<DynamicIndexList>($source_strides, $source_static_strides)
-    (`bd_id` `=` $source_bd_id^)?
-    `)`
-    attr-dict
-  }];
+  // Use a custom assembly format because of weird spaces being inserted around 
+  // the optional `target` by the default assembly format generator.
+  let hasCustomAssemblyFormat = 1;
 
   let builders = [
     // Build a NpuDmaCpyNdOp with mixed static and dynamic entries.
-    OpBuilder<(ins "Value":$dma, "ArrayRef<OpFoldResult>":$target_offsets,
+    OpBuilder<(ins "Value":$dma, "::mlir::Value":$target,
+      "ArrayRef<OpFoldResult>":$target_offsets,
       "ArrayRef<OpFoldResult>":$target_sizes,
-      "ArrayRef<OpFoldResult>":$target_strides,
-      "ArrayRef<OpFoldResult>":$source_offsets,
+      "ArrayRef<OpFoldResult>":$target_strides, "::mlir::Value":$target_bd_id,
+      "::mlir::Value":$source, "ArrayRef<OpFoldResult>":$source_offsets,
       "ArrayRef<OpFoldResult>":$source_sizes,
-      "ArrayRef<OpFoldResult>":$source_strides, "::mlir::Value":$target_bd_id, 
-      "::mlir::Value":$source_bd_id)>,
+      "ArrayRef<OpFoldResult>":$source_strides, "::mlir::Value":$source_bd_id)>,
     // Build a NpuDmaCpyNdOp with static entries.
-    OpBuilder<(ins "Value":$dma, "ArrayRef<int64_t>":$target_offsets,
-      "ArrayRef<int64_t>":$target_sizes, "ArrayRef<int64_t>":$target_strides,
-      "ArrayRef<int64_t>":$source_offsets, "ArrayRef<int64_t>":$source_sizes,
-      "ArrayRef<int64_t>":$source_strides, "::mlir::Value":$target_bd_id, 
+    OpBuilder<(ins "Value":$dma, "::mlir::Value":$target,
+      "ArrayRef<int64_t>":$target_offsets, "ArrayRef<int64_t>":$target_sizes,
+      "ArrayRef<int64_t>":$target_strides, "::mlir::Value":$target_bd_id,
+      "::mlir::Value":$source, "ArrayRef<int64_t>":$source_offsets, 
+      "ArrayRef<int64_t>":$source_sizes, "ArrayRef<int64_t>":$source_strides,
       "::mlir::Value":$source_bd_id)>,
     // Build a NpuDmaCpyNdOp with dynamic entries.
-    OpBuilder<(ins "Value":$dma, "ValueRange":$target_offsets,
-      "ValueRange":$target_sizes, "ValueRange":$target_strides,
-      "ValueRange":$source_offsets, "ValueRange":$source_sizes,
-      "ValueRange":$source_strides, "::mlir::Value":$target_bd_id, 
+    OpBuilder<(ins "Value":$dma, "::mlir::Value":$target,
+      "ValueRange":$target_offsets, "ValueRange":$target_sizes,
+      "ValueRange":$target_strides, "::mlir::Value":$target_bd_id,
+      "::mlir::Value":$source, "ValueRange":$source_offsets,
+      "ValueRange":$source_sizes, "ValueRange":$source_strides, 
       "::mlir::Value":$source_bd_id)>
   ];
 
@@ -523,7 +516,8 @@ def AMDAIE_LogicalObjectFifoAcquire:
 }
 
 def AMDAIE_LogicalObjectFifoFromMemrefOp
-    : AMDAIE_Op<"logicalobjectfifo.from_memref", [Pure]> {
+    : AMDAIE_Op<"logicalobjectfifo.from_memref", 
+    [LogicalObjFifoOpInterface, Pure]> {
   let summary = "Create a logical objectFifo from a memref";
   let description = [{
     Creates a logical objectFifo which encapsulates a memref. The logical objectFifo
@@ -629,6 +623,46 @@ def AMDAIE_LogicalObjectFifoLink
   let assemblyFormat = [{
     `[` ($ins^)? `]` `->` `[` ($outs^)? `]` `(` `)` attr-dict
   }];
+}
+
+def AMDAIE_LogicalObjectFifoPlaceholderOp: 
+    AMDAIE_Op<"logicalobjectfifo.placeholder", [
+      LogicalObjFifoOpInterface, Pure]> {
+  let summary = "A placeholder for a logical objectFifo.";
+  let description = [{
+    Represents a placeholder for a logical objectFifo. The actual logical
+    objectFifo can then be provided later. This is useful for creating static
+    connections (`amdaie.circular_dma_cpy_nd`) that can be reused for different
+    logical objectFifos.
+
+    Example:
+    ```mlir
+    %0 = hal.interface.binding.subspan layout(#pipeline_layout) set(0) 
+      binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<1024xi32>
+    %alloc = memref.alloc() : memref<1024xi32, 1 : i32>
+    %obj0 = amdaie.logicalobjectfifo.from_memref %alloc, {%tile_0_1}
+      : memref<1024xi32, 1> -> !amdaie.logicalobjectfifo<memref<1024xi32, 1 : i32>>
+    %ph = amdaie.logicalobjectfifo.placeholder{} 
+      : !amdaie.logicalobjectfifo<memref<2048xi32>>
+    %connection = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %ph[] [] [])
+      : (!amdaie.logicalobjectfifo<memref<1024xi32, 1 : i32>>,
+      !amdaie.logicalobjectfifo<memref<1024xi32>>)
+    amdaie.controlcode {
+      %obj1 = amdaie.logicalobjectfifo.from_memref %0, {%tile_0_0}
+        : memref<1024xi32> -> !amdaie.logicalobjectfifo<memref<1024xi32>>
+      %npu_dma = amdaie.npu.dma_cpy_nd %connection([] [] [], 
+        %obj0[%c0, %c32] [%c32, %c32] [%c32, %c1]) 
+        : source_type = !amdaie.logicalobjectfifo<memref<1024xi32>>
+      amdaie.end
+    }
+    ```
+  }];
+
+  let arguments = (ins Variadic<Index>:$tiles);
+
+  let results = (outs AnyAMDAIELogicalObjectFifoType:$output);
+
+  let assemblyFormat = [{ `{` $tiles `}` attr-dict `:` type($output)}];
 }
 
 def AMDAIE_LogicalObjectFifoRelease: 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_cc_library(
   HDRS
     "AMDAIEAttrs.h"
     "AMDAIEDialect.h"
+    "AMDAIELogicalObjFifoOpInterface.h"
     "AMDAIEOps.h"
     "AMDAIETypes.h"
   TEXTUAL_HDRS
@@ -29,15 +30,19 @@ iree_cc_library(
     "AMDAIEOps.h.inc"
     "AMDAIEDmaOpInterface.cpp.inc"
     "AMDAIEDmaOpInterface.h.inc"
+    "AMDAIELogicalObjFifoOpInterface.h.inc"
+    "AMDAIELogicalObjFifoOpInterface.cpp.inc"
   SRCS
     "AMDAIEAttrs.cpp"
     "AMDAIEDmaOpInterface.cpp"
     "AMDAIEDialect.cpp"
+    "AMDAIELogicalObjFifoOpInterface.cpp"
     "AMDAIEOps.cpp"
     "AMDAIETypes.cpp"
   DEPS
     ::AMDAIEDialectGen
     ::AMDAIEDmaOpInterfaceGen
+    ::AMDAIELogicalObjFifoOpInterface
     ::AMDAIEOpsGen
     ::AMDAIETypesGen
     ::AMDAIEAttrsGen
@@ -103,4 +108,14 @@ iree_tablegen_library(
   OUTS
     --gen-op-interface-decls AMDAIEDmaOpInterface.h.inc
     --gen-op-interface-defs AMDAIEDmaOpInterface.cpp.inc
+)
+
+iree_tablegen_library(
+  NAME
+    AMDAIELogicalObjFifoOpInterface
+  TD_FILE
+    "AMDAIELogicalObjFifoOpInterface.td"
+  OUTS
+    --gen-op-interface-decls AMDAIELogicalObjFifoOpInterface.h.inc
+    --gen-op-interface-defs AMDAIELogicalObjFifoOpInterface.cpp.inc
 )

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateLogicalObjectFifoLink.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateLogicalObjectFifoLink.cpp
@@ -88,15 +88,15 @@ LogicalResult createLogicalObjectFifoLink(
       auto sourceLogicalObjectFifo =
           dyn_cast<AMDAIE::LogicalObjectFifoFromMemrefOp>(
               stridedOp.getSource().getDefiningOp());
-      if (!sourceLogicalObjectFifo) {
-        stridedOp->emitError(
-            "does not have a `LogicalObjectFifoFromMemrefOp` as source");
-        return failure();
-      }
       if (!lastUserOp || lastUserOp->isBeforeInBlock(stridedOp)) {
         lastUserOp = stridedOp;
       }
-      if (logicalObjectFifo == sourceLogicalObjectFifo) {
+      // The `sourceLogicalObjectFifo` could be either a
+      // `LogicalObjectFifoFromMemrefOp` or `LogicalObjectFifoPlaceholderOp`,
+      // but currently the linking only works with
+      // `LogicalObjectFifoFromMemrefOp` on L2.
+      if (sourceLogicalObjectFifo &&
+          logicalObjectFifo == sourceLogicalObjectFifo) {
         if (std::optional<int64_t> offset =
                 stridedOp.getSourceStaticBaseOffset()) {
           outs.push_back(std::make_pair(stridedOp, offset.value()));

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
@@ -14,11 +14,12 @@ module {
 // CHECK-LABEL: @single_dma_cpy_nd_on_source
 // CHECK:       %[[C0:.+]] = arith.constant 0 : index
 // CHECK:       amdaie.workgroup
-// CHECK:         %[[TILE_0_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
-// CHECK:         %[[BD_ID_0:.+]] = amdaie.bd_id(%[[TILE_0_0]], 0)
+// CHECK-DAG:     %[[TILE_0_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
+// CHECK-DAG:     %[[BD_ID_0:.+]] = amdaie.bd_id(%[[TILE_0_0]], 0)
+// CHECK-DAG:     %[[FROM_MEMREF:.+]] = amdaie.logicalobjectfifo.from_memref %{{.+}}, {%[[TILE_0_0]]} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:         %[[CIRC_DMA:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         amdaie.controlcode
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], [0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], MM2S)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
@@ -29,11 +30,12 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %tile_0_0 = amdaie.tile(%c0, %c0)
       %tile_0_1 = amdaie.tile(%c0, %c1)
+      %placeholder = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<8x16xi32>>
       %from_memref_0 = amdaie.logicalobjectfifo.from_memref %arg0, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
       %from_memref_1 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_0_1} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
-      %0 = amdaie.circular_dma_cpy_nd(%from_memref_1[] [] [], %from_memref_0[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      %0 = amdaie.circular_dma_cpy_nd(%from_memref_1[] [] [], %placeholder[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0] [1, 8, 16] [128, 16, 1])
+        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], %from_memref_0[0, 0, 0] [1, 8, 16] [128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
         amdaie.npu.dma_wait(%1, MM2S)
         amdaie.end
       }
@@ -47,11 +49,12 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK-LABEL: @single_dma_cpy_nd_on_target
 // CHECK:       %[[C0:.+]] = arith.constant 0 : index
 // CHECK:       amdaie.workgroup
-// CHECK:         %[[TILE_0_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
-// CHECK:         %[[BD_ID_0:.+]] = amdaie.bd_id(%[[TILE_0_0]], 0)
+// CHECK-DAG:     %[[TILE_0_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
+// CHECK-DAG:     %[[BD_ID_0:.+]] = amdaie.bd_id(%[[TILE_0_0]], 0)
+// CHECK-DAG:     %[[FROM_MEMREF:.+]] = amdaie.logicalobjectfifo.from_memref %{{.+}}, {%[[TILE_0_0]]} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:         %[[CIRC_DMA:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         amdaie.controlcode
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]], [] [] [])
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]](%[[FROM_MEMREF]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]], [] [] [])
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
@@ -62,11 +65,12 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %tile_0_0 = amdaie.tile(%c0, %c0)
       %tile_0_1 = amdaie.tile(%c0, %c1)
+      %placeholder = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<8x16xi32>>
       %from_memref_0 = amdaie.logicalobjectfifo.from_memref %arg0, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
       %from_memref_1 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_0_1} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
-      %0 = amdaie.circular_dma_cpy_nd(%from_memref_0[] [] [], %from_memref_1[] [] []) : (!amdaie.logicalobjectfifo<memref<8x16xi32>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>)
+      %0 = amdaie.circular_dma_cpy_nd(%placeholder[] [] [], %from_memref_1[] [] []) : (!amdaie.logicalobjectfifo<memref<8x16xi32>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0] [1, 8, 16] [128, 16, 1], [] [] [])
+        %1 = amdaie.npu.dma_cpy_nd %0(%from_memref_0[0, 0, 0] [1, 8, 16] [128, 16, 1], [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
         amdaie.npu.dma_wait(%1, S2MM)
         amdaie.end
       }
@@ -82,19 +86,22 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[C1:.+]] = arith.constant 1 : index
 // CHECK:       %[[C2:.+]] = arith.constant 2 : index
 // CHECK:       amdaie.workgroup
-// CHECK:         %[[TILE_0_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
-// CHECK:         %[[BD_ID_0:.+]] = amdaie.bd_id(%[[TILE_0_0]], 0)
-// CHECK:         %[[TILE_1_0:.+]] = amdaie.tile(%[[C1]], %[[C0]])
-// CHECK:         %[[BD_ID_1:.+]] = amdaie.bd_id(%[[TILE_1_0]], 0)
-// CHECK:         %[[TILE_2_0:.+]] = amdaie.tile(%[[C2]], %[[C0]])
-// CHECK:         %[[BD_ID_2:.+]] = amdaie.bd_id(%[[TILE_2_0]], 0)
+// CHECK-DAG:     %[[TILE_0_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
+// CHECK-DAG:     %[[BD_ID_0:.+]] = amdaie.bd_id(%[[TILE_0_0]], 0)
+// CHECK-DAG:     %[[TILE_1_0:.+]] = amdaie.tile(%[[C1]], %[[C0]])
+// CHECK-DAG:     %[[BD_ID_1:.+]] = amdaie.bd_id(%[[TILE_1_0]], 0)
+// CHECK-DAG:     %[[TILE_2_0:.+]] = amdaie.tile(%[[C2]], %[[C0]])
+// CHECK-DAG:     %[[BD_ID_2:.+]] = amdaie.bd_id(%[[TILE_2_0]], 0)
+// CHECK-DAG:     %[[FROM_MEMREF_0:.+]] = amdaie.logicalobjectfifo.from_memref %{{.+}}, {%[[TILE_0_0]]} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+// CHECK-DAG:     %[[FROM_MEMREF_1:.+]] = amdaie.logicalobjectfifo.from_memref %{{.+}}, {%[[TILE_1_0]]} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+// CHECK-DAG:     %[[FROM_MEMREF_2:.+]] = amdaie.logicalobjectfifo.from_memref %{{.+}}, {%[[TILE_2_0]]} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:         %[[CIRC_DMA_0:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         %[[CIRC_DMA_1:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         %[[CIRC_DMA_2:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         amdaie.controlcode
-// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_0]]([] [] [], [0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
-// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_1]]([] [] [], [0, 0] [8, 16] [16, 1] bd_id = %[[BD_ID_1]])
-// CHECK:           %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_2]]([] [] [], [0] [128] [1] bd_id = %[[BD_ID_2]])
+// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_0]]([] [] [], %[[FROM_MEMREF_0]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
+// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_1]]([] [] [], %[[FROM_MEMREF_1]][0, 0] [8, 16] [16, 1] bd_id = %[[BD_ID_1]])
+// CHECK:           %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_2]]([] [] [], %[[FROM_MEMREF_2]][0] [128] [1] bd_id = %[[BD_ID_2]])
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]], MM2S)
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_1]], MM2S)
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_2]], MM2S)
@@ -110,17 +117,20 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %tile_1_0 = amdaie.tile(%c1, %c0)
       %tile_2_0 = amdaie.tile(%c2, %c0)
       %tile_0_1 = amdaie.tile(%c0, %c1)
+      %placeholder0 = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<8x16xi32>>
+      %placeholder1 = amdaie.logicalobjectfifo.placeholder{%tile_1_0} : !amdaie.logicalobjectfifo<memref<8x16xi32>>
+      %placeholder2 = amdaie.logicalobjectfifo.placeholder{%tile_2_0} : !amdaie.logicalobjectfifo<memref<8x16xi32>>
       %from_memref_0 = amdaie.logicalobjectfifo.from_memref %arg0, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
       %from_memref_1 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_1_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
       %from_memref_2 = amdaie.logicalobjectfifo.from_memref %arg2, {%tile_2_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
       %from_memref_3 = amdaie.logicalobjectfifo.from_memref %arg3, {%tile_0_1} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
-      %dma0 = amdaie.circular_dma_cpy_nd(%from_memref_3[] [] [], %from_memref_0[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
-      %dma1 = amdaie.circular_dma_cpy_nd(%from_memref_3[] [] [], %from_memref_1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
-      %dma2 = amdaie.circular_dma_cpy_nd(%from_memref_3[] [] [], %from_memref_2[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      %dma0 = amdaie.circular_dma_cpy_nd(%from_memref_3[] [] [], %placeholder0[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      %dma1 = amdaie.circular_dma_cpy_nd(%from_memref_3[] [] [], %placeholder1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      %dma2 = amdaie.circular_dma_cpy_nd(%from_memref_3[] [] [], %placeholder2[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %0 = amdaie.npu.dma_cpy_nd %dma0([] [] [], [0, 0, 0] [1, 8, 16] [128, 16, 1]) 
-        %1 = amdaie.npu.dma_cpy_nd %dma1([] [] [], [0, 0] [8, 16] [16, 1])
-        %2 = amdaie.npu.dma_cpy_nd %dma2([] [] [], [0] [128] [1])
+        %0 = amdaie.npu.dma_cpy_nd %dma0([] [] [], %from_memref_0[0, 0, 0] [1, 8, 16] [128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %1 = amdaie.npu.dma_cpy_nd %dma1([] [] [], %from_memref_1[0, 0] [8, 16] [16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %2 = amdaie.npu.dma_cpy_nd %dma2([] [] [], %from_memref_2[0] [128] [1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
         amdaie.npu.dma_wait(%0, MM2S)
         amdaie.npu.dma_wait(%1, MM2S)
         amdaie.npu.dma_wait(%2, MM2S)
@@ -136,15 +146,16 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK-LABEL: @multiple_dma_cpy_with_bd_id_reuse
 // CHECK:       %[[C0:.+]] = arith.constant 0 : index
 // CHECK:       amdaie.workgroup
-// CHECK:         %[[TILE_0_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
-// CHECK:         %[[BD_ID_0:.+]] = amdaie.bd_id(%[[TILE_0_0]], 0)
+// CHECK-DAG:     %[[TILE_0_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
+// CHECK-DAG:     %[[BD_ID_0:.+]] = amdaie.bd_id(%[[TILE_0_0]], 0)
+// CHECK-DAG:     %[[FROM_MEMREF_0:.+]] = amdaie.logicalobjectfifo.from_memref %{{.+}}, {%[[TILE_0_0]]} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:         %[[CIRC_DMA:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         amdaie.controlcode
-// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], [0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
+// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]], MM2S)
-// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], [0, 0] [8, 16] [16, 1] bd_id = %[[BD_ID_0]])
+// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0, 0] [8, 16] [16, 1] bd_id = %[[BD_ID_0]])
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_1]], MM2S)
-// CHECK:           %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], [0] [128] [1] bd_id = %[[BD_ID_0]])
+// CHECK:           %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0] [128] [1] bd_id = %[[BD_ID_0]])
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_2]], MM2S)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
@@ -155,15 +166,16 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %tile_0_0 = amdaie.tile(%c0, %c0)
       %tile_0_1 = amdaie.tile(%c0, %c1)
+      %placeholder0 = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<8x16xi32>>
       %from_memref_0 = amdaie.logicalobjectfifo.from_memref %arg0, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
       %from_memref_1 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_0_1} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
-      %0 = amdaie.circular_dma_cpy_nd(%from_memref_1[] [] [], %from_memref_0[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      %0 = amdaie.circular_dma_cpy_nd(%from_memref_1[] [] [], %placeholder0[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0] [1, 8, 16] [128, 16, 1])
+        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], %from_memref_0[0, 0, 0] [1, 8, 16] [128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
         amdaie.npu.dma_wait(%1, MM2S)
-        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0] [8, 16] [16, 1])
+        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], %from_memref_0[0, 0] [8, 16] [16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
         amdaie.npu.dma_wait(%2, MM2S)
-        %3 = amdaie.npu.dma_cpy_nd %0([] [] [], [0] [128] [1])
+        %3 = amdaie.npu.dma_cpy_nd %0([] [] [], %from_memref_0[0] [128] [1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
         amdaie.npu.dma_wait(%3, MM2S)
         amdaie.end
       }
@@ -181,11 +193,12 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK-DAG:     %[[BD_ID_0:.+]] = amdaie.bd_id(%[[TILE_0_0]], 0)
 // CHECK-DAG:     %[[BD_ID_1:.+]] = amdaie.bd_id(%[[TILE_0_0]], 1)
 // CHECK-DAG:     %[[BD_ID_2:.+]] = amdaie.bd_id(%[[TILE_0_0]], 2)
+// CHECK-DAG:     %[[FROM_MEMREF_0:.+]] = amdaie.logicalobjectfifo.from_memref %{{.+}}, {%[[TILE_0_0]]} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:         %[[CIRC_DMA:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         amdaie.controlcode
-// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], [0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
-// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], [0, 0] [8, 16] [16, 1] bd_id = %[[BD_ID_1]])
-// CHECK:           %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], [0] [128] [1] bd_id = %[[BD_ID_2]])
+// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
+// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0, 0] [8, 16] [16, 1] bd_id = %[[BD_ID_1]])
+// CHECK:           %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0] [128] [1] bd_id = %[[BD_ID_2]])
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]], MM2S)
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_1]], MM2S)
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_2]], MM2S)
@@ -198,13 +211,14 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %tile_0_0 = amdaie.tile(%c0, %c0)
       %tile_0_1 = amdaie.tile(%c0, %c1)
+      %placeholder0 = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<8x16xi32>>
       %from_memref_0 = amdaie.logicalobjectfifo.from_memref %arg0, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
       %from_memref_1 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_0_1} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
-      %0 = amdaie.circular_dma_cpy_nd(%from_memref_1[] [] [], %from_memref_0[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      %0 = amdaie.circular_dma_cpy_nd(%from_memref_1[] [] [], %placeholder0[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0] [1, 8, 16] [128, 16, 1])
-        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0] [8, 16] [16, 1])
-        %3 = amdaie.npu.dma_cpy_nd %0([] [] [], [0] [128] [1])
+        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], %from_memref_0[0, 0, 0] [1, 8, 16] [128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], %from_memref_0[0, 0] [8, 16] [16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %3 = amdaie.npu.dma_cpy_nd %0([] [] [], %from_memref_0[0] [128] [1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
         amdaie.npu.dma_wait(%1, MM2S)
         amdaie.npu.dma_wait(%2, MM2S)
         amdaie.npu.dma_wait(%3, MM2S)
@@ -231,19 +245,22 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK-DAG:     %[[BD_ID_1_1:.+]] = amdaie.bd_id(%[[TILE_1_0]], 1)
 // CHECK-DAG:     %[[TILE_2_0:.+]] = amdaie.tile(%[[C2]], %[[C0]])
 // CHECK-DAG:     %[[BD_ID_2_0:.+]] = amdaie.bd_id(%[[TILE_2_0]], 0)
+// CHECK-DAG:     %[[FROM_MEMREF_0:.+]] = amdaie.logicalobjectfifo.from_memref %{{.+}}, {%[[TILE_0_0]]} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+// CHECK-DAG:     %[[FROM_MEMREF_1:.+]] = amdaie.logicalobjectfifo.from_memref %{{.+}}, {%[[TILE_1_0]]} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+// CHECK-DAG:     %[[FROM_MEMREF_2:.+]] = amdaie.logicalobjectfifo.from_memref %{{.+}}, {%[[TILE_2_0]]} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:         %[[CIRC_DMA_0:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         %[[CIRC_DMA_1:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         %[[CIRC_DMA_2:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         amdaie.controlcode
-// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_0]]([] [] [], [0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1] bd_id = %[[BD_ID_0_0]])
+// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_0]]([] [] [], %[[FROM_MEMREF_0]][0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1] bd_id = %[[BD_ID_0_0]])
 // CHECK:           scf.forall (%{{.+}}, %{{.+}}) in (2, 2)
-// CHECK:             %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_1]]([] [] [], [0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_1_0]])
+// CHECK:             %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_1]]([] [] [], %[[FROM_MEMREF_1]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_1_0]])
 // CHECK:             scf.for %{{.+}} = %[[C0]] to %[[C6]] step %[[C1]]
-// CHECK:               %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_1]]([] [] [], [0, 0] [1, 128] [128, 1] bd_id = %[[BD_ID_1_1]])
-// CHECK:               %[[NPU_DMA_3:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_0]]([] [] [], [0] [128] [1] bd_id = %[[BD_ID_0_1]])
+// CHECK:               %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_1]]([] [] [], %[[FROM_MEMREF_1]][0, 0] [1, 128] [128, 1] bd_id = %[[BD_ID_1_1]])
+// CHECK:               %[[NPU_DMA_3:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_0]]([] [] [], %[[FROM_MEMREF_0]][0] [128] [1] bd_id = %[[BD_ID_0_1]])
 // CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_2]], MM2S)
 // CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_3]], MM2S)
-// CHECK:               %[[NPU_DMA_4:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_2]]([] [] [], [] [] [] bd_id = %[[BD_ID_2_0]])
+// CHECK:               %[[NPU_DMA_4:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_2]]([] [] [], %[[FROM_MEMREF_2]][] [] [] bd_id = %[[BD_ID_2_0]])
 // CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_4]], MM2S)
 // CHECK:             }
 // CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA_1]], MM2S)
@@ -262,23 +279,26 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %tile_1_0 = amdaie.tile(%c1, %c0)
       %tile_2_0 = amdaie.tile(%c2, %c0)
       %tile_0_1 = amdaie.tile(%c0, %c1)
+      %placeholder0 = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<8x16xi32>>
+      %placeholder1 = amdaie.logicalobjectfifo.placeholder{%tile_1_0} : !amdaie.logicalobjectfifo<memref<8x16xi32>>
+      %placeholder2 = amdaie.logicalobjectfifo.placeholder{%tile_2_0} : !amdaie.logicalobjectfifo<memref<8x16xi32>>
       %from_memref_0 = amdaie.logicalobjectfifo.from_memref %arg0, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
       %from_memref_1 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_1_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
       %from_memref_2 = amdaie.logicalobjectfifo.from_memref %arg2, {%tile_2_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
       %from_memref_3 = amdaie.logicalobjectfifo.from_memref %arg3, {%tile_0_1} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
-      %dma0 = amdaie.circular_dma_cpy_nd(%from_memref_3[] [] [], %from_memref_0[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
-      %dma1 = amdaie.circular_dma_cpy_nd(%from_memref_3[] [] [], %from_memref_1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
-      %dma2 = amdaie.circular_dma_cpy_nd(%from_memref_3[] [] [], %from_memref_2[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      %dma0 = amdaie.circular_dma_cpy_nd(%from_memref_3[] [] [], %placeholder0[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      %dma1 = amdaie.circular_dma_cpy_nd(%from_memref_3[] [] [], %placeholder1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      %dma2 = amdaie.circular_dma_cpy_nd(%from_memref_3[] [] [], %placeholder2[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %0 = amdaie.npu.dma_cpy_nd %dma0([] [] [], [0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1]) 
+        %0 = amdaie.npu.dma_cpy_nd %dma0([] [] [], %from_memref_0[0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
         scf.forall (%arg4, %arg5) in (2, 2) {
-          %1 = amdaie.npu.dma_cpy_nd %dma1([] [] [], [0, 0, 0] [1, 8, 16] [128, 16, 1])
+          %1 = amdaie.npu.dma_cpy_nd %dma1([] [] [], %from_memref_1[0, 0, 0] [1, 8, 16] [128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
           scf.for %arg6 = %c0 to %c6 step %c1 {
-            %2 = amdaie.npu.dma_cpy_nd %dma1([] [] [], [0, 0] [1, 128] [128, 1])
-            %3 = amdaie.npu.dma_cpy_nd %dma0([] [] [], [0] [128] [1])
+            %2 = amdaie.npu.dma_cpy_nd %dma1([] [] [], %from_memref_1[0, 0] [1, 128] [128, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+            %3 = amdaie.npu.dma_cpy_nd %dma0([] [] [], %from_memref_0[0] [128] [1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
             amdaie.npu.dma_wait(%2, MM2S)
             amdaie.npu.dma_wait(%3, MM2S)
-            %4 = amdaie.npu.dma_cpy_nd %dma2([] [] [], [] [] [])
+            %4 = amdaie.npu.dma_cpy_nd %dma2([] [] [], %from_memref_2[] [] []) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
             amdaie.npu.dma_wait(%4, MM2S)
           }
           amdaie.npu.dma_wait(%1, MM2S)

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
@@ -60,19 +60,19 @@ func.func @core() {
 // -----
 
 // CHECK-LABEL: @dma_cpy_nd_L3_L2
+// CHECK-SAME:  %[[ARG0:.+]]: memref<1x1x8x16xi32, 1>, %[[ARG1:.+]]: memref<8x16xi32>
 // CHECK:       amdaie.workgroup
-// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
-// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]]
+// CHECK-DAG:     %[[PLACEHOLDER:.+]] = amdaie.logicalobjectfifo.placeholder{} : !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK-SAME:    %[[FROMMEMREF0]][] [] []
-// CHECK-SAME:    %[[FROMMEMREF1]][] [] []
+// CHECK-SAME:    %[[PLACEHOLDER]][] [] []
 // CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
 // CHECK:         amdaie.controlcode
+// CHECK:           %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG1]], {} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
 // CHECK-SAME:      [] [] []
-// CHECK-SAME:      [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK-SAME:      %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], MM2S)
 func.func @dma_cpy_nd_L3_L2(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi32>) {
   %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
@@ -84,19 +84,19 @@ func.func @dma_cpy_nd_L3_L2(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi
 // -----
 
 // CHECK-LABEL: @dma_cpy_nd_L3_L2_target_addressing
+// CHECK-SAME:  %[[ARG0:.+]]: memref<1x1x8x16xi32, 1>, %[[ARG1:.+]]: memref<8x16xi32>
 // CHECK:       amdaie.workgroup
-// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
-// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]]
+// CHECK-DAG:     %[[PLACEHOLDER:.+]] = amdaie.logicalobjectfifo.placeholder{} : !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK-SAME:    %[[FROMMEMREF0]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
-// CHECK-SAME:    %[[FROMMEMREF1]][] [] []
+// CHECK-SAME:    %[[PLACEHOLDER]][] [] []
 // CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
 // CHECK:         amdaie.controlcode
+// CHECK:           %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG1]], {} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
 // CHECK-SAME:      [] [] []
-// CHECK-SAME:      [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK-SAME:      %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], MM2S)
 func.func @dma_cpy_nd_L3_L2_target_addressing(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi32>) {
   %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
@@ -108,19 +108,17 @@ func.func @dma_cpy_nd_L3_L2_target_addressing(%arg0: memref<1x1x8x16xi32, 1>, %a
 // -----
 
 // CHECK-LABEL: @dma_cpy_nd_L2_L3
+// CHECK-SAME:  %[[ARG0:.+]]: memref<1x1x8x16xi32>, %[[ARG1:.+]]: memref<8x16xi32, 1>
 // CHECK:       amdaie.workgroup
-// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
-// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+// CHECK-DAG:     %[[PLACEHOLDER:.+]] = amdaie.logicalobjectfifo.placeholder{} : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG1]]
 // CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
-// CHECK-SAME:    %[[FROMMEMREF0]][] [] []
-// CHECK-SAME:    %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK-SAME:    %[[PLACEHOLDER]][] [] []
+// CHECK-SAME:    %[[FROMMEMREF0]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
 // CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
 // CHECK:         amdaie.controlcode
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
-// CHECK-SAME:      [] [] []
-// CHECK-SAME:      [] [] []
+// CHECK:           %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]], {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]](%[[FROMMEMREF1]][] [] [], [] [] [])
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
 func.func @dma_cpy_nd_L2_L3(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) {
   %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
@@ -132,18 +130,18 @@ func.func @dma_cpy_nd_L2_L3(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32,
 // -----
 
 // CHECK-LABEL: @dma_cpy_nd_L2_L3_target_addressing
+// CHECK-SAME:  %[[ARG0:.+]]: memref<1x1x8x16xi32>, %[[ARG1:.+]]: memref<8x16xi32, 1>
 // CHECK:       amdaie.workgroup
-// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
-// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+// CHECK-DAG:     %[[PLACEHOLDER:.+]] = amdaie.logicalobjectfifo.placeholder{} : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG1]]
 // CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
-// CHECK-SAME:    %[[FROMMEMREF0]][] [] []
-// CHECK-SAME:    %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK-SAME:    %[[PLACEHOLDER]][] [] []
+// CHECK-SAME:    %[[FROMMEMREF0]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
 // CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
 // CHECK:         amdaie.controlcode
+// CHECK:           %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]], {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
 // CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
-// CHECK-SAME:      [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
+// CHECK-SAME:      %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
 // CHECK-SAME:      [] [] []
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
 func.func @dma_cpy_nd_L2_L3_target_addressing(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) {
@@ -226,26 +224,26 @@ func.func @for_cores() {
 // Verify that scf.for is inserted in control code with nested dmas.
 //
 // CHECK-LABEL: @for_dma
+// CHECK-SAME:  %[[ARG0:.+]]: memref<1x1x8x16xi32>, %[[ARG1:.+]]: memref<8x16xi32, 1>
 // CHECK:       amdaie.workgroup
 // CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
 // CHECK-DAG:     %[[C8:.+]] = arith.constant 8 : index
-// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
-// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+// CHECK-DAG:     %[[PLACEHOLDER:.+]] = amdaie.logicalobjectfifo.placeholder{} : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG1]]
 // CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK-SAME:    %[[FROMMEMREF0]][] [] []
-// CHECK-SAME:    %[[FROMMEMREF1]][] [] []
+// CHECK-SAME:    %[[PLACEHOLDER]][] [] []
 // CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>)
 // CHECK:         amdaie.controlcode
 // CHECK-DAG:       %[[C0_1:.+]] = arith.constant 0 : index
 // CHECK-DAG:       %[[C1_1:.+]] = arith.constant 1 : index
 // CHECK-DAG:       %[[C8_1:.+]] = arith.constant 8 : index
+// CHECK-DAG:       %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]]
 // CHECK:           scf.for %[[ARG:.+]] = %[[C0_1]] to %[[C8_1]] step %[[C1_1]]
 // CHECK:             %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
 // CHECK-SAME:        [] [] []
-// CHECK-SAME:        [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, %[[ARG]], 1]
+// CHECK-SAME:        %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, %[[ARG]], 1]
 // CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA]], MM2S)
 func.func @for_dma(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) {
   %c0 = arith.constant 0 : index
@@ -308,20 +306,20 @@ func.func @forall_cores() {
 // Verify that scf.forall is inserted in control code with nested dmas.
 //
 // CHECK-LABEL: @forall_dmas
+// CHECK-SAME:  %[[ARG0:.+]]: memref<1x1x8x16xi32>, %[[ARG1:.+]]: memref<8x16xi32, 1>
 // CHECK:       amdaie.workgroup
-// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
-// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+// CHECK-DAG:     %[[PLACEHOLDER:.+]] = amdaie.logicalobjectfifo.placeholder{} : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG1]]
 // CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK-SAME:    %[[FROMMEMREF0]][] [] []
-// CHECK-SAME:    %[[FROMMEMREF1]][] [] []
+// CHECK-SAME:    %[[PLACEHOLDER]][] [] []
 // CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>)
 // CHECK:         amdaie.controlcode
+// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]]
 // CHECK:           scf.forall (%[[ARG0:.*]], %[[ARG1:.*]]) in (2, 2)
 // CHECK:             %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
 // CHECK-SAME:        [] [] []
-// CHECK-SAME:        [0, 0, 0, 0] [1, 1, 8, 16] [128, %[[ARG1]], %[[ARG0]], 1]
+// CHECK-SAME:        %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, %[[ARG1]], %[[ARG0]], 1]
 // CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA]], MM2S)
 func.func @forall_dmas(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) {
   %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
@@ -337,57 +335,62 @@ func.func @forall_dmas(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) 
 // Verify that cores on the same location, but within different scope merge correctly.
 //
 // CHECK-LABEL: @merge_cores
+// CHECK-SAME:  %[[ARG0:.+]]: memref<1x1x8x16xi32>, %[[ARG1:.+]]: memref<8x16xi32, 2>
 // CHECK:       amdaie.workgroup
 // CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
 // CHECK-DAG:     %[[C8:.+]] = arith.constant 8 : index
 // CHECK-DAG:     %[[TILE_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
 // CHECK-DAG:     %[[TILE_1:.+]] = amdaie.tile(%[[C0]], %[[C1]])
-// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
-// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
-// CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd
-// CHECK-SAME:    %[[FROMMEMREF0]][] [] []
-// CHECK-SAME:    %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
-// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_0]], in : [], out : [])
+// CHECK-DAG:     %[[PLACEHOLDER:.+]] = amdaie.logicalobjectfifo.placeholder{} : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
+// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG1]]
+// CHECK:         %[[DMA:.+]] = amdaie.circular_dma_cpy_nd(%[[FROMMEMREF0]][] [] [], %[[PLACEHOLDER]][] [] []) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>)
+// CHECK-DAG:     %[[PLACEHOLDER2:.+]] = amdaie.logicalobjectfifo.placeholder{} : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
+// CHECK:         %[[DMA2:.+]] = amdaie.circular_dma_cpy_nd(%[[FROMMEMREF0]][] [] [], %[[PLACEHOLDER2]][] [] []) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>)
+// CHECK:         %{{.+}} = amdaie.core(%[[TILE_0]], in : [%[[DMA]], %[[DMA2]]], out : [])
 // CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF0]], Read)
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
-// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_1]], in : [], out : [])
+// CHECK:             amdaie.logicalobjectfifo.access(%[[FROMMEMREF0]], Read)
+// CHECK:         %{{.+}} = amdaie.core(%[[TILE_1]], in : [%[[DMA]], %[[DMA2]]], out : [])
 // CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF0]], Read)
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
+// CHECK:             amdaie.logicalobjectfifo.access(%[[FROMMEMREF0]], Read)
 // CHECK:         amdaie.controlcode
 // CHECK-DAG:       %[[C0_1:.+]] = arith.constant 0 : index
 // CHECK-DAG:       %[[C1_1:.+]] = arith.constant 1 : index
 // CHECK-DAG:       %[[C8_1:.+]] = arith.constant 8 : index
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]
-// CHECK-SAME:      [] [] []
-// CHECK-SAME:      [] [] []
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
-// CHECK:           scf.for %{{.*}} = %[[C0_1]] to %[[C8_1]] step %[[C1_1]]
-func.func @merge_cores(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) {
+// CHECK-DAG:       %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]]
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[DMA]]([] [] [], %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) 
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], MM2S)
+// CHECK:           scf.for %{{.*}} = %[[C0_1]] to %[[C8_1]] step %[[C1_1]] {
+// CHECK:             %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[DMA2]]([] [] [], %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
+// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA_2]], MM2S)
+// CHECK:           }
+func.func @merge_cores(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 2>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c8 = arith.constant 8 : index
   %tile_0_0 = amdaie.tile(%c0, %c0)
   %tile_0_1 = amdaie.tile(%c0, %c1)
   %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
-  %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
-  %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-  %core_0_0_0 = amdaie.core(%tile_0_0, in : [], out : []) {
-    amdaie.logicalobjectfifo.access(%0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>> -> memref<1x1x8x16xi32>
+  %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 2>>
+  %2 = amdaie.dma_cpy_nd(%1[] [] [], %0[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>)
+  %core_0_0_0 = amdaie.core(%tile_0_0, in : [%2], out : []) {
+    amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<8x16xi32, 2>> -> memref<8x16xi32, 2>
     amdaie.end
   }
-  %core_0_1_0 = amdaie.core(%tile_0_1, in : [], out : []) {
-    amdaie.logicalobjectfifo.access(%0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>> -> memref<1x1x8x16xi32>
+  %core_0_1_0 = amdaie.core(%tile_0_1, in : [%2], out : []) {
+    amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<8x16xi32, 2>> -> memref<8x16xi32, 2>
     amdaie.end
   }
   scf.for %arg2 = %c0 to %c8 step %c1  {
-    %core_0_0_1 = amdaie.core(%tile_0_0, in : [], out : []) {
+    %3 = amdaie.dma_cpy_nd(%1[] [] [], %0[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>)
+    %core_0_0_1 = amdaie.core(%tile_0_0, in : [%3], out : []) {
+      amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<8x16xi32, 2>> -> memref<8x16xi32, 2>
       amdaie.end
     }
-    %core_0_1_1 = amdaie.core(%tile_0_1, in : [], out : []) {
+    %core_0_1_1 = amdaie.core(%tile_0_1, in : [%3], out : []) {
+      amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<8x16xi32, 2>> -> memref<8x16xi32, 2>
       amdaie.end
     }
   }
@@ -397,64 +400,47 @@ func.func @merge_cores(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) 
 // -----
 
 // CHECK-LABEL: @complex_example
+// CHECK-SAME:  %[[ARG0:.+]]: memref<1x1x8x16xi32>, %[[ARG1:.+]]: memref<8x16xi32, 2>, %[[ARG2:.+]]: memref<1x1x16x16xi32>, %[[ARG3:.+]]: memref<16x16xi32, 2>, %[[ARG4:.+]]: memref<1x1x32x16xi32>, %[[ARG5:.+]]: memref<32x16xi32, 2>
 // CHECK:       amdaie.workgroup
 // CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
 // CHECK-DAG:     %[[C8:.+]] = arith.constant 8 : index
 // CHECK-DAG:     %[[TILE_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
 // CHECK-DAG:     %[[TILE_1:.+]] = amdaie.tile(%[[C0]], %[[C1]])
-// CHECK-DAG:     %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
-// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
-// CHECK-DAG:     %[[FROMMEMREF2:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x16x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x16x16xi32>>
-// CHECK-DAG:     %[[FROMMEMREF3:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<16x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<16x16xi32, 1>>
-// CHECK-DAG:     %[[FROMMEMREF4:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x32x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x32x16xi32>>
-// CHECK-DAG:     %[[FROMMEMREF5:.+]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<32x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>
-// CHECK-DAG:     %[[DMA0:.+]] = amdaie.circular_dma_cpy_nd
-// CHECK-SAME:    %[[FROMMEMREF0]][] [] []
-// CHECK-SAME:    %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
-// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-// CHECK-DAG:     %[[DMA1:.+]] = amdaie.circular_dma_cpy_nd
-// CHECK-SAME:    %[[FROMMEMREF2]][] [] []
-// CHECK-SAME:    %[[FROMMEMREF3]][0, 0, 0, 0] [1, 1, 16, 16] [128, 16, 8, 1]
-// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x16x16xi32>>, !amdaie.logicalobjectfifo<memref<16x16xi32, 1>>)
-// CHECK-DAG:     %[[DMA2:.+]] = amdaie.circular_dma_cpy_nd
-// CHECK-SAME:    %[[FROMMEMREF4]][] [] []
-// CHECK-SAME:    %[[FROMMEMREF5]][0, 0, 0, 0] [1, 1, 32, 16] [128, 16, 8, 1]
-// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1x1x32x16xi32>>, !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>)
-// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_0]], in : [], out : [])
-// CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF0]], Read)
+// CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG1]]
+// CHECK-DAG:     %[[FROMMEMREF3:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG3]]
+// CHECK-DAG:     %[[FROMMEMREF5:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG5]]
+// CHECK-DAG:     %[[PLACEHOLDER0:.+]] = amdaie.logicalobjectfifo.placeholder{} : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
+// CHECK-DAG:     %[[DMA0:.+]] = amdaie.circular_dma_cpy_nd(%[[FROMMEMREF1]][] [] [], %[[PLACEHOLDER0]][] [] []) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>)
+// CHECK-DAG:     %[[PLACEHOLDER1:.+]] = amdaie.logicalobjectfifo.placeholder{} : !amdaie.logicalobjectfifo<memref<1x1x16x16xi32>>
+// CHECK-DAG:     %[[DMA1:.+]] = amdaie.circular_dma_cpy_nd(%[[FROMMEMREF3]][] [] [], %[[PLACEHOLDER1]][] [] []) : (!amdaie.logicalobjectfifo<memref<16x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<1x1x16x16xi32>>)
+// CHECK-DAG:     %[[PLACEHOLDER2:.+]] = amdaie.logicalobjectfifo.placeholder{} : !amdaie.logicalobjectfifo<memref<1x1x32x16xi32>>
+// CHECK-DAG:     %[[DMA2:.+]] = amdaie.circular_dma_cpy_nd(%[[FROMMEMREF5]][] [] [], %[[PLACEHOLDER2]][] [] []) : (!amdaie.logicalobjectfifo<memref<32x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<1x1x32x16xi32>>)
+// CHECK:         %{{.+}} = amdaie.core(%[[TILE_0]], in : [], out : [])
+// CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF1]], Read)
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
-// CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF2]], Read)
+// CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF3]], Read)
 // CHECK:             linalg.fill
-// CHECK-DAG:     %{{.+}} = amdaie.core(%[[TILE_1]], in : [], out : [])
-// CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF0]], Read)
+// CHECK:         %{{.+}} = amdaie.core(%[[TILE_1]], in : [], out : [])
+// CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF1]], Read)
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
-// CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF4]], Read)
+// CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF5]], Read)
 // CHECK:             linalg.fill
 // CHECK:         amdaie.controlcode
+// CHECK-DAG:       %[[FROMMEMREF0:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]]
+// CHECK-DAG:       %[[FROMMEMREF2:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG2]]
+// CHECK-DAG:       %[[FROMMEMREF4:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG4]]
 // CHECK-DAG:       %[[C0_1:.+]] = arith.constant 0 : index
 // CHECK-DAG:       %[[C1_1:.+]] = arith.constant 1 : index
 // CHECK-DAG:       %[[C8_1:.+]] = arith.constant 8 : index
-// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[DMA0]]
-// CHECK-SAME:      [] [] []
-// CHECK-SAME:      [] [] []
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]], S2MM)
+// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[DMA0]]([] [] [], %[[FROMMEMREF0]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]], MM2S)
 // CHECK:           scf.for %{{.*}} = %[[C0_1]] to %[[C8_1]] step %[[C1_1]]
-// CHECK:             %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[DMA1]]
-// CHECK-SAME:        [] [] []
-// CHECK-SAME:        [] [] []
-// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA_1]], S2MM)
-// CHECK:             %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[DMA2]]
-// CHECK-SAME:        [] [] []
-// CHECK-SAME:        [] [] []
-// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA_2]], S2MM)
-func.func @complex_example(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>, %arg2: memref<1x1x16x16xi32>, %arg3: memref<16x16xi32, 1>, %arg4: memref<1x1x32x16xi32>, %arg5: memref<32x16xi32, 1>) {
+// CHECK:             %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[DMA1]]([] [] [], %[[FROMMEMREF2]][0, 0, 0, 0] [1, 1, 16, 16] [128, 16, 8, 1])
+// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA_1]], MM2S)
+// CHECK:             %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[DMA2]]([] [] [], %[[FROMMEMREF4]][0, 0, 0, 0] [1, 1, 32, 16] [128, 16, 8, 1])
+// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA_2]], MM2S)
+func.func @complex_example(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 2>, %arg2: memref<1x1x16x16xi32>, %arg3: memref<16x16xi32, 2>, %arg4: memref<1x1x32x16xi32>, %arg5: memref<32x16xi32, 2>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c8 = arith.constant 8 : index
@@ -462,31 +448,31 @@ func.func @complex_example(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 
   %tile_0_0 = amdaie.tile(%c0, %c0)
   %tile_0_1 = amdaie.tile(%c0, %c1)
   %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
-  %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
+  %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 2>>
   %2 = amdaie.logicalobjectfifo.from_memref %arg2, {} : memref<1x1x16x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x16x16xi32>>
-  %3 = amdaie.logicalobjectfifo.from_memref %arg3, {} : memref<16x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<16x16xi32, 1>>
+  %3 = amdaie.logicalobjectfifo.from_memref %arg3, {} : memref<16x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<16x16xi32, 2>>
   %4 = amdaie.logicalobjectfifo.from_memref %arg4, {} : memref<1x1x32x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x32x16xi32>>
-  %5 = amdaie.logicalobjectfifo.from_memref %arg5, {} : memref<32x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>
-  %dma_0 = amdaie.dma_cpy_nd(%0[] [] [], %1[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  %5 = amdaie.logicalobjectfifo.from_memref %arg5, {} : memref<32x16xi32, 2> -> !amdaie.logicalobjectfifo<memref<32x16xi32, 2>>
+  %dma_0 = amdaie.dma_cpy_nd(%1[] [] [], %0[0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>)
   %core_0_0_0 = amdaie.core(%tile_0_0, in : [], out : []) {
-    amdaie.logicalobjectfifo.access(%0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>> -> memref<1x1x8x16xi32>
+    amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<8x16xi32, 2>> -> memref<8x16xi32, 2>
     amdaie.end
   }
   %core_0_1_0 = amdaie.core(%tile_0_1, in : [], out : []) {
-    amdaie.logicalobjectfifo.access(%0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>> -> memref<1x1x8x16xi32>
+    amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<8x16xi32, 2>> -> memref<8x16xi32, 2>
     amdaie.end
   }
   scf.for %iv0 = %c0 to %c8 step %c1  {
-    %dma_1 = amdaie.dma_cpy_nd(%2[] [] [], %3[0, 0, 0, 0] [1, 1, 16, 16] [128, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x16x16xi32>>, !amdaie.logicalobjectfifo<memref<16x16xi32, 1>>)
-    %dma_2 = amdaie.dma_cpy_nd(%4[] [] [], %5[0, 0, 0, 0] [1, 1, 32, 16] [128, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x32x16xi32>>, !amdaie.logicalobjectfifo<memref<32x16xi32, 1>>)
+    %dma_1 = amdaie.dma_cpy_nd(%3[] [] [], %2[0, 0, 0, 0] [1, 1, 16, 16] [128, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<16x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<1x1x16x16xi32>>)
+    %dma_2 = amdaie.dma_cpy_nd(%5[] [] [], %4[0, 0, 0, 0] [1, 1, 32, 16] [128, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<32x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<1x1x32x16xi32>>)
     %core_0_0_1 = amdaie.core(%tile_0_0, in : [], out : []) {
-      amdaie.logicalobjectfifo.access(%2, Read) : !amdaie.logicalobjectfifo<memref<1x1x16x16xi32>> -> memref<1x1x16x16xi32>
-      linalg.fill ins(%c0_i32 : i32) outs(%arg2 : memref<1x1x16x16xi32>)
+      amdaie.logicalobjectfifo.access(%3, Read) : !amdaie.logicalobjectfifo<memref<16x16xi32, 2>> -> memref<16x16xi32, 2>
+      linalg.fill ins(%c0_i32 : i32) outs(%arg3 : memref<16x16xi32, 2>)
       amdaie.end
     }
     %core_0_1_1 = amdaie.core(%tile_0_1, in : [], out : []) {
-      amdaie.logicalobjectfifo.access(%4, Read) : !amdaie.logicalobjectfifo<memref<1x1x32x16xi32>> -> memref<1x1x32x16xi32>
-      linalg.fill ins(%c0_i32 : i32) outs(%arg4 : memref<1x1x32x16xi32>)
+      amdaie.logicalobjectfifo.access(%5, Read) : !amdaie.logicalobjectfifo<memref<32x16xi32, 2>> -> memref<32x16xi32, 2>
+      linalg.fill ins(%c0_i32 : i32) outs(%arg5 : memref<32x16xi32, 2>)
       amdaie.end
     }
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
@@ -420,18 +420,19 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %tile_0_2 = amdaie.tile(%c0, %c2)
       %alloc_1 = memref.alloc() : memref<32x32xi32, 1>
       %alloc_2 = memref.alloc() : memref<4x8x4x8xi32, 2>
-      %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x64xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
+      %placeholder = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<2048xi32>>
       %obj1 = amdaie.logicalobjectfifo.from_memref %alloc_1, {%tile_0_1} : memref<32x32xi32, 1> -> !amdaie.logicalobjectfifo<memref<1024xi32, 1>>
       %obj2 = amdaie.logicalobjectfifo.from_memref %alloc_2, {%tile_0_2} : memref<4x8x4x8xi32, 2> -> !amdaie.logicalobjectfifo<memref<1024xi32, 2>>
       %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj2[] [] []) : (!amdaie.logicalobjectfifo<memref<1024xi32, 1>>, !amdaie.logicalobjectfifo<memref<1024xi32, 2>>)
-      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
+      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%placeholder[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
       amdaie.logicalobjectfifo.link[%dma0] -> [%dma_target_l3] ()
       memref.dealloc %alloc_2 : memref<4x8x4x8xi32, 2>
       memref.dealloc %alloc_1 : memref<32x32xi32, 1>
       // expected-error @+1 {{could not convert to AIEDialect ops}}
       amdaie.controlcode {
+        %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x64xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
         // expected-error @+1 {{op expected to have a target BD ID op}}
-        %npu_dma_0 = amdaie.npu.dma_cpy_nd %dma_target_l3([%c0, %c32] [%c32, %c32] [%c64, %c1], [] [] [])
+        %npu_dma_0 = amdaie.npu.dma_cpy_nd %dma_target_l3(%obj0[%c0, %c32] [%c32, %c32] [%c64, %c1], [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<2048xi32>>
         amdaie.npu.dma_wait(%npu_dma_0, S2MM)
         amdaie.end
       }
@@ -464,18 +465,19 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %bd_id_0 = amdaie.bd_id(%tile_0_0, 0)
       %alloc_1 = memref.alloc() : memref<32x32xi32, 1>
       %alloc_2 = memref.alloc() : memref<4x8x4x8xi32, 2>
-      %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x64xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
+      %placeholder = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<2048xi32>>
       %obj1 = amdaie.logicalobjectfifo.from_memref %alloc_1, {%tile_0_1} : memref<32x32xi32, 1> -> !amdaie.logicalobjectfifo<memref<1024xi32, 1>>
       %obj2 = amdaie.logicalobjectfifo.from_memref %alloc_2, {%tile_0_2} : memref<4x8x4x8xi32, 2> -> !amdaie.logicalobjectfifo<memref<1024xi32, 2>>
       %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj2[] [] []) : (!amdaie.logicalobjectfifo<memref<1024xi32, 1>>, !amdaie.logicalobjectfifo<memref<1024xi32, 2>>)
-      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
+      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%placeholder[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
       amdaie.logicalobjectfifo.link[%dma0] -> [%dma_target_l3] ()
       memref.dealloc %alloc_2 : memref<4x8x4x8xi32, 2>
       memref.dealloc %alloc_1 : memref<32x32xi32, 1>
       // expected-error @+1 {{could not convert to AIEDialect ops}}
       amdaie.controlcode {
+        %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x64xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
         // expected-error @+1 {{op expected target addressing for DMA with target on L3}}
-        %npu_dma_0 = amdaie.npu.dma_cpy_nd %dma_target_l3([] [] [] bd_id = %bd_id_0, [] [] [])
+        %npu_dma_0 = amdaie.npu.dma_cpy_nd %dma_target_l3(%obj0[] [] [] bd_id = %bd_id_0, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<2048xi32>>
         amdaie.npu.dma_wait(%npu_dma_0, S2MM)
         amdaie.end
       }
@@ -506,18 +508,19 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %bd_id_0 = amdaie.bd_id(%tile_0_0, 0)
       %alloc_1 = memref.alloc() : memref<32x32xi32, 1>
       %alloc_2 = memref.alloc() : memref<4x8x4x8xi32, 2>
-      %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x64xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
+      %placeholder = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<2048xi32>>
       %obj1 = amdaie.logicalobjectfifo.from_memref %alloc_1, {%tile_0_1} : memref<32x32xi32, 1> -> !amdaie.logicalobjectfifo<memref<1024xi32, 1>>
       %obj2 = amdaie.logicalobjectfifo.from_memref %alloc_2, {%tile_0_2} : memref<4x8x4x8xi32, 2> -> !amdaie.logicalobjectfifo<memref<1024xi32, 2>>
       %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj2[] [] []) : (!amdaie.logicalobjectfifo<memref<1024xi32, 1>>, !amdaie.logicalobjectfifo<memref<1024xi32, 2>>)
-      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
+      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%placeholder[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
       amdaie.logicalobjectfifo.link[%dma0] -> [%dma_target_l3] ()
       memref.dealloc %alloc_2 : memref<4x8x4x8xi32, 2>
       memref.dealloc %alloc_1 : memref<32x32xi32, 1>
       // expected-error @+1 {{could not convert to AIEDialect ops}}
       amdaie.controlcode {
+        %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x64xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
         // expected-error @+1 {{could not canonicalize for AIE}}
-        %npu_dma_0 = amdaie.npu.dma_cpy_nd %dma_target_l3([0, 0, 0, 32] [1, 32, 2, 32] [0, 64, 0, 1] bd_id = %bd_id_0, [] [] [])
+        %npu_dma_0 = amdaie.npu.dma_cpy_nd %dma_target_l3(%obj0[0, 0, 0, 32] [1, 32, 2, 32] [0, 64, 0, 1] bd_id = %bd_id_0, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<2048xi32>>
         amdaie.end
       }
     }
@@ -547,18 +550,19 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %bd_id_0 = amdaie.bd_id(%tile_0_0, 0)
       %alloc_1 = memref.alloc() : memref<32x32xi32, 1>
       %alloc_2 = memref.alloc() : memref<4x8x4x8xi32, 2>
-      %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x64xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
+      %placeholder = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<2048xi32>>
       %obj1 = amdaie.logicalobjectfifo.from_memref %alloc_1, {%tile_0_1} : memref<32x32xi32, 1> -> !amdaie.logicalobjectfifo<memref<1024xi32, 1>>
       %obj2 = amdaie.logicalobjectfifo.from_memref %alloc_2, {%tile_0_2} : memref<4x8x4x8xi32, 2> -> !amdaie.logicalobjectfifo<memref<1024xi32, 2>>
       %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj2[] [] []) : (!amdaie.logicalobjectfifo<memref<1024xi32, 1>>, !amdaie.logicalobjectfifo<memref<1024xi32, 2>>)
-      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
+      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%placeholder[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
       amdaie.logicalobjectfifo.link[%dma0] -> [%dma_target_l3] ()
       memref.dealloc %alloc_2 : memref<4x8x4x8xi32, 2>
       memref.dealloc %alloc_1 : memref<32x32xi32, 1>
       // expected-error @+1 {{could not convert to AIEDialect ops}}
       amdaie.controlcode {
+        %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x64xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
         // expected-error @+1 {{could not canonicalize for AIE}}
-        %npu_dma_0 = amdaie.npu.dma_cpy_nd %dma_target_l3([0, 0, 0, 32] [2, 8, 2, 32] [0, 0, 64, 1] bd_id = %bd_id_0, [] [] [])
+        %npu_dma_0 = amdaie.npu.dma_cpy_nd %dma_target_l3(%obj0[0, 0, 0, 32] [2, 8, 2, 32] [0, 0, 64, 1] bd_id = %bd_id_0, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<2048xi32>>
         amdaie.end
       }
     }
@@ -591,16 +595,17 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %bd_id_0 = amdaie.bd_id(%tile_0_0, 0)
       %alloc_1 = memref.alloc() : memref<32x32xi32, 1>
       %alloc_2 = memref.alloc() : memref<4x8x4x8xi32, 2>
-      %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x64xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
+      %placeholder = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<2048xi32>>
       %obj1 = amdaie.logicalobjectfifo.from_memref %alloc_1, {%tile_0_1} : memref<32x32xi32, 1> -> !amdaie.logicalobjectfifo<memref<1024xi32, 1>>
       %obj2 = amdaie.logicalobjectfifo.from_memref %alloc_2, {%tile_0_2} : memref<4x8x4x8xi32, 2> -> !amdaie.logicalobjectfifo<memref<1024xi32, 2>>
       %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj2[] [] []) : (!amdaie.logicalobjectfifo<memref<1024xi32, 1>>, !amdaie.logicalobjectfifo<memref<1024xi32, 2>>)
-      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
+      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%placeholder[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
       amdaie.logicalobjectfifo.link[%dma0] -> [%dma_target_l3] ()
       memref.dealloc %alloc_2 : memref<4x8x4x8xi32, 2>
       memref.dealloc %alloc_1 : memref<32x32xi32, 1>
       amdaie.controlcode {
-        %npu_dma_0 = amdaie.npu.dma_cpy_nd %dma_target_l3([0, 0, 32] [1, 2, 32] [0, 0, 1] bd_id = %bd_id_0, [] [] [])
+        %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x64xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
+        %npu_dma_0 = amdaie.npu.dma_cpy_nd %dma_target_l3(%obj0[0, 0, 32] [1, 2, 32] [0, 0, 1] bd_id = %bd_id_0, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<2048xi32>>
         amdaie.end
       }
     }
@@ -633,16 +638,17 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %bd_id_0 = amdaie.bd_id(%tile_0_0, 0)
       %alloc_1 = memref.alloc() : memref<32x32xi32, 1>
       %alloc_2 = memref.alloc() : memref<4x8x4x8xi32, 2>
-      %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x64xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
+      %placeholder = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<2048xi32>>
       %obj1 = amdaie.logicalobjectfifo.from_memref %alloc_1, {%tile_0_1} : memref<32x32xi32, 1> -> !amdaie.logicalobjectfifo<memref<1024xi32, 1>>
       %obj2 = amdaie.logicalobjectfifo.from_memref %alloc_2, {%tile_0_2} : memref<4x8x4x8xi32, 2> -> !amdaie.logicalobjectfifo<memref<1024xi32, 2>>
       %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj2[] [] []) : (!amdaie.logicalobjectfifo<memref<1024xi32, 1>>, !amdaie.logicalobjectfifo<memref<1024xi32, 2>>)
-      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
+      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%placeholder[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
       amdaie.logicalobjectfifo.link[%dma0] -> [%dma_target_l3] ()
       memref.dealloc %alloc_2 : memref<4x8x4x8xi32, 2>
       memref.dealloc %alloc_1 : memref<32x32xi32, 1>
       amdaie.controlcode {
-        %npu_dma_0 = amdaie.npu.dma_cpy_nd %dma_target_l3([0, 0, 0, 32] [2, 1, 2, 32] [2, 0, 16, 1] bd_id = %bd_id_0, [] [] [])
+        %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x64xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
+        %npu_dma_0 = amdaie.npu.dma_cpy_nd %dma_target_l3(%obj0[0, 0, 0, 32] [2, 1, 2, 32] [2, 0, 16, 1] bd_id = %bd_id_0, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<2048xi32>>
         amdaie.end
       }
     }
@@ -707,24 +713,25 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %bd_id_0 = amdaie.bd_id(%tile_0_0, 0)
       %alloc_1 = memref.alloc() : memref<32x32xi32, 1>
       %alloc_2 = memref.alloc() : memref<4x8x4x8xi32, 2>
-      %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x64xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
+      %placeholder = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<2048xi32>>
       %obj1 = amdaie.logicalobjectfifo.from_memref %alloc_1, {%tile_0_1} : memref<32x32xi32, 1> -> !amdaie.logicalobjectfifo<memref<1024xi32, 1>>
       %obj2 = amdaie.logicalobjectfifo.from_memref %alloc_2, {%tile_0_2} : memref<4x8x4x8xi32, 2> -> !amdaie.logicalobjectfifo<memref<1024xi32, 2>>
       %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj2[] [] []) : (!amdaie.logicalobjectfifo<memref<1024xi32, 1>>, !amdaie.logicalobjectfifo<memref<1024xi32, 2>>)
-      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
-      %dma_source_l3 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj0[] [] []) : (!amdaie.logicalobjectfifo<memref<1024xi32, 1>>, !amdaie.logicalobjectfifo<memref<2048xi32>>)
-      %dma1 = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
+      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%placeholder[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
+      %dma_source_l3 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %placeholder[] [] []) : (!amdaie.logicalobjectfifo<memref<1024xi32, 1>>, !amdaie.logicalobjectfifo<memref<2048xi32>>)
+      %dma1 = amdaie.circular_dma_cpy_nd(%placeholder[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
       amdaie.logicalobjectfifo.link[%dma0] -> [%dma_target_l3] ()
       memref.dealloc %alloc_2 : memref<4x8x4x8xi32, 2>
       memref.dealloc %alloc_1 : memref<32x32xi32, 1>
       amdaie.controlcode {
-        %npu_dma_0 = amdaie.npu.dma_cpy_nd %dma_target_l3([%c0, %c32] [%c32, %c32] [%c64, %c1] bd_id = %bd_id_0, [] [] [])
+        %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x64xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
+        %npu_dma_0 = amdaie.npu.dma_cpy_nd %dma_target_l3(%obj0[%c0, %c32] [%c32, %c32] [%c64, %c1] bd_id = %bd_id_0, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<2048xi32>>
         amdaie.npu.dma_wait(%npu_dma_0, S2MM)
-        %npu_dma_1 = amdaie.npu.dma_cpy_nd %dma_target_l3([%c0] [%c1024] [%c1] bd_id = %bd_id_0, [] [] [])
+        %npu_dma_1 = amdaie.npu.dma_cpy_nd %dma_target_l3(%obj0[%c0] [%c1024] [%c1] bd_id = %bd_id_0, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<2048xi32>>
         amdaie.npu.dma_wait(%npu_dma_1, S2MM)
-        %npu_dma_2 = amdaie.npu.dma_cpy_nd %dma_source_l3([] [] [], [%c0, %c32] [%c32, %c32] [%c64, %c1] bd_id = %bd_id_0)
+        %npu_dma_2 = amdaie.npu.dma_cpy_nd %dma_source_l3([] [] [], %obj0[%c0, %c32] [%c32, %c32] [%c64, %c1] bd_id = %bd_id_0) : source_type = !amdaie.logicalobjectfifo<memref<2048xi32>>
         amdaie.npu.dma_wait(%npu_dma_2, MM2S)
-        %npu_dma_3 = amdaie.npu.dma_cpy_nd %dma_source_l3([] [] [], [%c0] [%c2048] [%c1] bd_id = %bd_id_0)
+        %npu_dma_3 = amdaie.npu.dma_cpy_nd %dma_source_l3([] [] [], %obj0[%c0] [%c2048] [%c1] bd_id = %bd_id_0) : source_type = !amdaie.logicalobjectfifo<memref<2048xi32>>
         amdaie.npu.dma_wait(%npu_dma_3, MM2S)
         amdaie.end
       }
@@ -736,12 +743,13 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // -----
 
 // CHECK:       aie.device(npu1_4col) {
-// CHECK:         %[[TILE_0_0:.*]] = aie.tile(0, 0)
-// CHECK:         %[[TILE_0_1:.*]] = aie.tile(0, 1)
+// CHECK-DAG:     %[[TILE_0_0:.*]] = aie.tile(0, 0)
+// CHECK-DAG:     %[[TILE_0_1:.*]] = aie.tile(0, 1)
+// CHECK-DAG:     %[[TILE_1_0:.*]] = aie.tile(1, 0)
 // CHECK:         aie.objectfifo @[[OBJ0:.*]](%[[TILE_0_0]], {%[[TILE_0_1]]}, 2 : i32) : !aie.objectfifo<memref<1024xbf16, 1 : i32>>
-// CHECK:         aie.objectfifo @[[OBJ1:.*]](%[[TILE_0_0]], {%[[TILE_0_1]]}, 2 : i32) : !aie.objectfifo<memref<1024xbf16, 1 : i32>>
-// CHECK:         aie.objectfifo @[[OBJ2:.*]](%[[TILE_0_1]]
-// CHECK-SAME:         %[[TILE_0_0]]}, 2 : i32) : !aie.objectfifo<memref<1024xf32>>
+// CHECK:         aie.objectfifo @[[OBJ1:.*]](%[[TILE_1_0]], {%[[TILE_0_1]]}, 2 : i32) : !aie.objectfifo<memref<1024xbf16, 1 : i32>>
+// CHECK:         aie.objectfifo @[[OBJ2:.*]](%[[TILE_0_1]] 
+// CHECK-SAME:    {%[[TILE_1_0]]}, 2 : i32) : !aie.objectfifo<memref<1024xf32>>
 // CHECK:         aiex.runtime_sequence @bf16_f32_lit_test
 // CHECK-SAME:         (%[[LHS:.*]]: memref<32x32xbf16>, %[[RHS:.*]]: memref<32x32xbf16>, %[[OUT:.*]]: memref<32x32xf32>) {
 // CHECK:           aiex.npu.dma_memcpy_nd
@@ -784,23 +792,27 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %2 = amdaie.logicalobjectfifo.from_memref %alloc_0, {%tile} : memref<1x2x32x16xbf16, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2x1x16x32xbf16, 1 : i32>, 2>
       %3 = hal.interface.binding.subspan layout(#pipeline_layout) set(0) binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<32x32xbf16>
       %tile_1 = amdaie.tile(%c0, %c0)
+      %tile_2 = amdaie.tile(%c1, %c0)
       %bd_id = amdaie.bd_id(%tile_1, 2)
       %bd_id_2 = amdaie.bd_id(%tile_1, 1)
       %bd_id_3 = amdaie.bd_id(%tile_1, 0)
-      %4 = amdaie.logicalobjectfifo.from_memref %3, {%tile_1} : memref<32x32xbf16> -> !amdaie.logicalobjectfifo<memref<32x32xbf16>>
+      %placeholder0 = amdaie.logicalobjectfifo.placeholder{%tile_1} : !amdaie.logicalobjectfifo<memref<32x32xbf16>>
       memref.assume_alignment %3, 64 : memref<32x32xbf16>
       %5 = hal.interface.binding.subspan layout(#pipeline_layout) set(0) binding(1) alignment(64) offset(%c0) flags(ReadOnly) : memref<32x32xbf16>
-      %6 = amdaie.logicalobjectfifo.from_memref %5, {%tile_1} : memref<32x32xbf16> -> !amdaie.logicalobjectfifo<memref<32x32xbf16>>
+      %placeholder1 = amdaie.logicalobjectfifo.placeholder{%tile_2} : !amdaie.logicalobjectfifo<memref<32x32xbf16>>
       memref.assume_alignment %5, 64 : memref<32x32xbf16>
       %7 = hal.interface.binding.subspan layout(#pipeline_layout) set(0) binding(2) alignment(64) offset(%c0) : memref<32x32xf32>
-      %8 = amdaie.logicalobjectfifo.from_memref %7, {%tile_1} : memref<32x32xf32> -> !amdaie.logicalobjectfifo<memref<1024xf32>>
-      %9 = amdaie.circular_dma_cpy_nd(%2[] [] [], %4[] [] []) : (!amdaie.logicalobjectfifo<memref<2x1x16x32xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<32x32xbf16>>)
-      %10 = amdaie.circular_dma_cpy_nd(%1[] [] [], %6[] [] []) : (!amdaie.logicalobjectfifo<memref<1x2x32x16xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<32x32xbf16>>)
-      %11 = amdaie.circular_dma_cpy_nd(%8[] [] [], %0[%c0, %c0, %c0, %c0] [%c2, %c16, %c2, %c16] [%c512, %c16, %c256, %c1]) : (!amdaie.logicalobjectfifo<memref<1024xf32>>, !amdaie.logicalobjectfifo<memref<2x2x16x16xf32, 1 : i32>, 2>)
+      %placeholder2 = amdaie.logicalobjectfifo.placeholder{%tile_2} : !amdaie.logicalobjectfifo<memref<1024xf32>>
+      %9 = amdaie.circular_dma_cpy_nd(%2[] [] [], %placeholder0[] [] []) : (!amdaie.logicalobjectfifo<memref<2x1x16x32xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<32x32xbf16>>)
+      %10 = amdaie.circular_dma_cpy_nd(%1[] [] [], %placeholder1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x2x32x16xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<32x32xbf16>>)
+      %11 = amdaie.circular_dma_cpy_nd(%placeholder2[] [] [], %0[%c0, %c0, %c0, %c0] [%c2, %c16, %c2, %c16] [%c512, %c16, %c256, %c1]) : (!amdaie.logicalobjectfifo<memref<1024xf32>>, !amdaie.logicalobjectfifo<memref<2x2x16x16xf32, 1 : i32>, 2>)
       amdaie.controlcode {
-        %12 = amdaie.npu.dma_cpy_nd %11([%c0] [%c1024] [%c1] bd_id = %bd_id_3, [] [] [])
-        %13 = amdaie.npu.dma_cpy_nd %10([] [] [], [%c0, %c1, %c2] [%c2, %c32, %c16] [%c16, %c32, %c1] bd_id = %bd_id_2)
-        %14 = amdaie.npu.dma_cpy_nd %9([] [] [], [%c0] [%c1024] [%c1] bd_id = %bd_id)
+        %obj0 = amdaie.logicalobjectfifo.from_memref %3, {%tile_1} : memref<32x32xbf16> -> !amdaie.logicalobjectfifo<memref<32x32xbf16>>
+        %obj1 = amdaie.logicalobjectfifo.from_memref %5, {%tile_1} : memref<32x32xbf16> -> !amdaie.logicalobjectfifo<memref<32x32xbf16>>
+        %obj2 = amdaie.logicalobjectfifo.from_memref %7, {%tile_1} : memref<32x32xf32> -> !amdaie.logicalobjectfifo<memref<1024xf32>>
+        %12 = amdaie.npu.dma_cpy_nd %11(%obj2[%c0] [%c1024] [%c1] bd_id = %bd_id_3, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<1024xf32>>
+        %13 = amdaie.npu.dma_cpy_nd %10([] [] [], %obj1[%c0, %c1, %c2] [%c2, %c32, %c16] [%c16, %c32, %c1] bd_id = %bd_id_2) : source_type = !amdaie.logicalobjectfifo<memref<32x32xbf16>>
+        %14 = amdaie.npu.dma_cpy_nd %9([] [] [], %obj0[%c0] [%c1024] [%c1] bd_id = %bd_id) : source_type = !amdaie.logicalobjectfifo<memref<32x32xbf16>>
         amdaie.npu.dma_wait(%12, S2MM)
         amdaie.npu.dma_wait(%13, MM2S)
         amdaie.npu.dma_wait(%14, MM2S)
@@ -837,18 +849,19 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %bd_id_0 = amdaie.bd_id(%tile_0_0, 0)
       %alloc_1 = memref.alloc() : memref<32x32xi32, 1>
       %alloc_2 = memref.alloc() : memref<4x8x4x8xi32, 2>
-      %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x16x64x128x32xi32> -> !amdaie.logicalobjectfifo<memref<32x16x64x128x32xi32>>
+      %placeholder = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<32x16x64x128x32xi32>>
       %obj1 = amdaie.logicalobjectfifo.from_memref %alloc_1, {%tile_0_1} : memref<32x32xi32, 1> -> !amdaie.logicalobjectfifo<memref<1024xi32, 1>>
       %obj2 = amdaie.logicalobjectfifo.from_memref %alloc_2, {%tile_0_2} : memref<4x8x4x8xi32, 2> -> !amdaie.logicalobjectfifo<memref<1024xi32, 2>>
       %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj2[] [] []) : (!amdaie.logicalobjectfifo<memref<1024xi32, 1>>, !amdaie.logicalobjectfifo<memref<1024xi32, 2>>)
-      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%obj0[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<32x16x64x128x32xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
+      %dma_target_l3 = amdaie.circular_dma_cpy_nd(%placeholder[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<32x16x64x128x32xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
       amdaie.logicalobjectfifo.link[%dma0] -> [%dma_target_l3] ()
       memref.dealloc %alloc_2 : memref<4x8x4x8xi32, 2>
       memref.dealloc %alloc_1 : memref<32x32xi32, 1>
       // expected-error @+1 {{could not convert to AIEDialect ops}}
       amdaie.controlcode {
+        %obj0 = amdaie.logicalobjectfifo.from_memref %2, {%tile_0_0} : memref<32x16x64x128x32xi32> -> !amdaie.logicalobjectfifo<memref<32x16x64x128x32xi32>>
         // expected-error @+1 {{op expected target addressing for DMA with target on L3}}
-        %npu_dma_1 = amdaie.npu.dma_cpy_nd %dma_target_l3([] [] [] bd_id = %bd_id_0, [] [] [])
+        %npu_dma_1 = amdaie.npu.dma_cpy_nd %dma_target_l3(%obj0[] [] [] bd_id = %bd_id_0, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<32x16x64x128x32xi32>>
         amdaie.npu.dma_wait(%npu_dma_1, S2MM)
         amdaie.end
       }
@@ -931,10 +944,10 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       memref.assume_alignment %0, 64 : memref<32x64xi32>
       %alloc_1 = memref.alloc() : memref<32x32xi32, 1>
       %alloc_2 = memref.alloc() : memref<4x8x4x8xi32, 2>
-      %obj0 = amdaie.logicalobjectfifo.from_memref %0, {%tile_0_0} : memref<32x64xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
+      %placeholder = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<2048xi32>>
       %obj1 = amdaie.logicalobjectfifo.from_memref %alloc_1, {%tile_0_1} : memref<32x32xi32, 1> -> !amdaie.logicalobjectfifo<memref<1024xi32, 1>>
       %obj2 = amdaie.logicalobjectfifo.from_memref %alloc_2, {%tile_0_2, %tile_1_2} : memref<4x8x4x8xi32, 2> -> !amdaie.logicalobjectfifo<memref<1024xi32, 2>>
-      %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj0[] [] []) : (!amdaie.logicalobjectfifo<memref<1024xi32, 1>>, !amdaie.logicalobjectfifo<memref<2048xi32>>)
+      %dma0 = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %placeholder[] [] []) : (!amdaie.logicalobjectfifo<memref<1024xi32, 1>>, !amdaie.logicalobjectfifo<memref<2048xi32>>)
       %dma1 = amdaie.circular_dma_cpy_nd(%obj2[] [] [], %obj1[] [] []) : (!amdaie.logicalobjectfifo<memref<1024xi32, 2>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
       amdaie.logicalobjectfifo.link[%dma0] -> [%dma1] ()
       %core_0_2 = amdaie.core(%tile_0_2, in : [%dma1], out : []) {
@@ -960,7 +973,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       memref.dealloc %alloc_2 : memref<4x8x4x8xi32, 2>
       memref.dealloc %alloc_1 : memref<32x32xi32, 1>
       amdaie.controlcode {
-        %npu_dma = amdaie.npu.dma_cpy_nd %dma0([] [] [], [%c0, %c32] [%c32, %c32] [%c64, %c1] bd_id = %bd_id_0)
+        %obj0 = amdaie.logicalobjectfifo.from_memref %0, {%tile_0_0} : memref<32x64xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
+        %npu_dma = amdaie.npu.dma_cpy_nd %dma0([] [] [], %obj0[%c0, %c32] [%c32, %c32] [%c64, %c1] bd_id = %bd_id_0) : source_type = !amdaie.logicalobjectfifo<memref<2048xi32>>
         amdaie.npu.dma_wait(%npu_dma, MM2S)
         amdaie.end
       }


### PR DESCRIPTION
Adds the `amdaie.logicalobjectfifo.placeholder` operation that represents a logical objectFifo to be filled in later. This enables reuse of connections/circular DMAs/physical AIE channels for different data packets, which helps with (fused) operations with more than 2 inputs. This is especially useful for reading from/writing to DDR. 

Before this PR, the circular DMA connections would be always be tied to a HAL buffer on DDR/L3 and the control code NPU instruction could only change the addressing and not the input buffer:

```mlir
%0 = hal.interface.binding.subspan layout(#pipeline_layout) set(0) 
  binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<1024xi32>
%obj0 = amdaie.logicalobjectfifo.from_memref %0, {%tile_0_0} 
  : memref<1024xi32> -> !amdaie.logicalobjectfifo<memref<1024xi32>>
%1 = memref.alloc() : memref<1024xi32, 1 : i32> 
%obj1 = amdaie.logicalobjectfifo.from_memref %1, {%tile_0_1} 
  : memref<1024xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1024xi32, 1 : i32>>
%connection = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %obj0[] [] []) 
  : (!amdaie.logicalobjectfifo<memref<1024xi32, 1 : i32>>, !amdaie.logicalobjectfifo<memref<1024xi32>>)
amdaie.controlcode {
      %npu_dma = amdaie.npu.dma_cpy_nd %connection([] [] [], [%c0, %c32] [%c32, %c32] [%c32, %c1])
      amdaie.end
    }
```

By introducing placeholders, the NPU dma operation can specify the actual logical objFifo to be used:

```mlir
%0 = hal.interface.binding.subspan layout(#pipeline_layout) set(0) 
  binding(0) alignment(64) offset(%c0) flags(ReadOnly) : memref<1024xi32>
%1 = memref.alloc() : <1024xi32, 1 : i32>
%obj1 = amdaie.logicalobjectfifo.from_memref %1, {%tile_0_1}
  : memref<1024xi32, 1> -> !amdaie.logicalobjectfifo<memref<1024xi32, 1>>
%ph = amdaie.logicalobjectfifo.placeholder{} 
  : !amdaie.logicalobjectfifo<memref<2048xi32>>
%connection = amdaie.circular_dma_cpy_nd(%obj1[] [] [], %ph[] [] [])
  : (!amdaie.logicalobjectfifo<memref<1024xi32, 1>>, !amdaie.logicalobjectfifo<memref<1024xi32>>)
amdaie.controlcode {
  %obj0 = amdaie.logicalobjectfifo.from_memref %0, {%tile_0_0}
     : memref<1024xi32> -> !amdaie.logicalobjectfifo<memref<1024xi32>>
   %npu_dma = amdaie.npu.dma_cpy_nd %connection([] [] [],  %obj0[%c0, %c32] [%c32, %c32] [%c32, %c1]) 
     : source_type = !amdaie.logicalobjectfifo<memref<1024xi32>>
   amdaie.end
}
```