### PR TITLE
Fix GHA caches

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -9,12 +9,23 @@ on:
     branches:
       - main
 
+  schedule:
+    # At minute 0 past every 6th hour. (see https://crontab.guru)
+    # this job is to keep the ccache cache warm
+    - cron: '0 */6 * * *'
+
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
   # queued and in-progress runs for the same PR (presubmit) or commit
   # (postsubmit).
   group: ci-build-test-cpp-linux-${{ github.event.number || github.sha }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+  # required to delete cache
+  # https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-github-actions-caches-for-a-repository-using-a-cache-key
+  actions: write
 
 jobs:
   build_and_ctest:
@@ -24,6 +35,7 @@ jobs:
       fail-fast: true
     env:
       CACHE_DIR: ${{ github.workspace }}/.container-cache
+      CACHE_KEY: linux-build-test-cpp-asserts-manylinux-v2-${{ github.event.number || github.ref_name }}
     steps:
       - name: Set unified TZ
         uses: szenius/set-timezone@v2.0
@@ -42,11 +54,16 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install static libs
+      - name: Install deps
         run: |
-          dnf install -y almalinux-release-devel
           yum remove -y openssl-devel zlib-devel || true
-          yum install -y protobuf-devel protobuf-compiler
+          
+          dnf install -y almalinux-release-devel
+          type -p yum-config-manager >/dev/null || yum -y install yum-utils
+          yum-config-manager -y --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+          
+          yum install -y protobuf-devel protobuf-compiler gh
+
       - name: Sync source deps
         run: |
           python ./sync_deps.py
@@ -59,7 +76,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: ${{ env.CACHE_DIR }}
-          key: linux-build-test-cpp-asserts-manylinux-v2-${{ github.sha }}
+          key:  ${{ env.CACHE_KEY }}
           restore-keys: linux-build-test-cpp-
 
       - name: Build packages
@@ -80,12 +97,22 @@ jobs:
           path: iree-dist-linux.tar
           if-no-files-found: warn
 
+      - name: Overwrite cache
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        env:
+          # required to run gh with privileges
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh extension install actions/gh-actions-cache
+          gh actions-cache delete ${{ env.CACHE_KEY }} --confirm -R ${{ github.repository }}
+
       - name: Save cache
         uses: actions/cache/save@v3
         if: ${{ !cancelled() }}
         with:
           path: ${{ env.CACHE_DIR }}
-          key: linux-build-test-cpp-asserts-manylinux-v2-${{ github.sha }}
+          key: ${{ env.CACHE_KEY }}
 
   test_linux:
     name: E2E Test linux

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -35,7 +35,8 @@ jobs:
       fail-fast: true
     env:
       CACHE_DIR: ${{ github.workspace }}/.container-cache
-      CACHE_KEY: linux-build-test-cpp-asserts-manylinux-v2-${{ github.event.number || github.ref_name }}
+      # either the PR number or `branch-N` where N always increments
+      CACHE_KEY: linux-build-test-cpp-asserts-manylinux-v2-${{ github.event.number || format('{0}-{1}', github.ref_name, github.run_number) }}
     steps:
       - name: Set unified TZ
         uses: szenius/set-timezone@v2.0
@@ -79,6 +80,15 @@ jobs:
           key:  ${{ env.CACHE_KEY }}
           restore-keys: linux-build-test-cpp-
 
+      - name: Configure ccache debug logs
+        run: |
+          # https://interrupt.memfault.com/blog/ccache-debugging
+          echo CCACHE_DEBUG=1 >> $GITHUB_ENV
+          echo CCACHE_DEBUGLEVEL=2 >> $GITHUB_ENV
+          echo CCACHE_DEBUGDIR="/ccache-debug" >> $GITHUB_ENV
+          echo CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime,time_macros >> $GITHUB_ENV
+          echo CCACHE_COMPILERCHECK=content >> $GITHUB_ENV
+
       - name: Build packages
         run: |
           export cache_dir="${{ env.CACHE_DIR }}"
@@ -88,6 +98,19 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           tar cf iree-dist-linux.tar -C iree-install .
+
+      - name: Tar ccache logs
+        if: ${{ !cancelled() }}
+        run: |
+          tar cf linux-ccache-logs.tar $CCACHE_DEBUGDIR
+
+      - name: Upload ccache logs
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: ccache_logs
+          path: linux-ccache-logs.tar
+          if-no-files-found: warn
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -21,12 +21,6 @@ concurrency:
   group: ci-build-test-cpp-linux-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  # required to delete cache
-  # https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-github-actions-caches-for-a-repository-using-a-cache-key
-  actions: write
-
 jobs:
   build_and_ctest:
     name: Build and Test (linux, ASSERTIONS)
@@ -58,12 +52,7 @@ jobs:
       - name: Install deps
         run: |
           yum remove -y openssl-devel zlib-devel || true
-          
-          dnf install -y almalinux-release-devel
-          type -p yum-config-manager >/dev/null || yum -y install yum-utils
-          yum-config-manager -y --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
-          
-          yum install -y protobuf-devel protobuf-compiler gh
+          yum install -y protobuf-devel protobuf-compiler
 
       - name: Sync source deps
         run: |
@@ -85,7 +74,7 @@ jobs:
           # https://interrupt.memfault.com/blog/ccache-debugging
           echo CCACHE_DEBUG=1 >> $GITHUB_ENV
           echo CCACHE_DEBUGLEVEL=2 >> $GITHUB_ENV
-          echo CCACHE_DEBUGDIR="/ccache-debug" >> $GITHUB_ENV
+          echo CCACHE_DEBUGDIR="$HOME/ccache-debug" >> $GITHUB_ENV
           echo CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime,time_macros >> $GITHUB_ENV
           echo CCACHE_COMPILERCHECK=content >> $GITHUB_ENV
 
@@ -102,6 +91,7 @@ jobs:
       - name: Tar ccache logs
         if: ${{ !cancelled() }}
         run: |
+          ccache --show-stats -v
           tar cf linux-ccache-logs.tar $CCACHE_DEBUGDIR
 
       - name: Upload ccache logs
@@ -120,19 +110,9 @@ jobs:
           path: iree-dist-linux.tar
           if-no-files-found: warn
 
-      - name: Overwrite cache
-        if: ${{ !cancelled() }}
-        continue-on-error: true
-        env:
-          # required to run gh with privileges
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh extension install actions/gh-actions-cache
-          gh actions-cache delete ${{ env.CACHE_KEY }} --confirm -R ${{ github.repository }}
-
       - name: Save cache
         uses: actions/cache/save@v3
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.event_name != 'pull_request' }}
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ env.CACHE_KEY }}

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -16,10 +16,6 @@ concurrency:
   group: ci-build-test-cpp-macos-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  actions: write
-
 jobs:
   build_and_ctest:
     name: Build and Test (${{ matrix.runs-on }}, ASSERTIONS)
@@ -70,12 +66,10 @@ jobs:
 
       - name: Configure ccache debug logs
         run: |
-          # https://interrupt.memfault.com/blog/ccache-debugging
           echo CCACHE_DEBUG=1 >> $GITHUB_ENV
           echo CCACHE_DEBUGLEVEL=2 >> $GITHUB_ENV
-          echo CCACHE_DEBUGDIR="/ccache-debug" >> $GITHUB_ENV
+          echo CCACHE_DEBUGDIR="$HOME/ccache-debug" >> $GITHUB_ENV
           echo CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime,time_macros >> $GITHUB_ENV
-          echo CCACHE_COMPILERCHECK=content >> $GITHUB_ENV
 
       - name: Build packages
         run: |
@@ -90,6 +84,7 @@ jobs:
       - name: Tar ccache logs
         if: ${{ !cancelled() }}
         run: |
+          ccache --show-stats -v
           tar cf macos-ccache-logs.tar $CCACHE_DEBUGDIR
 
       - name: Upload ccache logs
@@ -108,18 +103,9 @@ jobs:
           path: iree-dist-${{ matrix.runs-on }}.tar
           if-no-files-found: warn
 
-      - name: Overwrite cache
-        if: ${{ !cancelled() }}
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh extension install actions/gh-actions-cache
-          gh actions-cache delete ${{ env.CACHE_KEY }} --confirm -R ${{ github.repository }}
-
       - name: Save cache
         uses: actions/cache/save@v3
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.event_name != 'pull_request' }}
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ env.CACHE_KEY }}

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -30,7 +30,7 @@ jobs:
         runs-on: [macos-12, macos-14]
     env:
       CACHE_DIR: ${{ github.workspace }}/.container-cache
-      CACHE_KEY: ${{ matrix.runs-on }}-build-test-cpp-asserts-v1-${{ github.event.number || github.ref_name }}
+      CACHE_KEY: ${{ matrix.runs-on }}-build-test-cpp-asserts-v1-${{ github.event.number || format('{0}-{1}', github.ref_name, github.run_number) }}
     steps:
       - name: Set unified TZ
         uses: szenius/set-timezone@v2.0
@@ -68,6 +68,15 @@ jobs:
           key: ${{ env.CACHE_KEY }}
           restore-keys: ${{ matrix.runs-on }}-build-test-cpp-
 
+      - name: Configure ccache debug logs
+        run: |
+          # https://interrupt.memfault.com/blog/ccache-debugging
+          echo CCACHE_DEBUG=1 >> $GITHUB_ENV
+          echo CCACHE_DEBUGLEVEL=2 >> $GITHUB_ENV
+          echo CCACHE_DEBUGDIR="/ccache-debug" >> $GITHUB_ENV
+          echo CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime,time_macros >> $GITHUB_ENV
+          echo CCACHE_COMPILERCHECK=content >> $GITHUB_ENV
+
       - name: Build packages
         run: |
           export cache_dir="${{ env.CACHE_DIR }}"
@@ -76,9 +85,20 @@ jobs:
       - name: Create artifacts
         if: ${{ !cancelled() }}
         run: |
-          rm -f iree-install/bin/clang*
-          rm -f iree-install/bin/llvm-link*
-          tar cf iree-dist-${{ matrix.runs-on }}.tar -C iree-install . -C ../iree-build tools/testing/e2e/iree-e2e-matmul-test
+          tar cf iree-dist-${{ matrix.runs-on }}.tar -C iree-install .
+
+      - name: Tar ccache logs
+        if: ${{ !cancelled() }}
+        run: |
+          tar cf macos-ccache-logs.tar $CCACHE_DEBUGDIR
+
+      - name: Upload ccache logs
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: ccache_logs
+          path: macos-ccache-logs.tar
+          if-no-files-found: warn
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -9,12 +9,16 @@ on:
     branches:
       - main
 
+  schedule:
+    - cron: '0 */6 * * *'
+
 concurrency:
-  # A PR number if a pull request and otherwise the commit hash. This cancels
-  # queued and in-progress runs for the same PR (presubmit) or commit
-  # (postsubmit).
   group: ci-build-test-cpp-macos-${{ github.event.number || github.sha }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: write
 
 jobs:
   build_and_ctest:
@@ -26,6 +30,7 @@ jobs:
         runs-on: [macos-12, macos-14]
     env:
       CACHE_DIR: ${{ github.workspace }}/.container-cache
+      CACHE_KEY: ${{ matrix.runs-on }}-build-test-cpp-asserts-v1-${{ github.event.number || github.ref_name }}
     steps:
       - name: Set unified TZ
         uses: szenius/set-timezone@v2.0
@@ -60,9 +65,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: ${{ env.CACHE_DIR }}
-          # without datetime stamps you'll get collisions for the cache warming runs
-          # ("Failed to save: Unable to reserve cache with key ..., another job may be creating this cache.")
-          key: ${{ matrix.runs-on }}-build-test-cpp-asserts-v1-${{ github.sha }}-${{ github.event.repository.updated_at }}
+          key: ${{ env.CACHE_KEY }}
           restore-keys: ${{ matrix.runs-on }}-build-test-cpp-
 
       - name: Build packages
@@ -85,9 +88,18 @@ jobs:
           path: iree-dist-${{ matrix.runs-on }}.tar
           if-no-files-found: warn
 
+      - name: Overwrite cache
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh extension install actions/gh-actions-cache
+          gh actions-cache delete ${{ env.CACHE_KEY }} --confirm -R ${{ github.repository }}
+
       - name: Save cache
         uses: actions/cache/save@v3
         if: ${{ !cancelled() }}
         with:
           path: ${{ env.CACHE_DIR }}
-          key: ${{ matrix.runs-on }}-build-test-cpp-asserts-v1-${{ github.sha }}-${{ github.event.repository.updated_at }}
+          key: ${{ env.CACHE_KEY }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -10,14 +10,9 @@ on:
       - main
 
   schedule:
-      # At minute 0 past every 12th hour. (see https://crontab.guru)
-      # this job is to keep the ccache cache warm
-    - cron: '0 */12 * * *'
+    - cron: '0 */6 * * *'
 
 concurrency:
-  # A PR number if a pull request and otherwise the commit hash. This cancels
-  # queued and in-progress runs for the same PR (presubmit) or commit
-  # (postsubmit).
   group: ci-build-test-cpp-windows-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
@@ -25,6 +20,10 @@ defaults:
   run:
     # force bash for windows
     shell: bash
+
+permissions:
+  contents: read
+  actions: write
 
 jobs:
   build_and_ctest:
@@ -34,6 +33,7 @@ jobs:
       fail-fast: true
     env:
       CACHE_DIR: ${{ github.workspace }}/.container-cache
+      CACHE_KEY: windows-build-test-cpp-asserts-v1-${{ github.event.number || github.ref_name }}
     steps:
       - name: Set unified TZ
         uses: szenius/set-timezone@v2.0
@@ -73,9 +73,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: ${{ env.CACHE_DIR }}
-          # without datetime stamps you'll get collisions for the cache warming runs
-          # ("Failed to save: Unable to reserve cache with key ..., another job may be creating this cache.")
-          key: windows-build-test-cpp-asserts-v1-${{ github.sha }}-${{ github.event.repository.updated_at }}
+          key: ${{ env.CACHE_KEY }}
           restore-keys: windows-build-test-cpp-
 
       - name: Build packages
@@ -96,12 +94,21 @@ jobs:
           path: iree-dist-windows.tar
           if-no-files-found: warn
 
+      - name: Overwrite cache
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh extension install actions/gh-actions-cache
+          gh actions-cache delete ${{ env.CACHE_KEY }} --confirm -R ${{ github.repository }}
+
       - name: Save cache
         uses: actions/cache/save@v3
         if: ${{ !cancelled() }}
         with:
           path: ${{ env.CACHE_DIR }}
-          key: windows-build-test-cpp-asserts-v1-${{ github.sha }}-${{ github.event.repository.updated_at }}
+          key: ${{ env.CACHE_KEY }}
 
   test_windows:
     name: E2E Test windows

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -21,10 +21,6 @@ defaults:
     # force bash for windows
     shell: bash
 
-permissions:
-  contents: read
-  actions: write
-
 jobs:
   build_and_ctest:
     name: Build and Test (windows, ASSERTIONS)
@@ -78,10 +74,9 @@ jobs:
 
       - name: Configure ccache debug logs
         run: |
-          # https://interrupt.memfault.com/blog/ccache-debugging
           echo CCACHE_DEBUG=1 >> $GITHUB_ENV
           echo CCACHE_DEBUGLEVEL=2 >> $GITHUB_ENV
-          echo CCACHE_DEBUGDIR="/ccache-debug" >> $GITHUB_ENV
+          echo CCACHE_DEBUGDIR="/c/ccache-debug" >> $GITHUB_ENV
           echo CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime,time_macros >> $GITHUB_ENV
           echo CCACHE_COMPILERCHECK=content >> $GITHUB_ENV
 
@@ -98,6 +93,7 @@ jobs:
       - name: Tar ccache logs
         if: ${{ !cancelled() }}
         run: |
+          ccache --show-stats -v
           tar cf windows-ccache-logs.tar $CCACHE_DEBUGDIR
 
       - name: Upload ccache logs
@@ -116,18 +112,9 @@ jobs:
           path: iree-dist-windows.tar
           if-no-files-found: warn
 
-      - name: Overwrite cache
-        if: ${{ !cancelled() }}
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh extension install actions/gh-actions-cache
-          gh actions-cache delete ${{ env.CACHE_KEY }} --confirm -R ${{ github.repository }}
-
       - name: Save cache
         uses: actions/cache/save@v3
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.event_name != 'pull_request' }}
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ env.CACHE_KEY }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: true
     env:
       CACHE_DIR: ${{ github.workspace }}/.container-cache
-      CACHE_KEY: windows-build-test-cpp-asserts-v1-${{ github.event.number || github.ref_name }}
+      CACHE_KEY: windows-build-test-cpp-asserts-v1-${{ github.event.number || format('{0}-{1}', github.ref_name, github.run_number) }}
     steps:
       - name: Set unified TZ
         uses: szenius/set-timezone@v2.0
@@ -76,6 +76,15 @@ jobs:
           key: ${{ env.CACHE_KEY }}
           restore-keys: windows-build-test-cpp-
 
+      - name: Configure ccache debug logs
+        run: |
+          # https://interrupt.memfault.com/blog/ccache-debugging
+          echo CCACHE_DEBUG=1 >> $GITHUB_ENV
+          echo CCACHE_DEBUGLEVEL=2 >> $GITHUB_ENV
+          echo CCACHE_DEBUGDIR="/ccache-debug" >> $GITHUB_ENV
+          echo CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime,time_macros >> $GITHUB_ENV
+          echo CCACHE_COMPILERCHECK=content >> $GITHUB_ENV
+
       - name: Build packages
         run: |
           export cache_dir="${{ env.CACHE_DIR }}"
@@ -85,6 +94,19 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           tar cf iree-dist-windows.tar -C iree-install .
+
+      - name: Tar ccache logs
+        if: ${{ !cancelled() }}
+        run: |
+          tar cf windows-ccache-logs.tar $CCACHE_DEBUGDIR
+
+      - name: Upload ccache logs
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: ccache_logs
+          path: windows-ccache-logs.tar
+          if-no-files-found: warn
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/build_tools/ci/build_test_cpp.sh
+++ b/build_tools/ci/build_test_cpp.sh
@@ -116,7 +116,8 @@ elif [[ "$OSTYPE" == "msys"* ]]; then
 fi
 
 # Show ccache stats.
-ccache --show-stats
+ccache --show-stats -v
+grep -r -B15 'Result: .*_miss' $CCACHE_DEBUGDIR
 
 rm -f "$install_dir"/bin/clang*
 rm -f "$install_dir"/bin/llvm-link*

--- a/build_tools/ci/build_test_cpp.sh
+++ b/build_tools/ci/build_test_cpp.sh
@@ -115,10 +115,6 @@ elif [[ "$OSTYPE" == "msys"* ]]; then
   ctest --test-dir "$build_dir" -R amd-aie --output-on-failure -j --repeat until-pass:5
 fi
 
-# Show ccache stats.
-ccache --show-stats -v
-grep -r -B15 'Result: .*_miss' $CCACHE_DEBUGDIR
-
 rm -f "$install_dir"/bin/clang*
 rm -f "$install_dir"/bin/llvm-link*
 cp "$build_dir"/tools/testing/e2e/iree-e2e-matmul-test "$install_dir"/bin


### PR DESCRIPTION
GHA (github action) [caches](https://github.com/nod-ai/iree-amd-aie/actions/caches) aren't mutable so currently we're timestamping them:

```
windows-build-test-cpp-asserts-v1-f77db6670966b372878b4219599ba723feb41945-2024-08-28T19:33:14Z
```

 Thus PRs that run will upload new caches and push out old but useful caches, e.g., caches from main that could be used by PRs. 

~~This PR tries to mitigate that by using either PR number (in case the cache is produced by a PR) or `github.ref_name-N` where `N` always increments (in case the cache is produced by a branch run, like cache warming on `main`) to label the cache. The overwrite is done by first deleting any existing cache by that name and then uploading the new cache to the same label/key.~~

~~So PR caches look like this~~

```
linux-build-test-cpp-asserts-manylinux-v2-719
```

~~and will be fixed/reused for the duration of the PR.~~

~~And caches produced by `main` look like~~

```
linux-build-test-cpp-asserts-manylinux-v2-main-123
```

FYI for anyone wondering how this all works - the [`restore-keys`](https://github.com/nod-ai/iree-amd-aie/blob/main/.github/workflows/ci-linux.yml#L63) are ~~longest prefix matched~~ (see https://github.com/nod-ai/iree-amd-aie/pull/719#discussion_r1735941967); so

```
key: linux-build-test-cpp-asserts-manylinux-v2-${{ github.event.number || format('{0}-{1}', github.ref_name, github.run_number) }}
restore-keys: linux-build-test-cpp-
```

will create a cache with the aforementioned name but then restore the cache with ~~longest match~~ (see  https://github.com/nod-ai/iree-amd-aie/pull/719#discussion_r1735941967) starting from `linux-build-test-cpp-` (including caches created by main).~~

see https://github.com/nod-ai/iree-amd-aie/pull/719#issuecomment-2319190867