### PR TITLE
[XCLBinGen] Fix chess core elf generation

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -759,6 +759,18 @@ if [ -d "$VITIS" ]; then
       --num_repeat_runs "10" \
       --use_ukernel "1"
 
+  run_matmul_test \
+      --name_prefix "chess_i32_matmul_multi_core" \
+      --lower_to_aie_pipeline "objectFifo" \
+      --tile_pipeline "pack-peel" \
+      --lhs_rhs_type "i32" \
+      --acc_type "i32" \
+      --m "32" \
+      --n "32" \
+      --k "32" \
+      --use_chess "1" \
+      --num_repeat_runs "10"
+
 fi
 
 echo "\n\n"


### PR DESCRIPTION
When chess is enabled, the core elf generation returns early instead of generating an elf for all cores, leading to the following error:

> Run:  PATH=/home/jorn/workspace/Vitis/2024.2/aietools/tps/lnx64/target_aie2p/bin/LNa64bin:/opt/xilinx/xrt/bin:/opt/xilinx/xrt/bin:/home/jorn/miniconda3/bin:/home/jorn/miniconda3/condabin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/snap/bin LD_LIBRARY_PATH=/home/jorn/workspace/Vitis/2024.2/aietools/lib/lnx64.o:/home/jorn/workspace/Vitis/2024.2/aietools/lnx64/tools/dot/lib:/opt/xilinx/xrt/lib:/opt/xilinx/xrt/lib RDI_DATADIR=/home/jorn/workspace/Vitis/2024.2/aietools/data XILINXD_LICENSE_FILE=/home/jorn/workspace/iree-amd-aie/../Xilinx.lic /home/jorn/workspace/Vitis/2024.2/aietools/bin/unwrapped/lnx64.o/xchesscc -j1 -pme -P/home/jorn/workspace/Vitis/2024.2/aietools/data/aie2p/lib -f -CRelease_LLVM +w/home/jorn/workspace/iree-amelf doesn't exist: /home/jorn/workspace/iree-amd-aie/test_matmuls/module_matmul_32x32_32xi32__dispatch_0_amdaie_xclbin_fb/core_0_3.elf
failed to emit CDOFailed to generate CDO

I noticed this on Strix with chess, but I don't understand yet why the CI is not catching the same issue on Phoenix with chess enabled.