### PR TITLE
SSH into runners

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -9,11 +9,6 @@ on:
     branches:
       - main
 
-  schedule:
-    # At minute 0 past every 6th hour. (see https://crontab.guru)
-    # this job is to keep the ccache cache warm
-    - cron: '0 */6 * * *'
-
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
   # queued and in-progress runs for the same PR (presubmit) or commit
@@ -30,7 +25,7 @@ jobs:
     env:
       CACHE_DIR: ${{ github.workspace }}/.container-cache
       # either the PR number or `branch-N` where N always increments
-      CACHE_KEY: linux-build-test-cpp-asserts-manylinux-v2-${{ github.event.number || format('{0}-{1}', github.ref_name, github.run_number) }}
+      CACHE_KEY: linux-build-test-cpp-asserts-manylinux-v2-${{ format('{0}-{1}', github.ref_name, github.run_number) }}
     steps:
       - name: Set unified TZ
         uses: szenius/set-timezone@v2.0
@@ -51,8 +46,9 @@ jobs:
 
       - name: Install deps
         run: |
+          dnf install -y almalinux-release-devel epel-release
           yum remove -y openssl-devel zlib-devel || true
-          yum install -y protobuf-devel protobuf-compiler
+          yum install -y protobuf-devel protobuf-compiler tmate
 
       - name: Sync source deps
         run: |
@@ -78,7 +74,7 @@ jobs:
       - name: Create artifacts
         if: ${{ !cancelled() }}
         run: |
-          tar cf iree-dist-linux.tar -C iree-install .
+          tar cf iree-dist-linux.tar iree-install
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -90,7 +86,7 @@ jobs:
 
       - name: Save cache
         uses: actions/cache/save@v3
-        if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+        if: ${{ !cancelled() && github.event_name == 'push' && github.ref_name == 'main' }}
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ env.CACHE_KEY }}
@@ -118,8 +114,7 @@ jobs:
 
       - name: Extract artifact
         run: |
-          mkdir iree-install
-          tar -xf iree-dist-linux.tar -C iree-install
+          tar -xvf iree-dist-linux.tar
           bash build_tools/download_peano.sh
 
       - name: Create venv and install dependencies

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -3,14 +3,22 @@ name: CI MacOS
 on:
   workflow_call:
   workflow_dispatch:
+    inputs:
+      force_debug_with_tmate:
+        type: boolean
+        description: 'Run the build with tmate session'
+        required: false
+        default: false
+      debug_with_tmate:
+        type: boolean
+        description: 'Run the build with a tmate session ONLY in case of failure'
+        required: false
+        default: false
   pull_request:
   merge_group:
   push:
     branches:
       - main
-
-  schedule:
-    - cron: '0 */6 * * *'
 
 concurrency:
   group: ci-build-test-cpp-macos-${{ github.event.number || github.sha }}
@@ -26,7 +34,7 @@ jobs:
         runs-on: [macos-12, macos-14]
     env:
       CACHE_DIR: ${{ github.workspace }}/.container-cache
-      CACHE_KEY: ${{ matrix.runs-on }}-build-test-cpp-asserts-v1-${{ github.event.number || format('{0}-{1}', github.ref_name, github.run_number) }}
+      CACHE_KEY: ${{ matrix.runs-on }}-build-test-cpp-asserts-v1-${{ format('{0}-{1}', github.ref_name, github.run_number) }}
     steps:
       - name: Set unified TZ
         uses: szenius/set-timezone@v2.0
@@ -73,7 +81,7 @@ jobs:
       - name: Create artifacts
         if: ${{ !cancelled() }}
         run: |
-          tar cf iree-dist-${{ matrix.runs-on }}.tar -C iree-install .
+          tar cf iree-dist-${{ matrix.runs-on }}.tar iree-install
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -85,7 +93,13 @@ jobs:
 
       - name: Save cache
         uses: actions/cache/save@v3
-        if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+        if: ${{ !cancelled() && github.event_name == 'push' && github.ref_name == 'main' }}
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ env.CACHE_KEY }}
+
+      - name: Start tmate session
+        if: ${{ (failure() && inputs.debug_with_tmate) || inputs.force_debug_with_tmate }}
+        uses: mxschmitt/action-tmate@v3.18
+        with:
+          limit-access-to-actor: true

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -3,14 +3,22 @@ name: CI Windows
 on:
   workflow_call:
   workflow_dispatch:
+    inputs:
+      force_debug_with_tmate:
+        type: boolean
+        description: 'Run the build with tmate session'
+        required: false
+        default: false
+      debug_with_tmate:
+        type: boolean
+        description: 'Run the build with a tmate session ONLY in case of failure'
+        required: false
+        default: false
   pull_request:
   merge_group:
   push:
     branches:
       - main
-
-  schedule:
-    - cron: '0 */6 * * *'
 
 concurrency:
   group: ci-build-test-cpp-windows-${{ github.event.number || github.sha }}
@@ -29,7 +37,7 @@ jobs:
       fail-fast: true
     env:
       CACHE_DIR: ${{ github.workspace }}/.container-cache
-      CACHE_KEY: windows-build-test-cpp-asserts-v1-${{ github.event.number || format('{0}-{1}', github.ref_name, github.run_number) }}
+      CACHE_KEY: windows-build-test-cpp-asserts-v1-${{ format('{0}-{1}', github.ref_name, github.run_number) }}
     steps:
       - name: Set unified TZ
         uses: szenius/set-timezone@v2.0
@@ -81,7 +89,7 @@ jobs:
       - name: Create artifacts
         if: ${{ !cancelled() }}
         run: |
-          tar cf iree-dist-windows.tar -C iree-install .
+          tar cf iree-dist-windows.tar iree-install
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -93,10 +101,16 @@ jobs:
 
       - name: Save cache
         uses: actions/cache/save@v3
-        if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+        if: ${{ !cancelled() && github.event_name == 'push' && github.ref_name == 'main' }}
         with:
           path: ${{ env.CACHE_DIR }}
           key: ${{ env.CACHE_KEY }}
+
+      - name: Start tmate session
+        if: ${{ (failure() && inputs.debug_with_tmate) || inputs.force_debug_with_tmate }}
+        uses: mxschmitt/action-tmate@v3.18
+        with:
+          limit-access-to-actor: true
 
   test_windows:
     name: E2E Test windows
@@ -117,8 +131,7 @@ jobs:
 
       - name: Extract artifact
         run: |
-          mkdir iree-install
-          tar -xf iree-dist-windows.tar -C iree-install
+          tar -xf iree-dist-windows.tar
           bash build_tools/download_peano.sh
 
       - name: Create venv and install dependencies


### PR DESCRIPTION
This PR adds the ability to SSH into runners using https://github.com/mxschmitt/action-tmate. The way it works is like this:

1. You want to debug a runner either because it failed or for the heck of it;
2. You go to the `Actions` tab and find the list of actions in the left colum and select Mac or Windows (**but not Linux** - see Notes below): 
    ![Screenshot from 2024-08-30 17-28-05](https://github.com/user-attachments/assets/1b37bec7-9749-4148-a1ff-110cd0ab3aa7)
3. You then go to the far right and click the `Run workflow` dropdown:

    ![Screenshot from 2024-08-30 17-28-45](https://github.com/user-attachments/assets/60b69adc-2d93-44e8-aaf7-c9710b15948f)
    Note, the `Branch:` dropdown - currently (because this PR hasn't landed) I can only do it for this branch. After this PR lands you'll be able to do it for any branch;
5. You check either one of the options; hopefully the descriptions are sufficient - if not ask in this PR and I'll update the descriptions accordingly;
6. The runner will run to completion or failure and then, **at the end**, start spamming

    ![Screenshot from 2024-08-30 17-32-06](https://github.com/user-attachments/assets/afe3e69b-258b-4fd1-b9a9-03252f165b70) Note, not indefinitely but 600 spams;
7. Copy-paste and you'll arrive at a tmux session that looks like this:

    ![Screenshot from 2024-08-30 17-48-55](https://github.com/user-attachments/assets/85a41292-c9fa-4243-9e16-1d786517d18f)

    Hit `ctrl-c` and you'll be dropped into `tmux`:

    ![Screenshot from 2024-08-30 17-50-15](https://github.com/user-attachments/assets/eaa53401-caa6-4385-83f6-5a44a7b2febb)

9. The job (not the whole action) exits/ends when you quit the session.

A few things to call out:

1. You need an ssh key that's associated with your GH username (e.g., the one you're using to commit/push); Note you don't need to do the `-i` part, `ssh` will find it automatically if it's under `~/.ssh`;
2. This isn't enabled for the Linux runner. Why? I only added this to the **free GitHub** runners, **not any nod runners**, because this is clearly an attack vector. So don't add it to any of our runners (at least not until/unless I do [this](https://github.com/mxschmitt/action-tmate/issues/202));
3. Yes, this works on Windows too but you land in `git-bash`/`mingw`/`msys`. If you want powershell (or cmd) then you can do `powershell` (or `cmd`);
4. If you don't know how to use `tmux` just refer to this [cheatsheet](https://tmuxcheatsheet.com/).