### PR TITLE
[CreateLogicalObjFifoLink] Refactor unsafe walk for non-zero offset removal

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_logical_objectfifo_link.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_logical_objectfifo_link.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-amdaie-create-logical-objectfifo-link, cse))" --verify-diagnostics %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-amdaie-create-logical-objectfifo-link,cse,canonicalize))" --verify-diagnostics %s | FileCheck %s
 
 // CHECK-LABEL: func.func @link
 // CHECK:       %[[DMA0:.+]] = amdaie.circular_dma_cpy_nd


### PR DESCRIPTION
In a larger change to start extracting `aie.flow` ops from `AMDAIEStatefulTransform`, I ran into a segfault issue inside the walk to remove non-zero offsets. I extracted the fix from that effort to reduce the scope of that PR.