### PR TITLE
Use dyn_cast_if_present and isa_and_present with getDefiningOp

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.cpp
@@ -83,7 +83,7 @@ LogicalResult CoreOp::verify() {
 }
 
 TileOp CoreOp::getTileOp() {
-  return dyn_cast<TileOp>(getTile().getDefiningOp());
+  return dyn_cast_if_present<TileOp>(getTile().getDefiningOp());
 }
 
 //===----------------------------------------------------------------------===//
@@ -268,11 +268,13 @@ DoublyStridedOpInterface DmaCpyNdOp::createDoublyStridedOp(
 }
 
 LogicalObjectFifoFromMemrefOp DmaCpyNdOp::getSourceObjectFifo() {
-  return dyn_cast<LogicalObjectFifoFromMemrefOp>(getSource().getDefiningOp());
+  return dyn_cast_if_present<LogicalObjectFifoFromMemrefOp>(
+      getSource().getDefiningOp());
 };
 
 LogicalObjectFifoFromMemrefOp DmaCpyNdOp::getTargetObjectFifo() {
-  return dyn_cast<LogicalObjectFifoFromMemrefOp>(getTarget().getDefiningOp());
+  return dyn_cast_if_present<LogicalObjectFifoFromMemrefOp>(
+      getTarget().getDefiningOp());
 };
 
 void DmaCpyNdOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -395,11 +397,13 @@ DoublyStridedOpInterface CircularDmaCpyNdOp::createDoublyStridedOp(
 }
 
 LogicalObjectFifoFromMemrefOp CircularDmaCpyNdOp::getSourceObjectFifo() {
-  return dyn_cast<LogicalObjectFifoFromMemrefOp>(getSource().getDefiningOp());
+  return dyn_cast_if_present<LogicalObjectFifoFromMemrefOp>(
+      getSource().getDefiningOp());
 };
 
 LogicalObjectFifoFromMemrefOp CircularDmaCpyNdOp::getTargetObjectFifo() {
-  return dyn_cast<LogicalObjectFifoFromMemrefOp>(getTarget().getDefiningOp());
+  return dyn_cast_if_present<LogicalObjectFifoFromMemrefOp>(
+      getTarget().getDefiningOp());
 };
 
 void CircularDmaCpyNdOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -422,7 +426,8 @@ void LogicalObjectFifoAccessOp::build(OpBuilder &b,
 
 LogicalObjectFifoFromMemrefOp
 LogicalObjectFifoAccessOp::getLogicalObjectFifo() {
-  return dyn_cast<LogicalObjectFifoFromMemrefOp>(getInput().getDefiningOp());
+  return dyn_cast_if_present<LogicalObjectFifoFromMemrefOp>(
+      getInput().getDefiningOp());
 };
 
 //===----------------------------------------------------------------------===//
@@ -490,7 +495,7 @@ LogicalResult LogicalObjectFifoFromMemrefOp::canonicalize(
 LogicalResult LogicalObjectFifoFromMemrefOp::verify() {
   // Check whether the tile arguments are all of type AMDAIE::TileOp
   if (llvm::all_of(getTiles(), [](Value result) {
-        return isa<TileOp>(result.getDefiningOp());
+        return isa_and_present<TileOp>(result.getDefiningOp());
       })) {
     return success();
   }
@@ -878,8 +883,8 @@ bool TileOp::tileColumnComparator(AMDAIE::TileOp &a, AMDAIE::TileOp &b) {
 }
 
 bool TileOp::tileValueColumnAndRowComparator(Value a, Value b) {
-  TileOp tileA = dyn_cast<AMDAIE::TileOp>(a.getDefiningOp());
-  TileOp tileB = dyn_cast<AMDAIE::TileOp>(b.getDefiningOp());
+  TileOp tileA = cast<AMDAIE::TileOp>(a.getDefiningOp());
+  TileOp tileB = cast<AMDAIE::TileOp>(b.getDefiningOp());
   int64_t colA = getConstantIntValue(tileA.getCol()).value();
   int64_t rowA = getConstantIntValue(tileA.getRow()).value();
   int64_t colB = getConstantIntValue(tileB.getCol()).value();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -303,7 +303,7 @@ def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd", [
     }
     // Return the input circular dma copy operation.
     CircularDmaCpyNdOp getDmaCpyNdOp() {
-      return dyn_cast<CircularDmaCpyNdOp>(getDma().getDefiningOp());
+      return dyn_cast_if_present<CircularDmaCpyNdOp>(getDma().getDefiningOp());
     }
 
     // Return the source memref type. This is retrieved using information from
@@ -350,14 +350,14 @@ def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd", [
 
     BdIdOp getSourceBdIdOp() {
       Value bdIdValue = getSourceBdId();
-      if (!bdIdValue || !bdIdValue.getDefiningOp()) return nullptr;
-      return dyn_cast<BdIdOp>(bdIdValue.getDefiningOp());
+      if (!bdIdValue) return nullptr;
+      return dyn_cast_if_present<BdIdOp>(bdIdValue.getDefiningOp());
     }
 
     BdIdOp getTargetBdIdOp() {
       Value bdIdValue = getTargetBdId();
-      if (!bdIdValue || !bdIdValue.getDefiningOp()) return nullptr;
-      return dyn_cast<BdIdOp>(bdIdValue.getDefiningOp());
+      if (!bdIdValue) return nullptr;
+      return dyn_cast_if_present<BdIdOp>(bdIdValue.getDefiningOp());
     }
 
     // A utility to create a new doubly strided operation from this one with a
@@ -417,7 +417,7 @@ def AMDAIE_NpuDmaWaitOp: AMDAIE_Op<"npu.dma_wait", []> {
   let extraClassDeclaration = [{
     // Return the Npu DMA operation argument.
     NpuDmaCpyNdOp getDmaOp() { 
-      return dyn_cast<NpuDmaCpyNdOp>(getDma().getDefiningOp());
+      return dyn_cast_if_present<NpuDmaCpyNdOp>(getDma().getDefiningOp());
     }
   }];
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignNpuDmaBdIds.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignNpuDmaBdIds.cpp
@@ -53,7 +53,7 @@ LogicalResult assignNpuDmaBdIds(AMDAIE::WorkgroupOp workgroupOp) {
       return npuDmaOp.emitOpError()
              << "no channel BD ID generator found for tile: " << tile;
     }
-    tileOp = dyn_cast<AMDAIE::TileOp>(tile.getDefiningOp());
+    tileOp = dyn_cast_if_present<AMDAIE::TileOp>(tile.getDefiningOp());
     if (!tileOp) return npuDmaOp.emitOpError() << "no tile op found";
     return success();
   };
@@ -65,8 +65,9 @@ LogicalResult assignNpuDmaBdIds(AMDAIE::WorkgroupOp workgroupOp) {
   WalkResult res = controlCodeOp->walk([&](Operation *op) {
     if (auto npuDmaOp = dyn_cast<AMDAIE::NpuDmaCpyNdOp>(op)) {
       if (npuDmaOp.getSource()) {
-        auto logicalObjFifo = dyn_cast<AMDAIE::LogicalObjFifoOpInterface>(
-            npuDmaOp.getSource().getDefiningOp());
+        auto logicalObjFifo =
+            dyn_cast_if_present<AMDAIE::LogicalObjFifoOpInterface>(
+                npuDmaOp.getSource().getDefiningOp());
         if (!logicalObjFifo) {
           npuDmaOp.emitOpError() << "expected a source logical objectFifo";
           return WalkResult::interrupt();
@@ -96,8 +97,9 @@ LogicalResult assignNpuDmaBdIds(AMDAIE::WorkgroupOp workgroupOp) {
             bdIdOp);
       }
       if (npuDmaOp.getTarget()) {
-        auto logicalObjFifo = dyn_cast<AMDAIE::LogicalObjectFifoFromMemrefOp>(
-            npuDmaOp.getTarget().getDefiningOp());
+        auto logicalObjFifo =
+            dyn_cast_if_present<AMDAIE::LogicalObjectFifoFromMemrefOp>(
+                npuDmaOp.getTarget().getDefiningOp());
         if (!logicalObjFifo) {
           npuDmaOp.emitOpError()
               << "expected a target `amdaie.logicalobjectfifo.from_memref`";
@@ -132,14 +134,17 @@ LogicalResult assignNpuDmaBdIds(AMDAIE::WorkgroupOp workgroupOp) {
       AMDAIE::NpuDmaCpyNdOp npuDmaOp = npuWaitOp.getDmaOp();
       AMDAIE::BdIdOp bdIdOp;
       if (npuDmaOp.getSourceBdId()) {
-        bdIdOp = cast<AMDAIE::BdIdOp>(npuDmaOp.getSourceBdId().getDefiningOp());
+        bdIdOp = dyn_cast_if_present<AMDAIE::BdIdOp>(
+            npuDmaOp.getSourceBdId().getDefiningOp());
       } else if (npuDmaOp.getTargetBdId()) {
-        bdIdOp = cast<AMDAIE::BdIdOp>(npuDmaOp.getTargetBdId().getDefiningOp());
+        bdIdOp = dyn_cast_if_present<AMDAIE::BdIdOp>(
+            npuDmaOp.getTargetBdId().getDefiningOp());
       } else {
         return WalkResult::advance();
       }
       if (!bdIdOp) return WalkResult::advance();
-      auto tileOp = dyn_cast<AMDAIE::TileOp>(bdIdOp.getTile().getDefiningOp());
+      auto tileOp =
+          dyn_cast_if_present<AMDAIE::TileOp>(bdIdOp.getTile().getDefiningOp());
       if (!tileOp) {
         bdIdOp.emitOpError() << "doesn't operate on a `amdaie.tile` operation";
         return WalkResult::interrupt();
@@ -169,7 +174,7 @@ class AMDAIEAssignNpuDmaBdIdsPass
   }
 
   AMDAIEAssignNpuDmaBdIdsPass() = default;
-  AMDAIEAssignNpuDmaBdIdsPass(const AMDAIEAssignNpuDmaBdIdsPass &pass) {};
+  AMDAIEAssignNpuDmaBdIdsPass(const AMDAIEAssignNpuDmaBdIdsPass &pass){};
   void runOnOperation() override;
 };
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECoreLoopUnroll.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECoreLoopUnroll.cpp
@@ -25,7 +25,7 @@ LogicalResult coreLoopUnroll(RewriterBase &rewriter, AMDAIE::CoreOp coreOp) {
     llvm::SmallDenseSet<unsigned> depths;
     for (auto acqOp :
          forOp.getBody()->getOps<AMDAIE::LogicalObjectFifoAcquire>()) {
-      auto stridedOp = dyn_cast<DoublyStridedCopyOpInterface>(
+      auto stridedOp = dyn_cast_if_present<DoublyStridedCopyOpInterface>(
           acqOp.getDma().getDefiningOp());
       if (!stridedOp) {
         acqOp.emitOpError()
@@ -35,9 +35,9 @@ LogicalResult coreLoopUnroll(RewriterBase &rewriter, AMDAIE::CoreOp coreOp) {
       }
       auto logicalObjFifo =
           acqOp.getPort() == LogicalObjectFifoPort::Consume
-              ? dyn_cast<AMDAIE::LogicalObjectFifoFromMemrefOp>(
+              ? dyn_cast_if_present<AMDAIE::LogicalObjectFifoFromMemrefOp>(
                     stridedOp.getTarget().getDefiningOp())
-              : dyn_cast<AMDAIE::LogicalObjectFifoFromMemrefOp>(
+              : dyn_cast_if_present<AMDAIE::LogicalObjectFifoFromMemrefOp>(
                     stridedOp.getSource().getDefiningOp());
       depths.insert(
           cast<LogicalObjectFifoType>(logicalObjFifo.getType()).getDepth());

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
@@ -119,8 +119,9 @@ LogicalResult WorkgroupBuilder::buildForDmaCpyNdOp(
     // Check if the source of DmaCpyNd op is from L3 - then source addressing
     // will be controlled by the uController and target addressing will stay in
     // the circular DMA to be part of the AIE configuration.
-    auto logicalObjFifo = dyn_cast<AMDAIE::LogicalObjectFifoFromMemrefOp>(
-        dmaOp.getSource().getDefiningOp());
+    auto logicalObjFifo =
+        dyn_cast_if_present<AMDAIE::LogicalObjectFifoFromMemrefOp>(
+            dmaOp.getSource().getDefiningOp());
     if (!logicalObjFifo) {
       return dmaOp.emitOpError()
              << "`amdaie.logicalobjectfifo.from_memref` expected as source";
@@ -143,8 +144,9 @@ LogicalResult WorkgroupBuilder::buildForDmaCpyNdOp(
     // Check if the target of DmaCpyNd op is from L3 - then target addressing
     // will be controlled by the uController and source addressing will stay in
     // the circular DMA to be part of the AIE configuration.
-    auto logicalObjFifo = dyn_cast<AMDAIE::LogicalObjectFifoFromMemrefOp>(
-        dmaOp.getTarget().getDefiningOp());
+    auto logicalObjFifo =
+        dyn_cast_if_present<AMDAIE::LogicalObjectFifoFromMemrefOp>(
+            dmaOp.getTarget().getDefiningOp());
     if (!logicalObjFifo) {
       return dmaOp.emitOpError()
              << "`amdaie.logicalobjectfifo.from_memref` expected as source";
@@ -425,7 +427,7 @@ class AMDAIECreateAIEWorkgroupPass
   }
 
   AMDAIECreateAIEWorkgroupPass() = default;
-  AMDAIECreateAIEWorkgroupPass(const AMDAIECreateAIEWorkgroupPass &pass) {};
+  AMDAIECreateAIEWorkgroupPass(const AMDAIECreateAIEWorkgroupPass &pass){};
   void runOnOperation() override;
 };
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateLogicalObjectFifoLink.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateLogicalObjectFifoLink.cpp
@@ -97,7 +97,7 @@ LogicalResult createLogicalObjectFifoLink(
             "has copy-like users not residing in the same block");
       }
       auto sourceLogicalObjectFifo =
-          dyn_cast<AMDAIE::LogicalObjectFifoFromMemrefOp>(
+          dyn_cast_if_present<AMDAIE::LogicalObjectFifoFromMemrefOp>(
               stridedOp.getSource().getDefiningOp());
       if (!lastUserOp || lastUserOp->isBeforeInBlock(stridedOp)) {
         lastUserOp = stridedOp;
@@ -169,16 +169,18 @@ LogicalResult createLogicalObjectFifoLink(
 LogicalResult discardLinkNonZeroOffsets(RewriterBase &rewriter,
                                         AMDAIE::LogicalObjectFifoLink linkOp) {
   for (Value input : linkOp.getIns()) {
-    if (auto stridedOp = dyn_cast<AMDAIE::DoublyStridedCopyOpInterface>(
-            input.getDefiningOp())) {
+    if (auto stridedOp =
+            dyn_cast_if_present<AMDAIE::DoublyStridedCopyOpInterface>(
+                input.getDefiningOp())) {
       SmallVector<int64_t> shape;
       (void)discardAllNonZeroOffsets<CopyOpOperateOn::Target>(rewriter,
                                                               stridedOp, shape);
     }
   }
   for (Value output : linkOp.getOuts()) {
-    if (auto stridedOp = dyn_cast<AMDAIE::DoublyStridedCopyOpInterface>(
-            output.getDefiningOp())) {
+    if (auto stridedOp =
+            dyn_cast_if_present<AMDAIE::DoublyStridedCopyOpInterface>(
+                output.getDefiningOp())) {
       SmallVector<int64_t> shape;
       (void)discardAllNonZeroOffsets<CopyOpOperateOn::Source>(rewriter,
                                                               stridedOp, shape);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaLoopSubsumption.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaLoopSubsumption.cpp
@@ -153,8 +153,8 @@ struct SubsumeLoopIntoDMA
         // If the offset value is determined by an affine expression, retrieve
         // the affine expression's stride scale and calculate the actual
         // offset stride.
-        if (offsetValue.getDefiningOp() &&
-            isa<affine::AffineApplyOp>(offsetValue.getDefiningOp())) {
+        if (isa_and_present<affine::AffineApplyOp>(
+                offsetValue.getDefiningOp())) {
           auto applyOp =
               cast<affine::AffineApplyOp>(offsetValue.getDefiningOp());
           // Retrieve the scale and optional bias from the affine map using an

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEFusePackIntoLoop.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEFusePackIntoLoop.cpp
@@ -24,10 +24,10 @@ namespace {
 static FailureOr<tensor::ExtractSliceOp> getTensorExtractSliceDefiningOp(
     Value operand) {
   while (Operation *defOp = operand.getDefiningOp()) {
-    auto sliceOp = dyn_cast_or_null<tensor::ExtractSliceOp>(defOp);
+    auto sliceOp = dyn_cast_if_present<tensor::ExtractSliceOp>(defOp);
     if (sliceOp) {
       // The producer of sliceOp should be a pack op.
-      if (isa_and_nonnull<tensor::PackOp>(
+      if (isa_and_present<tensor::PackOp>(
               sliceOp.getSource().getDefiningOp())) {
         return sliceOp;
       }
@@ -35,7 +35,7 @@ static FailureOr<tensor::ExtractSliceOp> getTensorExtractSliceDefiningOp(
         auto blkArg = dyn_cast<BlockArgument>(sliceOp.getSource());
         for (Value blkOperand :
              blkArg.getOwner()->getParentOp()->getOperands()) {
-          if (isa_and_nonnull<tensor::PackOp>(blkOperand.getDefiningOp())) {
+          if (isa_and_present<tensor::PackOp>(blkOperand.getDefiningOp())) {
             return sliceOp;
           }
         }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertCores.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertCores.cpp
@@ -114,7 +114,7 @@ LogicalResult insertCoreOps(mlir::ModuleOp moduleOp) {
         // Fetch name of the ukernel function to look up its declaration in the
         // Symbol table.
         StringRef fnName = callOp.getCallee();
-        auto fnDecl = dyn_cast_or_null<func::FuncOp>(
+        auto fnDecl = dyn_cast_if_present<func::FuncOp>(
             SymbolTable::lookupSymbolIn(moduleOp, fnName));
         assert(fnDecl && "expected function declaration");
         assert(fnDecl->hasAttr("link_with") &&

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELogicalObjFifoSplittingUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELogicalObjFifoSplittingUtils.cpp
@@ -104,8 +104,8 @@ static FailureOr<OpFoldResult> updateL3SourceOffset(IRRewriter &rewriter,
       Operation *defOpOfL3SourceOffset = l3SourceOffsetVal.getDefiningOp();
       Location loc = defOpOfL3SourceOffset->getLoc();
       rewriter.setInsertionPoint(defOpOfL3SourceOffset);
-      if (auto applyOp =
-              dyn_cast<affine::AffineApplyOp>(defOpOfL3SourceOffset)) {
+      if (auto applyOp = dyn_cast_if_present<affine::AffineApplyOp>(
+              defOpOfL3SourceOffset)) {
         AffineExpr affineExpr = applyOp.getAffineMap().getResult(0);
         AffineMap newAffineMap = createAffineMap(affineExpr, offsetToAdd);
         newL3AsSourceOffset =
@@ -423,7 +423,7 @@ LogicalResult splitLogicalObjectFifos(
     op->dropAllUses();
     rewriter.eraseOp(op);
   }
-  
+
   return success();
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETile.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETile.cpp
@@ -64,7 +64,8 @@ void AMDAIETilePass::runOnOperation() {
 
   auto lhsOp = linalgOp->getOperand(0).getDefiningOp();
   auto rhsOp = linalgOp->getOperand(1).getDefiningOp();
-  if (!isa<linalg::CopyOp>(lhsOp) || !isa<linalg::CopyOp>(rhsOp)) {
+  if (!isa_and_present<linalg::CopyOp>(lhsOp) ||
+      !isa_and_present<linalg::CopyOp>(rhsOp)) {
     LLVM_DEBUG(llvm::dbgs()
                << "----- skip, producer is not linalg.copy -----\n");
     return;

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
@@ -117,7 +117,7 @@ void AMDAIETileAndFusePass::runOnOperation() {
     // indicate whether we want to tile the elementwise op. If flag
     // `tileElementwise == false`, and the linalg op is an elementwise op, it
     // will advance to find the next target op for tiling.
-    auto linalgOp = dyn_cast_or_null<linalg::LinalgOp>(op.getOperation());
+    auto linalgOp = dyn_cast_if_present<linalg::LinalgOp>(op.getOperation());
     if (linalgOp && isElementwise(linalgOp) && !tileElementwise)
       return WalkResult::advance();
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
@@ -243,8 +243,9 @@ static BlockArgument checkOptionalExtOps(Value val) {
   BlockArgument blockArg;
   if (!(blockArg = dyn_cast<BlockArgument>(val))) {
     auto defOp = val.getDefiningOp();
-    if (!dyn_cast<arith::ExtFOp>(defOp) && !dyn_cast<arith::ExtSIOp>(defOp) &&
-        !dyn_cast<arith::ExtUIOp>(defOp)) {
+    if (!dyn_cast_if_present<arith::ExtFOp>(defOp) &&
+        !dyn_cast_if_present<arith::ExtSIOp>(defOp) &&
+        !dyn_cast_if_present<arith::ExtUIOp>(defOp)) {
       return nullptr;
     }
     blockArg = dyn_cast<BlockArgument>(defOp->getOperand(0));
@@ -255,11 +256,11 @@ static BlockArgument checkOptionalExtOps(Value val) {
 /// Utility to match block body for matmul.
 static bool bodyMatcherForMatmul(Value yieldVal, Block *body) {
   Operation *addOp = yieldVal.getDefiningOp();
-  if (!isa_and_nonnull<arith::AddIOp, arith::AddFOp>(addOp)) {
+  if (!isa_and_present<arith::AddIOp, arith::AddFOp>(addOp)) {
     return false;
   }
   Operation *mulOp = addOp->getOperand(1).getDefiningOp();
-  if (!isa_and_nonnull<arith::MulIOp, arith::MulFOp>(mulOp)) {
+  if (!isa_and_present<arith::MulIOp, arith::MulFOp>(mulOp)) {
     return false;
   }
 
@@ -306,7 +307,7 @@ bool isMatmulInDefChain(Value operand) {
     return false;
   }
 
-  if (auto defLinalgOp = dyn_cast_or_null<linalg::LinalgOp>(defOp)) {
+  if (auto defLinalgOp = dyn_cast_if_present<linalg::LinalgOp>(defOp)) {
     if (isMatmul(defLinalgOp)) {
       return true;
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -26,7 +26,6 @@ using detail::findLargestFactor;
 
 namespace {
 
-
 FailureOr<std::array<uint32_t, 3>> getMatmulInstructionSize(
     linalg::LinalgOp op) {
   auto getElementType = [](Value v) {
@@ -496,8 +495,8 @@ static LogicalResult setRootConfigForConvDecomposePipeline(
     const uint16_t OH_1 = 1;
 
     auto operandType = getElementType(linalgOp->getOperand(0));
-    auto maybeMacNumElements =
-        getAIEMacNumElements(operandType, getElementType(linalgOp->getResult(0)));
+    auto maybeMacNumElements = getAIEMacNumElements(
+        operandType, getElementType(linalgOp->getResult(0)));
     uint16_t OC_0 = 16;
     if (!failed(maybeMacNumElements)) {
       OC_0 = maybeMacNumElements.value();
@@ -535,11 +534,11 @@ static LogicalResult setRootConfigForConvDecomposePipeline(
 /// TODO(avarma): This currently is skipping checking for ext* ops.
 static bool bodyMatcherForMatmulTranspose(Value yieldVal, Block *body) {
   Operation *addOp = yieldVal.getDefiningOp();
-  if (!isa_and_nonnull<arith::AddIOp, arith::AddFOp>(addOp)) {
+  if (!isa_and_present<arith::AddIOp, arith::AddFOp>(addOp)) {
     return false;
   }
   Operation *mulOp = addOp->getOperand(1).getDefiningOp();
-  if (!isa_and_nonnull<arith::MulIOp, arith::MulFOp>(mulOp)) {
+  if (!isa_and_present<arith::MulIOp, arith::MulFOp>(mulOp)) {
     return false;
   }
   auto lhsBlockArg = dyn_cast<BlockArgument>(mulOp->getOperand(0));


### PR DESCRIPTION
- Update `dyn_cast` to `dyn_cast_if_present` everywhere getDefiningOp is used
- Update `isa` to `isa_and_present ` everywhere getDefiningOp is used
- Update `dyn_cast_or_null` to `dyn_cast_if_present` because the former is deprecated (see below)
- Update `isa_and_nonnull` to `isa_and_present` because although not deprecated according to comments, the former calls the latter under the hood and to be consistent with `dyn_cast_if_present`

`dyn_cast_or_null` is deprecated (https://llvm.org/doxygen/Casting_8h_source.html):
> // Forwards to dyn_cast_if_present to avoid breaking current users. This is
// deprecated and will be removed in a future patch, use
// cast_if_present instead.
template <class X, class Y> auto dyn_cast_or_null(const Y &Val) {
  return dyn_cast_if_present<X>(Val);
}

