### PR TITLE
[gitmodules] Ignore dirty submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,31 +1,31 @@
 [submodule "third_party/XRT"]
-	path = third_party/XRT
-	url = https://github.com/nod-ai/XRT.git
-	shallow = true
-  branch = iree-amd-aie-patches
-  ignore=dirty
+       path = third_party/XRT
+       url = https://github.com/nod-ai/XRT.git
+       shallow = true
+       branch = iree-amd-aie-patches
+       ignore=dirty
 [submodule "third_party/mlir-air"]
-	path = third_party/mlir-air
-  url = https://github.com/nod-ai/mlir-air.git
-  shallow = true
-  ignore=dirty
+       path = third_party/mlir-air
+       url = https://github.com/nod-ai/mlir-air.git
+       shallow = true
+       ignore=dirty
 [submodule "third_party/aie-rt"]
-	path = third_party/aie-rt
-  url = https://github.com/Xilinx/aie-rt.git
-  shallow = true
-  ignore=dirty
+       path = third_party/aie-rt
+       url = https://github.com/Xilinx/aie-rt.git
+       shallow = true
+       ignore=dirty
 [submodule "third_party/bootgen"]
-	path = third_party/bootgen
-	url = https://github.com/Xilinx/bootgen.git
-  shallow = true
-  ignore=dirty
+       path = third_party/bootgen
+       url = https://github.com/Xilinx/bootgen.git
+       shallow = true
+       ignore=dirty
 [submodule "third_party/openssl"]
-	path = third_party/openssl
-	url = https://github.com/viaduck/openssl-cmake.git
-  shallow = true
-  ignore=dirty
+       path = third_party/openssl
+       url = https://github.com/viaduck/openssl-cmake.git
+       shallow = true
+       ignore=dirty
 [submodule "third_party/iree"]
-	path = third_party/iree
-	url = https://github.com/iree-org/iree.git
-  shallow = true
-  ignore=dirty
+       path = third_party/iree
+       url = https://github.com/iree-org/iree.git
+       shallow = true
+       ignore=dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,24 +2,30 @@
 	path = third_party/XRT
 	url = https://github.com/nod-ai/XRT.git
 	shallow = true
-	branch = iree-amd-aie-patches
+  branch = iree-amd-aie-patches
+  ignore=dirty
 [submodule "third_party/mlir-air"]
 	path = third_party/mlir-air
-	url = https://github.com/nod-ai/mlir-air.git
-	shallow = true
+  url = https://github.com/nod-ai/mlir-air.git
+  shallow = true
+  ignore=dirty
 [submodule "third_party/aie-rt"]
 	path = third_party/aie-rt
-	url = https://github.com/Xilinx/aie-rt.git
-	shallow = true
+  url = https://github.com/Xilinx/aie-rt.git
+  shallow = true
+  ignore=dirty
 [submodule "third_party/bootgen"]
 	path = third_party/bootgen
 	url = https://github.com/Xilinx/bootgen.git
-	shallow = true
+  shallow = true
+  ignore=dirty
 [submodule "third_party/openssl"]
 	path = third_party/openssl
 	url = https://github.com/viaduck/openssl-cmake.git
-	shallow = true
+  shallow = true
+  ignore=dirty
 [submodule "third_party/iree"]
 	path = third_party/iree
 	url = https://github.com/iree-org/iree.git
-	shallow = true
+  shallow = true
+  ignore=dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,31 +1,31 @@
 [submodule "third_party/XRT"]
-       path = third_party/XRT
-       url = https://github.com/nod-ai/XRT.git
-       shallow = true
-       branch = iree-amd-aie-patches
-       ignore=dirty
+  path = third_party/XRT
+  url = https://github.com/nod-ai/XRT.git
+  shallow = true
+  branch = iree-amd-aie-patches
+  ignore = dirty
 [submodule "third_party/mlir-air"]
-       path = third_party/mlir-air
-       url = https://github.com/nod-ai/mlir-air.git
-       shallow = true
-       ignore=dirty
+  path = third_party/mlir-air
+  url = https://github.com/nod-ai/mlir-air.git
+  shallow = true
+  ignore = dirty
 [submodule "third_party/aie-rt"]
-       path = third_party/aie-rt
-       url = https://github.com/Xilinx/aie-rt.git
-       shallow = true
-       ignore=dirty
+  path = third_party/aie-rt
+  url = https://github.com/Xilinx/aie-rt.git
+  shallow = true
+  ignore = dirty
 [submodule "third_party/bootgen"]
-       path = third_party/bootgen
-       url = https://github.com/Xilinx/bootgen.git
-       shallow = true
-       ignore=dirty
+  path = third_party/bootgen
+  url = https://github.com/Xilinx/bootgen.git
+  shallow = true
+  ignore = dirty
 [submodule "third_party/openssl"]
-       path = third_party/openssl
-       url = https://github.com/viaduck/openssl-cmake.git
-       shallow = true
-       ignore=dirty
+  path = third_party/openssl
+  url = https://github.com/viaduck/openssl-cmake.git
+  shallow = true
+  ignore = dirty
 [submodule "third_party/iree"]
-       path = third_party/iree
-       url = https://github.com/iree-org/iree.git
-       shallow = true
-       ignore=dirty
+  path = third_party/iree
+  url = https://github.com/iree-org/iree.git
+  shallow = true
+  ignore = dirty


### PR DESCRIPTION
Main motivation for this is to make switching between branches faster: Down from 15 seconds to light-speed.

For things like `git status` and `git diff` I've figured out how to make them fast without this change: use the `--ignore-submodules` flags. But for `git checkout` I haven't found an equivalent. 

I guess the underlying problem is that the submodules (XRT, etc.) get dirtied after cloning, and somehow this makes more work for `git`. Untracked files like  `src/runtime_src/core/common/api/version.h` etc appear. I'm not 100% sure of this. 

If someone has an alternative suggestion to getting lighting fast `git checkout` without this PR: please let me know. 