### PR TITLE
[CreateAIEWorkgroup] Make buildForCoreOp a member method for consistency

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
@@ -50,9 +50,9 @@ AMDAIE::CoreOp CoreContext::mergeCoreOps(AMDAIE::CoreOp source,
 }
 
 /// Clone CoreOp and add to or merge with coreContext.
-LogicalResult workgroupBuildForCoreOp(
-    IRRewriterAndMapper &rewriter, AMDAIE::CoreOp coreOp, Block *target,
-    Block *controlCode, CoreContext &coreContext, Block::iterator targetBegin,
+LogicalResult WorkgroupBuilder::buildForCoreOp(
+    AMDAIE::CoreOp coreOp, Block *target, Block *controlCode,
+    CoreContext &coreContext, Block::iterator targetBegin,
     Block::iterator controlCodeBegin, Block::iterator controlCodeEnd) {
   LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [amdaie.core] Start\n");
   OpBuilder::InsertionGuard guard(rewriter);
@@ -301,9 +301,8 @@ LogicalResult WorkgroupBuilder::build(Operation *op, Block *target,
   OpBuilder::InsertionGuard guard(rewriter);
   return TypeSwitch<Operation *, LogicalResult>(op)
       .Case<AMDAIE::CoreOp>([&](auto coreOp) {
-        return workgroupBuildForCoreOp(rewriter, coreOp, target, controlCode,
-                                       coreContext, targetBegin,
-                                       controlCodeBegin, controlCodeEnd);
+        return buildForCoreOp(coreOp, target, controlCode, coreContext,
+                              targetBegin, controlCodeBegin, controlCodeEnd);
       })
       .Case<AMDAIE::CircularDmaCpyNdOp>([&](auto dmaOp) {
         return buildForCircularDmaCpyNdOp(dmaOp, target, controlCode,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.h
@@ -226,6 +226,14 @@ class WorkgroupBuilder {
                                            Block::iterator controlCodeBegin,
                                            Block::iterator controlCodeEnd);
 
+  /// Build function that handles `amdaie.core` by cloning it and adding it to
+  /// or merging it wtith the CoreContext.
+  LogicalResult buildForCoreOp(AMDAIE::CoreOp coreOp, Block *target,
+                               Block *controlCode, CoreContext &coreContext,
+                               Block::iterator targetBegin,
+                               Block::iterator controlCodeBegin,
+                               Block::iterator controlCodeEnd);
+
   /// Build function that handles `amdaie.dma_cpy_nd` by converting it into a
   /// workgroup DMA with potentially corresponding control code.
   LogicalResult buildForDmaCpyNdOp(AMDAIE::DmaCpyNdOp dmaOp, Block *target,


### PR DESCRIPTION
Fixes a small inconsistency in the `AMDAIECreateAIEWorkgroup` pass I came across.