### PR TITLE
Move `getConstantIndexOrAssert` to AMDAIEUtils

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaUtils.cpp
@@ -8,6 +8,7 @@
 
 #include <cstdlib>
 
+#include "iree-amd-aie/Transforms/AMDAIEUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 
 namespace mlir::iree_compiler::AMDAIE {
@@ -19,13 +20,6 @@ Operation *getAncestorInBlock(Operation *op, Block *block) {
   while (parent && (parent->getBlock() != block))
     parent = parent->getParentOp();
   return parent;
-}
-
-/// Utility to retrieve a constant index from an OpFoldResult.
-int64_t getConstantIndexOrAssert(OpFoldResult dim) {
-  std::optional<int64_t> size = getConstantIntValue(dim);
-  assert(size.has_value() && "expect constant index");
-  return size.value();
 }
 
 bool areAccessPatternsCombinable(const SmallVector<OpFoldResult> &offsetsA,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaUtils.h
@@ -20,9 +20,6 @@
 
 namespace mlir::iree_compiler::AMDAIE {
 
-/// Utility to retrieve a constant index from an OpFoldResult.
-int64_t getConstantIndexOrAssert(OpFoldResult dim);
-
 /// Utility affine expression visitor to retrieve the scale and optional bias
 /// from the expression.
 struct RetrieveScaleAndBias

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELogicalObjFifoSplittingUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELogicalObjFifoSplittingUtils.cpp
@@ -9,6 +9,7 @@
 #include <numeric>
 
 #include "iree-amd-aie/Transforms/AMDAIEDmaUtils.h"
+#include "iree-amd-aie/Transforms/AMDAIEUtils.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
@@ -28,6 +28,13 @@ std::optional<AMDAIEDevice> getConfigAMDAIEDevice(Operation *op) {
   return getConfigAMDAIEDevice(targetAttr);
 }
 
+/// Utility to retrieve a constant index from an OpFoldResult.
+int64_t getConstantIndexOrAssert(OpFoldResult ofr) {
+  std::optional<int64_t> res = getConstantIntValue(ofr);
+  assert(res.has_value() && "expect constant index");
+  return res.value();
+}
+
 namespace {
 
 /// Generate a DenseMap key we can use for the element types (alternatives

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
@@ -24,6 +24,9 @@ std::optional<AMDAIEDevice> getConfigAMDAIEDevice(
 /// attr in the AST.
 std::optional<AMDAIEDevice> getConfigAMDAIEDevice(Operation *op);
 
+/// Utility to retrieve a constant index from an OpFoldResult.
+int64_t getConstantIndexOrAssert(OpFoldResult ofr);
+
 // This function is based on the following table pulled from the
 // AIEVec_MatMulOp documentation in
 // mlir-aie/include/aie/Dialect/AIEVec/IR/AIEVecOps.td


### PR DESCRIPTION
Move `getConstantIndexOrAssert` from `AMDAIEDmaUtils` to `AMDAIEUtils` to for more general reuse in non-dma related transformations.