### PR TITLE
[LogicalObjFifoOpInterface] Add getDepth method

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.td
@@ -22,8 +22,19 @@ def LogicalObjFifoOpInterface : OpInterface<"LogicalObjFifoOpInterface"> {
 
   let methods = [
     InterfaceMethod<
+      /*desc=*/"Return the buffer depth of the logical objectFifo. (E.g. 1 == "
+               "single buffer, 2 == double buffer)",
+      /*retTy=*/"uint8_t",
+      /*methodName=*/"getDepth",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return $_op.getDepth();
+      }]
+    >,
+    InterfaceMethod<
       /*desc=*/"Return the assigned tiles.",
-      /*retTy=*/"::mlir::OperandRange",
+      /*retTy=*/"::mlir::ValueRange",
       /*methodName=*/"getTiles",
       /*args=*/(ins),
       /*methodBody=*/"",

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -905,7 +905,6 @@ def AMDAIE_LogicalObjectFifoPlaceholderOp:
     uint8_t getDepth() {
       return cast<LogicalObjectFifoType>(getOutput().getType()).getDepth();
     }
-
   }];
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -792,7 +792,7 @@ def AMDAIE_LogicalObjectFifoFromMemrefOp
 
   let extraClassDeclaration = [{
     // Return the buffer depth (1 == single buffer, 2 == double buffer).
-    unsigned getDepth() {
+    uint8_t getDepth() {
       return cast<LogicalObjectFifoType>(getOutput().getType()).getDepth();
     }
 
@@ -899,6 +899,14 @@ def AMDAIE_LogicalObjectFifoPlaceholderOp:
   let results = (outs AnyAMDAIELogicalObjectFifoType:$output);
 
   let assemblyFormat = [{ `{` $tiles `}` attr-dict `:` type($output)}];
+
+  let extraClassDeclaration = [{
+    // Return the buffer depth (E.g. 1 == single buffer, 2 == double buffer).
+    uint8_t getDepth() {
+      return cast<LogicalObjectFifoType>(getOutput().getType()).getDepth();
+    }
+
+  }];
 }
 
 def AMDAIE_LogicalObjectFifoRelease: 


### PR DESCRIPTION
Adds the `getDepth` method to the `LogicalObjFifoOpInterface`. Also updates the `getTiles` return type to `ValueRange`, which makes the method easier to implement for logical objectFifos that don't have the tiles as operands themselves. This PR is prefetching some general changes needed to introduce a new logical objectFifo op which is created from a set of buffers, which I need for moving the bulk of the `StatefulTransform` logic into the `AMDAIE` dialect.