### PR TITLE
[CI] reorder tests in linux CI to make debug easier

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -144,9 +144,8 @@ jobs:
           source .venv/bin/activate
           pip install -r tests/matmul/requirements.txt
 
-      - name: E2E correctness matmul test
+      name: Unlimit locked memory for XRT
         run: |
-          source .venv/bin/activate
           # Without this additional line an error like
           #
           # [XRT] ERROR: Failed to allocate host memory buffer (mmap(len=10616832, prot=3, flags=8193, offset=4294967296)
@@ -174,6 +173,21 @@ jobs:
           # on the guthub CI machine.
           sudo prlimit -lunlimited --pid $$
 
+      - name : E2E comparison of AIE to llvm-cpu
+        run: |
+          source .venv/bin/activate
+          source /opt/xilinx/xrt/setup.sh
+          python3 build_tools/ci/cpu_comparison/run.py \
+            test_aie_vs_cpu \
+            $PWD/iree-install \
+            $PWD/llvm-aie \
+            --xrt-dir /opt/xilinx/xrt \
+            --vitis-dir /opt/Xilinx/Vitis/2024.2 \
+            --reset-npu-between-runs -v
+
+      - name: E2E correctness matmul test
+        run: |
+          source .venv/bin/activate
           source /opt/xilinx/xrt/setup.sh
           bash build_tools/ci/run_matmul_test.sh \
             test_matmuls \
@@ -181,6 +195,15 @@ jobs:
             $PWD/llvm-aie \
             /opt/xilinx/xrt \
             /opt/Xilinx/Vitis/2024.2
+
+      - name: Printing IR from aie2xclbin
+        run: |
+          source .venv/bin/activate
+          source /opt/xilinx/xrt/setup.sh
+          bash build_tools/ci/print_ir_aie2xclbin/print_ir_aie2xclbin.sh \
+            iree-install \
+            print_ir_aie2xclbin_results \
+            $PWD/llvm-aie
 
       - name : Smoke E2E comparison flag test
         run: |
@@ -207,24 +230,3 @@ jobs:
           else
             echo "smoke_output.log is empty"
           fi
-
-      - name : E2E comparison of AIE to llvm-cpu
-        run: |
-          source .venv/bin/activate
-          source /opt/xilinx/xrt/setup.sh
-          python3 build_tools/ci/cpu_comparison/run.py \
-            test_aie_vs_cpu \
-            $PWD/iree-install \
-            $PWD/llvm-aie \
-            --xrt-dir /opt/xilinx/xrt \
-            --vitis-dir /opt/Xilinx/Vitis/2024.2 \
-            --reset-npu-between-runs -v
-
-      - name: Printing IR from aie2xclbin
-        run: |
-          source .venv/bin/activate
-          source /opt/xilinx/xrt/setup.sh
-          bash build_tools/ci/print_ir_aie2xclbin/print_ir_aie2xclbin.sh \
-            iree-install \
-            print_ir_aie2xclbin_results \
-            $PWD/llvm-aie

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -144,9 +144,21 @@ jobs:
           source .venv/bin/activate
           pip install -r tests/matmul/requirements.txt
 
-      - name: Unlimit locked memory for XRT
+
+      - name : E2E comparison of AIE to llvm-cpu
         run: |
-          sudo prlimit -lunlimited --pid $$
+          source .venv/bin/activate
+          source /opt/xilinx/xrt/setup.sh
+          python3 build_tools/ci/cpu_comparison/run.py \
+            test_aie_vs_cpu \
+            $PWD/iree-install \
+            $PWD/llvm-aie \
+            --xrt-dir /opt/xilinx/xrt \
+            --vitis-dir /opt/Xilinx/Vitis/2024.2 \
+            --reset-npu-between-runs -v
+
+      - name: E2E correctness matmul test
+        run: |
           # Without this additional line an error like
           #
           # [XRT] ERROR: Failed to allocate host memory buffer (mmap(len=10616832, prot=3, flags=8193, offset=4294967296)
@@ -154,7 +166,7 @@ jobs:
           # iree-amd-aie/runtime/src/iree-amd-aie/driver/xrt/direct_allocator.cc:179: RESOURCE_EXHAUSTED; could not allocate
           # memory for buffer; while invoking C++ function matmul_test.generate_random_matrix; while calling import;
           #
-          # might be observed when too much memory is allocated. For example this
+          # might be observed when too much memory is allocated. This
           # error was seen when running a bf16->f32 matmul with m=n=k=2304.
           #
           # This line was suggested at https://github.com/Xilinx/mlir-air/issues/566
@@ -171,22 +183,8 @@ jobs:
           # ```
           # sudo visudo -f /etc/sudoers.d/github
           # ```
-          # on the guthub CI machine.
-
-      - name : E2E comparison of AIE to llvm-cpu
-        run: |
-          source .venv/bin/activate
-          source /opt/xilinx/xrt/setup.sh
-          python3 build_tools/ci/cpu_comparison/run.py \
-            test_aie_vs_cpu \
-            $PWD/iree-install \
-            $PWD/llvm-aie \
-            --xrt-dir /opt/xilinx/xrt \
-            --vitis-dir /opt/Xilinx/Vitis/2024.2 \
-            --reset-npu-between-runs -v
-
-      - name: E2E correctness matmul test
-        run: |
+          # on the github CI machine.
+          sudo prlimit -lunlimited --pid $$
           source .venv/bin/activate
           source /opt/xilinx/xrt/setup.sh
           bash build_tools/ci/run_matmul_test.sh \

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -144,8 +144,9 @@ jobs:
           source .venv/bin/activate
           pip install -r tests/matmul/requirements.txt
 
-      name: Unlimit locked memory for XRT
+      - name: Unlimit locked memory for XRT
         run: |
+          sudo prlimit -lunlimited --pid $$
           # Without this additional line an error like
           #
           # [XRT] ERROR: Failed to allocate host memory buffer (mmap(len=10616832, prot=3, flags=8193, offset=4294967296)
@@ -171,7 +172,6 @@ jobs:
           # sudo visudo -f /etc/sudoers.d/github
           # ```
           # on the guthub CI machine.
-          sudo prlimit -lunlimited --pid $$
 
       - name : E2E comparison of AIE to llvm-cpu
         run: |


### PR DESCRIPTION
This PR makes the order of tests on linux

```
E2E comparison of AIE to llvm-cpu
E2E correctness matmul test
Printing IR from aie2xclbin
Smoke E2E comparison flag test
```

'smoke' test last because it's testing with verbose=0, not a good test to run first because diagnosing unrelated failures is impossible. 