### PR TITLE
[DmaOpInterface] Add static size retrieval method

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDmaOpInterface.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDmaOpInterface.h
@@ -28,6 +28,10 @@ std::optional<int64_t> getSourceStaticBaseOffset(DoublyStridedOpInterface op);
 /// Otherwise, returns nullopt.
 std::optional<int64_t> getSourceStaticExtent(DoublyStridedOpInterface op);
 
+/// Return the static size of the access on the source side if it can be
+/// computed. Otherwise, returns nullopt.
+std::optional<int64_t> getSourceStaticSize(DoublyStridedOpInterface op);
+
 /// Return the static base offset on the target side if it can be computed.
 /// Otherwise, returns nullopt.
 std::optional<int64_t> getTargetStaticBaseOffset(DoublyStridedOpInterface op);
@@ -35,6 +39,10 @@ std::optional<int64_t> getTargetStaticBaseOffset(DoublyStridedOpInterface op);
 /// Return the static access extent on the target side if it can be computed.
 /// Otherwise, returns nullopt.
 std::optional<int64_t> getTargetStaticExtent(DoublyStridedOpInterface op);
+
+/// Return the static size of the access on the target side if it can be
+/// computed. Otherwise, returns nullopt.
+std::optional<int64_t> getTargetStaticSize(DoublyStridedOpInterface op);
 
 /// Common verifier for doubly-strided operations.
 LogicalResult verifyDoublyStridedOp(DoublyStridedOpInterface op);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDmaOpInterface.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDmaOpInterface.td
@@ -185,6 +185,20 @@ def DoublyStridedOpInterface : OpInterface<"DoublyStridedOpInterface"> {
       }]
     >,
     InterfaceMethod<
+      /*desc=*/[{
+        Return the static size of the access on the target side if it can be
+        computed. Otherwise, returns nullopt.
+      }],
+      /*retTy=*/"std::optional<int64_t>",
+      /*methodName=*/"getTargetStaticSize",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return detail::getTargetStaticSize(
+          ::mlir::cast<DoublyStridedOpInterface>($_op.getOperation()));
+      }]
+    >,
+    InterfaceMethod<
       /*desc=*/"Return the dynamic source offsets.",
       /*retTy=*/"::mlir::OperandRange",
       /*methodName=*/"getSourceOffsets",
@@ -318,6 +332,20 @@ def DoublyStridedOpInterface : OpInterface<"DoublyStridedOpInterface"> {
       /*methodBody=*/"",
       /*defaultImplementation=*/[{
         return detail::getSourceStaticExtent(
+          ::mlir::cast<DoublyStridedOpInterface>($_op.getOperation()));
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Return the static size of the access on the source side if it can be
+        computed. Otherwise, returns nullopt.
+      }],
+      /*retTy=*/"std::optional<int64_t>",
+      /*methodName=*/"getSourceStaticSize",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return detail::getSourceStaticSize(
           ::mlir::cast<DoublyStridedOpInterface>($_op.getOperation()));
       }]
     >,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/CMakeLists.txt
@@ -50,9 +50,13 @@ iree_cc_library(
     iree-amd-aie::aie_runtime::AMDAIEEnums
     iree::target::amd-aie::Utils::Utils
     LLVMSupport
+    MLIRArithUtils
+    MLIRCopyOpInterface
+    MLIRDialectUtils
     MLIRIR
     MLIRParser
     MLIRSupport
+    MLIRViewLikeInterface
   PUBLIC
 )
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/AMDAIEDmaOpInterfaceTest.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/AMDAIEDmaOpInterfaceTest.cpp
@@ -1,0 +1,80 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "gtest/gtest.h"
+#include "iree-amd-aie/IR/AMDAIEOps.h"
+
+using namespace mlir;
+using namespace mlir::iree_compiler::AMDAIE;
+
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Test Fixture
+//===----------------------------------------------------------------------===//
+
+class DmaOpInterfaceTest : public ::testing::Test {
+ protected:
+  DmaOpInterfaceTest() : rewriter(&context), loc(UnknownLoc::get(&context)) {
+    context.loadDialect<AMDAIEDialect>();
+    context.loadDialect<arith::ArithDialect>();
+  }
+
+  SmallVector<OpFoldResult> toOpFoldResult(const SmallVector<int64_t> &values) {
+    return llvm::map_to_vector(values, [&](int64_t v) -> OpFoldResult {
+      return rewriter.getI64IntegerAttr(v);
+    });
+  }
+
+  bool check(const SmallVector<int64_t> &sourceOffsets,
+             const SmallVector<int64_t> &sourceSizes,
+             const SmallVector<int64_t> &sourceStrides,
+             const SmallVector<int64_t> &targetOffsets,
+             const SmallVector<int64_t> &targetSizes,
+             const SmallVector<int64_t> &targetStrides,
+             int64_t expectedSourceSize, int64_t expectedTargetSize) {
+    SmallVector<OpFoldResult> sourceOffsetsOfr = toOpFoldResult(sourceOffsets);
+    SmallVector<OpFoldResult> sourceSizesOfr = toOpFoldResult(sourceSizes);
+    SmallVector<OpFoldResult> sourceStridesOfr = toOpFoldResult(sourceStrides);
+    SmallVector<OpFoldResult> targetOffsetsOfr = toOpFoldResult(targetOffsets);
+    SmallVector<OpFoldResult> targetSizesOfr = toOpFoldResult(targetSizes);
+    SmallVector<OpFoldResult> targetStridesOfr = toOpFoldResult(targetStrides);
+    Value target, source;
+    auto input =
+        rewriter.create<arith::ConstantIndexOp>(rewriter.getUnknownLoc(), 2);
+    auto dmaOp = rewriter.create<mlir::iree_compiler::AMDAIE::NpuDmaCpyNdOp>(
+        rewriter.getUnknownLoc(), input, target, targetOffsetsOfr,
+        targetSizesOfr, targetStridesOfr, nullptr, source, sourceOffsetsOfr,
+        sourceSizesOfr, sourceStridesOfr, nullptr);
+    std::optional<int64_t> sourceStaticSize = dmaOp.getSourceStaticSize();
+    std::optional<int64_t> targetStaticSize = dmaOp.getTargetStaticSize();
+    if (!sourceStaticSize || sourceStaticSize.value() != expectedSourceSize)
+      return false;
+    if (!targetStaticSize || targetStaticSize.value() != expectedTargetSize)
+      return false;
+    return true;
+  }
+
+  MLIRContext context;
+  IRRewriter rewriter;
+  Location loc;
+};
+
+TEST_F(DmaOpInterfaceTest, CombinableAccessPatterns) {
+  EXPECT_TRUE(check({}, {}, {}, {}, {}, {}, 0, 0));
+  EXPECT_TRUE(check({0}, {1}, {2}, {1}, {2}, {0}, 1, 2));
+  EXPECT_TRUE(
+      check({0, 0}, {1, 4}, {2, 1}, {0, 0}, {2, 4, 3}, {1, 1, 1}, 4, 24));
+  EXPECT_TRUE(
+      check({0, 0}, {1, 0}, {2, 1}, {0, 0}, {2, 0, 3}, {1, 1, 1}, 0, 0));
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/CMakeLists.txt
@@ -17,3 +17,13 @@ iree_lit_test_suite(
     FileCheck
     iree-opt
 )
+
+iree_cc_test(
+  NAME
+    AMDAIEDmaOpInterfaceTest
+  SRCS
+    "AMDAIEDmaOpInterfaceTest.cpp"
+  DEPS
+    gtest
+    iree::target::amd-aie::IR::AMDAIEDialect
+)


### PR DESCRIPTION
Add static size retrieval methods to the `AMDAIEDmaOpInterface`.

Needed as part of a larger effort to remove `StatefulTransform`: https://github.com/jtuyls/iree-amd-aie/tree/delete-stateful-transform