### PR TITLE
[DmaToNpu] Add packet support for NpuDmaMemcpyNdOp

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aie/AMDAIEDmaToNpu.cpp
+++ b/compiler/plugins/target/AMD-AIE/aie/AMDAIEDmaToNpu.cpp
@@ -376,6 +376,13 @@ struct DmaToNpuPattern : OpConversionPattern<NpuDmaMemcpyNdOp> {
     // repeat_count
     repeat_count = IntegerAttr::get(i32ty, sizes[3] - 1);
 
+    // enable_packet
+    if (auto packetInfo = op.getPacket()) {
+      enable_packet = IntegerAttr::get(i32ty, 1);
+      packet_type = IntegerAttr::get(i32ty, packetInfo->getPktType());
+      packet_id = IntegerAttr::get(i32ty, packetInfo->getPktId());
+    }
+
     // Set the issue_token
     issue_token = BoolAttr::get(ctx, op.getIssueToken());
     // Earlier, all S2MM channels were implicitly assumed to issue a token.

--- a/compiler/plugins/target/AMD-AIE/aie/test/dma_to_npu.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/dma_to_npu.mlir
@@ -77,3 +77,19 @@ module  {
   } {sym_name = "explicit_sym_name_0"}
 }
 
+// -----
+
+// Issue packet header from shim dma bd
+// CHECK: memref.global "public" @toMem : memref<16xi32>
+// CHECK: aie.shim_dma_allocation @toMem(S2MM, 0, 0)
+// CHECK: npu_instructions = dense_resource<npu_instructions> : tensor<34xui32>, runtime_sequence_name = "packet_enable"
+// CHECK: npu_instructions:
+module {
+  aie.device(npu1_4col) {
+    memref.global "public" @toMem : memref<16xi32>
+    aiex.runtime_sequence @packet_enable(%arg0: memref<16xi32>) {
+      aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1], packet = <pkt_id = 2, pkt_type = 3>) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
+    }
+    aie.shim_dma_allocation @toMem (S2MM, 0, 0)
+  }
+}


### PR DESCRIPTION
From: https://github.com/Xilinx/mlir-aie/pull/1671/files#diff-2dc661023141402b83d465f580b2aa2e72aad010c1b19da829d1e014fd2d324cR373

Adds packet routing support for `NpuDmaMemcpyNdOp`.