### PR TITLE
[WIP][AMDAIEPackAndTranpose] Undo folding of rank-preserving packs 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPackAndTranspose.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEPackAndTranspose.cpp
@@ -17,42 +17,26 @@ namespace mlir::iree_compiler::AMDAIE {
 
 namespace {
 
-static FailureOr<linalg::PackResult> applyPackOnLinalgOp(
-    RewriterBase &rewriter, linalg::LinalgOp op,
-    SmallVector<OpFoldResult> packedSizes) {
-  if (packedSizes.size() != op.getNumLoops()) {
-    op->emitOpError(
-        "requires number of packed sizes match the number of loops (")
-        << packedSizes.size() << " vs " << op.getNumLoops() << ")";
-    return failure();
-  }
-
-  rewriter.setInsertionPoint(op);
-  FailureOr<linalg::PackResult> maybePackResult =
-      linalg::pack(rewriter, op, packedSizes);
-  if (failed(maybePackResult)) {
-    op->emitOpError("failed to pack the operation");
-    return failure();
-  }
-
-  linalg::PackResult packResult = maybePackResult.value();
+/// The function `linalg::pack` doesn't create rank-preserving pack ops, see:
+///
+/// https://github.com/llvm/llvm-project/blob/644899addd8fd789c93e9a0f0727d37eb1b29c55/mlir/lib/Dialect/Linalg/Transforms/Transforms.cpp#L542
+///
+/// This design cannot easily be undone upstream, because it is thoroughly
+/// tested for. See:
+///
+/// https://github.com/llvm/llvm-project/blob/644899addd8fd789c93e9a0f0727d37eb1b29c55/mlir/test/Dialect/Linalg/transform-op-pack.mlir
+///
+/// In our use case it is sometimes useful to have identity pack ops,
+/// specifically if we don't want to pack any dimensions of an operand, but
+/// still want to set up a new tensor for bufferization.
+///
+/// The following logic inserts identity pack/unpack ops where needed into
+/// the pack result.
+static FailureOr<linalg::PackResult> ensureAllPacksPresent(
+    RewriterBase &rewriter, const linalg::PackResult &initialPackResult) {
+  linalg::PackResult packResult = initialPackResult;
   linalg::LinalgOp packedOp = packResult.packedLinalgOp;
-
-  // The function `linalg::pack` effectively folds rank-preserving pack ops,
-  // see:
-  //
-  // https://github.com/llvm/llvm-project/blob/644899addd8fd789c93e9a0f0727d37eb1b29c55/mlir/lib/Dialect/Linalg/Transforms/Transforms.cpp#L542
-  //
-  // This can't easily be removed upstream, it is thoroughly tested for. See:
-  //
-  // https://github.com/llvm/llvm-project/blob/644899addd8fd789c93e9a0f0727d37eb1b29c55/mlir/test/Dialect/Linalg/transform-op-pack.mlir
-  //
-  // In out use case it is sometimes to have identity pack ops, if we don't
-  // want to pack some operands but still set up a new tensor for bufferization.
-  //
-  // The following logic insert such identity pack/unpack ops if needed. 
-
-  // If `v` is the result of a pack op returned by `linalg::pack`, return it. 
+  // If `v` is the result of a pack op returned by `linalg::pack`, return it.
   // Else return an empty pack op.
   auto maybeGetPack = [&](Value v) -> tensor::PackOp {
     for (auto packOp : packResult.packOps) {
@@ -60,14 +44,14 @@ static FailureOr<linalg::PackResult> applyPackOnLinalgOp(
         return packOp;
       }
     }
-    return {};
+    return tensor::PackOp{};
   };
 
   SmallVector<tensor::PackOp> newPackOps;
   for (uint32_t i = 0; i < packedOp->getNumOperands(); ++i) {
     Value operand = packedOp->getOperand(i);
     tensor::PackOp packOp = maybeGetPack(operand);
-    if (packOp){
+    if (packOp) {
       newPackOps.push_back(packOp);
     } else {
       // Create an identity pack op.
@@ -87,7 +71,7 @@ static FailureOr<linalg::PackResult> applyPackOnLinalgOp(
 
   if (packResult.unPackOps.empty()) {
     if (packedOp->getNumResults() != 1) {
-      return op->emitOpError(
+      return packedOp->emitOpError(
           "is expected to have 1 result for the current packing approach.");
     }
     Value result = packedOp->getResult(0);
@@ -104,6 +88,27 @@ static FailureOr<linalg::PackResult> applyPackOnLinalgOp(
   }
 
   return packResult;
+}
+
+static FailureOr<linalg::PackResult> applyPackOnLinalgOp(
+    RewriterBase &rewriter, linalg::LinalgOp op,
+    SmallVector<OpFoldResult> packedSizes) {
+  if (packedSizes.size() != op.getNumLoops()) {
+    op->emitOpError(
+        "requires number of packed sizes match the number of loops (")
+        << packedSizes.size() << " vs " << op.getNumLoops() << ")";
+    return failure();
+  }
+
+  rewriter.setInsertionPoint(op);
+  FailureOr<linalg::PackResult> maybePackResult =
+      linalg::pack(rewriter, op, packedSizes);
+  if (failed(maybePackResult)) {
+    op->emitOpError("failed to pack the operation");
+    return failure();
+  }
+
+  return ensureAllPacksPresent(rewriter, maybePackResult.value());
 }
 
 class AMDAIEPackAndTransposePass


### PR DESCRIPTION
The function `linalg::pack` doesn't create rank-preserving pack ops, see: https://github.com/llvm/llvm-project/blob/644899addd8fd789c93e9a0f0727d37eb1b29c55/mlir/lib/Dialect/Linalg/Transforms/Transforms.cpp#L542

The upstream design cannot easily be undone, because it is thoroughly tested for. See: https://github.com/llvm/llvm-project/blob/644899addd8fd789c93e9a0f0727d37eb1b29c55/mlir/test/Dialect/Linalg/transform-op-pack.mlir

In our use case it is sometimes useful to have identity pack ops, specifically if we don't want to pack any dimensions of an operand, but still want to set up a new tensor for bufferization.

The use case I have for this is channel-first convolution. **This PR is not strictly necessary** because I have an alternative (packing input and output channel dimensions with size 1) but IMO this is maybe neater. 

If there's general approval I'll add tests. 
