### PR TITLE
[ConvertToUnpack] Apply correct permutation when lowering unpack to DMA

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEConvertToDma.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEConvertToDma.cpp
@@ -107,11 +107,14 @@ LogicalResult unPackDmaInputs(IREE::LinalgExt::UnPackOp unPackOp,
   SmallVector<OpFoldResult> outerSizes =
       SmallVector<OpFoldResult>(sizes.begin(), sizes.begin() + numOuterDims);
 
-  // Apply permutations to the outer dims if provided.
+  // Apply inverse permutation to the outer dims if permutation provided (if
+  // permutation not provided, it is identity, and therefore so is the inverse).
   if (!permutation.empty()) {
-    applyPermutationToVector(outerStrides, permutation);
-    applyPermutationToVector(outerSizes, permutation);
-    applyPermutationToVector(outerOffsets, permutation);
+    SmallVector<int64_t> inversePermutation =
+        invertPermutationVector(permutation);
+    applyPermutationToVector(outerStrides, inversePermutation);
+    applyPermutationToVector(outerSizes, inversePermutation);
+    applyPermutationToVector(outerOffsets, inversePermutation);
   }
   // Do the unpacking on the Outer dims.
   llvm::SmallDenseMap<int64_t, int64_t> outerDimsIndexMap;


### PR DESCRIPTION
Inverse permutation needs to be applied when converting unpack to DMA, not permutation. PR adds test with permutation P != P^{-1}, without which this bug is hidden. I've left a comment with that test explaining why this fix is required. Also, `--cse`  is removed from the test lit command, to reduce noise. 