### PR TITLE
[Router] Consider channel ID demand and congestion in Dijkstra

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aie/test/aie2_memtile_connection.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/aie2_memtile_connection.mlir
@@ -5,16 +5,16 @@
 //CHECK:    %[[T02:.*]] = aie.tile(0, 2)
 //CHECK:     %{{.*}} = aie.switchbox(%[[T02]]) {
 //CHECK:      %0 = aie.amsel<0> (0)
-//CHECK:      %1 = aie.masterset(SOUTH : 1, %0)
+//CHECK:      %1 = aie.masterset(SOUTH : 2, %0)
 //CHECK:      aie.packet_rules(DMA : 0) {
 //CHECK:        aie.rule(31, 0, %0)
 //CHECK:      }
 //CHECK:    }
 //CHECK:     %{{.*}} = aie.switchbox(%[[T00]]) {
-//CHECK:      aie.connect<NORTH : 0, SOUTH : 2>
+//CHECK:      aie.connect<NORTH : 1, SOUTH : 2>
 //CHECK:      %0 = aie.amsel<0> (0)
 //CHECK:      %1 = aie.masterset(SOUTH : 3, %0)
-//CHECK:      aie.packet_rules(NORTH : 1) {
+//CHECK:      aie.packet_rules(NORTH : 2) {
 //CHECK:        aie.rule(31, 0, %0)
 //CHECK:      }
 //CHECK:    }
@@ -23,10 +23,10 @@
 //CHECK:      aie.connect<NORTH : 2, DMA : 0>
 //CHECK:    }
 //CHECK:     %{{.*}} = aie.switchbox(%[[T01]]) {
-//CHECK:      aie.connect<DMA : 0, SOUTH : 0>
+//CHECK:      aie.connect<DMA : 0, SOUTH : 1>
 //CHECK:      %0 = aie.amsel<0> (0)
-//CHECK:      %1 = aie.masterset(SOUTH : 1, %0)
-//CHECK:      aie.packet_rules(NORTH : 1) {
+//CHECK:      %1 = aie.masterset(SOUTH : 2, %0)
+//CHECK:      aie.packet_rules(NORTH : 2) {
 //CHECK:        aie.rule(31, 0, %0)
 //CHECK:      }
 //CHECK:    }

--- a/compiler/plugins/target/AMD-AIE/aie/test/packet_routing_keep_pkt_header.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/packet_routing_keep_pkt_header.mlir
@@ -5,14 +5,14 @@
 // CHECK:   %[[VAL_1:.*]] = aie.switchbox(%[[VAL_0]]) {
 // CHECK:     %[[VAL_2:.*]] = aie.amsel<0> (0)
 // CHECK:     %[[VAL_3:.*]] = aie.masterset(DMA : 1, %[[VAL_2]])
-// CHECK:     aie.packet_rules(NORTH : 0) {
+// CHECK:     aie.packet_rules(NORTH : 2) {
 // CHECK:       aie.rule(31, 1, %[[VAL_2]])
 // CHECK:     }
 // CHECK:   }
 // CHECK:   %[[VAL_4:.*]] = aie.tile(6, 3)
 // CHECK:   %[[VAL_5:.*]] = aie.switchbox(%[[VAL_4]]) {
 // CHECK:     %[[VAL_6:.*]] = aie.amsel<0> (0)
-// CHECK:     %[[VAL_7:.*]] = aie.masterset(SOUTH : 0, %[[VAL_6]])
+// CHECK:     %[[VAL_7:.*]] = aie.masterset(SOUTH : 2, %[[VAL_6]])
 // CHECK:     aie.packet_rules(DMA : 0) {
 // CHECK:       aie.rule(31, 1, %[[VAL_6]])
 // CHECK:     }

--- a/compiler/plugins/target/AMD-AIE/aie/test/test_congestion0.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/test_congestion0.mlir
@@ -8,55 +8,69 @@
 // CHECK:             %[[VAL_2:.*]] = aie.amsel<2> (0)
 // CHECK:             %[[VAL_3:.*]] = aie.amsel<3> (0)
 // CHECK:             %[[VAL_4:.*]] = aie.masterset(DMA : 0, %[[VAL_0]])
-// CHECK:             %[[VAL_5:.*]] = aie.masterset(DMA : 1, %[[VAL_1]])
-// CHECK:             %[[VAL_6:.*]] = aie.masterset(DMA : 2, %[[VAL_2]])
-// CHECK:             %[[VAL_7:.*]] = aie.masterset(DMA : 3, %[[VAL_3]])
+// CHECK:             %[[VAL_5:.*]] = aie.masterset(DMA : 1, %[[VAL_2]])
+// CHECK:             %[[VAL_6:.*]] = aie.masterset(DMA : 2, %[[VAL_3]])
+// CHECK:             %[[VAL_7:.*]] = aie.masterset(DMA : 3, %[[VAL_1]])
 // CHECK:             aie.packet_rules(NORTH : 0) {
 // CHECK:               aie.rule(31, 0, %[[VAL_0]])
-// CHECK:               aie.rule(31, 1, %[[VAL_1]])
-// CHECK:               aie.rule(31, 2, %[[VAL_2]])
-// CHECK:               aie.rule(31, 3, %[[VAL_3]])
+// CHECK:             }
+// CHECK:             aie.packet_rules(NORTH : 2) {
+// CHECK:               aie.rule(31, 3, %[[VAL_1]])
+// CHECK:             }
+// CHECK:             aie.packet_rules(NORTH : 3) {
+// CHECK:               aie.rule(31, 1, %[[VAL_2]])
+// CHECK:               aie.rule(31, 2, %[[VAL_3]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_0_2:.*]] = aie.tile(0, 2)
 // CHECK:           %[[SWITCHBOX_0_2:.*]] = aie.switchbox(%[[TILE_0_2]]) {
 // CHECK:             %[[VAL_8:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_9:.*]] = aie.masterset(SOUTH : 0, %[[VAL_8]])
+// CHECK:             %[[VAL_9:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_10:.*]] = aie.amsel<2> (0)
+// CHECK:             %[[VAL_11:.*]] = aie.masterset(SOUTH : 0, %[[VAL_8]])
+// CHECK:             %[[VAL_12:.*]] = aie.masterset(SOUTH : 2, %[[VAL_10]])
+// CHECK:             %[[VAL_13:.*]] = aie.masterset(SOUTH : 3, %[[VAL_9]])
 // CHECK:             aie.packet_rules(DMA : 0) {
 // CHECK:               aie.rule(31, 0, %[[VAL_8]])
 // CHECK:             }
 // CHECK:             aie.packet_rules(NORTH : 0) {
-// CHECK:               aie.rule(28, 0, %[[VAL_8]])
+// CHECK:               aie.rule(31, 1, %[[VAL_9]])
+// CHECK:             }
+// CHECK:             aie.packet_rules(NORTH : 2) {
+// CHECK:               aie.rule(31, 2, %[[VAL_9]])
+// CHECK:               aie.rule(31, 3, %[[VAL_10]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_0_3:.*]] = aie.tile(0, 3)
 // CHECK:           %[[SWITCHBOX_0_3:.*]] = aie.switchbox(%[[TILE_0_3]]) {
-// CHECK:             %[[VAL_10:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_11:.*]] = aie.masterset(SOUTH : 0, %[[VAL_10]])
+// CHECK:             %[[VAL_14:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_15:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_16:.*]] = aie.masterset(SOUTH : 0, %[[VAL_14]])
+// CHECK:             %[[VAL_17:.*]] = aie.masterset(SOUTH : 2, %[[VAL_15]])
 // CHECK:             aie.packet_rules(DMA : 0) {
-// CHECK:               aie.rule(31, 1, %[[VAL_10]])
+// CHECK:               aie.rule(31, 1, %[[VAL_14]])
 // CHECK:             }
 // CHECK:             aie.packet_rules(NORTH : 0) {
-// CHECK:               aie.rule(30, 2, %[[VAL_10]])
+// CHECK:               aie.rule(30, 2, %[[VAL_15]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_0_4:.*]] = aie.tile(0, 4)
 // CHECK:           %[[SWITCHBOX_0_4:.*]] = aie.switchbox(%[[TILE_0_4]]) {
-// CHECK:             %[[VAL_12:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_13:.*]] = aie.masterset(SOUTH : 0, %[[VAL_12]])
+// CHECK:             %[[VAL_18:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_19:.*]] = aie.masterset(SOUTH : 0, %[[VAL_18]])
 // CHECK:             aie.packet_rules(DMA : 0) {
-// CHECK:               aie.rule(31, 2, %[[VAL_12]])
+// CHECK:               aie.rule(31, 2, %[[VAL_18]])
 // CHECK:             }
 // CHECK:             aie.packet_rules(NORTH : 0) {
-// CHECK:               aie.rule(31, 3, %[[VAL_12]])
+// CHECK:               aie.rule(31, 3, %[[VAL_18]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_0_5:.*]] = aie.tile(0, 5)
 // CHECK:           %[[SWITCHBOX_0_5:.*]] = aie.switchbox(%[[TILE_0_5]]) {
-// CHECK:             %[[VAL_14:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_15:.*]] = aie.masterset(SOUTH : 0, %[[VAL_14]])
+// CHECK:             %[[VAL_20:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_21:.*]] = aie.masterset(SOUTH : 0, %[[VAL_20]])
 // CHECK:             aie.packet_rules(DMA : 0) {
-// CHECK:               aie.rule(31, 3, %[[VAL_14]])
+// CHECK:               aie.rule(31, 3, %[[VAL_20]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           aie.packet_flow(0) {

--- a/compiler/plugins/target/AMD-AIE/aie/test/test_congestion1.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/test_congestion1.mlir
@@ -1,57 +1,73 @@
 // RUN: iree-opt --amdaie-create-pathfinder-flows %s | FileCheck %s
 
-// CHECK:    %[[T00:.*]] = aie.tile(0, 0)
-// CHECK:    %[[T01:.*]] = aie.tile(0, 1)
-// CHECK:    %[[T02:.*]] = aie.tile(0, 2)
-// CHECK:    %[[T03:.*]] = aie.tile(0, 3)
-// CHECK:    %[[T04:.*]] = aie.tile(0, 4)
-// CHECK:    %[[T05:.*]] = aie.tile(0, 5)
-// CHECK:    %{{.*}} = aie.switchbox(%[[T01]]) {
-// CHECK:      aie.connect<NORTH : 0, DMA : 0>
-// CHECK:      aie.connect<NORTH : 1, DMA : 1>
-// CHECK:      aie.connect<NORTH : 2, DMA : 2>
-// CHECK:      aie.connect<NORTH : 3, DMA : 3>
-// CHECK:      aie.connect<DMA : 0, SOUTH : 0>
-// CHECK:      %0 = aie.amsel<0> (0)
-// CHECK:      %1 = aie.masterset(DMA : 4, %0)
-// CHECK:      aie.packet_rules(SOUTH : 0) {
-// CHECK:        aie.rule(31, 0, %0)
-// CHECK:      }
-// CHECK:    }
-// CHECK:    %{{.*}} = aie.switchbox(%[[T02]]) {
-// CHECK:      aie.connect<DMA : 0, SOUTH : 0>
-// CHECK:      aie.connect<NORTH : 0, SOUTH : 1>
-// CHECK:      aie.connect<NORTH : 1, SOUTH : 2>
-// CHECK:      aie.connect<NORTH : 2, SOUTH : 3>
-// CHECK:    }
-// CHECK:    %{{.*}} = aie.switchbox(%[[T03]]) {
-// CHECK:      aie.connect<DMA : 0, SOUTH : 0>
-// CHECK:      aie.connect<NORTH : 0, SOUTH : 1>
-// CHECK:      aie.connect<NORTH : 1, SOUTH : 2>
-// CHECK:    }
-// CHECK:    %{{.*}} = aie.switchbox(%[[T04]]) {
-// CHECK:      aie.connect<DMA : 0, SOUTH : 0>
-// CHECK:      aie.connect<NORTH : 0, SOUTH : 1>
-// CHECK:    }
-// CHECK:    %{{.*}} = aie.switchbox(%[[T05]]) {
-// CHECK:      aie.connect<DMA : 0, SOUTH : 0>
-// CHECK:      %0 = aie.amsel<0> (0)
-// CHECK:      %1 = aie.masterset(EAST : 0, %0)
-// CHECK:      aie.packet_rules(DMA : 1) {
-// CHECK:        aie.rule(31, 0, %0)
-// CHECK:      }
-// CHECK:    }
-// CHECK:    %{{.*}} = aie.switchbox(%[[T00]]) {
-// CHECK:      aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK:      %0 = aie.amsel<0> (0)
-// CHECK:      %1 = aie.masterset(NORTH : 0, %0)
-// CHECK:      aie.packet_rules(EAST : 0) {
-// CHECK:        aie.rule(31, 0, %0)
-// CHECK:      }
-// CHECK:    }
-// CHECK:    %{{.*}} = aie.shim_mux(%[[T00]]) {
-// CHECK:      aie.connect<NORTH : 2, DMA : 0>
-// CHECK:    }
+// CHECK-LABEL:   aie.device(npu1_2col) {
+// CHECK:           %[[TILE_0_0:.*]] = aie.tile(0, 0)
+// CHECK:           %[[TILE_0_1:.*]] = aie.tile(0, 1)
+// CHECK:           %[[TILE_0_2:.*]] = aie.tile(0, 2)
+// CHECK:           %[[TILE_0_3:.*]] = aie.tile(0, 3)
+// CHECK:           %[[TILE_0_4:.*]] = aie.tile(0, 4)
+// CHECK:           %[[TILE_0_5:.*]] = aie.tile(0, 5)
+// CHECK:           %[[TILE_1_0:.*]] = aie.tile(1, 0)
+// CHECK:           %[[SHIM_MUX_1_0:.*]] = aie.shim_mux(%[[TILE_1_0]]) {
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_1_0:.*]] = aie.switchbox(%[[TILE_1_0]]) {
+// CHECK:             %[[VAL_0:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_1:.*]] = aie.masterset(WEST : 2, %[[VAL_0]])
+// CHECK:             aie.packet_rules(NORTH : 1) {
+// CHECK:               aie.rule(31, 0, %[[VAL_0]])
+// CHECK:             }
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_0_1:.*]] = aie.switchbox(%[[TILE_0_1]]) {
+// CHECK:             aie.connect<NORTH : 0, DMA : 0>
+// CHECK:             aie.connect<NORTH : 2, DMA : 1>
+// CHECK:             aie.connect<NORTH : 1, DMA : 2>
+// CHECK:             aie.connect<NORTH : 3, DMA : 3>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 1>
+// CHECK:             %[[VAL_2:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_3:.*]] = aie.masterset(DMA : 4, %[[VAL_2]])
+// CHECK:             aie.packet_rules(SOUTH : 2) {
+// CHECK:               aie.rule(31, 0, %[[VAL_2]])
+// CHECK:             }
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_0_2:.*]] = aie.switchbox(%[[TILE_0_2]]) {
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_0_3:.*]] = aie.switchbox(%[[TILE_0_3]]) {
+// CHECK:             aie.connect<DMA : 0, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_0_4:.*]] = aie.switchbox(%[[TILE_0_4]]) {
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_0_5:.*]] = aie.switchbox(%[[TILE_0_5]]) {
+// CHECK:             aie.connect<DMA : 0, SOUTH : 1>
+// CHECK:             %[[VAL_4:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_5:.*]] = aie.masterset(EAST : 3, %[[VAL_4]])
+// CHECK:             aie.packet_rules(DMA : 1) {
+// CHECK:               aie.rule(31, 0, %[[VAL_4]])
+// CHECK:             }
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_0_0:.*]] = aie.switchbox(%[[TILE_0_0]]) {
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 2>
+// CHECK:             %[[VAL_6:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_7:.*]] = aie.masterset(NORTH : 2, %[[VAL_6]])
+// CHECK:             aie.packet_rules(EAST : 2) {
+// CHECK:               aie.rule(31, 0, %[[VAL_6]])
+// CHECK:             }
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_0_0:.*]] = aie.shim_mux(%[[TILE_0_0]]) {
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:           }
+// CHECK:           aie.packet_flow(0) {
+// CHECK:             aie.packet_source<%[[TILE_0_5]], DMA : 1>
+// CHECK:             aie.packet_dest<%[[TILE_0_1]], DMA : 4>
+// CHECK:           }
+// CHECK:         }
 module {
  aie.device(npu1_2col) {
   %tile_0_0 = aie.tile(0, 0)

--- a/compiler/plugins/target/AMD-AIE/aie/test/test_create_packet_flows6.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/test_create_packet_flows6.mlir
@@ -4,7 +4,7 @@
 // CHECK:           %[[TILE_2_2:.*]] = aie.tile(2, 2)
 // CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
 // CHECK:             %[[VAL_0:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_1:.*]] = aie.masterset(EAST : 0, %[[VAL_0]])
+// CHECK:             %[[VAL_1:.*]] = aie.masterset(EAST : 2, %[[VAL_0]])
 // CHECK:             aie.packet_rules(DMA : 0) {
 // CHECK:               aie.rule(28, 0, %[[VAL_0]])
 // CHECK:             }
@@ -14,10 +14,10 @@
 // CHECK:             %[[VAL_2:.*]] = aie.amsel<0> (0)
 // CHECK:             %[[VAL_3:.*]] = aie.amsel<1> (0)
 // CHECK:             %[[VAL_4:.*]] = aie.masterset(DMA : 0, %[[VAL_2]])
-// CHECK:             %[[VAL_5:.*]] = aie.masterset(EAST : 0, %[[VAL_3]])
-// CHECK:             aie.packet_rules(WEST : 0) {
-// CHECK-DAG:           aie.rule(31, 0, %[[VAL_2]])
-// CHECK-DAG:           aie.rule(28, 0, %[[VAL_3]])
+// CHECK:             %[[VAL_5:.*]] = aie.masterset(EAST : 2, %[[VAL_3]])
+// CHECK:             aie.packet_rules(WEST : 2) {
+// CHECK:               aie.rule(31, 0, %[[VAL_2]])
+// CHECK:               aie.rule(28, 0, %[[VAL_3]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_4_2:.*]] = aie.tile(4, 2)
@@ -26,9 +26,9 @@
 // CHECK:             %[[VAL_7:.*]] = aie.amsel<1> (0)
 // CHECK:             %[[VAL_8:.*]] = aie.masterset(DMA : 0, %[[VAL_6]])
 // CHECK:             %[[VAL_9:.*]] = aie.masterset(EAST : 0, %[[VAL_7]])
-// CHECK:             aie.packet_rules(WEST : 0) {
-// CHECK-DAG:           aie.rule(30, 2, %[[VAL_7]])
-// CHECK-DAG:           aie.rule(31, 1, %[[VAL_6]])
+// CHECK:             aie.packet_rules(WEST : 2) {
+// CHECK:               aie.rule(31, 1, %[[VAL_6]])
+// CHECK:               aie.rule(30, 2, %[[VAL_7]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_5_2:.*]] = aie.tile(5, 2)
@@ -38,8 +38,8 @@
 // CHECK:             %[[VAL_12:.*]] = aie.masterset(DMA : 0, %[[VAL_10]])
 // CHECK:             %[[VAL_13:.*]] = aie.masterset(EAST : 0, %[[VAL_11]])
 // CHECK:             aie.packet_rules(WEST : 0) {
-// CHECK-DAG:           aie.rule(31, 2, %[[VAL_10]])
-// CHECK-DAG:           aie.rule(31, 3, %[[VAL_11]])
+// CHECK:               aie.rule(31, 2, %[[VAL_10]])
+// CHECK:               aie.rule(31, 3, %[[VAL_11]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_6_2:.*]] = aie.tile(6, 2)
@@ -67,7 +67,6 @@
 // CHECK:             aie.packet_dest<%[[TILE_6_2]], DMA : 0>
 // CHECK:           }
 // CHECK:         }
-
 module @test_create_packet_flows6 {
  aie.device(xcvc1902) {
   %tile22 = aie.tile(2, 2)

--- a/compiler/plugins/target/AMD-AIE/aie/test/test_pktflow_weight_pusher.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/test_pktflow_weight_pusher.mlir
@@ -5,7 +5,7 @@
 // CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
 // CHECK:             %[[VAL_0:.*]] = aie.amsel<0> (0)
 // CHECK:             %[[VAL_1:.*]] = aie.masterset(DMA : 1, %[[VAL_0]])
-// CHECK:             aie.packet_rules(EAST : 0) {
+// CHECK:             aie.packet_rules(EAST : 2) {
 // CHECK:               aie.rule(31, 0, %[[VAL_0]])
 // CHECK:             }
 // CHECK:           }
@@ -14,8 +14,8 @@
 // CHECK:             %[[VAL_2:.*]] = aie.amsel<0> (0)
 // CHECK:             %[[VAL_3:.*]] = aie.amsel<1> (0)
 // CHECK:             %[[VAL_4:.*]] = aie.masterset(DMA : 1, %[[VAL_3]])
-// CHECK:             %[[VAL_5:.*]] = aie.masterset(WEST : 0, %[[VAL_2]])
-// CHECK:             aie.packet_rules(EAST : 0) {
+// CHECK:             %[[VAL_5:.*]] = aie.masterset(WEST : 2, %[[VAL_2]])
+// CHECK:             aie.packet_rules(EAST : 2) {
 // CHECK:               aie.rule(31, 0, %[[VAL_2]])
 // CHECK:               aie.rule(31, 4, %[[VAL_3]])
 // CHECK:             }
@@ -24,85 +24,88 @@
 // CHECK:           %[[SWITCHBOX_4_2:.*]] = aie.switchbox(%[[TILE_4_2]]) {
 // CHECK:             %[[VAL_6:.*]] = aie.amsel<0> (0)
 // CHECK:             %[[VAL_7:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_8:.*]] = aie.masterset(DMA : 1, %[[VAL_7]])
-// CHECK:             %[[VAL_9:.*]] = aie.masterset(WEST : 0, %[[VAL_6]])
-// CHECK:             aie.packet_rules(NORTH : 0) {
-// CHECK:               aie.rule(27, 0, %[[VAL_6]])
-// CHECK:               aie.rule(31, 8, %[[VAL_7]])
+// CHECK:             %[[VAL_8:.*]] = aie.masterset(DMA : 1, %[[VAL_6]])
+// CHECK:             %[[VAL_9:.*]] = aie.masterset(WEST : 2, %[[VAL_7]])
+// CHECK:             aie.packet_rules(NORTH : 1) {
+// CHECK:               aie.rule(31, 8, %[[VAL_6]])
+// CHECK:             }
+// CHECK:             aie.packet_rules(EAST : 3) {
+// CHECK:               aie.rule(27, 0, %[[VAL_7]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_5_2:.*]] = aie.tile(5, 2)
 // CHECK:           %[[SWITCHBOX_5_2:.*]] = aie.switchbox(%[[TILE_5_2]]) {
 // CHECK:             %[[VAL_10:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_11:.*]] = aie.masterset(DMA : 1, %[[VAL_10]])
-// CHECK:             aie.packet_rules(NORTH : 0) {
+// CHECK:             %[[VAL_11:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_12:.*]] = aie.masterset(DMA : 1, %[[VAL_10]])
+// CHECK:             %[[VAL_13:.*]] = aie.masterset(WEST : 3, %[[VAL_11]])
+// CHECK:             aie.packet_rules(EAST : 1) {
 // CHECK:               aie.rule(31, 12, %[[VAL_10]])
+// CHECK:             }
+// CHECK:             aie.packet_rules(EAST : 3) {
+// CHECK:               aie.rule(27, 0, %[[VAL_11]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_2_3:.*]] = aie.tile(2, 3)
 // CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
-// CHECK:             %[[VAL_12:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_13:.*]] = aie.masterset(DMA : 1, %[[VAL_12]])
-// CHECK:             aie.packet_rules(NORTH : 0) {
-// CHECK:               aie.rule(31, 1, %[[VAL_12]])
+// CHECK:             %[[VAL_14:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_15:.*]] = aie.masterset(DMA : 1, %[[VAL_14]])
+// CHECK:             aie.packet_rules(NORTH : 2) {
+// CHECK:               aie.rule(31, 1, %[[VAL_14]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_3_3:.*]] = aie.tile(3, 3)
 // CHECK:           %[[SWITCHBOX_3_3:.*]] = aie.switchbox(%[[TILE_3_3]]) {
-// CHECK:             %[[VAL_14:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_15:.*]] = aie.masterset(DMA : 1, %[[VAL_14]])
-// CHECK:             aie.packet_rules(EAST : 0) {
-// CHECK:               aie.rule(31, 5, %[[VAL_14]])
+// CHECK:             %[[VAL_16:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_17:.*]] = aie.masterset(DMA : 1, %[[VAL_16]])
+// CHECK:             aie.packet_rules(EAST : 2) {
+// CHECK:               aie.rule(31, 5, %[[VAL_16]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_4_3:.*]] = aie.tile(4, 3)
 // CHECK:           %[[SWITCHBOX_4_3:.*]] = aie.switchbox(%[[TILE_4_3]]) {
-// CHECK:             %[[VAL_16:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_17:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_18:.*]] = aie.amsel<2> (0)
-// CHECK:             %[[VAL_19:.*]] = aie.masterset(DMA : 1, %[[VAL_18]])
-// CHECK:             %[[VAL_20:.*]] = aie.masterset(SOUTH : 0, %[[VAL_16]])
-// CHECK:             %[[VAL_21:.*]] = aie.masterset(WEST : 0, %[[VAL_17]])
-// CHECK:             aie.packet_rules(NORTH : 0) {
-// CHECK:               aie.rule(27, 0, %[[VAL_16]])
-// CHECK:               aie.rule(31, 5, %[[VAL_17]])
+// CHECK:             %[[VAL_18:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_19:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_20:.*]] = aie.amsel<2> (0)
+// CHECK:             %[[VAL_21:.*]] = aie.masterset(DMA : 1, %[[VAL_20]])
+// CHECK:             %[[VAL_22:.*]] = aie.masterset(SOUTH : 1, %[[VAL_19]])
+// CHECK:             %[[VAL_23:.*]] = aie.masterset(WEST : 2, %[[VAL_18]])
+// CHECK:             aie.packet_rules(NORTH : 1) {
+// CHECK:               aie.rule(31, 5, %[[VAL_18]])
 // CHECK:             }
-// CHECK:             aie.packet_rules(EAST : 0) {
-// CHECK:               aie.rule(31, 8, %[[VAL_16]])
-// CHECK:               aie.rule(31, 9, %[[VAL_18]])
+// CHECK:             aie.packet_rules(NORTH : 3) {
+// CHECK:               aie.rule(31, 8, %[[VAL_19]])
+// CHECK:               aie.rule(31, 9, %[[VAL_20]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_5_3:.*]] = aie.tile(5, 3)
 // CHECK:           %[[SWITCHBOX_5_3:.*]] = aie.switchbox(%[[TILE_5_3]]) {
-// CHECK:             %[[VAL_22:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_23:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_24:.*]] = aie.amsel<2> (0)
+// CHECK:             %[[VAL_24:.*]] = aie.amsel<0> (0)
 // CHECK:             %[[VAL_25:.*]] = aie.masterset(DMA : 1, %[[VAL_24]])
-// CHECK:             %[[VAL_26:.*]] = aie.masterset(SOUTH : 0, %[[VAL_23]])
-// CHECK:             %[[VAL_27:.*]] = aie.masterset(WEST : 0, %[[VAL_22]])
-// CHECK:             aie.packet_rules(NORTH : 0) {
-// CHECK:               aie.rule(30, 8, %[[VAL_22]])
-// CHECK:               aie.rule(31, 12, %[[VAL_23]])
+// CHECK:             aie.packet_rules(NORTH : 1) {
 // CHECK:               aie.rule(31, 13, %[[VAL_24]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_2_4:.*]] = aie.tile(2, 4)
 // CHECK:           %[[SWITCHBOX_2_4:.*]] = aie.switchbox(%[[TILE_2_4]]) {
-// CHECK:             %[[VAL_28:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_29:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_30:.*]] = aie.masterset(DMA : 1, %[[VAL_29]])
-// CHECK:             %[[VAL_31:.*]] = aie.masterset(SOUTH : 0, %[[VAL_28]])
-// CHECK:             aie.packet_rules(NORTH : 0) {
-// CHECK:               aie.rule(31, 1, %[[VAL_28]])
-// CHECK:               aie.rule(31, 2, %[[VAL_29]])
+// CHECK:             %[[VAL_26:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_27:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_28:.*]] = aie.masterset(DMA : 1, %[[VAL_27]])
+// CHECK:             %[[VAL_29:.*]] = aie.masterset(SOUTH : 2, %[[VAL_26]])
+// CHECK:             aie.packet_rules(EAST : 1) {
+// CHECK:               aie.rule(31, 1, %[[VAL_26]])
+// CHECK:               aie.rule(31, 2, %[[VAL_27]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_3_4:.*]] = aie.tile(3, 4)
 // CHECK:           %[[SWITCHBOX_3_4:.*]] = aie.switchbox(%[[TILE_3_4]]) {
-// CHECK:             %[[VAL_32:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_33:.*]] = aie.masterset(DMA : 1, %[[VAL_32]])
-// CHECK:             aie.packet_rules(EAST : 0) {
-// CHECK:               aie.rule(31, 6, %[[VAL_32]])
+// CHECK:             %[[VAL_30:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_31:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_32:.*]] = aie.masterset(DMA : 1, %[[VAL_31]])
+// CHECK:             %[[VAL_33:.*]] = aie.masterset(WEST : 1, %[[VAL_30]])
+// CHECK:             aie.packet_rules(NORTH : 1) {
+// CHECK:               aie.rule(28, 0, %[[VAL_30]])
+// CHECK:               aie.rule(31, 6, %[[VAL_31]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_4_4:.*]] = aie.tile(4, 4)
@@ -110,101 +113,109 @@
 // CHECK:             %[[VAL_34:.*]] = aie.amsel<0> (0)
 // CHECK:             %[[VAL_35:.*]] = aie.amsel<1> (0)
 // CHECK:             %[[VAL_36:.*]] = aie.amsel<2> (0)
-// CHECK:             %[[VAL_37:.*]] = aie.masterset(DMA : 1, %[[VAL_34]])
-// CHECK:             %[[VAL_38:.*]] = aie.masterset(SOUTH : 0, %[[VAL_35]])
-// CHECK:             %[[VAL_39:.*]] = aie.masterset(WEST : 0, %[[VAL_36]])
-// CHECK:             aie.packet_rules(NORTH : 0) {
-// CHECK:               aie.rule(31, 10, %[[VAL_34]])
-// CHECK:             }
-// CHECK:             aie.packet_rules(EAST : 0) {
-// CHECK:               aie.rule(26, 0, %[[VAL_35]])
-// CHECK:               aie.rule(31, 6, %[[VAL_36]])
+// CHECK:             %[[VAL_37:.*]] = aie.masterset(DMA : 1, %[[VAL_36]])
+// CHECK:             %[[VAL_38:.*]] = aie.masterset(SOUTH : 1, %[[VAL_34]])
+// CHECK:             %[[VAL_39:.*]] = aie.masterset(SOUTH : 3, %[[VAL_35]])
+// CHECK:             aie.packet_rules(NORTH : 3) {
+// CHECK:               aie.rule(31, 5, %[[VAL_34]])
+// CHECK:               aie.rule(30, 8, %[[VAL_35]])
+// CHECK:               aie.rule(31, 10, %[[VAL_36]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_5_4:.*]] = aie.tile(5, 4)
 // CHECK:           %[[SWITCHBOX_5_4:.*]] = aie.switchbox(%[[TILE_5_4]]) {
 // CHECK:             %[[VAL_40:.*]] = aie.amsel<0> (0)
 // CHECK:             %[[VAL_41:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_42:.*]] = aie.amsel<2> (0)
-// CHECK:             %[[VAL_43:.*]] = aie.masterset(DMA : 1, %[[VAL_42]])
-// CHECK:             %[[VAL_44:.*]] = aie.masterset(SOUTH : 0, %[[VAL_41]])
-// CHECK:             %[[VAL_45:.*]] = aie.masterset(WEST : 0, %[[VAL_40]])
-// CHECK:             aie.packet_rules(EAST : 0) {
-// CHECK:               aie.rule(24, 0, %[[VAL_40]])
-// CHECK:               aie.rule(26, 8, %[[VAL_41]])
-// CHECK:               aie.rule(31, 14, %[[VAL_42]])
+// CHECK:             %[[VAL_42:.*]] = aie.masterset(DMA : 1, %[[VAL_41]])
+// CHECK:             %[[VAL_43:.*]] = aie.masterset(SOUTH : 1, %[[VAL_40]])
+// CHECK:             aie.packet_rules(NORTH : 0) {
+// CHECK:               aie.rule(31, 13, %[[VAL_40]])
+// CHECK:               aie.rule(31, 14, %[[VAL_41]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_2_5:.*]] = aie.tile(2, 5)
 // CHECK:           %[[SWITCHBOX_2_5:.*]] = aie.switchbox(%[[TILE_2_5]]) {
-// CHECK:             %[[VAL_46:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_47:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_48:.*]] = aie.masterset(DMA : 1, %[[VAL_47]])
-// CHECK:             %[[VAL_49:.*]] = aie.masterset(SOUTH : 0, %[[VAL_46]])
-// CHECK:             aie.packet_rules(EAST : 0) {
-// CHECK:               aie.rule(28, 0, %[[VAL_46]])
-// CHECK:               aie.rule(31, 3, %[[VAL_47]])
+// CHECK:             %[[VAL_44:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_45:.*]] = aie.masterset(DMA : 1, %[[VAL_44]])
+// CHECK:             aie.packet_rules(EAST : 1) {
+// CHECK:               aie.rule(31, 3, %[[VAL_44]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_3_5:.*]] = aie.tile(3, 5)
 // CHECK:           %[[SWITCHBOX_3_5:.*]] = aie.switchbox(%[[TILE_3_5]]) {
-// CHECK:             %[[VAL_50:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_51:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_52:.*]] = aie.masterset(DMA : 1, %[[VAL_51]])
-// CHECK:             %[[VAL_53:.*]] = aie.masterset(WEST : 0, %[[VAL_50]])
-// CHECK:             aie.packet_rules(EAST : 0) {
-// CHECK:               aie.rule(28, 0, %[[VAL_50]])
-// CHECK:               aie.rule(31, 7, %[[VAL_51]])
+// CHECK:             %[[VAL_46:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_47:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_48:.*]] = aie.amsel<2> (0)
+// CHECK:             %[[VAL_49:.*]] = aie.masterset(DMA : 1, %[[VAL_48]])
+// CHECK:             %[[VAL_50:.*]] = aie.masterset(SOUTH : 1, %[[VAL_46]])
+// CHECK:             %[[VAL_51:.*]] = aie.masterset(WEST : 1, %[[VAL_47]])
+// CHECK:             aie.packet_rules(EAST : 2) {
+// CHECK:               aie.rule(24, 0, %[[VAL_46]])
+// CHECK:               aie.rule(31, 3, %[[VAL_47]])
+// CHECK:               aie.rule(31, 7, %[[VAL_48]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_4_5:.*]] = aie.tile(4, 5)
 // CHECK:           %[[SWITCHBOX_4_5:.*]] = aie.switchbox(%[[TILE_4_5]]) {
-// CHECK:             %[[VAL_54:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_55:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_56:.*]] = aie.amsel<2> (0)
-// CHECK:             %[[VAL_57:.*]] = aie.masterset(DMA : 1, %[[VAL_56]])
-// CHECK:             %[[VAL_58:.*]] = aie.masterset(SOUTH : 0, %[[VAL_55]])
-// CHECK:             %[[VAL_59:.*]] = aie.masterset(WEST : 0, %[[VAL_54]])
-// CHECK:             aie.packet_rules(EAST : 0) {
-// CHECK:               aie.rule(24, 0, %[[VAL_54]])
-// CHECK:               aie.rule(31, 10, %[[VAL_55]])
-// CHECK:               aie.rule(31, 11, %[[VAL_56]])
+// CHECK:             %[[VAL_52:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_53:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_54:.*]] = aie.amsel<2> (0)
+// CHECK:             %[[VAL_55:.*]] = aie.masterset(DMA : 1, %[[VAL_54]])
+// CHECK:             %[[VAL_56:.*]] = aie.masterset(SOUTH : 3, %[[VAL_53]])
+// CHECK:             %[[VAL_57:.*]] = aie.masterset(WEST : 2, %[[VAL_52]])
+// CHECK:             aie.packet_rules(EAST : 2) {
+// CHECK:               aie.rule(24, 0, %[[VAL_52]])
+// CHECK:               aie.rule(31, 5, %[[VAL_53]])
+// CHECK:             }
+// CHECK:             aie.packet_rules(EAST : 3) {
+// CHECK:               aie.rule(28, 8, %[[VAL_53]])
+// CHECK:               aie.rule(31, 11, %[[VAL_54]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_5_5:.*]] = aie.tile(5, 5)
 // CHECK:           %[[SWITCHBOX_5_5:.*]] = aie.switchbox(%[[TILE_5_5]]) {
-// CHECK:             %[[VAL_60:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_61:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_58:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_59:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_60:.*]] = aie.amsel<2> (0)
+// CHECK:             %[[VAL_61:.*]] = aie.amsel<3> (0)
 // CHECK:             %[[VAL_62:.*]] = aie.masterset(DMA : 1, %[[VAL_61]])
-// CHECK:             %[[VAL_63:.*]] = aie.masterset(WEST : 0, %[[VAL_60]])
-// CHECK:             aie.packet_rules(EAST : 0) {
-// CHECK:               aie.rule(16, 0, %[[VAL_60]])
+// CHECK:             %[[VAL_63:.*]] = aie.masterset(SOUTH : 0, %[[VAL_60]])
+// CHECK:             %[[VAL_64:.*]] = aie.masterset(WEST : 2, %[[VAL_58]])
+// CHECK:             %[[VAL_65:.*]] = aie.masterset(WEST : 3, %[[VAL_59]])
+// CHECK:             aie.packet_rules(EAST : 2) {
+// CHECK:               aie.rule(24, 0, %[[VAL_58]])
+// CHECK:             }
+// CHECK:             aie.packet_rules(EAST : 3) {
+// CHECK:               aie.rule(28, 8, %[[VAL_59]])
+// CHECK:               aie.rule(28, 12, %[[VAL_60]])
 // CHECK:               aie.rule(31, 15, %[[VAL_61]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_6_5:.*]] = aie.tile(6, 5)
 // CHECK:           %[[SWITCHBOX_6_5:.*]] = aie.switchbox(%[[TILE_6_5]]) {
-// CHECK:             %[[VAL_64:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_65:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_66:.*]] = aie.masterset(SOUTH : 0, %[[VAL_64]])
-// CHECK:             %[[VAL_67:.*]] = aie.masterset(WEST : 0, %[[VAL_65]])
+// CHECK:             %[[VAL_66:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_67:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_68:.*]] = aie.amsel<2> (0)
+// CHECK:             %[[VAL_69:.*]] = aie.masterset(SOUTH : 2, %[[VAL_66]])
+// CHECK:             %[[VAL_70:.*]] = aie.masterset(WEST : 2, %[[VAL_67]])
+// CHECK:             %[[VAL_71:.*]] = aie.masterset(WEST : 3, %[[VAL_68]])
 // CHECK:             aie.packet_rules(DMA : 0) {
-// CHECK:               aie.rule(24, 0, %[[VAL_64]])
-// CHECK:               aie.rule(24, 0, %[[VAL_65]])
+// CHECK:               aie.rule(27, 0, %[[VAL_66]])
+// CHECK:               aie.rule(24, 0, %[[VAL_67]])
 // CHECK:             }
 // CHECK:             aie.packet_rules(EAST : 0) {
-// CHECK:               aie.rule(26, 10, %[[VAL_65]])
+// CHECK:               aie.rule(24, 8, %[[VAL_68]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_7_5:.*]] = aie.tile(7, 5)
 // CHECK:           %[[SWITCHBOX_7_5:.*]] = aie.switchbox(%[[TILE_7_5]]) {
-// CHECK:             %[[VAL_68:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_69:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_70:.*]] = aie.masterset(SOUTH : 0, %[[VAL_68]])
-// CHECK:             %[[VAL_71:.*]] = aie.masterset(WEST : 0, %[[VAL_69]])
+// CHECK:             %[[VAL_72:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_73:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_74:.*]] = aie.masterset(SOUTH : 0, %[[VAL_73]])
+// CHECK:             %[[VAL_75:.*]] = aie.masterset(WEST : 0, %[[VAL_72]])
 // CHECK:             aie.packet_rules(DMA : 0) {
-// CHECK:               aie.rule(24, 8, %[[VAL_68]])
-// CHECK:               aie.rule(26, 10, %[[VAL_69]])
+// CHECK:               aie.rule(24, 8, %[[VAL_72]])
+// CHECK:               aie.rule(31, 12, %[[VAL_73]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           aie.packet_flow(0) {

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_broadcast.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_broadcast.mlir
@@ -3,6 +3,8 @@
 
 // CHECK-LABEL:   aie.device(xcvc1902) {
 // CHECK:           %[[TILE_0_3:.*]] = aie.tile(0, 3)
+// CHECK:           %[[SWITCHBOX_0_3:.*]] = aie.switchbox(%[[TILE_0_3]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_0_2:.*]] = aie.tile(0, 2)
 // CHECK:           %[[TILE_0_0:.*]] = aie.tile(0, 0)
 // CHECK:           %[[TILE_1_3:.*]] = aie.tile(1, 3)
@@ -10,124 +12,119 @@
 // CHECK:           %[[TILE_1_0:.*]] = aie.tile(1, 0)
 // CHECK:           %[[TILE_2_0:.*]] = aie.tile(2, 0)
 // CHECK:           %[[TILE_3_0:.*]] = aie.tile(3, 0)
+// CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_2_2:.*]] = aie.tile(2, 2)
 // CHECK:           %[[TILE_3_1:.*]] = aie.tile(3, 1)
 // CHECK:           %[[TILE_6_0:.*]] = aie.tile(6, 0)
 // CHECK:           %[[TILE_7_0:.*]] = aie.tile(7, 0)
+// CHECK:           %[[SHIM_MUX_7_0:.*]] = aie.shim_mux(%[[TILE_7_0]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_7_1:.*]] = aie.tile(7, 1)
 // CHECK:           %[[TILE_7_2:.*]] = aie.tile(7, 2)
 // CHECK:           %[[TILE_7_3:.*]] = aie.tile(7, 3)
+// CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_8_0:.*]] = aie.tile(8, 0)
 // CHECK:           %[[TILE_8_2:.*]] = aie.tile(8, 2)
 // CHECK:           %[[TILE_8_3:.*]] = aie.tile(8, 3)
+// CHECK:           %[[SWITCHBOX_1_0:.*]] = aie.switchbox(%[[TILE_1_0]]) {
+// CHECK:             aie.connect<EAST : 3, NORTH : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_1_1:.*]] = aie.switchbox(%[[TILE_1_1]]) {
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 5>
+// CHECK:           }
+// CHECK:           %[[TILE_1_2:.*]] = aie.tile(1, 2)
+// CHECK:           %[[SWITCHBOX_1_2:.*]] = aie.switchbox(%[[TILE_1_2]]) {
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 5>
+// CHECK:           }
 // CHECK:           %[[SWITCHBOX_1_3:.*]] = aie.switchbox(%[[TILE_1_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 5, DMA : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 1>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 5>
+// CHECK:             aie.connect<SOUTH : 3, EAST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_2_1:.*]] = aie.tile(2, 1)
 // CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, DMA : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_2_3:.*]] = aie.tile(2, 3)
-// CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 5, EAST : 1>
+// CHECK:             aie.connect<EAST : 1, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_0:.*]] = aie.switchbox(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<WEST : 2, EAST : 2>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, NORTH : 4>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_1:.*]] = aie.switchbox(%[[TILE_3_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 1>
+// CHECK:             aie.connect<WEST : 1, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 4, DMA : 1>
+// CHECK:             aie.connect<SOUTH : 4, WEST : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_4_0:.*]] = aie.tile(4, 0)
 // CHECK:           %[[SWITCHBOX_4_0:.*]] = aie.switchbox(%[[TILE_4_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<WEST : 2, EAST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_5_0:.*]] = aie.tile(5, 0)
 // CHECK:           %[[SWITCHBOX_5_0:.*]] = aie.switchbox(%[[TILE_5_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_6_0:.*]] = aie.switchbox(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_6_1:.*]] = aie.tile(6, 1)
-// CHECK:           %[[SWITCHBOX_6_1:.*]] = aie.switchbox(%[[TILE_6_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_6_2:.*]] = aie.tile(6, 2)
-// CHECK:           %[[SWITCHBOX_6_2:.*]] = aie.switchbox(%[[TILE_6_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, EAST : 1>
+// CHECK:             aie.connect<WEST : 1, EAST : 1>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 5>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_0:.*]] = aie.switchbox(%[[TILE_7_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
+// CHECK:             aie.connect<WEST : 1, NORTH : 2>
+// CHECK:             aie.connect<WEST : 1, EAST : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_1:.*]] = aie.switchbox(%[[TILE_7_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 2, DMA : 0>
+// CHECK:             aie.connect<WEST : 1, NORTH : 4>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_2:.*]] = aie.switchbox(%[[TILE_7_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, NORTH : 0>
+// CHECK:           %[[SWITCHBOX_8_0:.*]] = aie.switchbox(%[[TILE_8_0]]) {
+// CHECK:             aie.connect<WEST : 1, NORTH : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_8_1:.*]] = aie.tile(8, 1)
+// CHECK:           %[[SWITCHBOX_8_1:.*]] = aie.switchbox(%[[TILE_8_1]]) {
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 2>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_8_2:.*]] = aie.switchbox(%[[TILE_8_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 2, DMA : 0>
+// CHECK:             aie.connect<WEST : 3, NORTH : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_0_0:.*]] = aie.switchbox(%[[TILE_0_0]]) {
+// CHECK:             aie.connect<EAST : 2, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[TILE_0_1:.*]] = aie.tile(0, 1)
 // CHECK:           %[[SWITCHBOX_0_1:.*]] = aie.switchbox(%[[TILE_0_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_2:.*]] = aie.switchbox(%[[TILE_0_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 1>
+// CHECK:             aie.connect<SOUTH : 1, DMA : 1>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_1_1:.*]] = aie.switchbox(%[[TILE_1_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_3_2:.*]] = aie.tile(3, 2)
-// CHECK:           %[[SWITCHBOX_3_2:.*]] = aie.switchbox(%[[TILE_3_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_4_1:.*]] = aie.tile(4, 1)
-// CHECK:           %[[SWITCHBOX_4_1:.*]] = aie.switchbox(%[[TILE_4_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_4_2:.*]] = aie.tile(4, 2)
-// CHECK:           %[[SWITCHBOX_4_2:.*]] = aie.switchbox(%[[TILE_4_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_5_1:.*]] = aie.tile(5, 1)
-// CHECK:           %[[SWITCHBOX_5_1:.*]] = aie.switchbox(%[[TILE_5_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
+// CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
+// CHECK:             aie.connect<SOUTH : 0, DMA : 1>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_6_0:.*]] = aie.shim_mux(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
+// CHECK:           %[[TILE_6_1:.*]] = aie.tile(6, 1)
+// CHECK:           %[[SWITCHBOX_6_1:.*]] = aie.switchbox(%[[TILE_6_1]]) {
+// CHECK:             aie.connect<SOUTH : 5, EAST : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_7_2:.*]] = aie.switchbox(%[[TILE_7_2]]) {
+// CHECK:             aie.connect<SOUTH : 4, EAST : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_8_3:.*]] = aie.switchbox(%[[TILE_8_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, DMA : 1>
+// CHECK:             aie.connect<SOUTH : 1, DMA : 1>
 // CHECK:           }
 // CHECK:         }
 

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_flow_test_1.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_flow_test_1.mlir
@@ -15,269 +15,260 @@
 // CHECK:           %[[TILE_8_3:.*]] = aie.tile(8, 3)
 // CHECK:           %[[TILE_8_4:.*]] = aie.tile(8, 4)
 // CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, NORTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 3>
-// CHECK-DAG:         aie.connect<EAST : 1, SOUTH : 2>
+// CHECK:             aie.connect<SOUTH : 3, EAST : 2>
+// CHECK:             aie.connect<SOUTH : 7, EAST : 3>
+// CHECK:             aie.connect<EAST : 2, SOUTH : 3>
+// CHECK:             aie.connect<EAST : 0, SOUTH : 2>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_2_1:.*]] = aie.tile(2, 1)
-// CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_2_2:.*]] = aie.tile(2, 2)
-// CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, EAST : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_3_2:.*]] = aie.tile(3, 2)
-// CHECK:           %[[SWITCHBOX_3_2:.*]] = aie.switchbox(%[[TILE_3_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 2>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_4_2:.*]] = aie.tile(4, 2)
-// CHECK:           %[[SWITCHBOX_4_2:.*]] = aie.switchbox(%[[TILE_4_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<WEST : 2, EAST : 2>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 3>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_5_2:.*]] = aie.tile(5, 2)
-// CHECK:           %[[SWITCHBOX_5_2:.*]] = aie.switchbox(%[[TILE_5_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<WEST : 2, NORTH : 2>
-// CHECK-DAG:         aie.connect<WEST : 3, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 2>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_5_3:.*]] = aie.tile(5, 3)
-// CHECK:           %[[SWITCHBOX_5_3:.*]] = aie.switchbox(%[[TILE_5_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 2>
-// CHECK-DAG:         aie.connect<WEST : 1, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_6_3:.*]] = aie.switchbox(%[[TILE_6_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, CORE : 1>
-// CHECK-DAG:         aie.connect<WEST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 1>
-// CHECK-DAG:         aie.connect<CORE : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_7_3:.*]] = aie.tile(7, 3)
-// CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 2, EAST : 2>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 2, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_8_3:.*]] = aie.switchbox(%[[TILE_8_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 2, CORE : 1>
-// CHECK-DAG:         aie.connect<CORE : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 0>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_0:.*]] = aie.switchbox(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 3>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<WEST : 2, EAST : 2>
+// CHECK:             aie.connect<WEST : 3, EAST : 3>
+// CHECK:             aie.connect<SOUTH : 3, EAST : 0>
+// CHECK:             aie.connect<SOUTH : 7, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 2, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[TILE_4_0:.*]] = aie.tile(4, 0)
 // CHECK:           %[[SWITCHBOX_4_0:.*]] = aie.switchbox(%[[TILE_4_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<WEST : 2, EAST : 3>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<WEST : 0, EAST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, NORTH : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_5_0:.*]] = aie.tile(5, 0)
 // CHECK:           %[[SWITCHBOX_5_0:.*]] = aie.switchbox(%[[TILE_5_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 1, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 2, WEST : 1>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<WEST : 1, EAST : 2>
+// CHECK:             aie.connect<WEST : 2, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 0, EAST : 3>
+// CHECK:             aie.connect<NORTH : 1, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_6_0:.*]] = aie.switchbox(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
-// CHECK-DAG:         aie.connect<WEST : 1, SOUTH : 2>
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 0>
+// CHECK:             aie.connect<WEST : 1, NORTH : 2>
+// CHECK:             aie.connect<WEST : 2, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 3, EAST : 2>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 2>
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 5>
+// CHECK:             aie.connect<SOUTH : 7, NORTH : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_6_1:.*]] = aie.tile(6, 1)
 // CHECK:           %[[SWITCHBOX_6_1:.*]] = aie.switchbox(%[[TILE_6_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, SOUTH : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 2, NORTH : 1>
+// CHECK:             aie.connect<SOUTH : 1, EAST : 3>
+// CHECK:             aie.connect<WEST : 1, NORTH : 5>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 1>
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 2>
+// CHECK:             aie.connect<SOUTH : 0, WEST : 2>
+// CHECK:             aie.connect<NORTH : 3, WEST : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_6_2:.*]] = aie.tile(6, 2)
 // CHECK:           %[[SWITCHBOX_6_2:.*]] = aie.switchbox(%[[TILE_6_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 1>
+// CHECK:             aie.connect<SOUTH : 5, EAST : 2>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 2>
+// CHECK:             aie.connect<SOUTH : 2, NORTH : 3>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_2:.*]] = aie.switchbox(%[[TILE_7_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<CORE : 0, NORTH : 2>
-// CHECK-DAG:         aie.connect<DMA : 1, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, CORE : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_3_1:.*]] = aie.tile(3, 1)
-// CHECK:           %[[SWITCHBOX_3_1:.*]] = aie.switchbox(%[[TILE_3_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_5_4:.*]] = aie.switchbox(%[[TILE_5_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, CORE : 1>
-// CHECK-DAG:         aie.connect<CORE : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_3_4:.*]] = aie.switchbox(%[[TILE_3_4]]) {
-// CHECK-DAG:         aie.connect<CORE : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, CORE : 1>
-// CHECK-DAG:         aie.connect<EAST : 1, DMA : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_4_4:.*]] = aie.switchbox(%[[TILE_4_4]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, EAST : 1>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 1, CORE : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_6_4:.*]] = aie.tile(6, 4)
-// CHECK:           %[[SWITCHBOX_6_4:.*]] = aie.switchbox(%[[TILE_6_4]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_3_3:.*]] = aie.tile(3, 3)
-// CHECK:           %[[SWITCHBOX_3_3:.*]] = aie.switchbox(%[[TILE_3_3]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_4_3:.*]] = aie.switchbox(%[[TILE_4_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, CORE : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_5_1:.*]] = aie.tile(5, 1)
-// CHECK:           %[[SWITCHBOX_5_1:.*]] = aie.switchbox(%[[TILE_5_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 2, SOUTH : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 2>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_0:.*]] = aie.switchbox(%[[TILE_7_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, NORTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 3>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_7_0:.*]] = aie.shim_mux(%[[TILE_7_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_7_4:.*]] = aie.tile(7, 4)
-// CHECK:           %[[SWITCHBOX_7_4:.*]] = aie.switchbox(%[[TILE_7_4]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_8_4:.*]] = aie.switchbox(%[[TILE_8_4]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, CORE : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_6_0:.*]] = aie.shim_mux(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK:           }
-// CHECK:           %[[TILE_4_1:.*]] = aie.tile(4, 1)
-// CHECK:           %[[SWITCHBOX_4_1:.*]] = aie.switchbox(%[[TILE_4_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
+// CHECK:           %[[SWITCHBOX_6_3:.*]] = aie.switchbox(%[[TILE_6_3]]) {
+// CHECK:             aie.connect<SOUTH : 1, DMA : 0>
+// CHECK:             aie.connect<WEST : 3, CORE : 1>
+// CHECK:             aie.connect<WEST : 2, EAST : 1>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 1>
+// CHECK:             aie.connect<CORE : 0, WEST : 3>
+// CHECK:             aie.connect<DMA : 1, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 0, NORTH : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[TILE_7_1:.*]] = aie.tile(7, 1)
 // CHECK:           %[[SWITCHBOX_7_1:.*]] = aie.switchbox(%[[TILE_7_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_8_0:.*]] = aie.tile(8, 0)
-// CHECK:           %[[SWITCHBOX_8_0:.*]] = aie.switchbox(%[[TILE_8_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
+// CHECK:             aie.connect<WEST : 3, EAST : 3>
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 2>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 0>
 // CHECK:           }
 // CHECK:           %[[TILE_8_1:.*]] = aie.tile(8, 1)
 // CHECK:           %[[SWITCHBOX_8_1:.*]] = aie.switchbox(%[[TILE_8_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
+// CHECK:             aie.connect<WEST : 3, NORTH : 4>
 // CHECK:           }
 // CHECK:           %[[TILE_8_2:.*]] = aie.tile(8, 2)
 // CHECK:           %[[SWITCHBOX_8_2:.*]] = aie.switchbox(%[[TILE_8_2]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
+// CHECK:             aie.connect<SOUTH : 4, NORTH : 5>
+// CHECK:             aie.connect<WEST : 2, NORTH : 4>
+// CHECK:             aie.connect<NORTH : 3, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_8_3:.*]] = aie.switchbox(%[[TILE_8_3]]) {
+// CHECK:             aie.connect<SOUTH : 5, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 4, CORE : 1>
+// CHECK:             aie.connect<CORE : 0, WEST : 3>
+// CHECK:             aie.connect<DMA : 1, WEST : 0>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_5_1:.*]] = aie.tile(5, 1)
+// CHECK:           %[[SWITCHBOX_5_1:.*]] = aie.switchbox(%[[TILE_5_1]]) {
+// CHECK:             aie.connect<SOUTH : 1, EAST : 1>
+// CHECK:             aie.connect<NORTH : 3, EAST : 3>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, NORTH : 3>
+// CHECK:             aie.connect<EAST : 1, SOUTH : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_7_2:.*]] = aie.switchbox(%[[TILE_7_2]]) {
+// CHECK:             aie.connect<WEST : 2, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 2, NORTH : 3>
+// CHECK:             aie.connect<CORE : 0, EAST : 2>
+// CHECK:             aie.connect<DMA : 1, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 1, CORE : 1>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_3_1:.*]] = aie.tile(3, 1)
+// CHECK:           %[[SWITCHBOX_3_1:.*]] = aie.switchbox(%[[TILE_3_1]]) {
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 2>
+// CHECK:             aie.connect<EAST : 1, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_3_2:.*]] = aie.tile(3, 2)
+// CHECK:           %[[SWITCHBOX_3_2:.*]] = aie.switchbox(%[[TILE_3_2]]) {
+// CHECK:             aie.connect<SOUTH : 2, NORTH : 0>
+// CHECK:             aie.connect<NORTH : 1, EAST : 1>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_3_3:.*]] = aie.tile(3, 3)
+// CHECK:           %[[SWITCHBOX_3_3:.*]] = aie.switchbox(%[[TILE_3_3]]) {
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 2>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 3, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_3_4:.*]] = aie.switchbox(%[[TILE_3_4]]) {
+// CHECK:             aie.connect<SOUTH : 2, EAST : 1>
+// CHECK:             aie.connect<CORE : 0, EAST : 2>
+// CHECK:             aie.connect<DMA : 1, SOUTH : 2>
+// CHECK:             aie.connect<EAST : 2, CORE : 1>
+// CHECK:             aie.connect<EAST : 3, DMA : 0>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_4_4:.*]] = aie.switchbox(%[[TILE_4_4]]) {
+// CHECK:             aie.connect<WEST : 1, EAST : 0>
+// CHECK:             aie.connect<WEST : 2, EAST : 1>
+// CHECK:             aie.connect<CORE : 0, EAST : 2>
+// CHECK:             aie.connect<DMA : 1, SOUTH : 2>
+// CHECK:             aie.connect<EAST : 0, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 4, WEST : 2>
+// CHECK:             aie.connect<SOUTH : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, CORE : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_5_4:.*]] = aie.switchbox(%[[TILE_5_4]]) {
+// CHECK:             aie.connect<WEST : 0, DMA : 0>
+// CHECK:             aie.connect<WEST : 1, SOUTH : 3>
+// CHECK:             aie.connect<WEST : 2, CORE : 1>
+// CHECK:             aie.connect<CORE : 0, SOUTH : 2>
+// CHECK:             aie.connect<DMA : 1, SOUTH : 0>
+// CHECK:             aie.connect<SOUTH : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_5_3:.*]] = aie.tile(5, 3)
+// CHECK:           %[[SWITCHBOX_5_3:.*]] = aie.switchbox(%[[TILE_5_3]]) {
+// CHECK:             aie.connect<NORTH : 3, EAST : 3>
+// CHECK:             aie.connect<WEST : 2, EAST : 2>
+// CHECK:             aie.connect<NORTH : 2, WEST : 0>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 1, NORTH : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_4_2:.*]] = aie.tile(4, 2)
+// CHECK:           %[[SWITCHBOX_4_2:.*]] = aie.switchbox(%[[TILE_4_2]]) {
+// CHECK:             aie.connect<WEST : 1, EAST : 3>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 1, EAST : 0>
+// CHECK:             aie.connect<EAST : 1, NORTH : 5>
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_5_2:.*]] = aie.tile(5, 2)
+// CHECK:           %[[SWITCHBOX_5_2:.*]] = aie.switchbox(%[[TILE_5_2]]) {
+// CHECK:             aie.connect<WEST : 3, SOUTH : 3>
+// CHECK:             aie.connect<WEST : 0, EAST : 3>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 1>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_7_0:.*]] = aie.switchbox(%[[TILE_7_0]]) {
+// CHECK:             aie.connect<WEST : 2, SOUTH : 2>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 7, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 3, WEST : 1>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_7_0:.*]] = aie.shim_mux(%[[TILE_7_0]]) {
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_4_3:.*]] = aie.switchbox(%[[TILE_4_3]]) {
+// CHECK:             aie.connect<CORE : 0, EAST : 2>
+// CHECK:             aie.connect<DMA : 1, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 0, CORE : 1>
+// CHECK:             aie.connect<SOUTH : 5, DMA : 0>
+// CHECK:             aie.connect<EAST : 2, NORTH : 4>
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_7_3:.*]] = aie.tile(7, 3)
+// CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3]]) {
+// CHECK:             aie.connect<WEST : 1, NORTH : 3>
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_7_4:.*]] = aie.tile(7, 4)
+// CHECK:           %[[SWITCHBOX_7_4:.*]] = aie.switchbox(%[[TILE_7_4]]) {
+// CHECK:             aie.connect<SOUTH : 3, EAST : 0>
+// CHECK:             aie.connect<SOUTH : 0, EAST : 3>
+// CHECK:             aie.connect<EAST : 0, SOUTH : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_8_4:.*]] = aie.switchbox(%[[TILE_8_4]]) {
+// CHECK:             aie.connect<WEST : 0, CORE : 1>
+// CHECK:             aie.connect<WEST : 3, DMA : 0>
+// CHECK:             aie.connect<CORE : 0, SOUTH : 0>
+// CHECK:             aie.connect<DMA : 1, WEST : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_4_1:.*]] = aie.tile(4, 1)
+// CHECK:           %[[SWITCHBOX_4_1:.*]] = aie.switchbox(%[[TILE_4_1]]) {
+// CHECK:             aie.connect<NORTH : 3, EAST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 5>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_6_0:.*]] = aie.shim_mux(%[[TILE_6_0]]) {
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:           }
+// CHECK:           %[[TILE_6_4:.*]] = aie.tile(6, 4)
+// CHECK:           %[[SWITCHBOX_6_4:.*]] = aie.switchbox(%[[TILE_6_4]]) {
+// CHECK:             aie.connect<SOUTH : 0, WEST : 3>
 // CHECK:           }
 // CHECK:         }
 

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_flow_test_2.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_flow_test_2.mlir
@@ -22,127 +22,127 @@
 // CHECK:           %[[TILE_3_4:.*]] = aie.tile(3, 4)
 // CHECK:           %[[TILE_1_0:.*]] = aie.tile(1, 0)
 // CHECK:           %[[SWITCHBOX_1_0:.*]] = aie.switchbox(%[[TILE_1_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
+// CHECK:             aie.connect<EAST : 3, NORTH : 0>
+// CHECK:             aie.connect<NORTH : 1, EAST : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_1_1:.*]] = aie.switchbox(%[[TILE_1_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, DMA : 0>
+// CHECK:             aie.connect<CORE : 0, WEST : 3>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 3, EAST : 2>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<SOUTH : 7, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 3>
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 1, EAST : 0>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 2>
+// CHECK:             aie.connect<SOUTH : 7, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_1:.*]] = aie.switchbox(%[[TILE_0_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, NORTH : 0>
+// CHECK:             aie.connect<EAST : 3, CORE : 0>
+// CHECK:             aie.connect<CORE : 0, NORTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_2:.*]] = aie.switchbox(%[[TILE_0_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<DMA : 0, EAST : 1>
+// CHECK:             aie.connect<SOUTH : 3, EAST : 0>
+// CHECK:             aie.connect<EAST : 3, CORE : 0>
+// CHECK:             aie.connect<DMA : 0, EAST : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_1_2:.*]] = aie.switchbox(%[[TILE_1_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, DMA : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_1_4:.*]] = aie.switchbox(%[[TILE_1_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, WEST : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, CORE : 1>
-// CHECK-DAG:         aie.connect<CORE : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 1, EAST : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_4:.*]] = aie.switchbox(%[[TILE_2_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, CORE : 1>
-// CHECK-DAG:         aie.connect<CORE : 1, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_0_4:.*]] = aie.switchbox(%[[TILE_0_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_0_3:.*]] = aie.switchbox(%[[TILE_0_3]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
+// CHECK:             aie.connect<WEST : 0, CORE : 0>
+// CHECK:             aie.connect<CORE : 0, WEST : 3>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_1_3:.*]] = aie.switchbox(%[[TILE_1_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 3, NORTH : 2>
+// CHECK:             aie.connect<WEST : 0, CORE : 0>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_1_4:.*]] = aie.switchbox(%[[TILE_1_4]]) {
+// CHECK:             aie.connect<SOUTH : 2, DMA : 0>
+// CHECK:             aie.connect<CORE : 0, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 2>
+// CHECK:             aie.connect<WEST : 2, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 2, DMA : 0>
+// CHECK:             aie.connect<CORE : 0, NORTH : 0>
+// CHECK:             aie.connect<NORTH : 1, EAST : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
+// CHECK:             aie.connect<SOUTH : 2, NORTH : 3>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 0, CORE : 0>
+// CHECK:             aie.connect<CORE : 0, NORTH : 2>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 3, NORTH : 5>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 1, EAST : 2>
+// CHECK:             aie.connect<EAST : 3, SOUTH : 0>
+// CHECK:             aie.connect<SOUTH : 2, NORTH : 0>
+// CHECK:             aie.connect<NORTH : 2, CORE : 0>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 3>
+// CHECK:             aie.connect<SOUTH : 5, CORE : 1>
+// CHECK:             aie.connect<CORE : 1, NORTH : 2>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_0_4:.*]] = aie.switchbox(%[[TILE_0_4]]) {
+// CHECK:             aie.connect<EAST : 2, CORE : 0>
+// CHECK:             aie.connect<CORE : 0, SOUTH : 0>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_0_3:.*]] = aie.switchbox(%[[TILE_0_3]]) {
+// CHECK:             aie.connect<NORTH : 0, EAST : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_0:.*]] = aie.switchbox(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<SOUTH : 7, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 3>
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 0>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 2>
+// CHECK:             aie.connect<SOUTH : 7, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_3_2:.*]] = aie.switchbox(%[[TILE_3_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 1, CORE : 1>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_3_3:.*]] = aie.switchbox(%[[TILE_3_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, CORE : 1>
-// CHECK-DAG:         aie.connect<CORE : 1, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_3_4:.*]] = aie.switchbox(%[[TILE_3_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, CORE : 1>
-// CHECK-DAG:         aie.connect<CORE : 1, WEST : 1>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_1:.*]] = aie.switchbox(%[[TILE_3_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 1>
-// CHECK-DAG:         aie.connect<CORE : 1, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, WEST : 2>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 2>
+// CHECK:             aie.connect<SOUTH : 1, DMA : 1>
+// CHECK:             aie.connect<CORE : 1, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 0>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_3_3:.*]] = aie.switchbox(%[[TILE_3_3]]) {
+// CHECK:             aie.connect<WEST : 2, CORE : 0>
+// CHECK:             aie.connect<CORE : 0, WEST : 3>
+// CHECK:             aie.connect<NORTH : 3, CORE : 1>
+// CHECK:             aie.connect<CORE : 1, SOUTH : 0>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_2_4:.*]] = aie.switchbox(%[[TILE_2_4]]) {
+// CHECK:             aie.connect<SOUTH : 0, EAST : 0>
+// CHECK:             aie.connect<EAST : 0, CORE : 0>
+// CHECK:             aie.connect<CORE : 0, SOUTH : 2>
+// CHECK:             aie.connect<SOUTH : 2, EAST : 3>
+// CHECK:             aie.connect<EAST : 1, CORE : 1>
+// CHECK:             aie.connect<CORE : 1, EAST : 2>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_3_4:.*]] = aie.switchbox(%[[TILE_3_4]]) {
+// CHECK:             aie.connect<WEST : 0, CORE : 0>
+// CHECK:             aie.connect<CORE : 0, WEST : 0>
+// CHECK:             aie.connect<WEST : 3, CORE : 1>
+// CHECK:             aie.connect<CORE : 1, WEST : 1>
+// CHECK:             aie.connect<WEST : 2, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_3_2:.*]] = aie.switchbox(%[[TILE_3_2]]) {
+// CHECK:             aie.connect<SOUTH : 5, WEST : 3>
+// CHECK:             aie.connect<NORTH : 0, CORE : 1>
+// CHECK:             aie.connect<DMA : 1, SOUTH : 0>
 // CHECK:           }
 // CHECK:         }
 

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_flow_test_3.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_flow_test_3.mlir
@@ -6,6 +6,8 @@
 // CHECK:           %[[TILE_0_2:.*]] = aie.tile(0, 2)
 // CHECK:           %[[TILE_0_3:.*]] = aie.tile(0, 3)
 // CHECK:           %[[TILE_0_4:.*]] = aie.tile(0, 4)
+// CHECK:           %[[SWITCHBOX_0_4:.*]] = aie.switchbox(%[[TILE_0_4]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_1_1:.*]] = aie.tile(1, 1)
 // CHECK:           %[[TILE_1_2:.*]] = aie.tile(1, 2)
 // CHECK:           %[[TILE_1_3:.*]] = aie.tile(1, 3)
@@ -24,269 +26,275 @@
 // CHECK:           %[[TILE_8_2:.*]] = aie.tile(8, 2)
 // CHECK:           %[[TILE_8_3:.*]] = aie.tile(8, 3)
 // CHECK:           %[[TILE_8_4:.*]] = aie.tile(8, 4)
-// CHECK:           %[[SWITCHBOX_0_1:.*]] = aie.switchbox(%[[TILE_0_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 2, CORE : 1>
-// CHECK-DAG:         aie.connect<CORE : 1, EAST : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_0_2:.*]] = aie.switchbox(%[[TILE_0_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, CORE : 1>
-// CHECK-DAG:         aie.connect<CORE : 1, NORTH : 1>
-// CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_3:.*]] = aie.switchbox(%[[TILE_0_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 0>
+// CHECK:             aie.connect<EAST : 1, DMA : 0>
+// CHECK:             aie.connect<CORE : 0, EAST : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_1_0:.*]] = aie.tile(1, 0)
 // CHECK:           %[[SWITCHBOX_1_0:.*]] = aie.switchbox(%[[TILE_1_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
+// CHECK:             aie.connect<EAST : 3, NORTH : 3>
+// CHECK:             aie.connect<EAST : 1, NORTH : 4>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_1_1:.*]] = aie.switchbox(%[[TILE_1_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, WEST : 2>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_1_3:.*]] = aie.switchbox(%[[TILE_1_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_3_3:.*]] = aie.tile(3, 3)
-// CHECK:           %[[SWITCHBOX_3_3:.*]] = aie.switchbox(%[[TILE_3_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_4_3:.*]] = aie.tile(4, 3)
-// CHECK:           %[[SWITCHBOX_4_3:.*]] = aie.switchbox(%[[TILE_4_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_5_3:.*]] = aie.tile(5, 3)
-// CHECK:           %[[SWITCHBOX_5_3:.*]] = aie.switchbox(%[[TILE_5_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_6_3:.*]] = aie.tile(6, 3)
-// CHECK:           %[[SWITCHBOX_6_3:.*]] = aie.switchbox(%[[TILE_6_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<WEST : 2, EAST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_1:.*]] = aie.switchbox(%[[TILE_7_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, CORE : 1>
-// CHECK-DAG:         aie.connect<CORE : 1, NORTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_2:.*]] = aie.switchbox(%[[TILE_7_2]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, CORE : 1>
-// CHECK-DAG:         aie.connect<CORE : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 1, EAST : 2>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, SOUTH : 1>
-// CHECK-DAG:         aie.connect<WEST : 2, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_8_2:.*]] = aie.switchbox(%[[TILE_8_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, CORE : 0>
-// CHECK-DAG:         aie.connect<DMA : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 2, NORTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_8_3:.*]] = aie.switchbox(%[[TILE_8_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<CORE : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_8_4:.*]] = aie.switchbox(%[[TILE_8_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, CORE : 1>
-// CHECK-DAG:         aie.connect<DMA : 1, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, EAST : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 2>
-// CHECK-DAG:         aie.connect<EAST : 2, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_3_1:.*]] = aie.tile(3, 1)
-// CHECK:           %[[SWITCHBOX_3_1:.*]] = aie.switchbox(%[[TILE_3_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 2, EAST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 2>
-// CHECK:           }
-// CHECK:           %[[TILE_4_1:.*]] = aie.tile(4, 1)
-// CHECK:           %[[SWITCHBOX_4_1:.*]] = aie.switchbox(%[[TILE_4_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 2, EAST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 1, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_4_2:.*]] = aie.tile(4, 2)
-// CHECK:           %[[SWITCHBOX_4_2:.*]] = aie.switchbox(%[[TILE_4_2]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_4_4:.*]] = aie.tile(4, 4)
-// CHECK:           %[[SWITCHBOX_4_4:.*]] = aie.switchbox(%[[TILE_4_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_5_4:.*]] = aie.tile(5, 4)
-// CHECK:           %[[SWITCHBOX_5_4:.*]] = aie.switchbox(%[[TILE_5_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_6_4:.*]] = aie.tile(6, 4)
-// CHECK:           %[[SWITCHBOX_6_4:.*]] = aie.switchbox(%[[TILE_6_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_4:.*]] = aie.switchbox(%[[TILE_7_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 5>
+// CHECK:             aie.connect<EAST : 1, CORE : 0>
+// CHECK:             aie.connect<CORE : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 4, NORTH : 2>
+// CHECK:             aie.connect<NORTH : 3, WEST : 3>
+// CHECK:             aie.connect<WEST : 3, EAST : 2>
+// CHECK:             aie.connect<WEST : 2, EAST : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_1_2:.*]] = aie.switchbox(%[[TILE_1_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 5>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 1>
+// CHECK:             aie.connect<SOUTH : 2, NORTH : 2>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<WEST : 3, NORTH : 0>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:           %[[SWITCHBOX_1_3:.*]] = aie.switchbox(%[[TILE_1_3]]) {
+// CHECK:             aie.connect<SOUTH : 5, WEST : 1>
+// CHECK:             aie.connect<WEST : 3, EAST : 2>
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 4>
+// CHECK:             aie.connect<SOUTH : 2, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 1, SOUTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 3>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_4:.*]] = aie.switchbox(%[[TILE_2_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, CORE : 1>
-// CHECK-DAG:         aie.connect<CORE : 1, EAST : 0>
+// CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 7, EAST : 2>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 3>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_1_4:.*]] = aie.switchbox(%[[TILE_1_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
+// CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_3_0:.*]] = aie.switchbox(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_5_1:.*]] = aie.tile(5, 1)
-// CHECK:           %[[SWITCHBOX_5_1:.*]] = aie.switchbox(%[[TILE_5_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_6_1:.*]] = aie.tile(6, 1)
-// CHECK:           %[[SWITCHBOX_6_1:.*]] = aie.switchbox(%[[TILE_6_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_6_2:.*]] = aie.tile(6, 2)
-// CHECK:           %[[SWITCHBOX_6_2:.*]] = aie.switchbox(%[[TILE_6_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
+// CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
+// CHECK:             aie.connect<WEST : 2, EAST : 2>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_3_2:.*]] = aie.tile(3, 2)
 // CHECK:           %[[SWITCHBOX_3_2:.*]] = aie.switchbox(%[[TILE_3_2]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 0>
+// CHECK:             aie.connect<NORTH : 3, EAST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, SOUTH : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_3_3:.*]] = aie.tile(3, 3)
+// CHECK:           %[[SWITCHBOX_3_3:.*]] = aie.switchbox(%[[TILE_3_3]]) {
+// CHECK:             aie.connect<WEST : 2, SOUTH : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_4_2:.*]] = aie.tile(4, 2)
+// CHECK:           %[[SWITCHBOX_4_2:.*]] = aie.switchbox(%[[TILE_4_2]]) {
+// CHECK:             aie.connect<WEST : 0, EAST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<SOUTH : 3, EAST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<NORTH : 0, WEST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_5_1:.*]] = aie.tile(5, 1)
+// CHECK:           %[[SWITCHBOX_5_1:.*]] = aie.switchbox(%[[TILE_5_1]]) {
+// CHECK:             aie.connect<NORTH : 0, EAST : 2>
+// CHECK:             aie.connect<WEST : 0, EAST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<WEST : 3, NORTH : 5>
+// CHECK:             aie.connect<EAST : 0, SOUTH : 3>
+// CHECK:             aie.connect<WEST : 1, EAST : 0>
 // CHECK:           }
 // CHECK:           %[[TILE_5_2:.*]] = aie.tile(5, 2)
 // CHECK:           %[[SWITCHBOX_5_2:.*]] = aie.switchbox(%[[TILE_5_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<WEST : 0, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 3, WEST : 2>
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 3>
+// CHECK:             aie.connect<WEST : 1, EAST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_0_4:.*]] = aie.switchbox(%[[TILE_0_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
+// CHECK:           %[[TILE_6_1:.*]] = aie.tile(6, 1)
+// CHECK:           %[[SWITCHBOX_6_1:.*]] = aie.switchbox(%[[TILE_6_1]]) {
+// CHECK:             aie.connect<WEST : 2, EAST : 0>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<NORTH : 3, WEST : 0>
+// CHECK:             aie.connect<WEST : 0, EAST : 2>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_7_1:.*]] = aie.switchbox(%[[TILE_7_1]]) {
+// CHECK:             aie.connect<WEST : 0, CORE : 0>
+// CHECK:             aie.connect<CORE : 0, NORTH : 0>
+// CHECK:             aie.connect<WEST : 1, EAST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<WEST : 2, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 2, CORE : 1>
+// CHECK:             aie.connect<CORE : 1, NORTH : 5>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_7_2:.*]] = aie.switchbox(%[[TILE_7_2]]) {
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 0, EAST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<WEST : 0, NORTH : 3>
+// CHECK:             aie.connect<SOUTH : 1, CORE : 1>
+// CHECK:             aie.connect<CORE : 1, WEST : 3>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 2>
+// CHECK:             aie.connect<SOUTH : 5, EAST : 2>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3]]) {
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 5>
+// CHECK:             aie.connect<WEST : 2, CORE : 0>
+// CHECK:             aie.connect<CORE : 0, SOUTH : 0>
+// CHECK:             aie.connect<SOUTH : 3, EAST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_7_4:.*]] = aie.switchbox(%[[TILE_7_4]]) {
+// CHECK:             aie.connect<SOUTH : 5, EAST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_8_4:.*]] = aie.switchbox(%[[TILE_8_4]]) {
+// CHECK:             aie.connect<WEST : 3, CORE : 0>
+// CHECK:             aie.connect<CORE : 0, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 1, CORE : 1>
+// CHECK:             aie.connect<DMA : 1, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
+// CHECK:             aie.connect<NORTH : 2, WEST : 1>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 1>
+// CHECK:             aie.connect<WEST : 2, EAST : 0>
+// CHECK:             aie.connect<EAST : 2, CORE : 0>
+// CHECK:             aie.connect<CORE : 0, EAST : 2>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<EAST : 3, SOUTH : 2>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
+// CHECK:             aie.connect<EAST : 1, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_5_3:.*]] = aie.tile(5, 3)
+// CHECK:           %[[SWITCHBOX_5_3:.*]] = aie.switchbox(%[[TILE_5_3]]) {
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 3>
+// CHECK:             aie.connect<SOUTH : 3, EAST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<NORTH : 0, EAST : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_5_4:.*]] = aie.tile(5, 4)
+// CHECK:           %[[SWITCHBOX_5_4:.*]] = aie.switchbox(%[[TILE_5_4]]) {
+// CHECK:             aie.connect<EAST : 3, SOUTH : 2>
+// CHECK:             aie.connect<WEST : 0, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_6_4:.*]] = aie.tile(6, 4)
+// CHECK:           %[[SWITCHBOX_6_4:.*]] = aie.switchbox(%[[TILE_6_4]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_1_4:.*]] = aie.switchbox(%[[TILE_1_4]]) {
+// CHECK:             aie.connect<SOUTH : 4, EAST : 1>
+// CHECK:             aie.connect<SOUTH : 1, DMA : 0>
+// CHECK:             aie.connect<CORE : 0, SOUTH : 2>
+// CHECK:             aie.connect<SOUTH : 3, EAST : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_2_4:.*]] = aie.switchbox(%[[TILE_2_4]]) {
+// CHECK:             aie.connect<WEST : 1, CORE : 0>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 2>
+// CHECK:             aie.connect<WEST : 3, CORE : 1>
+// CHECK:             aie.connect<CORE : 1, EAST : 2>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_3_0:.*]] = aie.switchbox(%[[TILE_3_0]]) {
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, SOUTH : 2>
+// CHECK:             aie.connect<WEST : 2, EAST : 2>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_0_1:.*]] = aie.switchbox(%[[TILE_0_1]]) {
+// CHECK:             aie.connect<EAST : 3, CORE : 0>
+// CHECK:             aie.connect<CORE : 0, EAST : 3>
+// CHECK:             aie.connect<NORTH : 1, CORE : 1>
+// CHECK:             aie.connect<CORE : 1, EAST : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_3_1:.*]] = aie.tile(3, 1)
+// CHECK:           %[[SWITCHBOX_3_1:.*]] = aie.switchbox(%[[TILE_3_1]]) {
+// CHECK:             aie.connect<WEST : 0, EAST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<WEST : 2, EAST : 0>
+// CHECK:             aie.connect<WEST : 1, EAST : 2>
+// CHECK:             aie.connect<NORTH : 2, WEST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_4_1:.*]] = aie.tile(4, 1)
+// CHECK:           %[[SWITCHBOX_4_1:.*]] = aie.switchbox(%[[TILE_4_1]]) {
+// CHECK:             aie.connect<WEST : 1, EAST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<WEST : 0, EAST : 3>
+// CHECK:             aie.connect<SOUTH : 4, NORTH : 3>
+// CHECK:             aie.connect<WEST : 2, EAST : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_8_1:.*]] = aie.switchbox(%[[TILE_8_1]]) {
+// CHECK:             aie.connect<WEST : 1, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 2, WEST : 0>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_8_2:.*]] = aie.switchbox(%[[TILE_8_2]]) {
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 0>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
+// CHECK:             aie.connect<WEST : 3, CORE : 0>
+// CHECK:             aie.connect<DMA : 0, WEST : 3>
+// CHECK:             aie.connect<WEST : 2, NORTH : 4>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_8_3:.*]] = aie.switchbox(%[[TILE_8_3]]) {
+// CHECK:             aie.connect<SOUTH : 0, CORE : 0>
+// CHECK:             aie.connect<CORE : 0, SOUTH : 0>
+// CHECK:             aie.connect<WEST : 0, DMA : 1>
+// CHECK:             aie.connect<CORE : 1, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 4, NORTH : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_6_3:.*]] = aie.tile(6, 3)
+// CHECK:           %[[SWITCHBOX_6_3:.*]] = aie.switchbox(%[[TILE_6_3]]) {
+// CHECK:             aie.connect<WEST : 2, EAST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<WEST : 0, EAST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_4_0:.*]] = aie.tile(4, 0)
+// CHECK:           %[[SWITCHBOX_4_0:.*]] = aie.switchbox(%[[TILE_4_0]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<WEST : 2, NORTH : 4>
+// CHECK:           }
+// CHECK:           %[[TILE_5_0:.*]] = aie.tile(5, 0)
+// CHECK:           %[[SWITCHBOX_5_0:.*]] = aie.switchbox(%[[TILE_5_0]]) {
+// CHECK:             aie.connect<NORTH : 3, WEST : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_6_2:.*]] = aie.tile(6, 2)
+// CHECK:           %[[SWITCHBOX_6_2:.*]] = aie.switchbox(%[[TILE_6_2]]) {
+// CHECK:             aie.connect<EAST : 1, SOUTH : 3>
+// CHECK:             aie.connect<WEST : 2, EAST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_0_2:.*]] = aie.switchbox(%[[TILE_0_2]]) {
+// CHECK:             aie.connect<EAST : 3, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 0, CORE : 1>
+// CHECK:             aie.connect<CORE : 1, EAST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_4_3:.*]] = aie.tile(4, 3)
+// CHECK:           %[[SWITCHBOX_4_3:.*]] = aie.switchbox(%[[TILE_4_3]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 0>
 // CHECK:           }
 // CHECK:           %[[TILE_3_4:.*]] = aie.tile(3, 4)
 // CHECK:           %[[SWITCHBOX_3_4:.*]] = aie.switchbox(%[[TILE_3_4]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
+// CHECK:             aie.connect<WEST : 2, EAST : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_4_4:.*]] = aie.tile(4, 4)
+// CHECK:           %[[SWITCHBOX_4_4:.*]] = aie.switchbox(%[[TILE_4_4]]) {
+// CHECK:             aie.connect<WEST : 2, EAST : 0>
+// CHECK:             aie.connect<EAST : 1, SOUTH : 1>
 // CHECK:           }
 // CHECK:         }
 

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_many_flows.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_many_flows.mlir
@@ -14,182 +14,170 @@
 // CHECK:           %[[TILE_7_0:.*]] = aie.tile(7, 0)
 // CHECK:           %[[TILE_7_3:.*]] = aie.tile(7, 3)
 // CHECK:           %[[SWITCHBOX_0_2:.*]] = aie.switchbox(%[[TILE_0_2]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 1, EAST : 1>
+// CHECK:             aie.connect<NORTH : 0, EAST : 0>
+// CHECK:             aie.connect<DMA : 0, EAST : 3>
+// CHECK:             aie.connect<NORTH : 1, CORE : 0>
+// CHECK:             aie.connect<CORE : 1, EAST : 2>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_3:.*]] = aie.switchbox(%[[TILE_0_3]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<CORE : 1, SOUTH : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<CORE : 0, EAST : 0>
+// CHECK:             aie.connect<CORE : 1, SOUTH : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_1_2:.*]] = aie.tile(1, 2)
 // CHECK:           %[[SWITCHBOX_1_2:.*]] = aie.switchbox(%[[TILE_1_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 1>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 2>
-// CHECK:           }
-// CHECK:           %[[TILE_2_1:.*]] = aie.tile(2, 1)
-// CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
+// CHECK:             aie.connect<WEST : 0, EAST : 2>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 1>
+// CHECK:             aie.connect<WEST : 3, EAST : 3>
+// CHECK:             aie.connect<WEST : 2, EAST : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<DMA : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, CORE : 0>
-// CHECK-DAG:         aie.connect<WEST : 2, CORE : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_3_1:.*]] = aie.switchbox(%[[TILE_3_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, SOUTH : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 3>
-// CHECK-DAG:         aie.connect<EAST : 2, CORE : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, CORE : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_4_1:.*]] = aie.tile(4, 1)
-// CHECK:           %[[SWITCHBOX_4_1:.*]] = aie.switchbox(%[[TILE_4_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_5_1:.*]] = aie.tile(5, 1)
-// CHECK:           %[[SWITCHBOX_5_1:.*]] = aie.switchbox(%[[TILE_5_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<NORTH : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_6_0:.*]] = aie.switchbox(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<WEST : 1, SOUTH : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_6_1:.*]] = aie.tile(6, 1)
-// CHECK:           %[[SWITCHBOX_6_1:.*]] = aie.switchbox(%[[TILE_6_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_0:.*]] = aie.switchbox(%[[TILE_7_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<WEST : 1, SOUTH : 3>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_7_0:.*]] = aie.shim_mux(%[[TILE_7_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_1_3:.*]] = aie.switchbox(%[[TILE_1_3]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 1, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_2_3:.*]] = aie.tile(2, 3)
-// CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_3_3:.*]] = aie.tile(3, 3)
-// CHECK:           %[[SWITCHBOX_3_3:.*]] = aie.switchbox(%[[TILE_3_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_4_3:.*]] = aie.tile(4, 3)
-// CHECK:           %[[SWITCHBOX_4_3:.*]] = aie.switchbox(%[[TILE_4_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_5_3:.*]] = aie.tile(5, 3)
-// CHECK:           %[[SWITCHBOX_5_3:.*]] = aie.switchbox(%[[TILE_5_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_6_2:.*]] = aie.tile(6, 2)
-// CHECK:           %[[SWITCHBOX_6_2:.*]] = aie.switchbox(%[[TILE_6_2]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_6_3:.*]] = aie.tile(6, 3)
-// CHECK:           %[[SWITCHBOX_6_3:.*]] = aie.switchbox(%[[TILE_6_3]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_0_1:.*]] = aie.tile(0, 1)
-// CHECK:           %[[SWITCHBOX_0_1:.*]] = aie.switchbox(%[[TILE_0_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_1_0:.*]] = aie.tile(1, 0)
-// CHECK:           %[[SWITCHBOX_1_0:.*]] = aie.switchbox(%[[TILE_1_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_1_1:.*]] = aie.switchbox(%[[TILE_1_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, SOUTH : 3>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_3_0:.*]] = aie.switchbox(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 2, WEST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 3, SOUTH : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_4_0:.*]] = aie.tile(4, 0)
-// CHECK:           %[[SWITCHBOX_4_0:.*]] = aie.switchbox(%[[TILE_4_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_5_0:.*]] = aie.tile(5, 0)
-// CHECK:           %[[SWITCHBOX_5_0:.*]] = aie.switchbox(%[[TILE_5_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 1>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_6_0:.*]] = aie.shim_mux(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:             aie.connect<WEST : 2, EAST : 3>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 3>
+// CHECK:             aie.connect<DMA : 0, EAST : 2>
+// CHECK:             aie.connect<NORTH : 3, CORE : 0>
+// CHECK:             aie.connect<WEST : 1, CORE : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_3_2:.*]] = aie.tile(3, 2)
 // CHECK:           %[[SWITCHBOX_3_2:.*]] = aie.switchbox(%[[TILE_3_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
+// CHECK:             aie.connect<WEST : 3, EAST : 0>
+// CHECK:             aie.connect<WEST : 2, EAST : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_4_2:.*]] = aie.tile(4, 2)
 // CHECK:           %[[SWITCHBOX_4_2:.*]] = aie.switchbox(%[[TILE_4_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
+// CHECK:             aie.connect<WEST : 0, EAST : 1>
+// CHECK:             aie.connect<WEST : 3, EAST : 0>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 3>
 // CHECK:           }
-// CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           %[[TILE_5_1:.*]] = aie.tile(5, 1)
+// CHECK:           %[[SWITCHBOX_5_1:.*]] = aie.switchbox(%[[TILE_5_1]]) {
+// CHECK:             aie.connect<NORTH : 3, EAST : 3>
+// CHECK:             aie.connect<WEST : 1, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 2, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_5_2:.*]] = aie.tile(5, 2)
 // CHECK:           %[[SWITCHBOX_5_2:.*]] = aie.switchbox(%[[TILE_5_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, SOUTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, SOUTH : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, SOUTH : 3>
+// CHECK:             aie.connect<WEST : 1, SOUTH : 3>
+// CHECK:             aie.connect<WEST : 0, EAST : 1>
+// CHECK:             aie.connect<EAST : 0, SOUTH : 2>
 // CHECK:           }
-// CHECK:           %[[TILE_7_2:.*]] = aie.tile(7, 2)
-// CHECK:           %[[SWITCHBOX_7_2:.*]] = aie.switchbox(%[[TILE_7_2]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<NORTH : 3, WEST : 3>
+// CHECK:           %[[SWITCHBOX_6_0:.*]] = aie.switchbox(%[[TILE_6_0]]) {
+// CHECK:             aie.connect<NORTH : 1, EAST : 1>
+// CHECK:             aie.connect<WEST : 3, EAST : 2>
+// CHECK:             aie.connect<WEST : 0, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_6_1:.*]] = aie.tile(6, 1)
+// CHECK:           %[[SWITCHBOX_6_1:.*]] = aie.switchbox(%[[TILE_6_1]]) {
+// CHECK:             aie.connect<WEST : 3, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 2>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_7_0:.*]] = aie.switchbox(%[[TILE_7_0]]) {
+// CHECK:             aie.connect<WEST : 1, SOUTH : 2>
+// CHECK:             aie.connect<WEST : 2, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_7_0:.*]] = aie.shim_mux(%[[TILE_7_0]]) {
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_1_1:.*]] = aie.switchbox(%[[TILE_1_1]]) {
+// CHECK:             aie.connect<NORTH : 1, EAST : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_1_3:.*]] = aie.switchbox(%[[TILE_1_3]]) {
+// CHECK:             aie.connect<DMA : 0, SOUTH : 2>
+// CHECK:             aie.connect<WEST : 0, CORE : 0>
+// CHECK:             aie.connect<CORE : 1, EAST : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_2_1:.*]] = aie.tile(2, 1)
+// CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
+// CHECK:             aie.connect<WEST : 3, EAST : 3>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 2>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_3_1:.*]] = aie.switchbox(%[[TILE_3_1]]) {
+// CHECK:             aie.connect<WEST : 3, EAST : 2>
+// CHECK:             aie.connect<EAST : 3, SOUTH : 3>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<DMA : 1, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 2, CORE : 0>
+// CHECK:             aie.connect<EAST : 1, CORE : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_4_1:.*]] = aie.tile(4, 1)
+// CHECK:           %[[SWITCHBOX_4_1:.*]] = aie.switchbox(%[[TILE_4_1]]) {
+// CHECK:             aie.connect<WEST : 2, EAST : 1>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<NORTH : 1, WEST : 2>
+// CHECK:             aie.connect<NORTH : 3, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_5_0:.*]] = aie.tile(5, 0)
+// CHECK:           %[[SWITCHBOX_5_0:.*]] = aie.switchbox(%[[TILE_5_0]]) {
+// CHECK:             aie.connect<NORTH : 3, EAST : 3>
+// CHECK:             aie.connect<WEST : 3, EAST : 0>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
+// CHECK:             aie.connect<NORTH : 2, EAST : 3>
+// CHECK:             aie.connect<EAST : 3, SOUTH : 2>
+// CHECK:             aie.connect<EAST : 2, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_3_0:.*]] = aie.switchbox(%[[TILE_3_0]]) {
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 0, WEST : 2>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_4_0:.*]] = aie.tile(4, 0)
+// CHECK:           %[[SWITCHBOX_4_0:.*]] = aie.switchbox(%[[TILE_4_0]]) {
+// CHECK:             aie.connect<WEST : 1, EAST : 3>
+// CHECK:             aie.connect<NORTH : 2, WEST : 3>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_6_0:.*]] = aie.shim_mux(%[[TILE_6_0]]) {
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_6_2:.*]] = aie.tile(6, 2)
+// CHECK:           %[[SWITCHBOX_6_2:.*]] = aie.switchbox(%[[TILE_6_2]]) {
+// CHECK:             aie.connect<WEST : 1, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 3, WEST : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_2_3:.*]] = aie.tile(2, 3)
+// CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
+// CHECK:             aie.connect<WEST : 2, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_4_3:.*]] = aie.tile(4, 3)
+// CHECK:           %[[SWITCHBOX_4_3:.*]] = aie.switchbox(%[[TILE_4_3]]) {
+// CHECK:             aie.connect<EAST : 3, SOUTH : 3>
+// CHECK:             aie.connect<EAST : 0, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 1, SOUTH : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_5_3:.*]] = aie.tile(5, 3)
+// CHECK:           %[[SWITCHBOX_5_3:.*]] = aie.switchbox(%[[TILE_5_3]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_6_3:.*]] = aie.tile(6, 3)
+// CHECK:           %[[SWITCHBOX_6_3:.*]] = aie.switchbox(%[[TILE_6_3]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, SOUTH : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 1>
-// CHECK-DAG:         aie.connect<CORE : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<CORE : 1, SOUTH : 3>
+// CHECK:             aie.connect<DMA : 0, WEST : 0>
+// CHECK:             aie.connect<DMA : 1, WEST : 1>
+// CHECK:             aie.connect<CORE : 0, WEST : 3>
+// CHECK:             aie.connect<CORE : 1, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
 // CHECK:         }
 

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_many_flows2.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_many_flows2.mlir
@@ -13,167 +13,161 @@
 // CHECK:           %[[TILE_6_0:.*]] = aie.tile(6, 0)
 // CHECK:           %[[TILE_7_0:.*]] = aie.tile(7, 0)
 // CHECK:           %[[TILE_7_3:.*]] = aie.tile(7, 3)
+// CHECK:           %[[TILE_0_1:.*]] = aie.tile(0, 1)
+// CHECK:           %[[SWITCHBOX_0_1:.*]] = aie.switchbox(%[[TILE_0_1]]) {
+// CHECK:             aie.connect<NORTH : 1, EAST : 1>
+// CHECK:             aie.connect<NORTH : 0, EAST : 2>
+// CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_2:.*]] = aie.switchbox(%[[TILE_0_2]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 2, CORE : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, CORE : 1>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 1, CORE : 0>
+// CHECK:             aie.connect<NORTH : 3, CORE : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_3:.*]] = aie.switchbox(%[[TILE_0_3]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 1>
-// CHECK-DAG:         aie.connect<CORE : 1, SOUTH : 2>
-// CHECK-DAG:         aie.connect<CORE : 0, SOUTH : 3>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<DMA : 1, EAST : 0>
+// CHECK:             aie.connect<CORE : 1, SOUTH : 1>
+// CHECK:             aie.connect<CORE : 0, SOUTH : 3>
 // CHECK:           }
-// CHECK:           %[[TILE_1_2:.*]] = aie.tile(1, 2)
-// CHECK:           %[[SWITCHBOX_1_2:.*]] = aie.switchbox(%[[TILE_1_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 2>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 2>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 3>
+// CHECK:           %[[SWITCHBOX_1_1:.*]] = aie.switchbox(%[[TILE_1_1]]) {
+// CHECK:             aie.connect<WEST : 1, EAST : 0>
+// CHECK:             aie.connect<WEST : 2, EAST : 1>
+// CHECK:             aie.connect<NORTH : 1, EAST : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_2_1:.*]] = aie.tile(2, 1)
 // CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 2, SOUTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 3, EAST : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, SOUTH : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<CORE : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, CORE : 1>
-// CHECK-DAG:         aie.connect<WEST : 2, SOUTH : 3>
+// CHECK:             aie.connect<WEST : 0, EAST : 3>
+// CHECK:             aie.connect<WEST : 1, EAST : 2>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_0:.*]] = aie.switchbox(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 0, WEST : 2>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_1:.*]] = aie.switchbox(%[[TILE_3_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 1>
-// CHECK-DAG:         aie.connect<WEST : 1, CORE : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_4_1:.*]] = aie.tile(4, 1)
-// CHECK:           %[[SWITCHBOX_4_1:.*]] = aie.switchbox(%[[TILE_4_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_5_1:.*]] = aie.tile(5, 1)
-// CHECK:           %[[SWITCHBOX_5_1:.*]] = aie.switchbox(%[[TILE_5_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_6_0:.*]] = aie.switchbox(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_6_1:.*]] = aie.tile(6, 1)
-// CHECK:           %[[SWITCHBOX_6_1:.*]] = aie.switchbox(%[[TILE_6_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_0:.*]] = aie.switchbox(%[[TILE_7_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 3>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 2>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_7_0:.*]] = aie.shim_mux(%[[TILE_7_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_0_1:.*]] = aie.tile(0, 1)
-// CHECK:           %[[SWITCHBOX_0_1:.*]] = aie.switchbox(%[[TILE_0_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_1_0:.*]] = aie.tile(1, 0)
-// CHECK:           %[[SWITCHBOX_1_0:.*]] = aie.switchbox(%[[TILE_1_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_1_1:.*]] = aie.switchbox(%[[TILE_1_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_4_0:.*]] = aie.tile(4, 0)
-// CHECK:           %[[SWITCHBOX_4_0:.*]] = aie.switchbox(%[[TILE_4_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_5_0:.*]] = aie.tile(5, 0)
-// CHECK:           %[[SWITCHBOX_5_0:.*]] = aie.switchbox(%[[TILE_5_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_6_0:.*]] = aie.shim_mux(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 3>
+// CHECK:             aie.connect<WEST : 2, EAST : 3>
+// CHECK:             aie.connect<NORTH : 2, CORE : 0>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<DMA : 1, SOUTH : 1>
+// CHECK:             aie.connect<WEST : 1, CORE : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_1_3:.*]] = aie.switchbox(%[[TILE_1_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 1, SOUTH : 0>
+// CHECK:             aie.connect<WEST : 0, EAST : 3>
+// CHECK:             aie.connect<SOUTH : 0, CORE : 0>
+// CHECK:             aie.connect<CORE : 1, SOUTH : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_2_3:.*]] = aie.tile(2, 3)
 // CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_5_2:.*]] = aie.tile(5, 2)
-// CHECK:           %[[SWITCHBOX_5_2:.*]] = aie.switchbox(%[[TILE_5_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_6_2:.*]] = aie.tile(6, 2)
-// CHECK:           %[[SWITCHBOX_6_2:.*]] = aie.switchbox(%[[TILE_6_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_7_2:.*]] = aie.tile(7, 2)
-// CHECK:           %[[SWITCHBOX_7_2:.*]] = aie.switchbox(%[[TILE_7_2]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 2, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3]]) {
-// CHECK-DAG:         aie.connect<CORE : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<CORE : 1, WEST : 0>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 1>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 2>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<EAST : 0, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_3_3:.*]] = aie.tile(3, 3)
 // CHECK:           %[[SWITCHBOX_3_3:.*]] = aie.switchbox(%[[TILE_3_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<WEST : 1, EAST : 1>
+// CHECK:             aie.connect<EAST : 2, SOUTH : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[TILE_4_3:.*]] = aie.tile(4, 3)
 // CHECK:           %[[SWITCHBOX_4_3:.*]] = aie.switchbox(%[[TILE_4_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<WEST : 1, EAST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_5_3:.*]] = aie.tile(5, 3)
 // CHECK:           %[[SWITCHBOX_5_3:.*]] = aie.switchbox(%[[TILE_5_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<WEST : 2, EAST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_6_0:.*]] = aie.switchbox(%[[TILE_6_0]]) {
+// CHECK:             aie.connect<NORTH : 1, EAST : 3>
+// CHECK:             aie.connect<WEST : 1, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_6_1:.*]] = aie.tile(6, 1)
+// CHECK:           %[[SWITCHBOX_6_1:.*]] = aie.switchbox(%[[TILE_6_1]]) {
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_6_2:.*]] = aie.tile(6, 2)
+// CHECK:           %[[SWITCHBOX_6_2:.*]] = aie.switchbox(%[[TILE_6_2]]) {
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_6_3:.*]] = aie.tile(6, 3)
 // CHECK:           %[[SWITCHBOX_6_3:.*]] = aie.switchbox(%[[TILE_6_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_7_0:.*]] = aie.switchbox(%[[TILE_7_0]]) {
+// CHECK:             aie.connect<WEST : 3, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 2>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_7_0:.*]] = aie.shim_mux(%[[TILE_7_0]]) {
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_4_0:.*]] = aie.tile(4, 0)
+// CHECK:           %[[SWITCHBOX_4_0:.*]] = aie.switchbox(%[[TILE_4_0]]) {
+// CHECK:             aie.connect<NORTH : 2, EAST : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_4_1:.*]] = aie.tile(4, 1)
+// CHECK:           %[[SWITCHBOX_4_1:.*]] = aie.switchbox(%[[TILE_4_1]]) {
+// CHECK:             aie.connect<WEST : 3, SOUTH : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_5_0:.*]] = aie.tile(5, 0)
+// CHECK:           %[[SWITCHBOX_5_0:.*]] = aie.switchbox(%[[TILE_5_0]]) {
+// CHECK:             aie.connect<WEST : 1, EAST : 1>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_6_0:.*]] = aie.shim_mux(%[[TILE_6_0]]) {
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 2>
+// CHECK:             aie.connect<EAST : 2, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<CORE : 0, WEST : 3>
+// CHECK:             aie.connect<NORTH : 3, CORE : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_1_2:.*]] = aie.tile(1, 2)
+// CHECK:           %[[SWITCHBOX_1_2:.*]] = aie.switchbox(%[[TILE_1_2]]) {
+// CHECK:             aie.connect<EAST : 3, NORTH : 0>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_3_2:.*]] = aie.tile(3, 2)
+// CHECK:           %[[SWITCHBOX_3_2:.*]] = aie.switchbox(%[[TILE_3_2]]) {
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 2>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3]]) {
+// CHECK:             aie.connect<CORE : 0, WEST : 0>
+// CHECK:             aie.connect<CORE : 1, WEST : 1>
+// CHECK:             aie.connect<DMA : 0, WEST : 3>
+// CHECK:             aie.connect<DMA : 1, SOUTH : 0>
 // CHECK:           }
 // CHECK:           %[[TILE_7_1:.*]] = aie.tile(7, 1)
 // CHECK:           %[[SWITCHBOX_7_1:.*]] = aie.switchbox(%[[TILE_7_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_7_2:.*]] = aie.tile(7, 2)
+// CHECK:           %[[SWITCHBOX_7_2:.*]] = aie.switchbox(%[[TILE_7_2]]) {
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 1>
 // CHECK:           }
 // CHECK:         }
 

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_memtile.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_memtile.mlir
@@ -7,40 +7,40 @@
 // CHECK:           %[[TILE_0_2:.*]] = aie.tile(0, 2)
 // CHECK:           %[[TILE_0_1:.*]] = aie.tile(0, 1)
 // CHECK:           %[[SWITCHBOX_0_1:.*]] = aie.switchbox(%[[TILE_0_1]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, NORTH : 0>
+// CHECK:             aie.connect<DMA : 1, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 1, DMA : 0>
+// CHECK:             aie.connect<NORTH : 2, DMA : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_2:.*]] = aie.switchbox(%[[TILE_0_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 1>
-// CHECK-DAG:         aie.connect<DMA : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<DMA : 3, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, DMA : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, DMA : 3>
-// CHECK-DAG:         aie.connect<DMA : 4, NORTH : 2>
-// CHECK-DAG:         aie.connect<DMA : 5, NORTH : 3>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 4>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 5>
+// CHECK:             aie.connect<SOUTH : 0, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 5, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 1>
+// CHECK:             aie.connect<DMA : 1, SOUTH : 2>
+// CHECK:             aie.connect<DMA : 2, NORTH : 0>
+// CHECK:             aie.connect<DMA : 3, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 0, DMA : 2>
+// CHECK:             aie.connect<NORTH : 2, DMA : 3>
+// CHECK:             aie.connect<DMA : 4, NORTH : 4>
+// CHECK:             aie.connect<DMA : 5, NORTH : 3>
+// CHECK:             aie.connect<NORTH : 1, DMA : 4>
+// CHECK:             aie.connect<NORTH : 3, DMA : 5>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_3:.*]] = aie.switchbox(%[[TILE_0_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:             aie.connect<SOUTH : 0, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 5, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<DMA : 1, SOUTH : 2>
+// CHECK:             aie.connect<SOUTH : 4, NORTH : 3>
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_4:.*]] = aie.switchbox(%[[TILE_0_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 1>
+// CHECK:             aie.connect<SOUTH : 3, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 5, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<DMA : 1, SOUTH : 3>
 // CHECK:           }
 // CHECK:         }
 

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_memtile_routing_constraints.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_memtile_routing_constraints.mlir
@@ -7,21 +7,21 @@
 // CHECK:           %[[TILE_2_2:.*]] = aie.tile(2, 2)
 // CHECK:           %[[TILE_2_3:.*]] = aie.tile(2, 3)
 // CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 1, DMA : 0>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
 // CHECK:           }
 // CHECK:         }
 

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_mmult.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_mmult.mlir
@@ -165,173 +165,176 @@
 // CHECK:           ^bb7:
 // CHECK:             aie.end
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0:.*]]) {
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 7, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 3>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 1>
+// CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1:.*]]) {
+// CHECK:             aie.connect<SOUTH : 0, EAST : 3>
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 2>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 1>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_3_1:.*]] = aie.switchbox(%[[TILE_3_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 2>
-// CHECK-DAG:         aie.connect<SOUTH : 1, EAST : 3>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 1>
+// CHECK:           %[[SWITCHBOX_3_1:.*]] = aie.switchbox(%[[TILE_3_1:.*]]) {
+// CHECK:             aie.connect<WEST : 3, EAST : 3>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 3>
+// CHECK:             aie.connect<SOUTH : 1, EAST : 2>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 1, SOUTH : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_4_1:.*]] = aie.tile(4, 1)
 // CHECK:           %[[SWITCHBOX_4_1:.*]] = aie.switchbox(%[[TILE_4_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<WEST : 2, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 3, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_4_2:.*]] = aie.tile(4, 2)
-// CHECK:           %[[SWITCHBOX_4_2:.*]] = aie.switchbox(%[[TILE_4_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_5_2:.*]] = aie.tile(5, 2)
-// CHECK:           %[[SWITCHBOX_5_2:.*]] = aie.switchbox(%[[TILE_5_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 2>
-// CHECK-DAG:         aie.connect<SOUTH : 1, EAST : 3>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_6_2:.*]] = aie.switchbox(%[[TILE_6_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 2, EAST : 2>
-// CHECK-DAG:         aie.connect<WEST : 3, EAST : 3>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_2:.*]] = aie.switchbox(%[[TILE_7_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 2, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 3, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 2, EAST : 2>
-// CHECK-DAG:         aie.connect<SOUTH : 3, EAST : 3>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 2>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_3_2:.*]] = aie.switchbox(%[[TILE_3_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_3_0:.*]] = aie.switchbox(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<WEST : 2, EAST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_5_1:.*]] = aie.tile(5, 1)
 // CHECK:           %[[SWITCHBOX_5_1:.*]] = aie.switchbox(%[[TILE_5_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<WEST : 1, EAST : 0>
+// CHECK:             aie.connect<WEST : 2, EAST : 3>
+// CHECK:             aie.connect<NORTH : 0, WEST : 0>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_8_2:.*]] = aie.switchbox(%[[TILE_8_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 3, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 1>
+// CHECK:           %[[SWITCHBOX_6_1:.*]] = aie.switchbox(%[[TILE_6_1:.*]]) {
+// CHECK:             aie.connect<WEST : 0, EAST : 0>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<SOUTH : 0, EAST : 3>
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 2>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
+// CHECK:           %[[SWITCHBOX_7_1:.*]] = aie.switchbox(%[[TILE_7_1:.*]]) {
+// CHECK:             aie.connect<WEST : 0, NORTH : 5>
+// CHECK:             aie.connect<WEST : 1, EAST : 1>
+// CHECK:             aie.connect<WEST : 3, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, EAST : 3>
+// CHECK:             aie.connect<SOUTH : 1, EAST : 2>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_6_0:.*]] = aie.switchbox(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:           %[[SWITCHBOX_7_2:.*]] = aie.switchbox(%[[TILE_7_2:.*]]) {
+// CHECK:             aie.connect<SOUTH : 5, DMA : 0>
+// CHECK:             aie.connect<WEST : 2, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, WEST : 3>
+// CHECK:             aie.connect<WEST : 1, EAST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 1>
+// CHECK:             aie.connect<WEST : 3, NORTH : 3>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_6_1:.*]] = aie.switchbox(%[[TILE_6_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
+// CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2:.*]]) {
+// CHECK:             aie.connect<SOUTH : 2, EAST : 3>
+// CHECK:             aie.connect<EAST : 0, SOUTH : 3>
+// CHECK:             aie.connect<EAST : 2, SOUTH : 0>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_1:.*]] = aie.switchbox(%[[TILE_7_1]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 2>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 3>
+// CHECK:           %[[SWITCHBOX_3_2:.*]] = aie.switchbox(%[[TILE_3_2:.*]]) {
+// CHECK:             aie.connect<WEST : 3, EAST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 3, EAST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 1>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, WEST : 0>
+// CHECK:           %[[TILE_4_2:.*]] = aie.tile(4, 2)
+// CHECK:           %[[SWITCHBOX_4_2:.*]] = aie.switchbox(%[[TILE_4_2]]) {
+// CHECK:             aie.connect<WEST : 3, EAST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<WEST : 2, EAST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_5_2:.*]] = aie.tile(5, 2)
+// CHECK:           %[[SWITCHBOX_5_2:.*]] = aie.switchbox(%[[TILE_5_2]]) {
+// CHECK:             aie.connect<WEST : 0, EAST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 0>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_6_2:.*]] = aie.switchbox(%[[TILE_6_2:.*]]) {
+// CHECK:             aie.connect<WEST : 3, EAST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<WEST : 1, EAST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 2, EAST : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_3_0:.*]] = aie.switchbox(%[[TILE_3_0:.*]]) {
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 7, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_8_2:.*]] = aie.switchbox(%[[TILE_8_2:.*]]) {
+// CHECK:             aie.connect<WEST : 0, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 2, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 5>
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_8_1:.*]] = aie.tile(8, 1)
+// CHECK:           %[[SWITCHBOX_8_1:.*]] = aie.switchbox(%[[TILE_8_1]]) {
+// CHECK:             aie.connect<WEST : 1, NORTH : 2>
+// CHECK:             aie.connect<WEST : 3, NORTH : 0>
+// CHECK:             aie.connect<WEST : 2, NORTH : 5>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_6_0:.*]] = aie.switchbox(%[[TILE_6_0:.*]]) {
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 7, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3:.*]]) {
+// CHECK:             aie.connect<SOUTH : 1, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 3, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_3_3:.*]] = aie.tile(3, 3)
 // CHECK:           %[[SWITCHBOX_3_3:.*]] = aie.switchbox(%[[TILE_3_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 2, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_4_3:.*]] = aie.tile(4, 3)
 // CHECK:           %[[SWITCHBOX_4_3:.*]] = aie.switchbox(%[[TILE_4_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_5_3:.*]] = aie.tile(5, 3)
 // CHECK:           %[[SWITCHBOX_5_3:.*]] = aie.switchbox(%[[TILE_5_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_6_3:.*]] = aie.tile(6, 3)
 // CHECK:           %[[SWITCHBOX_6_3:.*]] = aie.switchbox(%[[TILE_6_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_0:.*]] = aie.switchbox(%[[TILE_7_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:           %[[SWITCHBOX_7_0:.*]] = aie.switchbox(%[[TILE_7_0:.*]]) {
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 7, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 3>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_8_3:.*]] = aie.switchbox(%[[TILE_8_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:           %[[SWITCHBOX_8_3:.*]] = aie.switchbox(%[[TILE_8_3:.*]]) {
+// CHECK:             aie.connect<SOUTH : 5, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 3, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, WEST : 0>
 // CHECK:           }
-// CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0:.*]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
-// CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0:.*]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
-// CHECK:           %[[SHIM_MUX_6_0:.*]] = aie.shim_mux(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           %[[SHIM_MUX_6_0:.*]] = aie.shim_mux(%[[TILE_6_0:.*]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
-// CHECK:           %[[SHIM_MUX_7_0:.*]] = aie.shim_mux(%[[TILE_7_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           %[[SHIM_MUX_7_0:.*]] = aie.shim_mux(%[[TILE_7_0:.*]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
 // CHECK:         }
 

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_over_flows.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_over_flows.mlir
@@ -3,14 +3,28 @@
 
 // CHECK-LABEL:   aie.device(xcvc1902) {
 // CHECK:           %[[TILE_0_3:.*]] = aie.tile(0, 3)
+// CHECK:           %[[SWITCHBOX_0_3:.*]] = aie.switchbox(%[[TILE_0_3]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_0_2:.*]] = aie.tile(0, 2)
+// CHECK:           %[[SWITCHBOX_0_2:.*]] = aie.switchbox(%[[TILE_0_2]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_0_0:.*]] = aie.tile(0, 0)
+// CHECK:           %[[SWITCHBOX_0_0:.*]] = aie.switchbox(%[[TILE_0_0]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_1_3:.*]] = aie.tile(1, 3)
+// CHECK:           %[[SWITCHBOX_1_3:.*]] = aie.switchbox(%[[TILE_1_3]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_1_1:.*]] = aie.tile(1, 1)
+// CHECK:           %[[SWITCHBOX_1_1:.*]] = aie.switchbox(%[[TILE_1_1]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_1_0:.*]] = aie.tile(1, 0)
+// CHECK:           %[[SWITCHBOX_1_0:.*]] = aie.switchbox(%[[TILE_1_0]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_2_0:.*]] = aie.tile(2, 0)
 // CHECK:           %[[TILE_3_0:.*]] = aie.tile(3, 0)
 // CHECK:           %[[TILE_2_2:.*]] = aie.tile(2, 2)
+// CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_3_1:.*]] = aie.tile(3, 1)
 // CHECK:           %[[TILE_6_0:.*]] = aie.tile(6, 0)
 // CHECK:           %[[TILE_7_0:.*]] = aie.tile(7, 0)
@@ -18,106 +32,126 @@
 // CHECK:           %[[TILE_7_2:.*]] = aie.tile(7, 2)
 // CHECK:           %[[TILE_7_3:.*]] = aie.tile(7, 3)
 // CHECK:           %[[TILE_8_0:.*]] = aie.tile(8, 0)
+// CHECK:           %[[SWITCHBOX_8_0:.*]] = aie.switchbox(%[[TILE_8_0]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_8_2:.*]] = aie.tile(8, 2)
+// CHECK:           %[[SWITCHBOX_8_2:.*]] = aie.switchbox(%[[TILE_8_2]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_8_3:.*]] = aie.tile(8, 3)
 // CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_3_0:.*]] = aie.switchbox(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, SOUTH : 3>
+// CHECK:           %[[TILE_2_1:.*]] = aie.tile(2, 1)
+// CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
+// CHECK:             aie.connect<EAST : 1, SOUTH : 3>
+// CHECK:             aie.connect<EAST : 3, SOUTH : 2>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_1:.*]] = aie.switchbox(%[[TILE_3_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_4_1:.*]] = aie.tile(4, 1)
 // CHECK:           %[[SWITCHBOX_4_1:.*]] = aie.switchbox(%[[TILE_4_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_5_1:.*]] = aie.tile(5, 1)
 // CHECK:           %[[SWITCHBOX_5_1:.*]] = aie.switchbox(%[[TILE_5_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_6_1:.*]] = aie.tile(6, 1)
 // CHECK:           %[[SWITCHBOX_6_1:.*]] = aie.switchbox(%[[TILE_6_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_1:.*]] = aie.switchbox(%[[TILE_7_1]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 2, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 3, SOUTH : 3>
+// CHECK:             aie.connect<DMA : 0, WEST : 3>
+// CHECK:             aie.connect<DMA : 1, WEST : 0>
+// CHECK:             aie.connect<NORTH : 0, WEST : 2>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 2>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_6_0:.*]] = aie.switchbox(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_6_0:.*]] = aie.shim_mux(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_0:.*]] = aie.switchbox(%[[TILE_7_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 2, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 3, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_2:.*]] = aie.switchbox(%[[TILE_7_2]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_7_0:.*]] = aie.shim_mux(%[[TILE_7_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_4_0:.*]] = aie.tile(4, 0)
-// CHECK:           %[[SWITCHBOX_4_0:.*]] = aie.switchbox(%[[TILE_4_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, WEST : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<DMA : 1, WEST : 3>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_6_2:.*]] = aie.tile(6, 2)
 // CHECK:           %[[SWITCHBOX_6_2:.*]] = aie.switchbox(%[[TILE_6_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 3, SOUTH : 3>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_8_2:.*]] = aie.switchbox(%[[TILE_8_2]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, WEST : 1>
+// CHECK:           %[[SWITCHBOX_7_0:.*]] = aie.switchbox(%[[TILE_7_0]]) {
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_7_0:.*]] = aie.shim_mux(%[[TILE_7_0]]) {
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3]]) {
+// CHECK:             aie.connect<DMA : 0, SOUTH : 2>
+// CHECK:             aie.connect<DMA : 1, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_3_0:.*]] = aie.switchbox(%[[TILE_3_0]]) {
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0]]) {
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_3_2:.*]] = aie.tile(3, 2)
+// CHECK:           %[[SWITCHBOX_3_2:.*]] = aie.switchbox(%[[TILE_3_2]]) {
+// CHECK:             aie.connect<EAST : 1, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_4_2:.*]] = aie.tile(4, 2)
+// CHECK:           %[[SWITCHBOX_4_2:.*]] = aie.switchbox(%[[TILE_4_2]]) {
+// CHECK:             aie.connect<NORTH : 3, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_4_3:.*]] = aie.tile(4, 3)
+// CHECK:           %[[SWITCHBOX_4_3:.*]] = aie.switchbox(%[[TILE_4_3]]) {
+// CHECK:             aie.connect<EAST : 2, SOUTH : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_5_3:.*]] = aie.tile(5, 3)
+// CHECK:           %[[SWITCHBOX_5_3:.*]] = aie.switchbox(%[[TILE_5_3]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_6_3:.*]] = aie.tile(6, 3)
+// CHECK:           %[[SWITCHBOX_6_3:.*]] = aie.switchbox(%[[TILE_6_3]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_8_3:.*]] = aie.switchbox(%[[TILE_8_3]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<DMA : 1, SOUTH : 1>
+// CHECK:             aie.connect<DMA : 0, WEST : 0>
+// CHECK:             aie.connect<DMA : 1, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_3_3:.*]] = aie.tile(3, 3)
+// CHECK:           %[[SWITCHBOX_3_3:.*]] = aie.switchbox(%[[TILE_3_3]]) {
+// CHECK:             aie.connect<EAST : 3, SOUTH : 2>
 // CHECK:           }
 // CHECK:         }
 

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_routed_herd_3x1.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_routed_herd_3x1.mlir
@@ -65,106 +65,114 @@
 // CHECK:           %[[TILE_11_3:.*]] = aie.tile(11, 3)
 // CHECK:           %[[TILE_11_4:.*]] = aie.tile(11, 4)
 // CHECK:           %[[TILE_12_1:.*]] = aie.tile(12, 1)
+// CHECK:           %[[SWITCHBOX_12_1:.*]] = aie.switchbox(%[[TILE_12_1]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_12_2:.*]] = aie.tile(12, 2)
+// CHECK:           %[[SWITCHBOX_12_2:.*]] = aie.switchbox(%[[TILE_12_2]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_12_3:.*]] = aie.tile(12, 3)
+// CHECK:           %[[SWITCHBOX_12_3:.*]] = aie.switchbox(%[[TILE_12_3]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_12_4:.*]] = aie.tile(12, 4)
+// CHECK:           %[[SWITCHBOX_12_4:.*]] = aie.switchbox(%[[TILE_12_4]]) {
+// CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_1:.*]] = aie.switchbox(%[[TILE_0_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_2:.*]] = aie.switchbox(%[[TILE_0_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_3:.*]] = aie.switchbox(%[[TILE_0_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, DMA : 1>
+// CHECK:             aie.connect<SOUTH : 0, DMA : 0>
+// CHECK:             aie.connect<EAST : 0, DMA : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_4:.*]] = aie.switchbox(%[[TILE_0_4]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_1_1:.*]] = aie.switchbox(%[[TILE_1_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_1_2:.*]] = aie.switchbox(%[[TILE_1_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_1_3:.*]] = aie.switchbox(%[[TILE_1_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 0, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_1_4:.*]] = aie.switchbox(%[[TILE_1_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, DMA : 0>
+// CHECK:             aie.connect<EAST : 0, DMA : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_4:.*]] = aie.switchbox(%[[TILE_2_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 0, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_1:.*]] = aie.switchbox(%[[TILE_3_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_2:.*]] = aie.switchbox(%[[TILE_3_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_3:.*]] = aie.switchbox(%[[TILE_3_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 0, DMA : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_4:.*]] = aie.switchbox(%[[TILE_3_4]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_4_1:.*]] = aie.switchbox(%[[TILE_4_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_4_2:.*]] = aie.switchbox(%[[TILE_4_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 0, DMA : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_4_3:.*]] = aie.switchbox(%[[TILE_4_3]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_4_4:.*]] = aie.switchbox(%[[TILE_4_4]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_5_1:.*]] = aie.switchbox(%[[TILE_5_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_5_2:.*]] = aie.switchbox(%[[TILE_5_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_5_3:.*]] = aie.switchbox(%[[TILE_5_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 0, DMA : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_5_4:.*]] = aie.switchbox(%[[TILE_5_4]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_6_1:.*]] = aie.switchbox(%[[TILE_6_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_6_2:.*]] = aie.switchbox(%[[TILE_6_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_6_3:.*]] = aie.switchbox(%[[TILE_6_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, DMA : 1>
+// CHECK:             aie.connect<SOUTH : 0, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 1, DMA : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_6_4:.*]] = aie.switchbox(%[[TILE_6_4]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_1:.*]] = aie.switchbox(%[[TILE_7_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_2:.*]] = aie.switchbox(%[[TILE_7_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_4:.*]] = aie.switchbox(%[[TILE_7_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, DMA : 1>
+// CHECK:             aie.connect<SOUTH : 0, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 1, DMA : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_8_1:.*]] = aie.switchbox(%[[TILE_8_1]]) {
 // CHECK:           }
@@ -175,193 +183,197 @@
 // CHECK:           %[[SWITCHBOX_8_4:.*]] = aie.switchbox(%[[TILE_8_4]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_9_1:.*]] = aie.switchbox(%[[TILE_9_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_9_2:.*]] = aie.switchbox(%[[TILE_9_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 0, DMA : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_9_3:.*]] = aie.switchbox(%[[TILE_9_3]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_9_4:.*]] = aie.switchbox(%[[TILE_9_4]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_10_1:.*]] = aie.switchbox(%[[TILE_10_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_10_2:.*]] = aie.switchbox(%[[TILE_10_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 0, DMA : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_10_3:.*]] = aie.switchbox(%[[TILE_10_3]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_10_4:.*]] = aie.switchbox(%[[TILE_10_4]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_11_1:.*]] = aie.switchbox(%[[TILE_11_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_11_2:.*]] = aie.switchbox(%[[TILE_11_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_11_3:.*]] = aie.switchbox(%[[TILE_11_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, DMA : 1>
+// CHECK:             aie.connect<SOUTH : 0, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 1, DMA : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_11_4:.*]] = aie.switchbox(%[[TILE_11_4]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 7, EAST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_0:.*]] = aie.switchbox(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<WEST : 2, EAST : 2>
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 7, EAST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_4_0:.*]] = aie.switchbox(%[[TILE_4_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<WEST : 2, EAST : 3>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, NORTH : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_5_0:.*]] = aie.switchbox(%[[TILE_5_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 0>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<WEST : 1, EAST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_6_0:.*]] = aie.switchbox(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 1>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
+// CHECK:             aie.connect<WEST : 1, NORTH : 1>
+// CHECK:             aie.connect<WEST : 3, EAST : 0>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 7, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_0:.*]] = aie.switchbox(%[[TILE_7_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 0>
+// CHECK:             aie.connect<WEST : 0, NORTH : 1>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 7, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_0:.*]] = aie.switchbox(%[[TILE_0_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
+// CHECK:             aie.connect<EAST : 1, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_1_0:.*]] = aie.switchbox(%[[TILE_1_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_6_0:.*]] = aie.shim_mux(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_7_0:.*]] = aie.shim_mux(%[[TILE_7_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_10_0:.*]] = aie.switchbox(%[[TILE_10_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_10_0:.*]] = aie.shim_mux(%[[TILE_10_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_11_0:.*]] = aie.switchbox(%[[TILE_11_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, NORTH : 1>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_11_0:.*]] = aie.shim_mux(%[[TILE_11_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_8_0:.*]] = aie.switchbox(%[[TILE_8_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_9_0:.*]] = aie.switchbox(%[[TILE_9_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, NORTH : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_12_0:.*]] = aie.tile(12, 0)
 // CHECK:           %[[SWITCHBOX_12_0:.*]] = aie.switchbox(%[[TILE_12_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_13_0:.*]] = aie.tile(13, 0)
 // CHECK:           %[[SWITCHBOX_13_0:.*]] = aie.switchbox(%[[TILE_13_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_14_0:.*]] = aie.tile(14, 0)
+// CHECK:           %[[SHIM_MUX_14_0:.*]] = aie.shim_mux(%[[TILE_14_0]]) {
+// CHECK:           }
 // CHECK:           %[[SWITCHBOX_14_0:.*]] = aie.switchbox(%[[TILE_14_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_15_0:.*]] = aie.tile(15, 0)
+// CHECK:           %[[SHIM_MUX_15_0:.*]] = aie.shim_mux(%[[TILE_15_0]]) {
+// CHECK:           }
 // CHECK:           %[[SWITCHBOX_15_0:.*]] = aie.switchbox(%[[TILE_15_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[TILE_16_0:.*]] = aie.tile(16, 0)
 // CHECK:           %[[SWITCHBOX_16_0:.*]] = aie.switchbox(%[[TILE_16_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_17_0:.*]] = aie.tile(17, 0)
 // CHECK:           %[[SWITCHBOX_17_0:.*]] = aie.switchbox(%[[TILE_17_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_18_0:.*]] = aie.switchbox(%[[TILE_18_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 7, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_18_0:.*]] = aie.shim_mux(%[[TILE_18_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_19_0:.*]] = aie.switchbox(%[[TILE_19_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 7, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_19_0:.*]] = aie.shim_mux(%[[TILE_19_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
 // CHECK:           }
 // CHECK:         }
 

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_routed_herd_3x2.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_routed_herd_3x2.mlir
@@ -3,51 +3,93 @@
 
 // CHECK-LABEL:   aie.device(xcvc1902) {
 // CHECK:           %[[TILE_0_0:.*]] = aie.tile(0, 0)
+// CHECK:           %[[SWITCHBOX_0_0:.*]] = aie.switchbox(%[[TILE_0_0]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_1_0:.*]] = aie.tile(1, 0)
+// CHECK:           %[[SWITCHBOX_1_0:.*]] = aie.switchbox(%[[TILE_1_0]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_2_0:.*]] = aie.tile(2, 0)
 // CHECK:           %[[TILE_3_0:.*]] = aie.tile(3, 0)
 // CHECK:           %[[TILE_4_0:.*]] = aie.tile(4, 0)
+// CHECK:           %[[SWITCHBOX_4_0:.*]] = aie.switchbox(%[[TILE_4_0]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_5_0:.*]] = aie.tile(5, 0)
+// CHECK:           %[[SWITCHBOX_5_0:.*]] = aie.switchbox(%[[TILE_5_0]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_6_0:.*]] = aie.tile(6, 0)
 // CHECK:           %[[TILE_7_0:.*]] = aie.tile(7, 0)
+// CHECK:           %[[SWITCHBOX_7_0:.*]] = aie.switchbox(%[[TILE_7_0]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_8_0:.*]] = aie.tile(8, 0)
+// CHECK:           %[[SWITCHBOX_8_0:.*]] = aie.switchbox(%[[TILE_8_0]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_9_0:.*]] = aie.tile(9, 0)
 // CHECK:           %[[TILE_10_0:.*]] = aie.tile(10, 0)
 // CHECK:           %[[TILE_11_0:.*]] = aie.tile(11, 0)
 // CHECK:           %[[TILE_18_0:.*]] = aie.tile(18, 0)
 // CHECK:           %[[TILE_19_0:.*]] = aie.tile(19, 0)
+// CHECK:           %[[SWITCHBOX_19_0:.*]] = aie.switchbox(%[[TILE_19_0]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_0_1:.*]] = aie.tile(0, 1)
 // CHECK:           %[[TILE_0_2:.*]] = aie.tile(0, 2)
 // CHECK:           %[[TILE_0_3:.*]] = aie.tile(0, 3)
 // CHECK:           %[[TILE_0_4:.*]] = aie.tile(0, 4)
 // CHECK:           %[[TILE_0_5:.*]] = aie.tile(0, 5)
+// CHECK:           %[[SWITCHBOX_0_5:.*]] = aie.switchbox(%[[TILE_0_5]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_0_6:.*]] = aie.tile(0, 6)
+// CHECK:           %[[SWITCHBOX_0_6:.*]] = aie.switchbox(%[[TILE_0_6]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_0_7:.*]] = aie.tile(0, 7)
+// CHECK:           %[[SWITCHBOX_0_7:.*]] = aie.switchbox(%[[TILE_0_7]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_0_8:.*]] = aie.tile(0, 8)
+// CHECK:           %[[SWITCHBOX_0_8:.*]] = aie.switchbox(%[[TILE_0_8]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_1_1:.*]] = aie.tile(1, 1)
 // CHECK:           %[[TILE_1_2:.*]] = aie.tile(1, 2)
 // CHECK:           %[[TILE_1_3:.*]] = aie.tile(1, 3)
 // CHECK:           %[[TILE_1_4:.*]] = aie.tile(1, 4)
 // CHECK:           %[[TILE_1_5:.*]] = aie.tile(1, 5)
+// CHECK:           %[[SWITCHBOX_1_5:.*]] = aie.switchbox(%[[TILE_1_5]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_1_6:.*]] = aie.tile(1, 6)
+// CHECK:           %[[SWITCHBOX_1_6:.*]] = aie.switchbox(%[[TILE_1_6]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_1_7:.*]] = aie.tile(1, 7)
+// CHECK:           %[[SWITCHBOX_1_7:.*]] = aie.switchbox(%[[TILE_1_7]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_1_8:.*]] = aie.tile(1, 8)
+// CHECK:           %[[SWITCHBOX_1_8:.*]] = aie.switchbox(%[[TILE_1_8]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_2_1:.*]] = aie.tile(2, 1)
 // CHECK:           %[[TILE_2_2:.*]] = aie.tile(2, 2)
 // CHECK:           %[[TILE_2_3:.*]] = aie.tile(2, 3)
 // CHECK:           %[[TILE_2_4:.*]] = aie.tile(2, 4)
 // CHECK:           %[[TILE_2_5:.*]] = aie.tile(2, 5)
 // CHECK:           %[[TILE_2_6:.*]] = aie.tile(2, 6)
+// CHECK:           %[[SWITCHBOX_2_6:.*]] = aie.switchbox(%[[TILE_2_6]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_2_7:.*]] = aie.tile(2, 7)
+// CHECK:           %[[SWITCHBOX_2_7:.*]] = aie.switchbox(%[[TILE_2_7]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_2_8:.*]] = aie.tile(2, 8)
+// CHECK:           %[[SWITCHBOX_2_8:.*]] = aie.switchbox(%[[TILE_2_8]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_3_1:.*]] = aie.tile(3, 1)
 // CHECK:           %[[TILE_3_2:.*]] = aie.tile(3, 2)
 // CHECK:           %[[TILE_3_3:.*]] = aie.tile(3, 3)
 // CHECK:           %[[TILE_3_4:.*]] = aie.tile(3, 4)
 // CHECK:           %[[TILE_3_5:.*]] = aie.tile(3, 5)
 // CHECK:           %[[TILE_3_6:.*]] = aie.tile(3, 6)
+// CHECK:           %[[SWITCHBOX_3_6:.*]] = aie.switchbox(%[[TILE_3_6]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_3_7:.*]] = aie.tile(3, 7)
+// CHECK:           %[[SWITCHBOX_3_7:.*]] = aie.switchbox(%[[TILE_3_7]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_3_8:.*]] = aie.tile(3, 8)
+// CHECK:           %[[SWITCHBOX_3_8:.*]] = aie.switchbox(%[[TILE_3_8]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_4_1:.*]] = aie.tile(4, 1)
 // CHECK:           %[[TILE_4_2:.*]] = aie.tile(4, 2)
 // CHECK:           %[[TILE_4_3:.*]] = aie.tile(4, 3)
@@ -55,7 +97,11 @@
 // CHECK:           %[[TILE_4_5:.*]] = aie.tile(4, 5)
 // CHECK:           %[[TILE_4_6:.*]] = aie.tile(4, 6)
 // CHECK:           %[[TILE_4_7:.*]] = aie.tile(4, 7)
+// CHECK:           %[[SWITCHBOX_4_7:.*]] = aie.switchbox(%[[TILE_4_7]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_4_8:.*]] = aie.tile(4, 8)
+// CHECK:           %[[SWITCHBOX_4_8:.*]] = aie.switchbox(%[[TILE_4_8]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_5_1:.*]] = aie.tile(5, 1)
 // CHECK:           %[[TILE_5_2:.*]] = aie.tile(5, 2)
 // CHECK:           %[[TILE_5_3:.*]] = aie.tile(5, 3)
@@ -63,7 +109,11 @@
 // CHECK:           %[[TILE_5_5:.*]] = aie.tile(5, 5)
 // CHECK:           %[[TILE_5_6:.*]] = aie.tile(5, 6)
 // CHECK:           %[[TILE_5_7:.*]] = aie.tile(5, 7)
+// CHECK:           %[[SWITCHBOX_5_7:.*]] = aie.switchbox(%[[TILE_5_7]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_5_8:.*]] = aie.tile(5, 8)
+// CHECK:           %[[SWITCHBOX_5_8:.*]] = aie.switchbox(%[[TILE_5_8]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_6_1:.*]] = aie.tile(6, 1)
 // CHECK:           %[[TILE_6_2:.*]] = aie.tile(6, 2)
 // CHECK:           %[[TILE_6_3:.*]] = aie.tile(6, 3)
@@ -71,7 +121,11 @@
 // CHECK:           %[[TILE_6_5:.*]] = aie.tile(6, 5)
 // CHECK:           %[[TILE_6_6:.*]] = aie.tile(6, 6)
 // CHECK:           %[[TILE_6_7:.*]] = aie.tile(6, 7)
+// CHECK:           %[[SWITCHBOX_6_7:.*]] = aie.switchbox(%[[TILE_6_7]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_6_8:.*]] = aie.tile(6, 8)
+// CHECK:           %[[SWITCHBOX_6_8:.*]] = aie.switchbox(%[[TILE_6_8]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_7_1:.*]] = aie.tile(7, 1)
 // CHECK:           %[[TILE_7_2:.*]] = aie.tile(7, 2)
 // CHECK:           %[[TILE_7_3:.*]] = aie.tile(7, 3)
@@ -79,47 +133,89 @@
 // CHECK:           %[[TILE_7_5:.*]] = aie.tile(7, 5)
 // CHECK:           %[[TILE_7_6:.*]] = aie.tile(7, 6)
 // CHECK:           %[[TILE_7_7:.*]] = aie.tile(7, 7)
+// CHECK:           %[[SWITCHBOX_7_7:.*]] = aie.switchbox(%[[TILE_7_7]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_7_8:.*]] = aie.tile(7, 8)
+// CHECK:           %[[SWITCHBOX_7_8:.*]] = aie.switchbox(%[[TILE_7_8]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_8_1:.*]] = aie.tile(8, 1)
 // CHECK:           %[[TILE_8_2:.*]] = aie.tile(8, 2)
 // CHECK:           %[[TILE_8_3:.*]] = aie.tile(8, 3)
 // CHECK:           %[[TILE_8_4:.*]] = aie.tile(8, 4)
 // CHECK:           %[[TILE_8_5:.*]] = aie.tile(8, 5)
+// CHECK:           %[[SWITCHBOX_8_5:.*]] = aie.switchbox(%[[TILE_8_5]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_8_6:.*]] = aie.tile(8, 6)
+// CHECK:           %[[SWITCHBOX_8_6:.*]] = aie.switchbox(%[[TILE_8_6]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_8_7:.*]] = aie.tile(8, 7)
+// CHECK:           %[[SWITCHBOX_8_7:.*]] = aie.switchbox(%[[TILE_8_7]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_8_8:.*]] = aie.tile(8, 8)
+// CHECK:           %[[SWITCHBOX_8_8:.*]] = aie.switchbox(%[[TILE_8_8]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_9_1:.*]] = aie.tile(9, 1)
 // CHECK:           %[[TILE_9_2:.*]] = aie.tile(9, 2)
 // CHECK:           %[[TILE_9_3:.*]] = aie.tile(9, 3)
 // CHECK:           %[[TILE_9_4:.*]] = aie.tile(9, 4)
 // CHECK:           %[[TILE_9_5:.*]] = aie.tile(9, 5)
+// CHECK:           %[[SWITCHBOX_9_5:.*]] = aie.switchbox(%[[TILE_9_5]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_9_6:.*]] = aie.tile(9, 6)
+// CHECK:           %[[SWITCHBOX_9_6:.*]] = aie.switchbox(%[[TILE_9_6]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_9_7:.*]] = aie.tile(9, 7)
+// CHECK:           %[[SWITCHBOX_9_7:.*]] = aie.switchbox(%[[TILE_9_7]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_9_8:.*]] = aie.tile(9, 8)
+// CHECK:           %[[SWITCHBOX_9_8:.*]] = aie.switchbox(%[[TILE_9_8]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_10_1:.*]] = aie.tile(10, 1)
 // CHECK:           %[[TILE_10_2:.*]] = aie.tile(10, 2)
 // CHECK:           %[[TILE_10_3:.*]] = aie.tile(10, 3)
 // CHECK:           %[[TILE_10_4:.*]] = aie.tile(10, 4)
 // CHECK:           %[[TILE_10_5:.*]] = aie.tile(10, 5)
+// CHECK:           %[[SWITCHBOX_10_5:.*]] = aie.switchbox(%[[TILE_10_5]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_10_6:.*]] = aie.tile(10, 6)
+// CHECK:           %[[SWITCHBOX_10_6:.*]] = aie.switchbox(%[[TILE_10_6]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_10_7:.*]] = aie.tile(10, 7)
+// CHECK:           %[[SWITCHBOX_10_7:.*]] = aie.switchbox(%[[TILE_10_7]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_10_8:.*]] = aie.tile(10, 8)
+// CHECK:           %[[SWITCHBOX_10_8:.*]] = aie.switchbox(%[[TILE_10_8]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_11_1:.*]] = aie.tile(11, 1)
 // CHECK:           %[[TILE_11_2:.*]] = aie.tile(11, 2)
 // CHECK:           %[[TILE_11_3:.*]] = aie.tile(11, 3)
 // CHECK:           %[[TILE_11_4:.*]] = aie.tile(11, 4)
 // CHECK:           %[[TILE_11_5:.*]] = aie.tile(11, 5)
+// CHECK:           %[[SWITCHBOX_11_5:.*]] = aie.switchbox(%[[TILE_11_5]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_11_6:.*]] = aie.tile(11, 6)
+// CHECK:           %[[SWITCHBOX_11_6:.*]] = aie.switchbox(%[[TILE_11_6]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_11_7:.*]] = aie.tile(11, 7)
+// CHECK:           %[[SWITCHBOX_11_7:.*]] = aie.switchbox(%[[TILE_11_7]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_11_8:.*]] = aie.tile(11, 8)
+// CHECK:           %[[SWITCHBOX_11_8:.*]] = aie.switchbox(%[[TILE_11_8]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_12_1:.*]] = aie.tile(12, 1)
 // CHECK:           %[[TILE_12_2:.*]] = aie.tile(12, 2)
 // CHECK:           %[[TILE_12_3:.*]] = aie.tile(12, 3)
 // CHECK:           %[[TILE_12_4:.*]] = aie.tile(12, 4)
 // CHECK:           %[[TILE_12_5:.*]] = aie.tile(12, 5)
 // CHECK:           %[[TILE_12_6:.*]] = aie.tile(12, 6)
+// CHECK:           %[[SWITCHBOX_12_6:.*]] = aie.switchbox(%[[TILE_12_6]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_12_7:.*]] = aie.tile(12, 7)
+// CHECK:           %[[SWITCHBOX_12_7:.*]] = aie.switchbox(%[[TILE_12_7]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_12_8:.*]] = aie.tile(12, 8)
+// CHECK:           %[[SWITCHBOX_12_8:.*]] = aie.switchbox(%[[TILE_12_8]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_13_0:.*]] = aie.tile(13, 0)
 // CHECK:           %[[TILE_13_1:.*]] = aie.tile(13, 1)
 // CHECK:           %[[TILE_13_2:.*]] = aie.tile(13, 2)
@@ -127,16 +223,32 @@
 // CHECK:           %[[TILE_13_4:.*]] = aie.tile(13, 4)
 // CHECK:           %[[TILE_13_5:.*]] = aie.tile(13, 5)
 // CHECK:           %[[TILE_13_6:.*]] = aie.tile(13, 6)
+// CHECK:           %[[SWITCHBOX_13_6:.*]] = aie.switchbox(%[[TILE_13_6]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_13_7:.*]] = aie.tile(13, 7)
+// CHECK:           %[[SWITCHBOX_13_7:.*]] = aie.switchbox(%[[TILE_13_7]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_13_8:.*]] = aie.tile(13, 8)
+// CHECK:           %[[SWITCHBOX_13_8:.*]] = aie.switchbox(%[[TILE_13_8]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_14_1:.*]] = aie.tile(14, 1)
+// CHECK:           %[[SWITCHBOX_14_1:.*]] = aie.switchbox(%[[TILE_14_1]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_14_2:.*]] = aie.tile(14, 2)
+// CHECK:           %[[SWITCHBOX_14_2:.*]] = aie.switchbox(%[[TILE_14_2]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_14_3:.*]] = aie.tile(14, 3)
 // CHECK:           %[[TILE_14_4:.*]] = aie.tile(14, 4)
 // CHECK:           %[[TILE_14_5:.*]] = aie.tile(14, 5)
 // CHECK:           %[[TILE_14_6:.*]] = aie.tile(14, 6)
+// CHECK:           %[[SWITCHBOX_14_6:.*]] = aie.switchbox(%[[TILE_14_6]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_14_7:.*]] = aie.tile(14, 7)
+// CHECK:           %[[SWITCHBOX_14_7:.*]] = aie.switchbox(%[[TILE_14_7]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_14_8:.*]] = aie.tile(14, 8)
+// CHECK:           %[[SWITCHBOX_14_8:.*]] = aie.switchbox(%[[TILE_14_8]]) {
+// CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_1:.*]] = aie.switchbox(%[[TILE_0_1]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_2:.*]] = aie.switchbox(%[[TILE_0_2]]) {
@@ -154,56 +266,56 @@
 // CHECK:           %[[SWITCHBOX_1_4:.*]] = aie.switchbox(%[[TILE_1_4]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
+// CHECK:             aie.connect<EAST : 3, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_4:.*]] = aie.switchbox(%[[TILE_2_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
+// CHECK:             aie.connect<EAST : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_5:.*]] = aie.switchbox(%[[TILE_2_5]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<DMA : 0, EAST : 0>
+// CHECK:             aie.connect<SOUTH : 0, CORE : 0>
+// CHECK:             aie.connect<DMA : 0, EAST : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_1:.*]] = aie.switchbox(%[[TILE_3_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 0, DMA : 0>
+// CHECK:             aie.connect<CORE : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_2:.*]] = aie.switchbox(%[[TILE_3_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_3:.*]] = aie.switchbox(%[[TILE_3_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_4:.*]] = aie.switchbox(%[[TILE_3_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_5:.*]] = aie.switchbox(%[[TILE_3_5]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
+// CHECK:             aie.connect<WEST : 0, EAST : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_4_1:.*]] = aie.switchbox(%[[TILE_4_1]]) {
+// CHECK:             aie.connect<NORTH : 3, EAST : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_4_2:.*]] = aie.switchbox(%[[TILE_4_2]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 1, WEST : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_4_3:.*]] = aie.switchbox(%[[TILE_4_3]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_4_4:.*]] = aie.switchbox(%[[TILE_4_4]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, WEST : 0>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 2>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_5_1:.*]] = aie.switchbox(%[[TILE_5_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_5_2:.*]] = aie.switchbox(%[[TILE_5_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_5_3:.*]] = aie.switchbox(%[[TILE_5_3]]) {
 // CHECK:           }
@@ -212,9 +324,10 @@
 // CHECK:           %[[SWITCHBOX_5_5:.*]] = aie.switchbox(%[[TILE_5_5]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_5_6:.*]] = aie.switchbox(%[[TILE_5_6]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_6_1:.*]] = aie.switchbox(%[[TILE_6_1]]) {
+// CHECK:             aie.connect<WEST : 1, SOUTH : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_6_2:.*]] = aie.switchbox(%[[TILE_6_2]]) {
 // CHECK:           }
@@ -225,52 +338,51 @@
 // CHECK:           %[[SWITCHBOX_6_5:.*]] = aie.switchbox(%[[TILE_6_5]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_6_6:.*]] = aie.switchbox(%[[TILE_6_6]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<DMA : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, CORE : 0>
+// CHECK:             aie.connect<DMA : 0, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_1:.*]] = aie.switchbox(%[[TILE_7_1]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_2:.*]] = aie.switchbox(%[[TILE_7_2]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, NORTH : 0>
+// CHECK:             aie.connect<EAST : 0, DMA : 0>
+// CHECK:             aie.connect<CORE : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_4:.*]] = aie.switchbox(%[[TILE_7_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_5:.*]] = aie.switchbox(%[[TILE_7_5]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_6:.*]] = aie.switchbox(%[[TILE_7_6]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 0, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_8_1:.*]] = aie.switchbox(%[[TILE_8_1]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_8_2:.*]] = aie.switchbox(%[[TILE_8_2]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_8_3:.*]] = aie.switchbox(%[[TILE_8_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_8_4:.*]] = aie.switchbox(%[[TILE_8_4]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_9_1:.*]] = aie.switchbox(%[[TILE_9_1]]) {
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 5>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_9_2:.*]] = aie.switchbox(%[[TILE_9_2]]) {
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_9_3:.*]] = aie.switchbox(%[[TILE_9_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 0, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_9_4:.*]] = aie.switchbox(%[[TILE_9_4]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_10_1:.*]] = aie.switchbox(%[[TILE_10_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_10_2:.*]] = aie.switchbox(%[[TILE_10_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_10_3:.*]] = aie.switchbox(%[[TILE_10_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_10_4:.*]] = aie.switchbox(%[[TILE_10_4]]) {
 // CHECK:           }
@@ -291,110 +403,111 @@
 // CHECK:           %[[SWITCHBOX_12_4:.*]] = aie.switchbox(%[[TILE_12_4]]) {
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_12_5:.*]] = aie.switchbox(%[[TILE_12_5]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<DMA : 0, EAST : 0>
+// CHECK:             aie.connect<EAST : 0, CORE : 0>
+// CHECK:             aie.connect<DMA : 0, EAST : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_13_1:.*]] = aie.switchbox(%[[TILE_13_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_13_2:.*]] = aie.switchbox(%[[TILE_13_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_13_3:.*]] = aie.switchbox(%[[TILE_13_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<CORE : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, DMA : 0>
+// CHECK:             aie.connect<CORE : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_13_4:.*]] = aie.switchbox(%[[TILE_13_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_13_5:.*]] = aie.switchbox(%[[TILE_13_5]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
+// CHECK:             aie.connect<SOUTH : 0, WEST : 0>
+// CHECK:             aie.connect<WEST : 0, EAST : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_0:.*]] = aie.switchbox(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_4_5:.*]] = aie.switchbox(%[[TILE_4_5]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_5_0:.*]] = aie.switchbox(%[[TILE_5_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
+// CHECK:             aie.connect<WEST : 0, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_6_0:.*]] = aie.switchbox(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 2>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_6_0:.*]] = aie.shim_mux(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_9_0:.*]] = aie.switchbox(%[[TILE_9_0]]) {
+// CHECK:             aie.connect<EAST : 3, NORTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_10_0:.*]] = aie.switchbox(%[[TILE_10_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_10_0:.*]] = aie.shim_mux(%[[TILE_10_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_4_6:.*]] = aie.switchbox(%[[TILE_4_6]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 0, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_11_0:.*]] = aie.switchbox(%[[TILE_11_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, EAST : 0>
+// CHECK:             aie.connect<SOUTH : 3, EAST : 2>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_11_0:.*]] = aie.shim_mux(%[[TILE_11_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_12_0:.*]] = aie.tile(12, 0)
 // CHECK:           %[[SWITCHBOX_12_0:.*]] = aie.switchbox(%[[TILE_12_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
+// CHECK:             aie.connect<WEST : 2, EAST : 2>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_13_0:.*]] = aie.switchbox(%[[TILE_13_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_14_2:.*]] = aie.switchbox(%[[TILE_14_2]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
+// CHECK:             aie.connect<WEST : 2, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_14_3:.*]] = aie.switchbox(%[[TILE_14_3]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 3, EAST : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_14_4:.*]] = aie.switchbox(%[[TILE_14_4]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_14_5:.*]] = aie.switchbox(%[[TILE_14_5]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
+// CHECK:             aie.connect<WEST : 0, SOUTH : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_15_2:.*]] = aie.tile(15, 2)
 // CHECK:           %[[SWITCHBOX_15_2:.*]] = aie.switchbox(%[[TILE_15_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
+// CHECK:             aie.connect<NORTH : 2, EAST : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_15_3:.*]] = aie.tile(15, 3)
+// CHECK:           %[[SWITCHBOX_15_3:.*]] = aie.switchbox(%[[TILE_15_3]]) {
+// CHECK:             aie.connect<WEST : 3, SOUTH : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_16_1:.*]] = aie.tile(16, 1)
+// CHECK:           %[[SWITCHBOX_16_1:.*]] = aie.switchbox(%[[TILE_16_1]]) {
+// CHECK:             aie.connect<NORTH : 2, EAST : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_16_2:.*]] = aie.tile(16, 2)
 // CHECK:           %[[SWITCHBOX_16_2:.*]] = aie.switchbox(%[[TILE_16_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_17_0:.*]] = aie.tile(17, 0)
-// CHECK:           %[[SWITCHBOX_17_0:.*]] = aie.switchbox(%[[TILE_17_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
+// CHECK:             aie.connect<WEST : 0, SOUTH : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_17_1:.*]] = aie.tile(17, 1)
 // CHECK:           %[[SWITCHBOX_17_1:.*]] = aie.switchbox(%[[TILE_17_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_17_2:.*]] = aie.tile(17, 2)
-// CHECK:           %[[SWITCHBOX_17_2:.*]] = aie.switchbox(%[[TILE_17_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_18_0:.*]] = aie.switchbox(%[[TILE_18_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_18_0:.*]] = aie.shim_mux(%[[TILE_18_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_18_1:.*]] = aie.tile(18, 1)
+// CHECK:           %[[SWITCHBOX_18_1:.*]] = aie.switchbox(%[[TILE_18_1]]) {
+// CHECK:             aie.connect<WEST : 1, SOUTH : 0>
 // CHECK:           }
 // CHECK:         }
 

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_simple.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_simple.mlir
@@ -6,13 +6,14 @@
 // CHECK:           %[[TILE_1_2:.*]] = aie.tile(1, 2)
 // CHECK:           %[[TILE_0_2:.*]] = aie.tile(0, 2)
 // CHECK:           %[[SWITCHBOX_0_1:.*]] = aie.switchbox(%[[TILE_0_1]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 0>
+// CHECK:             aie.connect<DMA : 0, EAST : 3>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_0_2:.*]] = aie.switchbox(%[[TILE_0_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
+// CHECK:           %[[TILE_1_1:.*]] = aie.tile(1, 1)
+// CHECK:           %[[SWITCHBOX_1_1:.*]] = aie.switchbox(%[[TILE_1_1]]) {
+// CHECK:             aie.connect<WEST : 3, NORTH : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_1_2:.*]] = aie.switchbox(%[[TILE_1_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, CORE : 1>
+// CHECK:             aie.connect<SOUTH : 1, CORE : 1>
 // CHECK:           }
 // CHECK:           aie.packet_flow(16) {
 // CHECK:             aie.packet_source<%[[TILE_0_1]], CORE : 0>

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_simple2.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_simple2.mlir
@@ -4,18 +4,17 @@
 // CHECK-LABEL:   aie.device(xcvc1902) {
 // CHECK:           %[[TILE_2_3:.*]] = aie.tile(2, 3)
 // CHECK:           %[[TILE_3_2:.*]] = aie.tile(3, 2)
-// CHECK:           %[[TILE_2_2:.*]] = aie.tile(2, 2)
-// CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
-// CHECK-DAG:         aie.connect<CORE : 1, SOUTH : 0>
+// CHECK:             aie.connect<CORE : 1, EAST : 2>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_2:.*]] = aie.switchbox(%[[TILE_3_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_3_3:.*]] = aie.tile(3, 3)
+// CHECK:           %[[SWITCHBOX_3_3:.*]] = aie.switchbox(%[[TILE_3_3]]) {
+// CHECK:             aie.connect<WEST : 2, SOUTH : 3>
 // CHECK:           }
 // CHECK:         }
-
 module {
   aie.device(xcvc1902) {
     %0 = aie.tile(2, 3)

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_simple_flows.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_simple_flows.mlir
@@ -5,16 +5,15 @@
 // CHECK:           %[[TILE_2_3:.*]] = aie.tile(2, 3)
 // CHECK:           %[[TILE_2_2:.*]] = aie.tile(2, 2)
 // CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, CORE : 1>
-// CHECK-DAG:         aie.connect<CORE : 0, CORE : 0>
-// CHECK-DAG:         aie.connect<CORE : 1, NORTH : 0>
+// CHECK:             aie.connect<NORTH : 0, CORE : 1>
+// CHECK:             aie.connect<CORE : 0, CORE : 0>
+// CHECK:             aie.connect<CORE : 1, NORTH : 5>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
-// CHECK-DAG:         aie.connect<CORE : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, CORE : 1>
+// CHECK:             aie.connect<CORE : 0, SOUTH : 0>
+// CHECK:             aie.connect<SOUTH : 5, CORE : 1>
 // CHECK:           }
 // CHECK:         }
-
 module {
   aie.device(xcvc1902) {
     %t23 = aie.tile(2, 3)

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_simple_flows2.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_simple_flows2.mlir
@@ -6,18 +6,18 @@
 // CHECK:           %[[TILE_2_2:.*]] = aie.tile(2, 2)
 // CHECK:           %[[TILE_1_1:.*]] = aie.tile(1, 1)
 // CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, CORE : 1>
-// CHECK-DAG:         aie.connect<CORE : 0, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 0, CORE : 1>
+// CHECK:             aie.connect<CORE : 0, WEST : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
-// CHECK-DAG:         aie.connect<CORE : 0, SOUTH : 0>
+// CHECK:             aie.connect<CORE : 0, SOUTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_1_1:.*]] = aie.switchbox(%[[TILE_1_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, CORE : 0>
+// CHECK:             aie.connect<NORTH : 0, CORE : 0>
 // CHECK:           }
-// CHECK:           %[[TILE_2_1:.*]] = aie.tile(2, 1)
-// CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
+// CHECK:           %[[TILE_1_2:.*]] = aie.tile(1, 2)
+// CHECK:           %[[SWITCHBOX_1_2:.*]] = aie.switchbox(%[[TILE_1_2]]) {
+// CHECK:             aie.connect<EAST : 3, SOUTH : 0>
 // CHECK:           }
 // CHECK:         }
 

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_simple_flows_shim.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_simple_flows_shim.mlir
@@ -5,13 +5,13 @@
 // CHECK:           %[[TILE_2_0:.*]] = aie.tile(2, 0)
 // CHECK:           %[[TILE_2_1:.*]] = aie.tile(2, 1)
 // CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
-// CHECK-DAG:         aie.connect<CORE : 0, SOUTH : 0>
+// CHECK:             aie.connect<CORE : 0, SOUTH : 0>
 // CHECK:           }
 // CHECK:         }
 
@@ -29,16 +29,16 @@ module {
 // CHECK:           %[[TILE_2_0:.*]] = aie.tile(2, 0)
 // CHECK:           %[[TILE_3_0:.*]] = aie.tile(3, 0)
 // CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, EAST : 0>
+// CHECK:             aie.connect<SOUTH : 3, EAST : 1>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_0:.*]] = aie.switchbox(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 3>
+// CHECK:             aie.connect<WEST : 1, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
 // CHECK:         }
 
@@ -49,3 +49,5 @@ module {
     aie.flow(%t20, DMA : 0, %t30, DMA : 1)
   }
 }
+
+

--- a/compiler/plugins/target/AMD-AIE/aie/test/unit_vecmul_4x4.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/unit_vecmul_4x4.mlir
@@ -1,37 +1,42 @@
-
 // RUN: iree-opt --amdaie-create-pathfinder-flows %s | FileCheck %s
 
 // CHECK-LABEL:   aie.device(xcvc1902) {
 // CHECK:           %[[TILE_47_2:.*]] = aie.tile(47, 2)
+// CHECK:           %[[SWITCHBOX_47_2:.*]] = aie.switchbox(%[[TILE_47_2]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_47_1:.*]] = aie.tile(47, 1)
+// CHECK:           %[[SWITCHBOX_47_1:.*]] = aie.switchbox(%[[TILE_47_1]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_47_0:.*]] = aie.tile(47, 0)
 // CHECK:           %[[TILE_3_3:.*]] = aie.tile(3, 3)
+// CHECK:           %[[SWITCHBOX_3_3:.*]] = aie.switchbox(%[[TILE_3_3]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_10_5:.*]] = aie.tile(10, 5)
 // CHECK:           %[[LOCK_10_5:.*]] = aie.lock(%[[TILE_10_5]], 2)
-// CHECK:           %[[BUF47:.*]] = aie.buffer(%[[TILE_10_5]]) {sym_name = "buf47"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_10_5:.*]] = aie.buffer(%[[TILE_10_5]]) {sym_name = "buf47"} : memref<64xi32, 2>
 // CHECK:           %[[LOCK_10_5_0:.*]] = aie.lock(%[[TILE_10_5]], 1)
-// CHECK:           %[[BUF46:.*]] = aie.buffer(%[[TILE_10_5]]) {sym_name = "buf46"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_10_5_1:.*]] = aie.lock(%[[TILE_10_5]], 0)
-// CHECK:           %[[BUF45:.*]] = aie.buffer(%[[TILE_10_5]]) {sym_name = "buf45"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_10_5_1:.*]] = aie.buffer(%[[TILE_10_5]]) {sym_name = "buf46"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_10_5_2:.*]] = aie.lock(%[[TILE_10_5]], 0)
+// CHECK:           %[[BUFFER_10_5_3:.*]] = aie.buffer(%[[TILE_10_5]]) {sym_name = "buf45"} : memref<64xi32, 2>
 // CHECK:           %[[MEM_10_5:.*]] = aie.mem(%[[TILE_10_5]]) {
 // CHECK:             %[[VAL_0:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
-// CHECK:             aie.use_lock(%[[LOCK_10_5_1]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF45]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_10_5_1]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_10_5_2]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_10_5_3]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_10_5_2]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_1:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[LOCK_10_5_0]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF46]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_10_5_1]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_10_5_0]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_2:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[LOCK_10_5]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[BUF47]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_10_5]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_10_5]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -42,50 +47,50 @@
 // CHECK:           ^bb1:
 // CHECK:             cf.br ^bb2
 // CHECK:           ^bb2:
-// CHECK:             aie.use_lock(%[[LOCK_10_5_1]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_10_5_2]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_10_5_0]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_10_5]], Acquire, 0)
-// CHECK:             affine.for %[[ARG0:.*]] = 0 to 64 {
-// CHECK:               %[[VAL_3:.*]] = affine.load %[[BUF45]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_4:.*]] = affine.load %[[BUF46]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_5:.*]] = arith.muli %[[VAL_3]], %[[VAL_4]] : i32
-// CHECK:               affine.store %[[VAL_5]], %[[BUF47]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:             }
 // CHECK:             aie.use_lock(%[[LOCK_10_5]], Release, 1)
 // CHECK:             aie.use_lock(%[[LOCK_10_5_0]], Release, 0)
-// CHECK:             aie.use_lock(%[[LOCK_10_5_1]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_10_5_2]], Release, 0)
 // CHECK:             cf.br ^bb1
 // CHECK:           }
 // CHECK:           %[[TILE_46_2:.*]] = aie.tile(46, 2)
+// CHECK:           %[[SWITCHBOX_46_2:.*]] = aie.switchbox(%[[TILE_46_2]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_46_1:.*]] = aie.tile(46, 1)
+// CHECK:           %[[SWITCHBOX_46_1:.*]] = aie.switchbox(%[[TILE_46_1]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_46_0:.*]] = aie.tile(46, 0)
 // CHECK:           %[[TILE_2_3:.*]] = aie.tile(2, 3)
+// CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_9_5:.*]] = aie.tile(9, 5)
 // CHECK:           %[[LOCK_9_5:.*]] = aie.lock(%[[TILE_9_5]], 2)
-// CHECK:           %[[BUF44:.*]] = aie.buffer(%[[TILE_9_5]]) {sym_name = "buf44"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_9_5_2:.*]] = aie.lock(%[[TILE_9_5]], 1)
-// CHECK:           %[[BUF43:.*]] = aie.buffer(%[[TILE_9_5]]) {sym_name = "buf43"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_9_5_3:.*]] = aie.lock(%[[TILE_9_5]], 0)
-// CHECK:           %[[BUF42:.*]] = aie.buffer(%[[TILE_9_5]]) {sym_name = "buf42"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_9_5:.*]] = aie.buffer(%[[TILE_9_5]]) {sym_name = "buf44"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_9_5_4:.*]] = aie.lock(%[[TILE_9_5]], 1)
+// CHECK:           %[[BUFFER_9_5_5:.*]] = aie.buffer(%[[TILE_9_5]]) {sym_name = "buf43"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_9_5_6:.*]] = aie.lock(%[[TILE_9_5]], 0)
+// CHECK:           %[[BUFFER_9_5_7:.*]] = aie.buffer(%[[TILE_9_5]]) {sym_name = "buf42"} : memref<64xi32, 2>
 // CHECK:           %[[MEM_9_5:.*]] = aie.mem(%[[TILE_9_5]]) {
-// CHECK:             %[[VAL_6:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
+// CHECK:             %[[VAL_3:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
-// CHECK:             aie.use_lock(%[[LOCK_9_5_3]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF42]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_9_5_3]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_9_5_6]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_9_5_7]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_9_5_6]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_7:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
+// CHECK:             %[[VAL_4:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
-// CHECK:             aie.use_lock(%[[LOCK_9_5_2]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF43]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_9_5_2]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_9_5_4]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_9_5_5]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_9_5_4]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_8:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
+// CHECK:             %[[VAL_5:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[LOCK_9_5]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[BUF44]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_9_5]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_9_5]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -96,50 +101,48 @@
 // CHECK:           ^bb1:
 // CHECK:             cf.br ^bb2
 // CHECK:           ^bb2:
-// CHECK:             aie.use_lock(%[[LOCK_9_5_3]], Acquire, 1)
-// CHECK:             aie.use_lock(%[[LOCK_9_5_2]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_9_5_6]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_9_5_4]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_9_5]], Acquire, 0)
-// CHECK:             affine.for %[[ARG0:.*]] = 0 to 64 {
-// CHECK:               %[[VAL_9:.*]] = affine.load %[[BUF42]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_10:.*]] = affine.load %[[BUF43]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_11:.*]] = arith.muli %[[VAL_9]], %[[VAL_10]] : i32
-// CHECK:               affine.store %[[VAL_11]], %[[BUF44]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:             }
 // CHECK:             aie.use_lock(%[[LOCK_9_5]], Release, 1)
-// CHECK:             aie.use_lock(%[[LOCK_9_5_2]], Release, 0)
-// CHECK:             aie.use_lock(%[[LOCK_9_5_3]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_9_5_4]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_9_5_6]], Release, 0)
 // CHECK:             cf.br ^bb1
 // CHECK:           }
 // CHECK:           %[[TILE_43_2:.*]] = aie.tile(43, 2)
+// CHECK:           %[[SWITCHBOX_43_2:.*]] = aie.switchbox(%[[TILE_43_2]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_43_1:.*]] = aie.tile(43, 1)
 // CHECK:           %[[TILE_43_0:.*]] = aie.tile(43, 0)
 // CHECK:           %[[TILE_1_3:.*]] = aie.tile(1, 3)
+// CHECK:           %[[SWITCHBOX_1_3:.*]] = aie.switchbox(%[[TILE_1_3]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_8_5:.*]] = aie.tile(8, 5)
 // CHECK:           %[[LOCK_8_5:.*]] = aie.lock(%[[TILE_8_5]], 2)
-// CHECK:           %[[BUF41:.*]] = aie.buffer(%[[TILE_8_5]]) {sym_name = "buf41"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_8_5_4:.*]] = aie.lock(%[[TILE_8_5]], 1)
-// CHECK:           %[[BUF40:.*]] = aie.buffer(%[[TILE_8_5]]) {sym_name = "buf40"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_8_5_5:.*]] = aie.lock(%[[TILE_8_5]], 0)
-// CHECK:           %[[BUF39:.*]] = aie.buffer(%[[TILE_8_5]]) {sym_name = "buf39"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_8_5:.*]] = aie.buffer(%[[TILE_8_5]]) {sym_name = "buf41"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_8_5_8:.*]] = aie.lock(%[[TILE_8_5]], 1)
+// CHECK:           %[[BUFFER_8_5_9:.*]] = aie.buffer(%[[TILE_8_5]]) {sym_name = "buf40"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_8_5_10:.*]] = aie.lock(%[[TILE_8_5]], 0)
+// CHECK:           %[[BUFFER_8_5_11:.*]] = aie.buffer(%[[TILE_8_5]]) {sym_name = "buf39"} : memref<64xi32, 2>
 // CHECK:           %[[MEM_8_5:.*]] = aie.mem(%[[TILE_8_5]]) {
-// CHECK:             %[[VAL_12:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
+// CHECK:             %[[VAL_6:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
-// CHECK:             aie.use_lock(%[[LOCK_8_5_5]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF39]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_8_5_5]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_8_5_10]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_8_5_11]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_8_5_10]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_13:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
+// CHECK:             %[[VAL_7:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
-// CHECK:             aie.use_lock(%[[LOCK_8_5_4]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF40]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_8_5_4]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_8_5_8]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_8_5_9]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_8_5_8]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_14:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
+// CHECK:             %[[VAL_8:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[LOCK_8_5]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[BUF41]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_8_5]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_8_5]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -150,50 +153,48 @@
 // CHECK:           ^bb1:
 // CHECK:             cf.br ^bb2
 // CHECK:           ^bb2:
-// CHECK:             aie.use_lock(%[[LOCK_8_5_5]], Acquire, 1)
-// CHECK:             aie.use_lock(%[[LOCK_8_5_4]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_8_5_10]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_8_5_8]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_8_5]], Acquire, 0)
-// CHECK:             affine.for %[[ARG0:.*]] = 0 to 64 {
-// CHECK:               %[[VAL_15:.*]] = affine.load %[[BUF39]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_16:.*]] = affine.load %[[BUF40]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_17:.*]] = arith.muli %[[VAL_15]], %[[VAL_16]] : i32
-// CHECK:               affine.store %[[VAL_17]], %[[BUF41]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:             }
 // CHECK:             aie.use_lock(%[[LOCK_8_5]], Release, 1)
-// CHECK:             aie.use_lock(%[[LOCK_8_5_4]], Release, 0)
-// CHECK:             aie.use_lock(%[[LOCK_8_5_5]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_8_5_8]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_8_5_10]], Release, 0)
 // CHECK:             cf.br ^bb1
 // CHECK:           }
 // CHECK:           %[[TILE_42_2:.*]] = aie.tile(42, 2)
+// CHECK:           %[[SWITCHBOX_42_2:.*]] = aie.switchbox(%[[TILE_42_2]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_42_1:.*]] = aie.tile(42, 1)
 // CHECK:           %[[TILE_42_0:.*]] = aie.tile(42, 0)
 // CHECK:           %[[TILE_0_3:.*]] = aie.tile(0, 3)
+// CHECK:           %[[SWITCHBOX_0_3:.*]] = aie.switchbox(%[[TILE_0_3]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_7_5:.*]] = aie.tile(7, 5)
 // CHECK:           %[[LOCK_7_5:.*]] = aie.lock(%[[TILE_7_5]], 2)
-// CHECK:           %[[BUF38:.*]] = aie.buffer(%[[TILE_7_5]]) {sym_name = "buf38"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_7_5_6:.*]] = aie.lock(%[[TILE_7_5]], 1)
-// CHECK:           %[[BUF37:.*]] = aie.buffer(%[[TILE_7_5]]) {sym_name = "buf37"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_7_5_7:.*]] = aie.lock(%[[TILE_7_5]], 0)
-// CHECK:           %[[BUF36:.*]] = aie.buffer(%[[TILE_7_5]]) {sym_name = "buf36"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_7_5:.*]] = aie.buffer(%[[TILE_7_5]]) {sym_name = "buf38"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_7_5_12:.*]] = aie.lock(%[[TILE_7_5]], 1)
+// CHECK:           %[[BUFFER_7_5_13:.*]] = aie.buffer(%[[TILE_7_5]]) {sym_name = "buf37"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_7_5_14:.*]] = aie.lock(%[[TILE_7_5]], 0)
+// CHECK:           %[[BUFFER_7_5_15:.*]] = aie.buffer(%[[TILE_7_5]]) {sym_name = "buf36"} : memref<64xi32, 2>
 // CHECK:           %[[MEM_7_5:.*]] = aie.mem(%[[TILE_7_5]]) {
-// CHECK:             %[[VAL_18:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
+// CHECK:             %[[VAL_9:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
-// CHECK:             aie.use_lock(%[[LOCK_7_5_7]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF36]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_7_5_7]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_7_5_14]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_7_5_15]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_7_5_14]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_19:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
+// CHECK:             %[[VAL_10:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
-// CHECK:             aie.use_lock(%[[LOCK_7_5_6]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF37]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_7_5_6]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_7_5_12]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_7_5_13]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_7_5_12]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_20:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
+// CHECK:             %[[VAL_11:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[LOCK_7_5]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[BUF38]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_7_5]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_7_5]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -204,18 +205,12 @@
 // CHECK:           ^bb1:
 // CHECK:             cf.br ^bb2
 // CHECK:           ^bb2:
-// CHECK:             aie.use_lock(%[[LOCK_7_5_7]], Acquire, 1)
-// CHECK:             aie.use_lock(%[[LOCK_7_5_6]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_7_5_14]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_7_5_12]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_7_5]], Acquire, 0)
-// CHECK:             affine.for %[[ARG0:.*]] = 0 to 64 {
-// CHECK:               %[[VAL_21:.*]] = affine.load %[[BUF36]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_22:.*]] = affine.load %[[BUF37]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_23:.*]] = arith.muli %[[VAL_21]], %[[VAL_22]] : i32
-// CHECK:               affine.store %[[VAL_23]], %[[BUF38]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:             }
 // CHECK:             aie.use_lock(%[[LOCK_7_5]], Release, 1)
-// CHECK:             aie.use_lock(%[[LOCK_7_5_6]], Release, 0)
-// CHECK:             aie.use_lock(%[[LOCK_7_5_7]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_7_5_12]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_7_5_14]], Release, 0)
 // CHECK:             cf.br ^bb1
 // CHECK:           }
 // CHECK:           %[[TILE_35_2:.*]] = aie.tile(35, 2)
@@ -223,30 +218,30 @@
 // CHECK:           %[[TILE_35_0:.*]] = aie.tile(35, 0)
 // CHECK:           %[[TILE_10_4:.*]] = aie.tile(10, 4)
 // CHECK:           %[[LOCK_10_4:.*]] = aie.lock(%[[TILE_10_4]], 2)
-// CHECK:           %[[BUF35:.*]] = aie.buffer(%[[TILE_10_4]]) {sym_name = "buf35"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_10_4_8:.*]] = aie.lock(%[[TILE_10_4]], 1)
-// CHECK:           %[[BUF34:.*]] = aie.buffer(%[[TILE_10_4]]) {sym_name = "buf34"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_10_4_9:.*]] = aie.lock(%[[TILE_10_4]], 0)
-// CHECK:           %[[BUF33:.*]] = aie.buffer(%[[TILE_10_4]]) {sym_name = "buf33"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_10_4:.*]] = aie.buffer(%[[TILE_10_4]]) {sym_name = "buf35"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_10_4_16:.*]] = aie.lock(%[[TILE_10_4]], 1)
+// CHECK:           %[[BUFFER_10_4_17:.*]] = aie.buffer(%[[TILE_10_4]]) {sym_name = "buf34"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_10_4_18:.*]] = aie.lock(%[[TILE_10_4]], 0)
+// CHECK:           %[[BUFFER_10_4_19:.*]] = aie.buffer(%[[TILE_10_4]]) {sym_name = "buf33"} : memref<64xi32, 2>
 // CHECK:           %[[MEM_10_4:.*]] = aie.mem(%[[TILE_10_4]]) {
-// CHECK:             %[[VAL_24:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
+// CHECK:             %[[VAL_12:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
-// CHECK:             aie.use_lock(%[[LOCK_10_4_9]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF33]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_10_4_9]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_10_4_18]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_10_4_19]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_10_4_18]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_25:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
+// CHECK:             %[[VAL_13:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
-// CHECK:             aie.use_lock(%[[LOCK_10_4_8]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF34]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_10_4_8]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_10_4_16]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_10_4_17]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_10_4_16]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_26:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
+// CHECK:             %[[VAL_14:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[LOCK_10_4]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[BUF35]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_10_4]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_10_4]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -257,18 +252,12 @@
 // CHECK:           ^bb1:
 // CHECK:             cf.br ^bb2
 // CHECK:           ^bb2:
-// CHECK:             aie.use_lock(%[[LOCK_10_4_9]], Acquire, 1)
-// CHECK:             aie.use_lock(%[[LOCK_10_4_8]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_10_4_18]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_10_4_16]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_10_4]], Acquire, 0)
-// CHECK:             affine.for %[[ARG0:.*]] = 0 to 64 {
-// CHECK:               %[[VAL_27:.*]] = affine.load %[[BUF33]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_28:.*]] = affine.load %[[BUF34]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_29:.*]] = arith.muli %[[VAL_27]], %[[VAL_28]] : i32
-// CHECK:               affine.store %[[VAL_29]], %[[BUF35]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:             }
 // CHECK:             aie.use_lock(%[[LOCK_10_4]], Release, 1)
-// CHECK:             aie.use_lock(%[[LOCK_10_4_8]], Release, 0)
-// CHECK:             aie.use_lock(%[[LOCK_10_4_9]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_10_4_16]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_10_4_18]], Release, 0)
 // CHECK:             cf.br ^bb1
 // CHECK:           }
 // CHECK:           %[[TILE_34_2:.*]] = aie.tile(34, 2)
@@ -276,30 +265,30 @@
 // CHECK:           %[[TILE_34_0:.*]] = aie.tile(34, 0)
 // CHECK:           %[[TILE_9_4:.*]] = aie.tile(9, 4)
 // CHECK:           %[[LOCK_9_4:.*]] = aie.lock(%[[TILE_9_4]], 2)
-// CHECK:           %[[BUF32:.*]] = aie.buffer(%[[TILE_9_4]]) {sym_name = "buf32"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_9_4_10:.*]] = aie.lock(%[[TILE_9_4]], 1)
-// CHECK:           %[[BUF31:.*]] = aie.buffer(%[[TILE_9_4]]) {sym_name = "buf31"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_9_4_11:.*]] = aie.lock(%[[TILE_9_4]], 0)
-// CHECK:           %[[BUF30:.*]] = aie.buffer(%[[TILE_9_4]]) {sym_name = "buf30"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_9_4:.*]] = aie.buffer(%[[TILE_9_4]]) {sym_name = "buf32"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_9_4_20:.*]] = aie.lock(%[[TILE_9_4]], 1)
+// CHECK:           %[[BUFFER_9_4_21:.*]] = aie.buffer(%[[TILE_9_4]]) {sym_name = "buf31"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_9_4_22:.*]] = aie.lock(%[[TILE_9_4]], 0)
+// CHECK:           %[[BUFFER_9_4_23:.*]] = aie.buffer(%[[TILE_9_4]]) {sym_name = "buf30"} : memref<64xi32, 2>
 // CHECK:           %[[MEM_9_4:.*]] = aie.mem(%[[TILE_9_4]]) {
-// CHECK:             %[[VAL_30:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
+// CHECK:             %[[VAL_15:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
-// CHECK:             aie.use_lock(%[[LOCK_9_4_11]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF30]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_9_4_11]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_9_4_22]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_9_4_23]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_9_4_22]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_31:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
+// CHECK:             %[[VAL_16:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
-// CHECK:             aie.use_lock(%[[LOCK_9_4_10]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF31]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_9_4_10]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_9_4_20]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_9_4_21]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_9_4_20]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_32:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
+// CHECK:             %[[VAL_17:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[LOCK_9_4]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[BUF32]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_9_4]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_9_4]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -310,50 +299,46 @@
 // CHECK:           ^bb1:
 // CHECK:             cf.br ^bb2
 // CHECK:           ^bb2:
-// CHECK:             aie.use_lock(%[[LOCK_9_4_11]], Acquire, 1)
-// CHECK:             aie.use_lock(%[[LOCK_9_4_10]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_9_4_22]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_9_4_20]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_9_4]], Acquire, 0)
-// CHECK:             affine.for %[[ARG0:.*]] = 0 to 64 {
-// CHECK:               %[[VAL_33:.*]] = affine.load %[[BUF30]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_34:.*]] = affine.load %[[BUF31]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_35:.*]] = arith.muli %[[VAL_33]], %[[VAL_34]] : i32
-// CHECK:               affine.store %[[VAL_35]], %[[BUF32]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:             }
 // CHECK:             aie.use_lock(%[[LOCK_9_4]], Release, 1)
-// CHECK:             aie.use_lock(%[[LOCK_9_4_10]], Release, 0)
-// CHECK:             aie.use_lock(%[[LOCK_9_4_11]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_9_4_20]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_9_4_22]], Release, 0)
 // CHECK:             cf.br ^bb1
 // CHECK:           }
 // CHECK:           %[[TILE_27_2:.*]] = aie.tile(27, 2)
 // CHECK:           %[[TILE_27_1:.*]] = aie.tile(27, 1)
 // CHECK:           %[[TILE_27_0:.*]] = aie.tile(27, 0)
 // CHECK:           %[[TILE_1_2:.*]] = aie.tile(1, 2)
+// CHECK:           %[[SWITCHBOX_1_2:.*]] = aie.switchbox(%[[TILE_1_2]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_8_4:.*]] = aie.tile(8, 4)
 // CHECK:           %[[LOCK_8_4:.*]] = aie.lock(%[[TILE_8_4]], 2)
-// CHECK:           %[[BUF29:.*]] = aie.buffer(%[[TILE_8_4]]) {sym_name = "buf29"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_8_4_12:.*]] = aie.lock(%[[TILE_8_4]], 1)
-// CHECK:           %[[BUF28:.*]] = aie.buffer(%[[TILE_8_4]]) {sym_name = "buf28"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_8_4_13:.*]] = aie.lock(%[[TILE_8_4]], 0)
-// CHECK:           %[[BUF27:.*]] = aie.buffer(%[[TILE_8_4]]) {sym_name = "buf27"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_8_4:.*]] = aie.buffer(%[[TILE_8_4]]) {sym_name = "buf29"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_8_4_24:.*]] = aie.lock(%[[TILE_8_4]], 1)
+// CHECK:           %[[BUFFER_8_4_25:.*]] = aie.buffer(%[[TILE_8_4]]) {sym_name = "buf28"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_8_4_26:.*]] = aie.lock(%[[TILE_8_4]], 0)
+// CHECK:           %[[BUFFER_8_4_27:.*]] = aie.buffer(%[[TILE_8_4]]) {sym_name = "buf27"} : memref<64xi32, 2>
 // CHECK:           %[[MEM_8_4:.*]] = aie.mem(%[[TILE_8_4]]) {
-// CHECK:             %[[VAL_36:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
+// CHECK:             %[[VAL_18:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
-// CHECK:             aie.use_lock(%[[LOCK_8_4_13]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF27]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_8_4_13]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_8_4_26]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_8_4_27]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_8_4_26]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_37:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
+// CHECK:             %[[VAL_19:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
-// CHECK:             aie.use_lock(%[[LOCK_8_4_12]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF28]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_8_4_12]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_8_4_24]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_8_4_25]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_8_4_24]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_38:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
+// CHECK:             %[[VAL_20:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[LOCK_8_4]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[BUF29]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_8_4]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_8_4]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -364,50 +349,46 @@
 // CHECK:           ^bb1:
 // CHECK:             cf.br ^bb2
 // CHECK:           ^bb2:
-// CHECK:             aie.use_lock(%[[LOCK_8_4_13]], Acquire, 1)
-// CHECK:             aie.use_lock(%[[LOCK_8_4_12]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_8_4_26]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_8_4_24]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_8_4]], Acquire, 0)
-// CHECK:             affine.for %[[ARG0:.*]] = 0 to 64 {
-// CHECK:               %[[VAL_39:.*]] = affine.load %[[BUF27]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_40:.*]] = affine.load %[[BUF28]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_41:.*]] = arith.muli %[[VAL_39]], %[[VAL_40]] : i32
-// CHECK:               affine.store %[[VAL_41]], %[[BUF29]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:             }
 // CHECK:             aie.use_lock(%[[LOCK_8_4]], Release, 1)
-// CHECK:             aie.use_lock(%[[LOCK_8_4_12]], Release, 0)
-// CHECK:             aie.use_lock(%[[LOCK_8_4_13]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_8_4_24]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_8_4_26]], Release, 0)
 // CHECK:             cf.br ^bb1
 // CHECK:           }
 // CHECK:           %[[TILE_26_2:.*]] = aie.tile(26, 2)
 // CHECK:           %[[TILE_26_1:.*]] = aie.tile(26, 1)
 // CHECK:           %[[TILE_26_0:.*]] = aie.tile(26, 0)
 // CHECK:           %[[TILE_0_2:.*]] = aie.tile(0, 2)
+// CHECK:           %[[SWITCHBOX_0_2:.*]] = aie.switchbox(%[[TILE_0_2]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_7_4:.*]] = aie.tile(7, 4)
 // CHECK:           %[[LOCK_7_4:.*]] = aie.lock(%[[TILE_7_4]], 2)
-// CHECK:           %[[BUF26:.*]] = aie.buffer(%[[TILE_7_4]]) {sym_name = "buf26"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_7_4_14:.*]] = aie.lock(%[[TILE_7_4]], 1)
-// CHECK:           %[[BUF25:.*]] = aie.buffer(%[[TILE_7_4]]) {sym_name = "buf25"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_7_4_15:.*]] = aie.lock(%[[TILE_7_4]], 0)
-// CHECK:           %[[BUF24:.*]] = aie.buffer(%[[TILE_7_4]]) {sym_name = "buf24"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_7_4:.*]] = aie.buffer(%[[TILE_7_4]]) {sym_name = "buf26"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_7_4_28:.*]] = aie.lock(%[[TILE_7_4]], 1)
+// CHECK:           %[[BUFFER_7_4_29:.*]] = aie.buffer(%[[TILE_7_4]]) {sym_name = "buf25"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_7_4_30:.*]] = aie.lock(%[[TILE_7_4]], 0)
+// CHECK:           %[[BUFFER_7_4_31:.*]] = aie.buffer(%[[TILE_7_4]]) {sym_name = "buf24"} : memref<64xi32, 2>
 // CHECK:           %[[MEM_7_4:.*]] = aie.mem(%[[TILE_7_4]]) {
-// CHECK:             %[[VAL_42:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
+// CHECK:             %[[VAL_21:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
-// CHECK:             aie.use_lock(%[[LOCK_7_4_15]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF24]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_7_4_15]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_7_4_30]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_7_4_31]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_7_4_30]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_43:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
+// CHECK:             %[[VAL_22:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
-// CHECK:             aie.use_lock(%[[LOCK_7_4_14]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF25]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_7_4_14]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_7_4_28]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_7_4_29]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_7_4_28]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_44:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
+// CHECK:             %[[VAL_23:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[LOCK_7_4]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[BUF26]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_7_4]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_7_4]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -418,18 +399,12 @@
 // CHECK:           ^bb1:
 // CHECK:             cf.br ^bb2
 // CHECK:           ^bb2:
-// CHECK:             aie.use_lock(%[[LOCK_7_4_15]], Acquire, 1)
-// CHECK:             aie.use_lock(%[[LOCK_7_4_14]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_7_4_30]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_7_4_28]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_7_4]], Acquire, 0)
-// CHECK:             affine.for %[[ARG0:.*]] = 0 to 64 {
-// CHECK:               %[[VAL_45:.*]] = affine.load %[[BUF24]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_46:.*]] = affine.load %[[BUF25]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_47:.*]] = arith.muli %[[VAL_45]], %[[VAL_46]] : i32
-// CHECK:               affine.store %[[VAL_47]], %[[BUF26]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:             }
 // CHECK:             aie.use_lock(%[[LOCK_7_4]], Release, 1)
-// CHECK:             aie.use_lock(%[[LOCK_7_4_14]], Release, 0)
-// CHECK:             aie.use_lock(%[[LOCK_7_4_15]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_7_4_28]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_7_4_30]], Release, 0)
 // CHECK:             cf.br ^bb1
 // CHECK:           }
 // CHECK:           %[[TILE_19_2:.*]] = aie.tile(19, 2)
@@ -437,30 +412,30 @@
 // CHECK:           %[[TILE_19_0:.*]] = aie.tile(19, 0)
 // CHECK:           %[[TILE_10_3:.*]] = aie.tile(10, 3)
 // CHECK:           %[[LOCK_10_3:.*]] = aie.lock(%[[TILE_10_3]], 2)
-// CHECK:           %[[BUF23:.*]] = aie.buffer(%[[TILE_10_3]]) {sym_name = "buf23"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_10_3_16:.*]] = aie.lock(%[[TILE_10_3]], 1)
-// CHECK:           %[[BUF22:.*]] = aie.buffer(%[[TILE_10_3]]) {sym_name = "buf22"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_10_3_17:.*]] = aie.lock(%[[TILE_10_3]], 0)
-// CHECK:           %[[BUF21:.*]] = aie.buffer(%[[TILE_10_3]]) {sym_name = "buf21"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_10_3:.*]] = aie.buffer(%[[TILE_10_3]]) {sym_name = "buf23"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_10_3_32:.*]] = aie.lock(%[[TILE_10_3]], 1)
+// CHECK:           %[[BUFFER_10_3_33:.*]] = aie.buffer(%[[TILE_10_3]]) {sym_name = "buf22"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_10_3_34:.*]] = aie.lock(%[[TILE_10_3]], 0)
+// CHECK:           %[[BUFFER_10_3_35:.*]] = aie.buffer(%[[TILE_10_3]]) {sym_name = "buf21"} : memref<64xi32, 2>
 // CHECK:           %[[MEM_10_3:.*]] = aie.mem(%[[TILE_10_3]]) {
-// CHECK:             %[[VAL_48:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
+// CHECK:             %[[VAL_24:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
-// CHECK:             aie.use_lock(%[[LOCK_10_3_17]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF21]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_10_3_17]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_10_3_34]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_10_3_35]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_10_3_34]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_49:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
+// CHECK:             %[[VAL_25:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
-// CHECK:             aie.use_lock(%[[LOCK_10_3_16]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF22]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_10_3_16]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_10_3_32]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_10_3_33]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_10_3_32]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_50:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
+// CHECK:             %[[VAL_26:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[LOCK_10_3]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[BUF23]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_10_3]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_10_3]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -471,18 +446,12 @@
 // CHECK:           ^bb1:
 // CHECK:             cf.br ^bb2
 // CHECK:           ^bb2:
-// CHECK:             aie.use_lock(%[[LOCK_10_3_17]], Acquire, 1)
-// CHECK:             aie.use_lock(%[[LOCK_10_3_16]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_10_3_34]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_10_3_32]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_10_3]], Acquire, 0)
-// CHECK:             affine.for %[[ARG0:.*]] = 0 to 64 {
-// CHECK:               %[[VAL_51:.*]] = affine.load %[[BUF21]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_52:.*]] = affine.load %[[BUF22]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_53:.*]] = arith.muli %[[VAL_51]], %[[VAL_52]] : i32
-// CHECK:               affine.store %[[VAL_53]], %[[BUF23]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:             }
 // CHECK:             aie.use_lock(%[[LOCK_10_3]], Release, 1)
-// CHECK:             aie.use_lock(%[[LOCK_10_3_16]], Release, 0)
-// CHECK:             aie.use_lock(%[[LOCK_10_3_17]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_10_3_32]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_10_3_34]], Release, 0)
 // CHECK:             cf.br ^bb1
 // CHECK:           }
 // CHECK:           %[[TILE_18_2:.*]] = aie.tile(18, 2)
@@ -490,30 +459,30 @@
 // CHECK:           %[[TILE_18_0:.*]] = aie.tile(18, 0)
 // CHECK:           %[[TILE_9_3:.*]] = aie.tile(9, 3)
 // CHECK:           %[[LOCK_9_3:.*]] = aie.lock(%[[TILE_9_3]], 2)
-// CHECK:           %[[BUF20:.*]] = aie.buffer(%[[TILE_9_3]]) {sym_name = "buf20"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_9_3_18:.*]] = aie.lock(%[[TILE_9_3]], 1)
-// CHECK:           %[[BUF19:.*]] = aie.buffer(%[[TILE_9_3]]) {sym_name = "buf19"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_9_3_19:.*]] = aie.lock(%[[TILE_9_3]], 0)
-// CHECK:           %[[BUF18:.*]] = aie.buffer(%[[TILE_9_3]]) {sym_name = "buf18"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_9_3:.*]] = aie.buffer(%[[TILE_9_3]]) {sym_name = "buf20"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_9_3_36:.*]] = aie.lock(%[[TILE_9_3]], 1)
+// CHECK:           %[[BUFFER_9_3_37:.*]] = aie.buffer(%[[TILE_9_3]]) {sym_name = "buf19"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_9_3_38:.*]] = aie.lock(%[[TILE_9_3]], 0)
+// CHECK:           %[[BUFFER_9_3_39:.*]] = aie.buffer(%[[TILE_9_3]]) {sym_name = "buf18"} : memref<64xi32, 2>
 // CHECK:           %[[MEM_9_3:.*]] = aie.mem(%[[TILE_9_3]]) {
-// CHECK:             %[[VAL_54:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
+// CHECK:             %[[VAL_27:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
-// CHECK:             aie.use_lock(%[[LOCK_9_3_19]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF18]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_9_3_19]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_9_3_38]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_9_3_39]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_9_3_38]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_55:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
+// CHECK:             %[[VAL_28:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
-// CHECK:             aie.use_lock(%[[LOCK_9_3_18]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF19]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_9_3_18]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_9_3_36]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_9_3_37]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_9_3_36]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_56:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
+// CHECK:             %[[VAL_29:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[LOCK_9_3]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[BUF20]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_9_3]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_9_3]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -524,50 +493,46 @@
 // CHECK:           ^bb1:
 // CHECK:             cf.br ^bb2
 // CHECK:           ^bb2:
-// CHECK:             aie.use_lock(%[[LOCK_9_3_19]], Acquire, 1)
-// CHECK:             aie.use_lock(%[[LOCK_9_3_18]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_9_3_38]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_9_3_36]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_9_3]], Acquire, 0)
-// CHECK:             affine.for %[[ARG0:.*]] = 0 to 64 {
-// CHECK:               %[[VAL_57:.*]] = affine.load %[[BUF18]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_58:.*]] = affine.load %[[BUF19]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_59:.*]] = arith.muli %[[VAL_57]], %[[VAL_58]] : i32
-// CHECK:               affine.store %[[VAL_59]], %[[BUF20]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:             }
 // CHECK:             aie.use_lock(%[[LOCK_9_3]], Release, 1)
-// CHECK:             aie.use_lock(%[[LOCK_9_3_18]], Release, 0)
-// CHECK:             aie.use_lock(%[[LOCK_9_3_19]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_9_3_36]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_9_3_38]], Release, 0)
 // CHECK:             cf.br ^bb1
 // CHECK:           }
 // CHECK:           %[[TILE_11_2:.*]] = aie.tile(11, 2)
 // CHECK:           %[[TILE_11_1:.*]] = aie.tile(11, 1)
 // CHECK:           %[[TILE_11_0:.*]] = aie.tile(11, 0)
 // CHECK:           %[[TILE_1_1:.*]] = aie.tile(1, 1)
+// CHECK:           %[[SWITCHBOX_1_1:.*]] = aie.switchbox(%[[TILE_1_1]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_8_3:.*]] = aie.tile(8, 3)
 // CHECK:           %[[LOCK_8_3:.*]] = aie.lock(%[[TILE_8_3]], 2)
-// CHECK:           %[[BUF17:.*]] = aie.buffer(%[[TILE_8_3]]) {sym_name = "buf17"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_8_3_20:.*]] = aie.lock(%[[TILE_8_3]], 1)
-// CHECK:           %[[BUF16:.*]] = aie.buffer(%[[TILE_8_3]]) {sym_name = "buf16"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_8_3_21:.*]] = aie.lock(%[[TILE_8_3]], 0)
-// CHECK:           %[[BUF15:.*]] = aie.buffer(%[[TILE_8_3]]) {sym_name = "buf15"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_8_3:.*]] = aie.buffer(%[[TILE_8_3]]) {sym_name = "buf17"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_8_3_40:.*]] = aie.lock(%[[TILE_8_3]], 1)
+// CHECK:           %[[BUFFER_8_3_41:.*]] = aie.buffer(%[[TILE_8_3]]) {sym_name = "buf16"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_8_3_42:.*]] = aie.lock(%[[TILE_8_3]], 0)
+// CHECK:           %[[BUFFER_8_3_43:.*]] = aie.buffer(%[[TILE_8_3]]) {sym_name = "buf15"} : memref<64xi32, 2>
 // CHECK:           %[[MEM_8_3:.*]] = aie.mem(%[[TILE_8_3]]) {
-// CHECK:             %[[VAL_60:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
+// CHECK:             %[[VAL_30:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
-// CHECK:             aie.use_lock(%[[LOCK_8_3_21]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF15]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_8_3_21]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_8_3_42]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_8_3_43]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_8_3_42]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_61:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
+// CHECK:             %[[VAL_31:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
-// CHECK:             aie.use_lock(%[[LOCK_8_3_20]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF16]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_8_3_20]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_8_3_40]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_8_3_41]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_8_3_40]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_62:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
+// CHECK:             %[[VAL_32:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[LOCK_8_3]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[BUF17]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_8_3]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_8_3]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -578,49 +543,45 @@
 // CHECK:           ^bb1:
 // CHECK:             cf.br ^bb2
 // CHECK:           ^bb2:
-// CHECK:             aie.use_lock(%[[LOCK_8_3_21]], Acquire, 1)
-// CHECK:             aie.use_lock(%[[LOCK_8_3_20]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_8_3_42]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_8_3_40]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_8_3]], Acquire, 0)
-// CHECK:             affine.for %[[ARG0:.*]] = 0 to 64 {
-// CHECK:               %[[VAL_63:.*]] = affine.load %[[BUF15]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_64:.*]] = affine.load %[[BUF16]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_65:.*]] = arith.muli %[[VAL_63]], %[[VAL_64]] : i32
-// CHECK:               affine.store %[[VAL_65]], %[[BUF17]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:             }
 // CHECK:             aie.use_lock(%[[LOCK_8_3]], Release, 1)
-// CHECK:             aie.use_lock(%[[LOCK_8_3_20]], Release, 0)
-// CHECK:             aie.use_lock(%[[LOCK_8_3_21]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_8_3_40]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_8_3_42]], Release, 0)
 // CHECK:             cf.br ^bb1
 // CHECK:           }
 // CHECK:           %[[TILE_10_1:.*]] = aie.tile(10, 1)
 // CHECK:           %[[TILE_10_0:.*]] = aie.tile(10, 0)
 // CHECK:           %[[TILE_0_1:.*]] = aie.tile(0, 1)
+// CHECK:           %[[SWITCHBOX_0_1:.*]] = aie.switchbox(%[[TILE_0_1]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_7_3:.*]] = aie.tile(7, 3)
 // CHECK:           %[[LOCK_7_3:.*]] = aie.lock(%[[TILE_7_3]], 2)
-// CHECK:           %[[BUF14:.*]] = aie.buffer(%[[TILE_7_3]]) {sym_name = "buf14"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_7_3_22:.*]] = aie.lock(%[[TILE_7_3]], 1)
-// CHECK:           %[[BUF13:.*]] = aie.buffer(%[[TILE_7_3]]) {sym_name = "buf13"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_7_3_23:.*]] = aie.lock(%[[TILE_7_3]], 0)
-// CHECK:           %[[BUF12:.*]] = aie.buffer(%[[TILE_7_3]]) {sym_name = "buf12"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_7_3:.*]] = aie.buffer(%[[TILE_7_3]]) {sym_name = "buf14"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_7_3_44:.*]] = aie.lock(%[[TILE_7_3]], 1)
+// CHECK:           %[[BUFFER_7_3_45:.*]] = aie.buffer(%[[TILE_7_3]]) {sym_name = "buf13"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_7_3_46:.*]] = aie.lock(%[[TILE_7_3]], 0)
+// CHECK:           %[[BUFFER_7_3_47:.*]] = aie.buffer(%[[TILE_7_3]]) {sym_name = "buf12"} : memref<64xi32, 2>
 // CHECK:           %[[MEM_7_3:.*]] = aie.mem(%[[TILE_7_3]]) {
-// CHECK:             %[[VAL_66:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
+// CHECK:             %[[VAL_33:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
-// CHECK:             aie.use_lock(%[[LOCK_7_3_23]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF12]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_7_3_23]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_7_3_46]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_7_3_47]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_7_3_46]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_67:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
+// CHECK:             %[[VAL_34:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
-// CHECK:             aie.use_lock(%[[LOCK_7_3_22]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF13]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_7_3_22]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_7_3_44]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_7_3_45]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_7_3_44]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_68:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
+// CHECK:             %[[VAL_35:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[LOCK_7_3]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[BUF14]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_7_3]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_7_3]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -631,48 +592,42 @@
 // CHECK:           ^bb1:
 // CHECK:             cf.br ^bb2
 // CHECK:           ^bb2:
-// CHECK:             aie.use_lock(%[[LOCK_7_3_23]], Acquire, 1)
-// CHECK:             aie.use_lock(%[[LOCK_7_3_22]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_7_3_46]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_7_3_44]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_7_3]], Acquire, 0)
-// CHECK:             affine.for %[[ARG0:.*]] = 0 to 64 {
-// CHECK:               %[[VAL_69:.*]] = affine.load %[[BUF12]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_70:.*]] = affine.load %[[BUF13]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_71:.*]] = arith.muli %[[VAL_69]], %[[VAL_70]] : i32
-// CHECK:               affine.store %[[VAL_71]], %[[BUF14]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:             }
 // CHECK:             aie.use_lock(%[[LOCK_7_3]], Release, 1)
-// CHECK:             aie.use_lock(%[[LOCK_7_3_22]], Release, 0)
-// CHECK:             aie.use_lock(%[[LOCK_7_3_23]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_7_3_44]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_7_3_46]], Release, 0)
 // CHECK:             cf.br ^bb1
 // CHECK:           }
 // CHECK:           %[[TILE_7_1:.*]] = aie.tile(7, 1)
 // CHECK:           %[[TILE_7_0:.*]] = aie.tile(7, 0)
 // CHECK:           %[[TILE_10_2:.*]] = aie.tile(10, 2)
 // CHECK:           %[[LOCK_10_2:.*]] = aie.lock(%[[TILE_10_2]], 2)
-// CHECK:           %[[BUF11:.*]] = aie.buffer(%[[TILE_10_2]]) {sym_name = "buf11"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_10_2_24:.*]] = aie.lock(%[[TILE_10_2]], 1)
-// CHECK:           %[[BUF10:.*]] = aie.buffer(%[[TILE_10_2]]) {sym_name = "buf10"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_10_2_25:.*]] = aie.lock(%[[TILE_10_2]], 0)
-// CHECK:           %[[BUF9:.*]] = aie.buffer(%[[TILE_10_2]]) {sym_name = "buf9"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_10_2:.*]] = aie.buffer(%[[TILE_10_2]]) {sym_name = "buf11"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_10_2_48:.*]] = aie.lock(%[[TILE_10_2]], 1)
+// CHECK:           %[[BUFFER_10_2_49:.*]] = aie.buffer(%[[TILE_10_2]]) {sym_name = "buf10"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_10_2_50:.*]] = aie.lock(%[[TILE_10_2]], 0)
+// CHECK:           %[[BUFFER_10_2_51:.*]] = aie.buffer(%[[TILE_10_2]]) {sym_name = "buf9"} : memref<64xi32, 2>
 // CHECK:           %[[MEM_10_2:.*]] = aie.mem(%[[TILE_10_2]]) {
-// CHECK:             %[[VAL_72:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
+// CHECK:             %[[VAL_36:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
-// CHECK:             aie.use_lock(%[[LOCK_10_2_25]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF9]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_10_2_25]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_10_2_50]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_10_2_51]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_10_2_50]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_73:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
+// CHECK:             %[[VAL_37:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
-// CHECK:             aie.use_lock(%[[LOCK_10_2_24]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF10]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_10_2_24]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_10_2_48]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_10_2_49]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_10_2_48]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_74:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
+// CHECK:             %[[VAL_38:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[LOCK_10_2]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[BUF11]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_10_2]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_10_2]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -683,18 +638,12 @@
 // CHECK:           ^bb1:
 // CHECK:             cf.br ^bb2
 // CHECK:           ^bb2:
-// CHECK:             aie.use_lock(%[[LOCK_10_2_25]], Acquire, 1)
-// CHECK:             aie.use_lock(%[[LOCK_10_2_24]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_10_2_50]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_10_2_48]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_10_2]], Acquire, 0)
-// CHECK:             affine.for %[[ARG0:.*]] = 0 to 64 {
-// CHECK:               %[[VAL_75:.*]] = affine.load %[[BUF9]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_76:.*]] = affine.load %[[BUF10]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_77:.*]] = arith.muli %[[VAL_75]], %[[VAL_76]] : i32
-// CHECK:               affine.store %[[VAL_77]], %[[BUF11]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:             }
 // CHECK:             aie.use_lock(%[[LOCK_10_2]], Release, 1)
-// CHECK:             aie.use_lock(%[[LOCK_10_2_24]], Release, 0)
-// CHECK:             aie.use_lock(%[[LOCK_10_2_25]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_10_2_48]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_10_2_50]], Release, 0)
 // CHECK:             cf.br ^bb1
 // CHECK:           }
 // CHECK:           %[[TILE_6_2:.*]] = aie.tile(6, 2)
@@ -702,30 +651,30 @@
 // CHECK:           %[[TILE_6_0:.*]] = aie.tile(6, 0)
 // CHECK:           %[[TILE_9_2:.*]] = aie.tile(9, 2)
 // CHECK:           %[[LOCK_9_2:.*]] = aie.lock(%[[TILE_9_2]], 2)
-// CHECK:           %[[BUF8:.*]] = aie.buffer(%[[TILE_9_2]]) {sym_name = "buf8"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_9_2_26:.*]] = aie.lock(%[[TILE_9_2]], 1)
-// CHECK:           %[[BUF7:.*]] = aie.buffer(%[[TILE_9_2]]) {sym_name = "buf7"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_9_2_27:.*]] = aie.lock(%[[TILE_9_2]], 0)
-// CHECK:           %[[BUF6:.*]] = aie.buffer(%[[TILE_9_2]]) {sym_name = "buf6"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_9_2:.*]] = aie.buffer(%[[TILE_9_2]]) {sym_name = "buf8"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_9_2_52:.*]] = aie.lock(%[[TILE_9_2]], 1)
+// CHECK:           %[[BUFFER_9_2_53:.*]] = aie.buffer(%[[TILE_9_2]]) {sym_name = "buf7"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_9_2_54:.*]] = aie.lock(%[[TILE_9_2]], 0)
+// CHECK:           %[[BUFFER_9_2_55:.*]] = aie.buffer(%[[TILE_9_2]]) {sym_name = "buf6"} : memref<64xi32, 2>
 // CHECK:           %[[MEM_9_2:.*]] = aie.mem(%[[TILE_9_2]]) {
-// CHECK:             %[[VAL_78:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
+// CHECK:             %[[VAL_39:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
-// CHECK:             aie.use_lock(%[[LOCK_9_2_27]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF6]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_9_2_27]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_9_2_54]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_9_2_55]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_9_2_54]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_79:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
+// CHECK:             %[[VAL_40:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
-// CHECK:             aie.use_lock(%[[LOCK_9_2_26]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF7]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_9_2_26]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_9_2_52]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_9_2_53]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_9_2_52]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_80:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
+// CHECK:             %[[VAL_41:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[LOCK_9_2]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[BUF8]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_9_2]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_9_2]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -736,50 +685,46 @@
 // CHECK:           ^bb1:
 // CHECK:             cf.br ^bb2
 // CHECK:           ^bb2:
-// CHECK:             aie.use_lock(%[[LOCK_9_2_27]], Acquire, 1)
-// CHECK:             aie.use_lock(%[[LOCK_9_2_26]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_9_2_54]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_9_2_52]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_9_2]], Acquire, 0)
-// CHECK:             affine.for %[[ARG0:.*]] = 0 to 64 {
-// CHECK:               %[[VAL_81:.*]] = affine.load %[[BUF6]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_82:.*]] = affine.load %[[BUF7]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_83:.*]] = arith.muli %[[VAL_81]], %[[VAL_82]] : i32
-// CHECK:               affine.store %[[VAL_83]], %[[BUF8]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:             }
 // CHECK:             aie.use_lock(%[[LOCK_9_2]], Release, 1)
-// CHECK:             aie.use_lock(%[[LOCK_9_2_26]], Release, 0)
-// CHECK:             aie.use_lock(%[[LOCK_9_2_27]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_9_2_52]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_9_2_54]], Release, 0)
 // CHECK:             cf.br ^bb1
 // CHECK:           }
 // CHECK:           %[[TILE_3_2:.*]] = aie.tile(3, 2)
 // CHECK:           %[[TILE_3_1:.*]] = aie.tile(3, 1)
 // CHECK:           %[[TILE_3_0:.*]] = aie.tile(3, 0)
 // CHECK:           %[[TILE_1_0:.*]] = aie.tile(1, 0)
+// CHECK:           %[[SWITCHBOX_1_0:.*]] = aie.switchbox(%[[TILE_1_0]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_8_2:.*]] = aie.tile(8, 2)
 // CHECK:           %[[LOCK_8_2:.*]] = aie.lock(%[[TILE_8_2]], 2)
-// CHECK:           %[[BUF5:.*]] = aie.buffer(%[[TILE_8_2]]) {sym_name = "buf5"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_8_2_28:.*]] = aie.lock(%[[TILE_8_2]], 1)
-// CHECK:           %[[BUF4:.*]] = aie.buffer(%[[TILE_8_2]]) {sym_name = "buf4"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_8_2_29:.*]] = aie.lock(%[[TILE_8_2]], 0)
-// CHECK:           %[[BUF3:.*]] = aie.buffer(%[[TILE_8_2]]) {sym_name = "buf3"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_8_2:.*]] = aie.buffer(%[[TILE_8_2]]) {sym_name = "buf5"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_8_2_56:.*]] = aie.lock(%[[TILE_8_2]], 1)
+// CHECK:           %[[BUFFER_8_2_57:.*]] = aie.buffer(%[[TILE_8_2]]) {sym_name = "buf4"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_8_2_58:.*]] = aie.lock(%[[TILE_8_2]], 0)
+// CHECK:           %[[BUFFER_8_2_59:.*]] = aie.buffer(%[[TILE_8_2]]) {sym_name = "buf3"} : memref<64xi32, 2>
 // CHECK:           %[[MEM_8_2:.*]] = aie.mem(%[[TILE_8_2]]) {
-// CHECK:             %[[VAL_84:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
+// CHECK:             %[[VAL_42:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
-// CHECK:             aie.use_lock(%[[LOCK_8_2_29]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF3]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_8_2_29]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_8_2_58]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_8_2_59]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_8_2_58]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_85:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
+// CHECK:             %[[VAL_43:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
-// CHECK:             aie.use_lock(%[[LOCK_8_2_28]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF4]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_8_2_28]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_8_2_56]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_8_2_57]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_8_2_56]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_86:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
+// CHECK:             %[[VAL_44:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[LOCK_8_2]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[BUF5]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_8_2]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_8_2]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -790,50 +735,48 @@
 // CHECK:           ^bb1:
 // CHECK:             cf.br ^bb2
 // CHECK:           ^bb2:
-// CHECK:             aie.use_lock(%[[LOCK_8_2_29]], Acquire, 1)
-// CHECK:             aie.use_lock(%[[LOCK_8_2_28]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_8_2_58]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_8_2_56]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_8_2]], Acquire, 0)
-// CHECK:             affine.for %[[ARG0:.*]] = 0 to 64 {
-// CHECK:               %[[VAL_87:.*]] = affine.load %[[BUF3]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_88:.*]] = affine.load %[[BUF4]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_89:.*]] = arith.muli %[[VAL_87]], %[[VAL_88]] : i32
-// CHECK:               affine.store %[[VAL_89]], %[[BUF5]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:             }
 // CHECK:             aie.use_lock(%[[LOCK_8_2]], Release, 1)
-// CHECK:             aie.use_lock(%[[LOCK_8_2_28]], Release, 0)
-// CHECK:             aie.use_lock(%[[LOCK_8_2_29]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_8_2_56]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_8_2_58]], Release, 0)
 // CHECK:             cf.br ^bb1
 // CHECK:           }
 // CHECK:           %[[TILE_2_2:.*]] = aie.tile(2, 2)
+// CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_2_1:.*]] = aie.tile(2, 1)
 // CHECK:           %[[TILE_2_0:.*]] = aie.tile(2, 0)
 // CHECK:           %[[TILE_0_0:.*]] = aie.tile(0, 0)
+// CHECK:           %[[SWITCHBOX_0_0:.*]] = aie.switchbox(%[[TILE_0_0]]) {
+// CHECK:           }
 // CHECK:           %[[TILE_7_2:.*]] = aie.tile(7, 2)
 // CHECK:           %[[LOCK_7_2:.*]] = aie.lock(%[[TILE_7_2]], 2)
-// CHECK:           %[[BUF2:.*]] = aie.buffer(%[[TILE_7_2]]) {sym_name = "buf2"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_7_2_30:.*]] = aie.lock(%[[TILE_7_2]], 1)
-// CHECK:           %[[BUF1:.*]] = aie.buffer(%[[TILE_7_2]]) {sym_name = "buf1"} : memref<64xi32, 2>
-// CHECK:           %[[LOCK_7_2_31:.*]] = aie.lock(%[[TILE_7_2]], 0)
-// CHECK:           %[[BUF0:.*]] = aie.buffer(%[[TILE_7_2]]) {sym_name = "buf0"} : memref<64xi32, 2>
+// CHECK:           %[[BUFFER_7_2:.*]] = aie.buffer(%[[TILE_7_2]]) {sym_name = "buf2"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_7_2_60:.*]] = aie.lock(%[[TILE_7_2]], 1)
+// CHECK:           %[[BUFFER_7_2_61:.*]] = aie.buffer(%[[TILE_7_2]]) {sym_name = "buf1"} : memref<64xi32, 2>
+// CHECK:           %[[LOCK_7_2_62:.*]] = aie.lock(%[[TILE_7_2]], 0)
+// CHECK:           %[[BUFFER_7_2_63:.*]] = aie.buffer(%[[TILE_7_2]]) {sym_name = "buf0"} : memref<64xi32, 2>
 // CHECK:           %[[MEM_7_2:.*]] = aie.mem(%[[TILE_7_2]]) {
-// CHECK:             %[[VAL_90:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
+// CHECK:             %[[VAL_45:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
-// CHECK:             aie.use_lock(%[[LOCK_7_2_31]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF0]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_7_2_31]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_7_2_62]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_7_2_63]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_7_2_62]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
-// CHECK:             %[[VAL_91:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
+// CHECK:             %[[VAL_46:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
-// CHECK:             aie.use_lock(%[[LOCK_7_2_30]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[BUF1]] : memref<64xi32, 2>) {len = 64 : i32}
-// CHECK:             aie.use_lock(%[[LOCK_7_2_30]], Release, 1)
+// CHECK:             aie.use_lock(%[[LOCK_7_2_60]], Acquire, 0)
+// CHECK:             aie.dma_bd(%[[BUFFER_7_2_61]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.use_lock(%[[LOCK_7_2_60]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
-// CHECK:             %[[VAL_92:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
+// CHECK:             %[[VAL_47:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[LOCK_7_2]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[BUF2]] : memref<64xi32, 2>) {len = 64 : i32}
+// CHECK:             aie.dma_bd(%[[BUFFER_7_2]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[LOCK_7_2]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -844,1470 +787,1418 @@
 // CHECK:           ^bb1:
 // CHECK:             cf.br ^bb2
 // CHECK:           ^bb2:
-// CHECK:             aie.use_lock(%[[LOCK_7_2_31]], Acquire, 1)
-// CHECK:             aie.use_lock(%[[LOCK_7_2_30]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_7_2_62]], Acquire, 1)
+// CHECK:             aie.use_lock(%[[LOCK_7_2_60]], Acquire, 1)
 // CHECK:             aie.use_lock(%[[LOCK_7_2]], Acquire, 0)
-// CHECK:             affine.for %[[ARG0:.*]] = 0 to 64 {
-// CHECK:               %[[VAL_93:.*]] = affine.load %[[BUF0]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_94:.*]] = affine.load %[[BUF1]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:               %[[VAL_95:.*]] = arith.muli %[[VAL_93]], %[[VAL_94]] : i32
-// CHECK:               affine.store %[[VAL_95]], %[[BUF2]]{{\[}}%[[ARG0]]] : memref<64xi32, 2>
-// CHECK:             }
 // CHECK:             aie.use_lock(%[[LOCK_7_2]], Release, 1)
-// CHECK:             aie.use_lock(%[[LOCK_7_2_30]], Release, 0)
-// CHECK:             aie.use_lock(%[[LOCK_7_2_31]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_7_2_60]], Release, 0)
+// CHECK:             aie.use_lock(%[[LOCK_7_2_62]], Release, 0)
 // CHECK:             cf.br ^bb1
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_2_0:.*]] = aie.switchbox(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:             aie.connect<SOUTH : 3, EAST : 2>
+// CHECK:             aie.connect<SOUTH : 7, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_2_0:.*]] = aie.shim_mux(%[[TILE_2_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_2_2:.*]] = aie.switchbox(%[[TILE_2_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_3_2:.*]] = aie.switchbox(%[[TILE_3_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_4_2:.*]] = aie.tile(4, 2)
-// CHECK:           %[[SWITCHBOX_4_2:.*]] = aie.switchbox(%[[TILE_4_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_5_2:.*]] = aie.tile(5, 2)
-// CHECK:           %[[SWITCHBOX_5_2:.*]] = aie.switchbox(%[[TILE_5_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_6_2:.*]] = aie.switchbox(%[[TILE_6_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, EAST : 2>
-// CHECK-DAG:         aie.connect<SOUTH : 1, EAST : 3>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_2:.*]] = aie.switchbox(%[[TILE_7_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<WEST : 2, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 3, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 3>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 1>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_0:.*]] = aie.switchbox(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, EAST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:             aie.connect<WEST : 2, EAST : 2>
+// CHECK:             aie.connect<SOUTH : 3, EAST : 3>
+// CHECK:             aie.connect<SOUTH : 7, EAST : 0>
+// CHECK:             aie.connect<EAST : 3, SOUTH : 2>
+// CHECK:             aie.connect<EAST : 1, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_4_0:.*]] = aie.tile(4, 0)
 // CHECK:           %[[SWITCHBOX_4_0:.*]] = aie.switchbox(%[[TILE_4_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
+// CHECK:             aie.connect<WEST : 2, EAST : 3>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<WEST : 0, EAST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_5_0:.*]] = aie.tile(5, 0)
 // CHECK:           %[[SWITCHBOX_5_0:.*]] = aie.switchbox(%[[TILE_5_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<WEST : 1, NORTH : 0>
+// CHECK:             aie.connect<WEST : 2, NORTH : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_6_0:.*]] = aie.switchbox(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 3, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, EAST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_6_1:.*]] = aie.switchbox(%[[TILE_6_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_8_2:.*]] = aie.switchbox(%[[TILE_8_2]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 2>
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_6_0:.*]] = aie.shim_mux(%[[TILE_6_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:             aie.connect<WEST : 1, EAST : 0>
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 5>
+// CHECK:             aie.connect<SOUTH : 7, EAST : 2>
+// CHECK:             aie.connect<NORTH : 2, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, SOUTH : 2>
+// CHECK:             aie.connect<EAST : 0, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_7_0:.*]] = aie.switchbox(%[[TILE_7_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 3, EAST : 2>
-// CHECK-DAG:         aie.connect<SOUTH : 7, EAST : 3>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:             aie.connect<WEST : 0, NORTH : 1>
+// CHECK:             aie.connect<WEST : 2, NORTH : 3>
+// CHECK:             aie.connect<SOUTH : 3, EAST : 2>
+// CHECK:             aie.connect<SOUTH : 7, EAST : 3>
+// CHECK:             aie.connect<NORTH : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 2>
+// CHECK:             aie.connect<EAST : 3, SOUTH : 3>
 // CHECK:           }
-// CHECK:           %[[TILE_8_0:.*]] = aie.tile(8, 0)
-// CHECK:           %[[SWITCHBOX_8_0:.*]] = aie.switchbox(%[[TILE_8_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<WEST : 2, EAST : 2>
-// CHECK-DAG:         aie.connect<WEST : 3, EAST : 3>
+// CHECK:           %[[SWITCHBOX_7_1:.*]] = aie.switchbox(%[[TILE_7_1]]) {
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 0>
+// CHECK:             aie.connect<WEST : 3, EAST : 3>
+// CHECK:             aie.connect<WEST : 2, EAST : 1>
+// CHECK:             aie.connect<WEST : 1, NORTH : 2>
+// CHECK:             aie.connect<SOUTH : 3, EAST : 2>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 2>
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 4>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 3>
+// CHECK:             aie.connect<EAST : 2, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 1, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 1, EAST : 0>
 // CHECK:           }
-// CHECK:           %[[TILE_9_0:.*]] = aie.tile(9, 0)
-// CHECK:           %[[SWITCHBOX_9_0:.*]] = aie.switchbox(%[[TILE_9_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<WEST : 2, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 3, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 3>
+// CHECK:           %[[SWITCHBOX_7_2:.*]] = aie.switchbox(%[[TILE_7_2]]) {
+// CHECK:             aie.connect<SOUTH : 0, DMA : 0>
+// CHECK:             aie.connect<WEST : 2, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<SOUTH : 2, EAST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, SOUTH : 3>
+// CHECK:             aie.connect<SOUTH : 4, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 4>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 1, EAST : 1>
 // CHECK:           }
-// CHECK:           %[[TILE_9_1:.*]] = aie.tile(9, 1)
-// CHECK:           %[[SWITCHBOX_9_1:.*]] = aie.switchbox(%[[TILE_9_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 2, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 3>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 4>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 1, EAST : 2>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_9_2:.*]] = aie.switchbox(%[[TILE_9_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 4, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 2>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 3>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 4>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 1>
+// CHECK:           %[[SWITCHBOX_2_1:.*]] = aie.switchbox(%[[TILE_2_1]]) {
+// CHECK:             aie.connect<SOUTH : 5, EAST : 1>
+// CHECK:             aie.connect<EAST : 3, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 0, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_3_1:.*]] = aie.switchbox(%[[TILE_3_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 1>
+// CHECK:             aie.connect<WEST : 1, NORTH : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
 // CHECK:           }
-// CHECK:           %[[SHIM_MUX_7_0:.*]] = aie.shim_mux(%[[TILE_7_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           %[[SWITCHBOX_3_2:.*]] = aie.switchbox(%[[TILE_3_2]]) {
+// CHECK:             aie.connect<SOUTH : 3, EAST : 3>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_10_0:.*]] = aie.switchbox(%[[TILE_10_0]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 3>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 4>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 5>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:           %[[TILE_4_2:.*]] = aie.tile(4, 2)
+// CHECK:           %[[SWITCHBOX_4_2:.*]] = aie.switchbox(%[[TILE_4_2]]) {
+// CHECK:             aie.connect<WEST : 3, EAST : 3>
+// CHECK:             aie.connect<EAST : 0, SOUTH : 0>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_10_1:.*]] = aie.switchbox(%[[TILE_10_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 2, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 4, NORTH : 2>
-// CHECK-DAG:         aie.connect<SOUTH : 5, NORTH : 3>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 4>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 5>
-// CHECK-DAG:         aie.connect<WEST : 1, SOUTH : 1>
-// CHECK-DAG:         aie.connect<WEST : 2, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, EAST : 1>
+// CHECK:           %[[TILE_5_2:.*]] = aie.tile(5, 2)
+// CHECK:           %[[SWITCHBOX_5_2:.*]] = aie.switchbox(%[[TILE_5_2]]) {
+// CHECK:             aie.connect<WEST : 3, EAST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, SOUTH : 3>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_10_2:.*]] = aie.switchbox(%[[TILE_10_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 4, WEST : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 5, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 2>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 3>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 1>
+// CHECK:           %[[SWITCHBOX_6_2:.*]] = aie.switchbox(%[[TILE_6_2]]) {
+// CHECK:             aie.connect<WEST : 0, EAST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, SOUTH : 3>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 1>
+// CHECK:           %[[TILE_4_1:.*]] = aie.tile(4, 1)
+// CHECK:           %[[SWITCHBOX_4_1:.*]] = aie.switchbox(%[[TILE_4_1]]) {
+// CHECK:             aie.connect<NORTH : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_3_0:.*]] = aie.shim_mux(%[[TILE_3_0]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_5_1:.*]] = aie.tile(5, 1)
+// CHECK:           %[[SWITCHBOX_5_1:.*]] = aie.switchbox(%[[TILE_5_1]]) {
+// CHECK:             aie.connect<SOUTH : 0, EAST : 2>
+// CHECK:             aie.connect<SOUTH : 2, EAST : 1>
+// CHECK:             aie.connect<NORTH : 3, WEST : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_6_1:.*]] = aie.switchbox(%[[TILE_6_1]]) {
+// CHECK:             aie.connect<WEST : 2, EAST : 3>
+// CHECK:             aie.connect<WEST : 1, EAST : 2>
+// CHECK:             aie.connect<SOUTH : 5, EAST : 1>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_8_1:.*]] = aie.tile(8, 1)
 // CHECK:           %[[SWITCHBOX_8_1:.*]] = aie.switchbox(%[[TILE_8_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 2>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, EAST : 1>
+// CHECK:             aie.connect<WEST : 3, NORTH : 3>
+// CHECK:             aie.connect<WEST : 1, NORTH : 0>
+// CHECK:             aie.connect<WEST : 2, NORTH : 2>
+// CHECK:             aie.connect<SOUTH : 0, EAST : 3>
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 1, WEST : 2>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<WEST : 0, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 0>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_8_2:.*]] = aie.switchbox(%[[TILE_8_2]]) {
+// CHECK:             aie.connect<SOUTH : 3, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 0, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, WEST : 3>
+// CHECK:             aie.connect<WEST : 3, EAST : 0>
+// CHECK:             aie.connect<SOUTH : 2, EAST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:             aie.connect<EAST : 0, NORTH : 2>
+// CHECK:             aie.connect<EAST : 1, NORTH : 4>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 0>
+// CHECK:             aie.connect<WEST : 1, EAST : 1>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_6_0:.*]] = aie.shim_mux(%[[TILE_6_0]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_9_2:.*]] = aie.switchbox(%[[TILE_9_2]]) {
+// CHECK:             aie.connect<WEST : 0, DMA : 0>
+// CHECK:             aie.connect<WEST : 3, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 5>
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 2>
+// CHECK:             aie.connect<WEST : 1, EAST : 0>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_7_0:.*]] = aie.shim_mux(%[[TILE_7_0]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_8_0:.*]] = aie.tile(8, 0)
+// CHECK:           %[[SWITCHBOX_8_0:.*]] = aie.switchbox(%[[TILE_8_0]]) {
+// CHECK:             aie.connect<WEST : 2, NORTH : 0>
+// CHECK:             aie.connect<WEST : 3, EAST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 2, WEST : 2>
+// CHECK:             aie.connect<NORTH : 1, WEST : 3>
+// CHECK:             aie.connect<NORTH : 3, EAST : 2>
+// CHECK:             aie.connect<NORTH : 0, EAST : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_9_1:.*]] = aie.tile(9, 1)
+// CHECK:           %[[SWITCHBOX_9_1:.*]] = aie.switchbox(%[[TILE_9_1]]) {
+// CHECK:             aie.connect<WEST : 3, EAST : 2>
+// CHECK:             aie.connect<SOUTH : 4, NORTH : 3>
+// CHECK:             aie.connect<SOUTH : 2, NORTH : 5>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, NORTH : 0>
+// CHECK:             aie.connect<NORTH : 2, EAST : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_10_1:.*]] = aie.switchbox(%[[TILE_10_1]]) {
+// CHECK:             aie.connect<WEST : 2, NORTH : 4>
+// CHECK:             aie.connect<SOUTH : 4, NORTH : 3>
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 5>
+// CHECK:             aie.connect<SOUTH : 2, NORTH : 2>
+// CHECK:             aie.connect<EAST : 0, NORTH : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<WEST : 3, EAST : 0>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 0>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_10_2:.*]] = aie.switchbox(%[[TILE_10_2]]) {
+// CHECK:             aie.connect<SOUTH : 4, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 3, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 0>
+// CHECK:             aie.connect<SOUTH : 2, NORTH : 3>
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 5>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, NORTH : 4>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, NORTH : 2>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 2>
+// CHECK:             aie.connect<WEST : 0, EAST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_9_0:.*]] = aie.tile(9, 0)
+// CHECK:           %[[SWITCHBOX_9_0:.*]] = aie.switchbox(%[[TILE_9_0]]) {
+// CHECK:             aie.connect<WEST : 3, EAST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, NORTH : 4>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, NORTH : 2>
+// CHECK:             aie.connect<WEST : 2, EAST : 2>
+// CHECK:             aie.connect<WEST : 1, EAST : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_10_0:.*]] = aie.switchbox(%[[TILE_10_0]]) {
+// CHECK:             aie.connect<WEST : 0, NORTH : 4>
+// CHECK:             aie.connect<SOUTH : 3, NORTH : 5>
+// CHECK:             aie.connect<SOUTH : 7, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, NORTH : 2>
+// CHECK:             aie.connect<WEST : 2, SOUTH : 2>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 0, EAST : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_7_3:.*]] = aie.switchbox(%[[TILE_7_3]]) {
+// CHECK:             aie.connect<EAST : 0, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 5, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 3, NORTH : 2>
+// CHECK:             aie.connect<SOUTH : 4, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_8_3:.*]] = aie.switchbox(%[[TILE_8_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_10_0:.*]] = aie.shim_mux(%[[TILE_10_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_1:.*]] = aie.switchbox(%[[TILE_7_1]]) {
-// CHECK-DAG:         aie.connect<NORTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 1, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 2, SOUTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 1, EAST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 5, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 0, SOUTH : 3>
+// CHECK:             aie.connect<EAST : 1, SOUTH : 1>
+// CHECK:             aie.connect<SOUTH : 2, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 4, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 1, EAST : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_9_3:.*]] = aie.switchbox(%[[TILE_9_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 4, NORTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 3>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 1, EAST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 5, WEST : 2>
+// CHECK:             aie.connect<SOUTH : 2, DMA : 0>
+// CHECK:             aie.connect<EAST : 0, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 1, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
+// CHECK:             aie.connect<EAST : 2, NORTH : 4>
+// CHECK:             aie.connect<WEST : 1, EAST : 2>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_11_0:.*]] = aie.switchbox(%[[TILE_11_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_11_0:.*]] = aie.shim_mux(%[[TILE_11_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:           %[[SHIM_MUX_10_0:.*]] = aie.shim_mux(%[[TILE_10_0]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_10_3:.*]] = aie.switchbox(%[[TILE_10_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
+// CHECK:             aie.connect<SOUTH : 0, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 5, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 4, NORTH : 4>
+// CHECK:             aie.connect<EAST : 2, NORTH : 2>
+// CHECK:             aie.connect<SOUTH : 2, NORTH : 3>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<WEST : 2, EAST : 1>
+// CHECK:             aie.connect<NORTH : 1, EAST : 0>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_11_0:.*]] = aie.switchbox(%[[TILE_11_0]]) {
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 7, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 2>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_11_0:.*]] = aie.shim_mux(%[[TILE_11_0]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_12_0:.*]] = aie.tile(12, 0)
 // CHECK:           %[[SWITCHBOX_12_0:.*]] = aie.switchbox(%[[TILE_12_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_13_0:.*]] = aie.tile(13, 0)
 // CHECK:           %[[SWITCHBOX_13_0:.*]] = aie.switchbox(%[[TILE_13_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, NORTH : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<NORTH : 3, EAST : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_14_0:.*]] = aie.tile(14, 0)
+// CHECK:           %[[SHIM_MUX_14_0:.*]] = aie.shim_mux(%[[TILE_14_0]]) {
+// CHECK:           }
 // CHECK:           %[[SWITCHBOX_14_0:.*]] = aie.switchbox(%[[TILE_14_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<WEST : 3, EAST : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_15_0:.*]] = aie.tile(15, 0)
+// CHECK:           %[[SHIM_MUX_15_0:.*]] = aie.shim_mux(%[[TILE_15_0]]) {
+// CHECK:           }
 // CHECK:           %[[SWITCHBOX_15_0:.*]] = aie.switchbox(%[[TILE_15_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<WEST : 3, EAST : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_16_0:.*]] = aie.tile(16, 0)
 // CHECK:           %[[SWITCHBOX_16_0:.*]] = aie.switchbox(%[[TILE_16_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
+// CHECK:             aie.connect<NORTH : 2, EAST : 3>
+// CHECK:             aie.connect<WEST : 3, EAST : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_17_0:.*]] = aie.tile(17, 0)
 // CHECK:           %[[SWITCHBOX_17_0:.*]] = aie.switchbox(%[[TILE_17_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<NORTH : 1, EAST : 3>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<NORTH : 3, EAST : 2>
+// CHECK:             aie.connect<WEST : 2, EAST : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_18_0:.*]] = aie.switchbox(%[[TILE_18_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 7, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, NORTH : 1>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 2>
+// CHECK:             aie.connect<WEST : 1, SOUTH : 3>
+// CHECK:             aie.connect<WEST : 2, EAST : 1>
+// CHECK:             aie.connect<WEST : 0, EAST : 0>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_18_0:.*]] = aie.shim_mux(%[[TILE_18_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_11_1:.*]] = aie.switchbox(%[[TILE_11_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 2>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 1, NORTH : 2>
+// CHECK:             aie.connect<SOUTH : 5, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, NORTH : 5>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<WEST : 0, SOUTH : 2>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_11_2:.*]] = aie.switchbox(%[[TILE_11_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 2, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 2>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
+// CHECK:             aie.connect<SOUTH : 2, NORTH : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 5, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, NORTH : 5>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<NORTH : 3, EAST : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_11_3:.*]] = aie.tile(11, 3)
 // CHECK:           %[[SWITCHBOX_11_3:.*]] = aie.switchbox(%[[TILE_11_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_19_0:.*]] = aie.switchbox(%[[TILE_19_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 2>
-// CHECK-DAG:         aie.connect<NORTH : 1, SOUTH : 3>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_19_0:.*]] = aie.shim_mux(%[[TILE_19_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK-DAG:         aie.connect<NORTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<NORTH : 3, DMA : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_4:.*]] = aie.switchbox(%[[TILE_7_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<SOUTH : 1, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 5, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, NORTH : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<WEST : 1, EAST : 3>
+// CHECK:             aie.connect<NORTH : 3, EAST : 2>
+// CHECK:             aie.connect<WEST : 0, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_12_1:.*]] = aie.tile(12, 1)
 // CHECK:           %[[SWITCHBOX_12_1:.*]] = aie.switchbox(%[[TILE_12_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<NORTH : 1, EAST : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_13_1:.*]] = aie.tile(13, 1)
 // CHECK:           %[[SWITCHBOX_13_1:.*]] = aie.switchbox(%[[TILE_13_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<WEST : 2, SOUTH : 3>
 // CHECK:           }
-// CHECK:           %[[TILE_14_1:.*]] = aie.tile(14, 1)
-// CHECK:           %[[SWITCHBOX_14_1:.*]] = aie.switchbox(%[[TILE_14_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:           %[[SWITCHBOX_19_0:.*]] = aie.switchbox(%[[TILE_19_0]]) {
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 7, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, NORTH : 5>
+// CHECK:             aie.connect<WEST : 1, SOUTH : 2>
+// CHECK:             aie.connect<WEST : 0, SOUTH : 3>
 // CHECK:           }
-// CHECK:           %[[TILE_15_1:.*]] = aie.tile(15, 1)
-// CHECK:           %[[SWITCHBOX_15_1:.*]] = aie.switchbox(%[[TILE_15_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:           %[[SHIM_MUX_19_0:.*]] = aie.shim_mux(%[[TILE_19_0]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<NORTH : 2, DMA : 0>
+// CHECK:             aie.connect<NORTH : 3, DMA : 1>
 // CHECK:           }
-// CHECK:           %[[TILE_16_1:.*]] = aie.tile(16, 1)
-// CHECK:           %[[SWITCHBOX_16_1:.*]] = aie.switchbox(%[[TILE_16_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_17_1:.*]] = aie.tile(17, 1)
-// CHECK:           %[[SWITCHBOX_17_1:.*]] = aie.switchbox(%[[TILE_17_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 2>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_18_1:.*]] = aie.switchbox(%[[TILE_18_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, SOUTH : 1>
-// CHECK-DAG:         aie.connect<WEST : 2, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_20_0:.*]] = aie.tile(20, 0)
-// CHECK:           %[[SWITCHBOX_20_0:.*]] = aie.switchbox(%[[TILE_20_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_21_0:.*]] = aie.tile(21, 0)
-// CHECK:           %[[SWITCHBOX_21_0:.*]] = aie.switchbox(%[[TILE_21_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_22_0:.*]] = aie.tile(22, 0)
-// CHECK:           %[[SWITCHBOX_22_0:.*]] = aie.switchbox(%[[TILE_22_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_23_0:.*]] = aie.tile(23, 0)
-// CHECK:           %[[SWITCHBOX_23_0:.*]] = aie.switchbox(%[[TILE_23_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_24_0:.*]] = aie.tile(24, 0)
-// CHECK:           %[[SWITCHBOX_24_0:.*]] = aie.switchbox(%[[TILE_24_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_25_0:.*]] = aie.tile(25, 0)
-// CHECK:           %[[SWITCHBOX_25_0:.*]] = aie.switchbox(%[[TILE_25_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_26_0:.*]] = aie.switchbox(%[[TILE_26_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_26_0:.*]] = aie.shim_mux(%[[TILE_26_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_8_4:.*]] = aie.switchbox(%[[TILE_8_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_9_4:.*]] = aie.switchbox(%[[TILE_9_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 3, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_19_1:.*]] = aie.switchbox(%[[TILE_19_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_27_0:.*]] = aie.switchbox(%[[TILE_27_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_27_0:.*]] = aie.shim_mux(%[[TILE_27_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
+// CHECK:           %[[SWITCHBOX_7_4:.*]] = aie.switchbox(%[[TILE_7_4]]) {
+// CHECK:             aie.connect<SOUTH : 2, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 5, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 2, NORTH : 3>
+// CHECK:             aie.connect<EAST : 1, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_12_2:.*]] = aie.tile(12, 2)
 // CHECK:           %[[SWITCHBOX_12_2:.*]] = aie.switchbox(%[[TILE_12_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<WEST : 1, EAST : 2>
+// CHECK:             aie.connect<NORTH : 3, EAST : 3>
+// CHECK:             aie.connect<WEST : 2, SOUTH : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_13_2:.*]] = aie.tile(13, 2)
 // CHECK:           %[[SWITCHBOX_13_2:.*]] = aie.switchbox(%[[TILE_13_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<WEST : 2, EAST : 3>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_14_2:.*]] = aie.tile(14, 2)
 // CHECK:           %[[SWITCHBOX_14_2:.*]] = aie.switchbox(%[[TILE_14_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<WEST : 3, EAST : 1>
+// CHECK:             aie.connect<WEST : 1, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 1, EAST : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_15_2:.*]] = aie.tile(15, 2)
 // CHECK:           %[[SWITCHBOX_15_2:.*]] = aie.switchbox(%[[TILE_15_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 5, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, NORTH : 0>
+// CHECK:             aie.connect<WEST : 1, SOUTH : 2>
+// CHECK:             aie.connect<WEST : 3, EAST : 0>
 // CHECK:           }
 // CHECK:           %[[TILE_16_2:.*]] = aie.tile(16, 2)
 // CHECK:           %[[SWITCHBOX_16_2:.*]] = aie.switchbox(%[[TILE_16_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<WEST : 0, EAST : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_17_2:.*]] = aie.tile(17, 2)
 // CHECK:           %[[SWITCHBOX_17_2:.*]] = aie.switchbox(%[[TILE_17_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<WEST : 2, SOUTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_18_2:.*]] = aie.switchbox(%[[TILE_18_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_19_2:.*]] = aie.switchbox(%[[TILE_19_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 1, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 0, NORTH : 5>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, NORTH : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_20_0:.*]] = aie.tile(20, 0)
+// CHECK:           %[[SWITCHBOX_20_0:.*]] = aie.switchbox(%[[TILE_20_0]]) {
+// CHECK:             aie.connect<EAST : 1, NORTH : 5>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_20_1:.*]] = aie.tile(20, 1)
 // CHECK:           %[[SWITCHBOX_20_1:.*]] = aie.switchbox(%[[TILE_20_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 3>
+// CHECK:             aie.connect<SOUTH : 5, NORTH : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
 // CHECK:           }
 // CHECK:           %[[TILE_20_2:.*]] = aie.tile(20, 2)
 // CHECK:           %[[SWITCHBOX_20_2:.*]] = aie.switchbox(%[[TILE_20_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<SOUTH : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 3, NORTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, NORTH : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_21_0:.*]] = aie.tile(21, 0)
+// CHECK:           %[[SWITCHBOX_21_0:.*]] = aie.switchbox(%[[TILE_21_0]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, NORTH : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_22_0:.*]] = aie.tile(22, 0)
+// CHECK:           %[[SHIM_MUX_22_0:.*]] = aie.shim_mux(%[[TILE_22_0]]) {
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_22_0:.*]] = aie.switchbox(%[[TILE_22_0]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_23_0:.*]] = aie.tile(23, 0)
+// CHECK:           %[[SHIM_MUX_23_0:.*]] = aie.shim_mux(%[[TILE_23_0]]) {
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_23_0:.*]] = aie.switchbox(%[[TILE_23_0]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_24_0:.*]] = aie.tile(24, 0)
+// CHECK:           %[[SWITCHBOX_24_0:.*]] = aie.switchbox(%[[TILE_24_0]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_25_0:.*]] = aie.tile(25, 0)
+// CHECK:           %[[SWITCHBOX_25_0:.*]] = aie.switchbox(%[[TILE_25_0]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_26_0:.*]] = aie.switchbox(%[[TILE_26_0]]) {
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 7, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, NORTH : 1>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_26_0:.*]] = aie.shim_mux(%[[TILE_26_0]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:           }
+// CHECK:           %[[TILE_14_1:.*]] = aie.tile(14, 1)
+// CHECK:           %[[SWITCHBOX_14_1:.*]] = aie.switchbox(%[[TILE_14_1]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<NORTH : 2, EAST : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_15_1:.*]] = aie.tile(15, 1)
+// CHECK:           %[[SWITCHBOX_15_1:.*]] = aie.switchbox(%[[TILE_15_1]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 2, EAST : 2>
+// CHECK:             aie.connect<WEST : 1, EAST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_16_1:.*]] = aie.tile(16, 1)
+// CHECK:           %[[SWITCHBOX_16_1:.*]] = aie.switchbox(%[[TILE_16_1]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<WEST : 2, EAST : 2>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_17_1:.*]] = aie.tile(17, 1)
+// CHECK:           %[[SWITCHBOX_17_1:.*]] = aie.switchbox(%[[TILE_17_1]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<WEST : 2, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_18_1:.*]] = aie.switchbox(%[[TILE_18_1]]) {
+// CHECK:             aie.connect<SOUTH : 1, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_8_4:.*]] = aie.switchbox(%[[TILE_8_4]]) {
+// CHECK:             aie.connect<EAST : 3, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 5, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_9_4:.*]] = aie.switchbox(%[[TILE_9_4]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 1, DMA : 0>
+// CHECK:             aie.connect<EAST : 3, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<SOUTH : 4, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_10_4:.*]] = aie.switchbox(%[[TILE_10_4]]) {
+// CHECK:             aie.connect<SOUTH : 4, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 2, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 3, DMA : 0>
+// CHECK:             aie.connect<EAST : 0, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, NORTH : 1>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_19_1:.*]] = aie.switchbox(%[[TILE_19_1]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 5, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, NORTH : 1>
+// CHECK:             aie.connect<EAST : 3, NORTH : 0>
 // CHECK:           }
 // CHECK:           %[[TILE_21_1:.*]] = aie.tile(21, 1)
 // CHECK:           %[[SWITCHBOX_21_1:.*]] = aie.switchbox(%[[TILE_21_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, NORTH : 5>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_27_0:.*]] = aie.switchbox(%[[TILE_27_0]]) {
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 7, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, NORTH : 5>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_27_0:.*]] = aie.shim_mux(%[[TILE_27_0]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
 // CHECK:           }
 // CHECK:           %[[TILE_22_1:.*]] = aie.tile(22, 1)
 // CHECK:           %[[SWITCHBOX_22_1:.*]] = aie.switchbox(%[[TILE_22_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_23_1:.*]] = aie.tile(23, 1)
 // CHECK:           %[[SWITCHBOX_23_1:.*]] = aie.switchbox(%[[TILE_23_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[TILE_24_1:.*]] = aie.tile(24, 1)
 // CHECK:           %[[SWITCHBOX_24_1:.*]] = aie.switchbox(%[[TILE_24_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[TILE_25_1:.*]] = aie.tile(25, 1)
 // CHECK:           %[[SWITCHBOX_25_1:.*]] = aie.switchbox(%[[TILE_25_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_26_1:.*]] = aie.switchbox(%[[TILE_26_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, NORTH : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_27_1:.*]] = aie.switchbox(%[[TILE_27_1]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 5, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, NORTH : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_28_0:.*]] = aie.tile(28, 0)
 // CHECK:           %[[SWITCHBOX_28_0:.*]] = aie.switchbox(%[[TILE_28_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_29_0:.*]] = aie.tile(29, 0)
-// CHECK:           %[[SWITCHBOX_29_0:.*]] = aie.switchbox(%[[TILE_29_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_30_0:.*]] = aie.tile(30, 0)
-// CHECK:           %[[SWITCHBOX_30_0:.*]] = aie.switchbox(%[[TILE_30_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_31_0:.*]] = aie.tile(31, 0)
-// CHECK:           %[[SWITCHBOX_31_0:.*]] = aie.switchbox(%[[TILE_31_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_32_0:.*]] = aie.tile(32, 0)
-// CHECK:           %[[SWITCHBOX_32_0:.*]] = aie.switchbox(%[[TILE_32_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_33_0:.*]] = aie.tile(33, 0)
-// CHECK:           %[[SWITCHBOX_33_0:.*]] = aie.switchbox(%[[TILE_33_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_34_0:.*]] = aie.switchbox(%[[TILE_34_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_34_0:.*]] = aie.shim_mux(%[[TILE_34_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_10_4:.*]] = aie.switchbox(%[[TILE_10_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_12_3:.*]] = aie.tile(12, 3)
-// CHECK:           %[[SWITCHBOX_12_3:.*]] = aie.switchbox(%[[TILE_12_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_13_3:.*]] = aie.tile(13, 3)
-// CHECK:           %[[SWITCHBOX_13_3:.*]] = aie.switchbox(%[[TILE_13_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_14_3:.*]] = aie.tile(14, 3)
-// CHECK:           %[[SWITCHBOX_14_3:.*]] = aie.switchbox(%[[TILE_14_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_15_3:.*]] = aie.tile(15, 3)
-// CHECK:           %[[SWITCHBOX_15_3:.*]] = aie.switchbox(%[[TILE_15_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_16_3:.*]] = aie.tile(16, 3)
-// CHECK:           %[[SWITCHBOX_16_3:.*]] = aie.switchbox(%[[TILE_16_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_17_3:.*]] = aie.tile(17, 3)
-// CHECK:           %[[SWITCHBOX_17_3:.*]] = aie.switchbox(%[[TILE_17_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_18_3:.*]] = aie.tile(18, 3)
-// CHECK:           %[[SWITCHBOX_18_3:.*]] = aie.switchbox(%[[TILE_18_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_19_3:.*]] = aie.tile(19, 3)
-// CHECK:           %[[SWITCHBOX_19_3:.*]] = aie.switchbox(%[[TILE_19_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_20_3:.*]] = aie.tile(20, 3)
-// CHECK:           %[[SWITCHBOX_20_3:.*]] = aie.switchbox(%[[TILE_20_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_27_1:.*]] = aie.switchbox(%[[TILE_27_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_35_0:.*]] = aie.switchbox(%[[TILE_35_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_35_0:.*]] = aie.shim_mux(%[[TILE_35_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_7_5:.*]] = aie.switchbox(%[[TILE_7_5]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_8_5:.*]] = aie.switchbox(%[[TILE_8_5]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_9_5:.*]] = aie.switchbox(%[[TILE_9_5]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK-DAG:         aie.connect<SOUTH : 0, DMA : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, EAST : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_10_5:.*]] = aie.switchbox(%[[TILE_10_5]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, DMA : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, DMA : 1>
-// CHECK-DAG:         aie.connect<DMA : 0, EAST : 2>
-// CHECK:           }
-// CHECK:           %[[TILE_11_5:.*]] = aie.tile(11, 5)
-// CHECK:           %[[SWITCHBOX_11_5:.*]] = aie.switchbox(%[[TILE_11_5]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK-DAG:         aie.connect<WEST : 2, EAST : 2>
-// CHECK:           }
-// CHECK:           %[[TILE_12_5:.*]] = aie.tile(12, 5)
-// CHECK:           %[[SWITCHBOX_12_5:.*]] = aie.switchbox(%[[TILE_12_5]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK-DAG:         aie.connect<WEST : 2, EAST : 2>
-// CHECK:           }
-// CHECK:           %[[TILE_13_5:.*]] = aie.tile(13, 5)
-// CHECK:           %[[SWITCHBOX_13_5:.*]] = aie.switchbox(%[[TILE_13_5]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK-DAG:         aie.connect<WEST : 2, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_14_5:.*]] = aie.tile(14, 5)
-// CHECK:           %[[SWITCHBOX_14_5:.*]] = aie.switchbox(%[[TILE_14_5]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_15_4:.*]] = aie.tile(15, 4)
-// CHECK:           %[[SWITCHBOX_15_4:.*]] = aie.switchbox(%[[TILE_15_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_15_5:.*]] = aie.tile(15, 5)
-// CHECK:           %[[SWITCHBOX_15_5:.*]] = aie.switchbox(%[[TILE_15_5]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<WEST : 1, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_21_3:.*]] = aie.tile(21, 3)
-// CHECK:           %[[SWITCHBOX_21_3:.*]] = aie.switchbox(%[[TILE_21_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_22_3:.*]] = aie.tile(22, 3)
-// CHECK:           %[[SWITCHBOX_22_3:.*]] = aie.switchbox(%[[TILE_22_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_23_3:.*]] = aie.tile(23, 3)
-// CHECK:           %[[SWITCHBOX_23_3:.*]] = aie.switchbox(%[[TILE_23_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_24_2:.*]] = aie.tile(24, 2)
-// CHECK:           %[[SWITCHBOX_24_2:.*]] = aie.switchbox(%[[TILE_24_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_24_3:.*]] = aie.tile(24, 3)
-// CHECK:           %[[SWITCHBOX_24_3:.*]] = aie.switchbox(%[[TILE_24_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_25_2:.*]] = aie.tile(25, 2)
-// CHECK:           %[[SWITCHBOX_25_2:.*]] = aie.switchbox(%[[TILE_25_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_26_2:.*]] = aie.switchbox(%[[TILE_26_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
+// CHECK:             aie.connect<EAST : 1, NORTH : 5>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_28_1:.*]] = aie.tile(28, 1)
 // CHECK:           %[[SWITCHBOX_28_1:.*]] = aie.switchbox(%[[TILE_28_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 5, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, NORTH : 2>
 // CHECK:           }
-// CHECK:           %[[TILE_29_1:.*]] = aie.tile(29, 1)
-// CHECK:           %[[SWITCHBOX_29_1:.*]] = aie.switchbox(%[[TILE_29_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:           %[[TILE_29_0:.*]] = aie.tile(29, 0)
+// CHECK:           %[[SWITCHBOX_29_0:.*]] = aie.switchbox(%[[TILE_29_0]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, NORTH : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
 // CHECK:           }
-// CHECK:           %[[TILE_30_1:.*]] = aie.tile(30, 1)
-// CHECK:           %[[SWITCHBOX_30_1:.*]] = aie.switchbox(%[[TILE_30_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:           %[[TILE_30_0:.*]] = aie.tile(30, 0)
+// CHECK:           %[[SHIM_MUX_30_0:.*]] = aie.shim_mux(%[[TILE_30_0]]) {
 // CHECK:           }
-// CHECK:           %[[TILE_31_1:.*]] = aie.tile(31, 1)
-// CHECK:           %[[SWITCHBOX_31_1:.*]] = aie.switchbox(%[[TILE_31_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:           %[[SWITCHBOX_30_0:.*]] = aie.switchbox(%[[TILE_30_0]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
 // CHECK:           }
-// CHECK:           %[[TILE_32_1:.*]] = aie.tile(32, 1)
-// CHECK:           %[[SWITCHBOX_32_1:.*]] = aie.switchbox(%[[TILE_32_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:           %[[TILE_31_0:.*]] = aie.tile(31, 0)
+// CHECK:           %[[SHIM_MUX_31_0:.*]] = aie.shim_mux(%[[TILE_31_0]]) {
 // CHECK:           }
-// CHECK:           %[[TILE_33_1:.*]] = aie.tile(33, 1)
-// CHECK:           %[[SWITCHBOX_33_1:.*]] = aie.switchbox(%[[TILE_33_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:           %[[SWITCHBOX_31_0:.*]] = aie.switchbox(%[[TILE_31_0]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_34_1:.*]] = aie.switchbox(%[[TILE_34_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
+// CHECK:           %[[TILE_32_0:.*]] = aie.tile(32, 0)
+// CHECK:           %[[SWITCHBOX_32_0:.*]] = aie.switchbox(%[[TILE_32_0]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
 // CHECK:           }
-// CHECK:           %[[TILE_36_0:.*]] = aie.tile(36, 0)
-// CHECK:           %[[SWITCHBOX_36_0:.*]] = aie.switchbox(%[[TILE_36_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:           %[[TILE_33_0:.*]] = aie.tile(33, 0)
+// CHECK:           %[[SWITCHBOX_33_0:.*]] = aie.switchbox(%[[TILE_33_0]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
 // CHECK:           }
-// CHECK:           %[[TILE_37_0:.*]] = aie.tile(37, 0)
-// CHECK:           %[[SWITCHBOX_37_0:.*]] = aie.switchbox(%[[TILE_37_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
+// CHECK:           %[[SWITCHBOX_34_0:.*]] = aie.switchbox(%[[TILE_34_0]]) {
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 7, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, NORTH : 4>
+// CHECK:             aie.connect<EAST : 2, NORTH : 3>
 // CHECK:           }
-// CHECK:           %[[TILE_38_0:.*]] = aie.tile(38, 0)
-// CHECK:           %[[SWITCHBOX_38_0:.*]] = aie.switchbox(%[[TILE_38_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_39_0:.*]] = aie.tile(39, 0)
-// CHECK:           %[[SWITCHBOX_39_0:.*]] = aie.switchbox(%[[TILE_39_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_40_0:.*]] = aie.tile(40, 0)
-// CHECK:           %[[SWITCHBOX_40_0:.*]] = aie.switchbox(%[[TILE_40_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_41_0:.*]] = aie.tile(41, 0)
-// CHECK:           %[[SWITCHBOX_41_0:.*]] = aie.switchbox(%[[TILE_41_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_42_0:.*]] = aie.switchbox(%[[TILE_42_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_42_0:.*]] = aie.shim_mux(%[[TILE_42_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK:           }
-// CHECK:           %[[TILE_11_4:.*]] = aie.tile(11, 4)
-// CHECK:           %[[SWITCHBOX_11_4:.*]] = aie.switchbox(%[[TILE_11_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_12_4:.*]] = aie.tile(12, 4)
-// CHECK:           %[[SWITCHBOX_12_4:.*]] = aie.switchbox(%[[TILE_12_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_13_4:.*]] = aie.tile(13, 4)
-// CHECK:           %[[SWITCHBOX_13_4:.*]] = aie.switchbox(%[[TILE_13_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_14_4:.*]] = aie.tile(14, 4)
-// CHECK:           %[[SWITCHBOX_14_4:.*]] = aie.switchbox(%[[TILE_14_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_16_4:.*]] = aie.tile(16, 4)
-// CHECK:           %[[SWITCHBOX_16_4:.*]] = aie.switchbox(%[[TILE_16_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK-DAG:         aie.connect<NORTH : 0, EAST : 0>
-// CHECK:           }
-// CHECK:           %[[TILE_17_4:.*]] = aie.tile(17, 4)
-// CHECK:           %[[SWITCHBOX_17_4:.*]] = aie.switchbox(%[[TILE_17_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
+// CHECK:           %[[SHIM_MUX_34_0:.*]] = aie.shim_mux(%[[TILE_34_0]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
 // CHECK:           }
 // CHECK:           %[[TILE_21_2:.*]] = aie.tile(21, 2)
 // CHECK:           %[[SWITCHBOX_21_2:.*]] = aie.switchbox(%[[TILE_21_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 5, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, NORTH : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_29_1:.*]] = aie.tile(29, 1)
+// CHECK:           %[[SWITCHBOX_29_1:.*]] = aie.switchbox(%[[TILE_29_1]]) {
+// CHECK:             aie.connect<SOUTH : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, NORTH : 4>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_35_0:.*]] = aie.switchbox(%[[TILE_35_0]]) {
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 7, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, NORTH : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[SHIM_MUX_35_0:.*]] = aie.shim_mux(%[[TILE_35_0]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:           }
+// CHECK:           %[[TILE_11_4:.*]] = aie.tile(11, 4)
+// CHECK:           %[[SWITCHBOX_11_4:.*]] = aie.switchbox(%[[TILE_11_4]]) {
+// CHECK:             aie.connect<SOUTH : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, NORTH : 5>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_12_3:.*]] = aie.tile(12, 3)
+// CHECK:           %[[SWITCHBOX_12_3:.*]] = aie.switchbox(%[[TILE_12_3]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, NORTH : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, NORTH : 4>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 3>
+// CHECK:             aie.connect<WEST : 2, EAST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_13_3:.*]] = aie.tile(13, 3)
+// CHECK:           %[[SWITCHBOX_13_3:.*]] = aie.switchbox(%[[TILE_13_3]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<WEST : 3, EAST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_14_3:.*]] = aie.tile(14, 3)
+// CHECK:           %[[SWITCHBOX_14_3:.*]] = aie.switchbox(%[[TILE_14_3]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<WEST : 3, SOUTH : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_15_3:.*]] = aie.tile(15, 3)
+// CHECK:           %[[SWITCHBOX_15_3:.*]] = aie.switchbox(%[[TILE_15_3]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, NORTH : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_16_3:.*]] = aie.tile(16, 3)
+// CHECK:           %[[SWITCHBOX_16_3:.*]] = aie.switchbox(%[[TILE_16_3]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_17_3:.*]] = aie.tile(17, 3)
+// CHECK:           %[[SWITCHBOX_17_3:.*]] = aie.switchbox(%[[TILE_17_3]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_18_3:.*]] = aie.tile(18, 3)
+// CHECK:           %[[SWITCHBOX_18_3:.*]] = aie.switchbox(%[[TILE_18_3]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_19_3:.*]] = aie.tile(19, 3)
+// CHECK:           %[[SWITCHBOX_19_3:.*]] = aie.switchbox(%[[TILE_19_3]]) {
+// CHECK:             aie.connect<SOUTH : 5, WEST : 2>
+// CHECK:             aie.connect<SOUTH : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, NORTH : 1>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_7_5:.*]] = aie.switchbox(%[[TILE_7_5]]) {
+// CHECK:             aie.connect<SOUTH : 3, DMA : 0>
+// CHECK:             aie.connect<SOUTH : 1, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_12_4:.*]] = aie.tile(12, 4)
+// CHECK:           %[[SWITCHBOX_12_4:.*]] = aie.switchbox(%[[TILE_12_4]]) {
+// CHECK:             aie.connect<SOUTH : 3, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 4, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, NORTH : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_22_2:.*]] = aie.tile(22, 2)
 // CHECK:           %[[SWITCHBOX_22_2:.*]] = aie.switchbox(%[[TILE_22_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[TILE_23_2:.*]] = aie.tile(23, 2)
 // CHECK:           %[[SWITCHBOX_23_2:.*]] = aie.switchbox(%[[TILE_23_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_24_2:.*]] = aie.tile(24, 2)
+// CHECK:           %[[SWITCHBOX_24_2:.*]] = aie.switchbox(%[[TILE_24_2]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_25_2:.*]] = aie.tile(25, 2)
+// CHECK:           %[[SWITCHBOX_25_2:.*]] = aie.switchbox(%[[TILE_25_2]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_26_2:.*]] = aie.switchbox(%[[TILE_26_2]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, NORTH : 4>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_27_2:.*]] = aie.switchbox(%[[TILE_27_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_35_1:.*]] = aie.switchbox(%[[TILE_35_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[SWITCHBOX_43_0:.*]] = aie.switchbox(%[[TILE_43_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[SHIM_MUX_43_0:.*]] = aie.shim_mux(%[[TILE_43_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
-// CHECK:           }
-// CHECK:           %[[TILE_18_4:.*]] = aie.tile(18, 4)
-// CHECK:           %[[SWITCHBOX_18_4:.*]] = aie.switchbox(%[[TILE_18_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, EAST : 0>
-// CHECK-DAG:         aie.connect<EAST : 2, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 3, NORTH : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_19_4:.*]] = aie.tile(19, 4)
-// CHECK:           %[[SWITCHBOX_19_4:.*]] = aie.switchbox(%[[TILE_19_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 2, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 3, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_20_4:.*]] = aie.tile(20, 4)
-// CHECK:           %[[SWITCHBOX_20_4:.*]] = aie.switchbox(%[[TILE_20_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 2>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 3>
-// CHECK:           }
-// CHECK:           %[[TILE_25_3:.*]] = aie.tile(25, 3)
-// CHECK:           %[[SWITCHBOX_25_3:.*]] = aie.switchbox(%[[TILE_25_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
-// CHECK:           }
-// CHECK:           %[[TILE_26_3:.*]] = aie.tile(26, 3)
-// CHECK:           %[[SWITCHBOX_26_3:.*]] = aie.switchbox(%[[TILE_26_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<SOUTH : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, NORTH : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[TILE_28_2:.*]] = aie.tile(28, 2)
 // CHECK:           %[[SWITCHBOX_28_2:.*]] = aie.switchbox(%[[TILE_28_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 2, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, NORTH : 1>
 // CHECK:           }
 // CHECK:           %[[TILE_29_2:.*]] = aie.tile(29, 2)
 // CHECK:           %[[SWITCHBOX_29_2:.*]] = aie.switchbox(%[[TILE_29_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 4, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
 // CHECK:           }
-// CHECK:           %[[TILE_30_2:.*]] = aie.tile(30, 2)
-// CHECK:           %[[SWITCHBOX_30_2:.*]] = aie.switchbox(%[[TILE_30_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_30_1:.*]] = aie.tile(30, 1)
+// CHECK:           %[[SWITCHBOX_30_1:.*]] = aie.switchbox(%[[TILE_30_1]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
 // CHECK:           }
-// CHECK:           %[[TILE_31_2:.*]] = aie.tile(31, 2)
-// CHECK:           %[[SWITCHBOX_31_2:.*]] = aie.switchbox(%[[TILE_31_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_31_1:.*]] = aie.tile(31, 1)
+// CHECK:           %[[SWITCHBOX_31_1:.*]] = aie.switchbox(%[[TILE_31_1]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
 // CHECK:           }
-// CHECK:           %[[TILE_32_2:.*]] = aie.tile(32, 2)
-// CHECK:           %[[SWITCHBOX_32_2:.*]] = aie.switchbox(%[[TILE_32_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_32_1:.*]] = aie.tile(32, 1)
+// CHECK:           %[[SWITCHBOX_32_1:.*]] = aie.switchbox(%[[TILE_32_1]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
 // CHECK:           }
-// CHECK:           %[[TILE_33_2:.*]] = aie.tile(33, 2)
-// CHECK:           %[[SWITCHBOX_33_2:.*]] = aie.switchbox(%[[TILE_33_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_33_1:.*]] = aie.tile(33, 1)
+// CHECK:           %[[SWITCHBOX_33_1:.*]] = aie.switchbox(%[[TILE_33_1]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_34_2:.*]] = aie.switchbox(%[[TILE_34_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[SWITCHBOX_34_1:.*]] = aie.switchbox(%[[TILE_34_1]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 4, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, NORTH : 5>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_35_2:.*]] = aie.switchbox(%[[TILE_35_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[SWITCHBOX_35_1:.*]] = aie.switchbox(%[[TILE_35_1]]) {
+// CHECK:             aie.connect<SOUTH : 2, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
 // CHECK:           }
-// CHECK:           %[[TILE_36_2:.*]] = aie.tile(36, 2)
-// CHECK:           %[[SWITCHBOX_36_2:.*]] = aie.switchbox(%[[TILE_36_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_36_0:.*]] = aie.tile(36, 0)
+// CHECK:           %[[SWITCHBOX_36_0:.*]] = aie.switchbox(%[[TILE_36_0]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, NORTH : 2>
 // CHECK:           }
-// CHECK:           %[[TILE_37_2:.*]] = aie.tile(37, 2)
-// CHECK:           %[[SWITCHBOX_37_2:.*]] = aie.switchbox(%[[TILE_37_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_37_0:.*]] = aie.tile(37, 0)
+// CHECK:           %[[SWITCHBOX_37_0:.*]] = aie.switchbox(%[[TILE_37_0]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
 // CHECK:           }
-// CHECK:           %[[TILE_38_2:.*]] = aie.tile(38, 2)
-// CHECK:           %[[SWITCHBOX_38_2:.*]] = aie.switchbox(%[[TILE_38_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_38_0:.*]] = aie.tile(38, 0)
+// CHECK:           %[[SHIM_MUX_38_0:.*]] = aie.shim_mux(%[[TILE_38_0]]) {
 // CHECK:           }
-// CHECK:           %[[TILE_39_2:.*]] = aie.tile(39, 2)
-// CHECK:           %[[SWITCHBOX_39_2:.*]] = aie.switchbox(%[[TILE_39_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[SWITCHBOX_38_0:.*]] = aie.switchbox(%[[TILE_38_0]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
 // CHECK:           }
-// CHECK:           %[[TILE_40_2:.*]] = aie.tile(40, 2)
-// CHECK:           %[[SWITCHBOX_40_2:.*]] = aie.switchbox(%[[TILE_40_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_39_0:.*]] = aie.tile(39, 0)
+// CHECK:           %[[SHIM_MUX_39_0:.*]] = aie.shim_mux(%[[TILE_39_0]]) {
 // CHECK:           }
-// CHECK:           %[[TILE_41_1:.*]] = aie.tile(41, 1)
-// CHECK:           %[[SWITCHBOX_41_1:.*]] = aie.switchbox(%[[TILE_41_1]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 1>
+// CHECK:           %[[SWITCHBOX_39_0:.*]] = aie.switchbox(%[[TILE_39_0]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
 // CHECK:           }
-// CHECK:           %[[TILE_41_2:.*]] = aie.tile(41, 2)
-// CHECK:           %[[SWITCHBOX_41_2:.*]] = aie.switchbox(%[[TILE_41_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
+// CHECK:           %[[TILE_40_0:.*]] = aie.tile(40, 0)
+// CHECK:           %[[SWITCHBOX_40_0:.*]] = aie.switchbox(%[[TILE_40_0]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_42_1:.*]] = aie.switchbox(%[[TILE_42_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
+// CHECK:           %[[TILE_41_0:.*]] = aie.tile(41, 0)
+// CHECK:           %[[SWITCHBOX_41_0:.*]] = aie.switchbox(%[[TILE_41_0]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
 // CHECK:           }
-// CHECK:           %[[TILE_44_0:.*]] = aie.tile(44, 0)
-// CHECK:           %[[SWITCHBOX_44_0:.*]] = aie.switchbox(%[[TILE_44_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[SWITCHBOX_42_0:.*]] = aie.switchbox(%[[TILE_42_0]]) {
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 7, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, NORTH : 1>
+// CHECK:             aie.connect<EAST : 1, NORTH : 0>
 // CHECK:           }
-// CHECK:           %[[TILE_45_0:.*]] = aie.tile(45, 0)
-// CHECK:           %[[SWITCHBOX_45_0:.*]] = aie.switchbox(%[[TILE_45_0]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[SHIM_MUX_42_0:.*]] = aie.shim_mux(%[[TILE_42_0]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_46_0:.*]] = aie.switchbox(%[[TILE_46_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 1>
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 1>
+// CHECK:           %[[SWITCHBOX_8_5:.*]] = aie.switchbox(%[[TILE_8_5]]) {
+// CHECK:             aie.connect<SOUTH : 1, DMA : 0>
+// CHECK:             aie.connect<EAST : 1, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 2>
 // CHECK:           }
-// CHECK:           %[[SHIM_MUX_46_0:.*]] = aie.shim_mux(%[[TILE_46_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
+// CHECK:           %[[TILE_20_3:.*]] = aie.tile(20, 3)
+// CHECK:           %[[SWITCHBOX_20_3:.*]] = aie.switchbox(%[[TILE_20_3]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, NORTH : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, NORTH : 4>
 // CHECK:           }
-// CHECK:           %[[TILE_16_5:.*]] = aie.tile(16, 5)
-// CHECK:           %[[SWITCHBOX_16_5:.*]] = aie.switchbox(%[[TILE_16_5]]) {
-// CHECK-DAG:         aie.connect<WEST : 0, SOUTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_21_3:.*]] = aie.tile(21, 3)
+// CHECK:           %[[SWITCHBOX_21_3:.*]] = aie.switchbox(%[[TILE_21_3]]) {
+// CHECK:             aie.connect<SOUTH : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
 // CHECK:           }
-// CHECK:           %[[TILE_17_5:.*]] = aie.tile(17, 5)
-// CHECK:           %[[SWITCHBOX_17_5:.*]] = aie.switchbox(%[[TILE_17_5]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[SWITCHBOX_43_0:.*]] = aie.switchbox(%[[TILE_43_0]]) {
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 7, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, NORTH : 4>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
 // CHECK:           }
-// CHECK:           %[[TILE_18_5:.*]] = aie.tile(18, 5)
-// CHECK:           %[[SWITCHBOX_18_5:.*]] = aie.switchbox(%[[TILE_18_5]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
+// CHECK:           %[[SHIM_MUX_43_0:.*]] = aie.shim_mux(%[[TILE_43_0]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_9_5:.*]] = aie.switchbox(%[[TILE_9_5]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, DMA : 0>
+// CHECK:             aie.connect<EAST : 3, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, EAST : 2>
+// CHECK:           }
+// CHECK:           %[[SWITCHBOX_10_5:.*]] = aie.switchbox(%[[TILE_10_5]]) {
+// CHECK:             aie.connect<SOUTH : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<WEST : 2, EAST : 2>
+// CHECK:             aie.connect<EAST : 1, DMA : 0>
+// CHECK:             aie.connect<EAST : 0, DMA : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_13_4:.*]] = aie.tile(13, 4)
+// CHECK:           %[[SWITCHBOX_13_4:.*]] = aie.switchbox(%[[TILE_13_4]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, NORTH : 4>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_14_4:.*]] = aie.tile(14, 4)
+// CHECK:           %[[SWITCHBOX_14_4:.*]] = aie.switchbox(%[[TILE_14_4]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_15_4:.*]] = aie.tile(15, 4)
+// CHECK:           %[[SWITCHBOX_15_4:.*]] = aie.switchbox(%[[TILE_15_4]]) {
+// CHECK:             aie.connect<SOUTH : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, NORTH : 5>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_36_1:.*]] = aie.tile(36, 1)
+// CHECK:           %[[SWITCHBOX_36_1:.*]] = aie.switchbox(%[[TILE_36_1]]) {
+// CHECK:             aie.connect<SOUTH : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, NORTH : 4>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_11_5:.*]] = aie.tile(11, 5)
+// CHECK:           %[[SWITCHBOX_11_5:.*]] = aie.switchbox(%[[TILE_11_5]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 5, WEST : 2>
+// CHECK:             aie.connect<WEST : 2, SOUTH : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_12_5:.*]] = aie.tile(12, 5)
+// CHECK:           %[[SWITCHBOX_12_5:.*]] = aie.switchbox(%[[TILE_12_5]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<SOUTH : 1, WEST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_13_5:.*]] = aie.tile(13, 5)
+// CHECK:           %[[SWITCHBOX_13_5:.*]] = aie.switchbox(%[[TILE_13_5]]) {
+// CHECK:             aie.connect<SOUTH : 4, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:           }
+// CHECK:           %[[TILE_16_4:.*]] = aie.tile(16, 4)
+// CHECK:           %[[SWITCHBOX_16_4:.*]] = aie.switchbox(%[[TILE_16_4]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_17_4:.*]] = aie.tile(17, 4)
+// CHECK:           %[[SWITCHBOX_17_4:.*]] = aie.switchbox(%[[TILE_17_4]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_18_4:.*]] = aie.tile(18, 4)
+// CHECK:           %[[SWITCHBOX_18_4:.*]] = aie.switchbox(%[[TILE_18_4]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_19_4:.*]] = aie.tile(19, 4)
+// CHECK:           %[[SWITCHBOX_19_4:.*]] = aie.switchbox(%[[TILE_19_4]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_20_4:.*]] = aie.tile(20, 4)
+// CHECK:           %[[SWITCHBOX_20_4:.*]] = aie.switchbox(%[[TILE_20_4]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 4, WEST : 0>
 // CHECK:           }
 // CHECK:           %[[TILE_21_4:.*]] = aie.tile(21, 4)
 // CHECK:           %[[SWITCHBOX_21_4:.*]] = aie.switchbox(%[[TILE_21_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_22_3:.*]] = aie.tile(22, 3)
+// CHECK:           %[[SWITCHBOX_22_3:.*]] = aie.switchbox(%[[TILE_22_3]]) {
+// CHECK:             aie.connect<EAST : 1, NORTH : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[TILE_22_4:.*]] = aie.tile(22, 4)
 // CHECK:           %[[SWITCHBOX_22_4:.*]] = aie.switchbox(%[[TILE_22_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 1>
 // CHECK:           }
-// CHECK:           %[[TILE_23_4:.*]] = aie.tile(23, 4)
-// CHECK:           %[[SWITCHBOX_23_4:.*]] = aie.switchbox(%[[TILE_23_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_23_3:.*]] = aie.tile(23, 3)
+// CHECK:           %[[SWITCHBOX_23_3:.*]] = aie.switchbox(%[[TILE_23_3]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
 // CHECK:           }
-// CHECK:           %[[TILE_24_4:.*]] = aie.tile(24, 4)
-// CHECK:           %[[SWITCHBOX_24_4:.*]] = aie.switchbox(%[[TILE_24_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_24_3:.*]] = aie.tile(24, 3)
+// CHECK:           %[[SWITCHBOX_24_3:.*]] = aie.switchbox(%[[TILE_24_3]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
 // CHECK:           }
-// CHECK:           %[[TILE_25_4:.*]] = aie.tile(25, 4)
-// CHECK:           %[[SWITCHBOX_25_4:.*]] = aie.switchbox(%[[TILE_25_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_25_3:.*]] = aie.tile(25, 3)
+// CHECK:           %[[SWITCHBOX_25_3:.*]] = aie.switchbox(%[[TILE_25_3]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
 // CHECK:           }
-// CHECK:           %[[TILE_26_4:.*]] = aie.tile(26, 4)
-// CHECK:           %[[SWITCHBOX_26_4:.*]] = aie.switchbox(%[[TILE_26_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_26_3:.*]] = aie.tile(26, 3)
+// CHECK:           %[[SWITCHBOX_26_3:.*]] = aie.switchbox(%[[TILE_26_3]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 4, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
 // CHECK:           }
-// CHECK:           %[[TILE_27_4:.*]] = aie.tile(27, 4)
-// CHECK:           %[[SWITCHBOX_27_4:.*]] = aie.switchbox(%[[TILE_27_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_27_3:.*]] = aie.tile(27, 3)
+// CHECK:           %[[SWITCHBOX_27_3:.*]] = aie.switchbox(%[[TILE_27_3]]) {
+// CHECK:             aie.connect<SOUTH : 0, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
 // CHECK:           }
-// CHECK:           %[[TILE_28_4:.*]] = aie.tile(28, 4)
-// CHECK:           %[[SWITCHBOX_28_4:.*]] = aie.switchbox(%[[TILE_28_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_30_2:.*]] = aie.tile(30, 2)
+// CHECK:           %[[SWITCHBOX_30_2:.*]] = aie.switchbox(%[[TILE_30_2]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
 // CHECK:           }
-// CHECK:           %[[TILE_29_4:.*]] = aie.tile(29, 4)
-// CHECK:           %[[SWITCHBOX_29_4:.*]] = aie.switchbox(%[[TILE_29_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_31_2:.*]] = aie.tile(31, 2)
+// CHECK:           %[[SWITCHBOX_31_2:.*]] = aie.switchbox(%[[TILE_31_2]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, NORTH : 1>
 // CHECK:           }
-// CHECK:           %[[TILE_30_4:.*]] = aie.tile(30, 4)
-// CHECK:           %[[SWITCHBOX_30_4:.*]] = aie.switchbox(%[[TILE_30_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_32_2:.*]] = aie.tile(32, 2)
+// CHECK:           %[[SWITCHBOX_32_2:.*]] = aie.switchbox(%[[TILE_32_2]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 0>
 // CHECK:           }
-// CHECK:           %[[TILE_31_4:.*]] = aie.tile(31, 4)
-// CHECK:           %[[SWITCHBOX_31_4:.*]] = aie.switchbox(%[[TILE_31_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_33_2:.*]] = aie.tile(33, 2)
+// CHECK:           %[[SWITCHBOX_33_2:.*]] = aie.switchbox(%[[TILE_33_2]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
 // CHECK:           }
-// CHECK:           %[[TILE_32_4:.*]] = aie.tile(32, 4)
-// CHECK:           %[[SWITCHBOX_32_4:.*]] = aie.switchbox(%[[TILE_32_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[SWITCHBOX_34_2:.*]] = aie.switchbox(%[[TILE_34_2]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 5, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 2>
 // CHECK:           }
-// CHECK:           %[[TILE_33_4:.*]] = aie.tile(33, 4)
-// CHECK:           %[[SWITCHBOX_33_4:.*]] = aie.switchbox(%[[TILE_33_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[SWITCHBOX_35_2:.*]] = aie.switchbox(%[[TILE_35_2]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
 // CHECK:           }
-// CHECK:           %[[TILE_34_4:.*]] = aie.tile(34, 4)
-// CHECK:           %[[SWITCHBOX_34_4:.*]] = aie.switchbox(%[[TILE_34_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_36_2:.*]] = aie.tile(36, 2)
+// CHECK:           %[[SWITCHBOX_36_2:.*]] = aie.switchbox(%[[TILE_36_2]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 4, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
 // CHECK:           }
-// CHECK:           %[[TILE_35_4:.*]] = aie.tile(35, 4)
-// CHECK:           %[[SWITCHBOX_35_4:.*]] = aie.switchbox(%[[TILE_35_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_37_1:.*]] = aie.tile(37, 1)
+// CHECK:           %[[SWITCHBOX_37_1:.*]] = aie.switchbox(%[[TILE_37_1]]) {
+// CHECK:             aie.connect<EAST : 2, NORTH : 4>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, NORTH : 5>
 // CHECK:           }
-// CHECK:           %[[TILE_36_4:.*]] = aie.tile(36, 4)
-// CHECK:           %[[SWITCHBOX_36_4:.*]] = aie.switchbox(%[[TILE_36_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_37_2:.*]] = aie.tile(37, 2)
+// CHECK:           %[[SWITCHBOX_37_2:.*]] = aie.switchbox(%[[TILE_37_2]]) {
+// CHECK:             aie.connect<SOUTH : 4, WEST : 0>
+// CHECK:             aie.connect<SOUTH : 5, WEST : 1>
 // CHECK:           }
-// CHECK:           %[[TILE_37_4:.*]] = aie.tile(37, 4)
-// CHECK:           %[[SWITCHBOX_37_4:.*]] = aie.switchbox(%[[TILE_37_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_38_1:.*]] = aie.tile(38, 1)
+// CHECK:           %[[SWITCHBOX_38_1:.*]] = aie.switchbox(%[[TILE_38_1]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 1, WEST : 0>
 // CHECK:           }
-// CHECK:           %[[TILE_38_4:.*]] = aie.tile(38, 4)
-// CHECK:           %[[SWITCHBOX_38_4:.*]] = aie.switchbox(%[[TILE_38_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_39_1:.*]] = aie.tile(39, 1)
+// CHECK:           %[[SWITCHBOX_39_1:.*]] = aie.switchbox(%[[TILE_39_1]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
 // CHECK:           }
-// CHECK:           %[[TILE_39_4:.*]] = aie.tile(39, 4)
-// CHECK:           %[[SWITCHBOX_39_4:.*]] = aie.switchbox(%[[TILE_39_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_40_1:.*]] = aie.tile(40, 1)
+// CHECK:           %[[SWITCHBOX_40_1:.*]] = aie.switchbox(%[[TILE_40_1]]) {
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
 // CHECK:           }
-// CHECK:           %[[TILE_40_4:.*]] = aie.tile(40, 4)
-// CHECK:           %[[SWITCHBOX_40_4:.*]] = aie.switchbox(%[[TILE_40_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_41_1:.*]] = aie.tile(41, 1)
+// CHECK:           %[[SWITCHBOX_41_1:.*]] = aie.switchbox(%[[TILE_41_1]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
 // CHECK:           }
-// CHECK:           %[[TILE_41_4:.*]] = aie.tile(41, 4)
-// CHECK:           %[[SWITCHBOX_41_4:.*]] = aie.switchbox(%[[TILE_41_4]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[SWITCHBOX_42_1:.*]] = aie.switchbox(%[[TILE_42_1]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 1, WEST : 0>
+// CHECK:             aie.connect<EAST : 0, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 0, WEST : 2>
 // CHECK:           }
-// CHECK:           %[[TILE_42_3:.*]] = aie.tile(42, 3)
-// CHECK:           %[[SWITCHBOX_42_3:.*]] = aie.switchbox(%[[TILE_42_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 1>
+// CHECK:           %[[SWITCHBOX_43_1:.*]] = aie.switchbox(%[[TILE_43_1]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 4, WEST : 0>
 // CHECK:           }
-// CHECK:           %[[TILE_42_4:.*]] = aie.tile(42, 4)
-// CHECK:           %[[SWITCHBOX_42_4:.*]] = aie.switchbox(%[[TILE_42_4]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
+// CHECK:           %[[TILE_44_0:.*]] = aie.tile(44, 0)
+// CHECK:           %[[SWITCHBOX_44_0:.*]] = aie.switchbox(%[[TILE_44_0]]) {
+// CHECK:             aie.connect<EAST : 3, NORTH : 5>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:             aie.connect<EAST : 1, WEST : 1>
 // CHECK:           }
-// CHECK:           %[[TILE_43_3:.*]] = aie.tile(43, 3)
-// CHECK:           %[[SWITCHBOX_43_3:.*]] = aie.switchbox(%[[TILE_43_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_44_1:.*]] = aie.tile(44, 1)
+// CHECK:           %[[SWITCHBOX_44_1:.*]] = aie.switchbox(%[[TILE_44_1]]) {
+// CHECK:             aie.connect<SOUTH : 5, WEST : 2>
 // CHECK:           }
-// CHECK:           %[[TILE_44_3:.*]] = aie.tile(44, 3)
-// CHECK:           %[[SWITCHBOX_44_3:.*]] = aie.switchbox(%[[TILE_44_3]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, WEST : 1>
+// CHECK:           %[[TILE_45_0:.*]] = aie.tile(45, 0)
+// CHECK:           %[[SWITCHBOX_45_0:.*]] = aie.switchbox(%[[TILE_45_0]]) {
+// CHECK:             aie.connect<EAST : 3, WEST : 3>
+// CHECK:             aie.connect<EAST : 0, WEST : 0>
+// CHECK:             aie.connect<EAST : 1, WEST : 2>
+// CHECK:             aie.connect<EAST : 2, WEST : 1>
 // CHECK:           }
-// CHECK:           %[[TILE_45_2:.*]] = aie.tile(45, 2)
-// CHECK:           %[[SWITCHBOX_45_2:.*]] = aie.switchbox(%[[TILE_45_2]]) {
-// CHECK-DAG:         aie.connect<EAST : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<EAST : 1, NORTH : 1>
+// CHECK:           %[[SWITCHBOX_46_0:.*]] = aie.switchbox(%[[TILE_46_0]]) {
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 7, WEST : 0>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
 // CHECK:           }
-// CHECK:           %[[TILE_45_3:.*]] = aie.tile(45, 3)
-// CHECK:           %[[SWITCHBOX_45_3:.*]] = aie.switchbox(%[[TILE_45_3]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
+// CHECK:           %[[SHIM_MUX_46_0:.*]] = aie.shim_mux(%[[TILE_46_0]]) {
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_46_1:.*]] = aie.switchbox(%[[TILE_46_1]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, NORTH : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, NORTH : 1>
+// CHECK:           %[[TILE_14_5:.*]] = aie.tile(14, 5)
+// CHECK:           %[[SWITCHBOX_14_5:.*]] = aie.switchbox(%[[TILE_14_5]]) {
+// CHECK:             aie.connect<EAST : 0, WEST : 3>
 // CHECK:           }
-// CHECK:           %[[SWITCHBOX_46_2:.*]] = aie.switchbox(%[[TILE_46_2]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 0, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 1, WEST : 1>
+// CHECK:           %[[TILE_15_5:.*]] = aie.tile(15, 5)
+// CHECK:           %[[SWITCHBOX_15_5:.*]] = aie.switchbox(%[[TILE_15_5]]) {
+// CHECK:             aie.connect<SOUTH : 5, WEST : 0>
+// CHECK:           }
+// CHECK:           %[[TILE_28_3:.*]] = aie.tile(28, 3)
+// CHECK:           %[[SWITCHBOX_28_3:.*]] = aie.switchbox(%[[TILE_28_3]]) {
+// CHECK:             aie.connect<SOUTH : 1, WEST : 3>
+// CHECK:             aie.connect<EAST : 3, WEST : 1>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_47_0:.*]] = aie.switchbox(%[[TILE_47_0]]) {
-// CHECK-DAG:         aie.connect<SOUTH : 3, WEST : 0>
-// CHECK-DAG:         aie.connect<SOUTH : 7, WEST : 1>
+// CHECK:             aie.connect<SOUTH : 3, WEST : 3>
+// CHECK:             aie.connect<SOUTH : 7, WEST : 2>
 // CHECK:           }
 // CHECK:           %[[SHIM_MUX_47_0:.*]] = aie.shim_mux(%[[TILE_47_0]]) {
-// CHECK-DAG:         aie.connect<DMA : 0, NORTH : 3>
-// CHECK-DAG:         aie.connect<DMA : 1, NORTH : 7>
+// CHECK:             aie.connect<DMA : 0, NORTH : 3>
+// CHECK:             aie.connect<DMA : 1, NORTH : 7>
+// CHECK:           }
+// CHECK:           %[[TILE_29_3:.*]] = aie.tile(29, 3)
+// CHECK:           %[[SWITCHBOX_29_3:.*]] = aie.switchbox(%[[TILE_29_3]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 3>
+// CHECK:           }
+// CHECK:           %[[TILE_30_3:.*]] = aie.tile(30, 3)
+// CHECK:           %[[SWITCHBOX_30_3:.*]] = aie.switchbox(%[[TILE_30_3]]) {
+// CHECK:             aie.connect<EAST : 2, WEST : 2>
+// CHECK:           }
+// CHECK:           %[[TILE_31_3:.*]] = aie.tile(31, 3)
+// CHECK:           %[[SWITCHBOX_31_3:.*]] = aie.switchbox(%[[TILE_31_3]]) {
+// CHECK:             aie.connect<SOUTH : 1, WEST : 2>
 // CHECK:           }
 // CHECK:         }
-
 module @vecmul_4x4  {
   aie.device(xcvc1902) {
     %0 = aie.tile(47, 2)
@@ -2325,21 +2216,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%9, Acquire, 0)
-      aie.dma_bd(%10 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%10 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%9, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%7, Acquire, 0)
-      aie.dma_bd(%8 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%8 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%7, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%5, Acquire, 1)
-      aie.dma_bd(%6 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%6 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%5, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -2353,12 +2244,6 @@ module @vecmul_4x4  {
       aie.use_lock(%9, Acquire, 1)
       aie.use_lock(%7, Acquire, 1)
       aie.use_lock(%5, Acquire, 0)
-      affine.for %arg0 = 0 to 64 {
-        %200 = affine.load %10[%arg0] : memref<64xi32, 2>
-        %201 = affine.load %8[%arg0] : memref<64xi32, 2>
-        %202 = arith.muli %200, %201 : i32
-        affine.store %202, %6[%arg0] : memref<64xi32, 2>
-      }
       aie.use_lock(%5, Release, 1)
       aie.use_lock(%7, Release, 0)
       aie.use_lock(%9, Release, 0)
@@ -2379,21 +2264,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%22, Acquire, 0)
-      aie.dma_bd(%23 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%23 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%22, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%20, Acquire, 0)
-      aie.dma_bd(%21 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%21 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%20, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%18, Acquire, 1)
-      aie.dma_bd(%19 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%19 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%18, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -2407,12 +2292,6 @@ module @vecmul_4x4  {
       aie.use_lock(%22, Acquire, 1)
       aie.use_lock(%20, Acquire, 1)
       aie.use_lock(%18, Acquire, 0)
-      affine.for %arg0 = 0 to 64 {
-        %200 = affine.load %23[%arg0] : memref<64xi32, 2>
-        %201 = affine.load %21[%arg0] : memref<64xi32, 2>
-        %202 = arith.muli %200, %201 : i32
-        affine.store %202, %19[%arg0] : memref<64xi32, 2>
-      }
       aie.use_lock(%18, Release, 1)
       aie.use_lock(%20, Release, 0)
       aie.use_lock(%22, Release, 0)
@@ -2433,21 +2312,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%35, Acquire, 0)
-      aie.dma_bd(%36 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%36 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%35, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%33, Acquire, 0)
-      aie.dma_bd(%34 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%34 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%33, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%31, Acquire, 1)
-      aie.dma_bd(%32 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%32 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%31, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -2461,12 +2340,6 @@ module @vecmul_4x4  {
       aie.use_lock(%35, Acquire, 1)
       aie.use_lock(%33, Acquire, 1)
       aie.use_lock(%31, Acquire, 0)
-      affine.for %arg0 = 0 to 64 {
-        %200 = affine.load %36[%arg0] : memref<64xi32, 2>
-        %201 = affine.load %34[%arg0] : memref<64xi32, 2>
-        %202 = arith.muli %200, %201 : i32
-        affine.store %202, %32[%arg0] : memref<64xi32, 2>
-      }
       aie.use_lock(%31, Release, 1)
       aie.use_lock(%33, Release, 0)
       aie.use_lock(%35, Release, 0)
@@ -2487,21 +2360,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%48, Acquire, 0)
-      aie.dma_bd(%49 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%49 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%48, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%46, Acquire, 0)
-      aie.dma_bd(%47 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%47 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%46, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%44, Acquire, 1)
-      aie.dma_bd(%45 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%45 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%44, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -2515,12 +2388,12 @@ module @vecmul_4x4  {
       aie.use_lock(%48, Acquire, 1)
       aie.use_lock(%46, Acquire, 1)
       aie.use_lock(%44, Acquire, 0)
-      affine.for %arg0 = 0 to 64 {
-        %200 = affine.load %49[%arg0] : memref<64xi32, 2>
-        %201 = affine.load %47[%arg0] : memref<64xi32, 2>
-        %202 = arith.muli %200, %201 : i32
-        affine.store %202, %45[%arg0] : memref<64xi32, 2>
-      }
+      // affine.for %arg0 = 0 to 64 {
+      //   %200 = affine.load %49[%arg0] : memref<64xi32, 2>
+      //   %201 = affine.load %47[%arg0] : memref<64xi32, 2>
+      //   %202 = arith.muli %200, %201 : i32
+      //   affine.store %202, %45[%arg0] : memref<64xi32, 2>
+      // }
       aie.use_lock(%44, Release, 1)
       aie.use_lock(%46, Release, 0)
       aie.use_lock(%48, Release, 0)
@@ -2540,21 +2413,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%60, Acquire, 0)
-      aie.dma_bd(%61 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%61 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%60, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%58, Acquire, 0)
-      aie.dma_bd(%59 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%59 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%58, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%56, Acquire, 1)
-      aie.dma_bd(%57 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%57 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%56, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -2568,12 +2441,12 @@ module @vecmul_4x4  {
       aie.use_lock(%60, Acquire, 1)
       aie.use_lock(%58, Acquire, 1)
       aie.use_lock(%56, Acquire, 0)
-      affine.for %arg0 = 0 to 64 {
-        %200 = affine.load %61[%arg0] : memref<64xi32, 2>
-        %201 = affine.load %59[%arg0] : memref<64xi32, 2>
-        %202 = arith.muli %200, %201 : i32
-        affine.store %202, %57[%arg0] : memref<64xi32, 2>
-      }
+      // affine.for %arg0 = 0 to 64 {
+      //   %200 = affine.load %61[%arg0] : memref<64xi32, 2>
+      //   %201 = affine.load %59[%arg0] : memref<64xi32, 2>
+      //   %202 = arith.muli %200, %201 : i32
+      //   affine.store %202, %57[%arg0] : memref<64xi32, 2>
+      // }
       aie.use_lock(%56, Release, 1)
       aie.use_lock(%58, Release, 0)
       aie.use_lock(%60, Release, 0)
@@ -2593,21 +2466,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%72, Acquire, 0)
-      aie.dma_bd(%73 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%73 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%72, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%70, Acquire, 0)
-      aie.dma_bd(%71 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%71 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%70, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%68, Acquire, 1)
-      aie.dma_bd(%69 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%69 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%68, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -2621,12 +2494,6 @@ module @vecmul_4x4  {
       aie.use_lock(%72, Acquire, 1)
       aie.use_lock(%70, Acquire, 1)
       aie.use_lock(%68, Acquire, 0)
-      affine.for %arg0 = 0 to 64 {
-        %200 = affine.load %73[%arg0] : memref<64xi32, 2>
-        %201 = affine.load %71[%arg0] : memref<64xi32, 2>
-        %202 = arith.muli %200, %201 : i32
-        affine.store %202, %69[%arg0] : memref<64xi32, 2>
-      }
       aie.use_lock(%68, Release, 1)
       aie.use_lock(%70, Release, 0)
       aie.use_lock(%72, Release, 0)
@@ -2647,21 +2514,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%85, Acquire, 0)
-      aie.dma_bd(%86 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%86 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%85, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%83, Acquire, 0)
-      aie.dma_bd(%84 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%84 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%83, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%81, Acquire, 1)
-      aie.dma_bd(%82 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%82 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%81, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -2675,12 +2542,12 @@ module @vecmul_4x4  {
       aie.use_lock(%85, Acquire, 1)
       aie.use_lock(%83, Acquire, 1)
       aie.use_lock(%81, Acquire, 0)
-      affine.for %arg0 = 0 to 64 {
-        %200 = affine.load %86[%arg0] : memref<64xi32, 2>
-        %201 = affine.load %84[%arg0] : memref<64xi32, 2>
-        %202 = arith.muli %200, %201 : i32
-        affine.store %202, %82[%arg0] : memref<64xi32, 2>
-      }
+      // affine.for %arg0 = 0 to 64 {
+      //   %200 = affine.load %86[%arg0] : memref<64xi32, 2>
+      //   %201 = affine.load %84[%arg0] : memref<64xi32, 2>
+      //   %202 = arith.muli %200, %201 : i32
+      //   affine.store %202, %82[%arg0] : memref<64xi32, 2>
+      // }
       aie.use_lock(%81, Release, 1)
       aie.use_lock(%83, Release, 0)
       aie.use_lock(%85, Release, 0)
@@ -2701,21 +2568,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%98, Acquire, 0)
-      aie.dma_bd(%99 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%99 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%98, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%96, Acquire, 0)
-      aie.dma_bd(%97 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%97 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%96, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%94, Acquire, 1)
-      aie.dma_bd(%95 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%95 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%94, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -2729,12 +2596,12 @@ module @vecmul_4x4  {
       aie.use_lock(%98, Acquire, 1)
       aie.use_lock(%96, Acquire, 1)
       aie.use_lock(%94, Acquire, 0)
-      affine.for %arg0 = 0 to 64 {
-        %200 = affine.load %99[%arg0] : memref<64xi32, 2>
-        %201 = affine.load %97[%arg0] : memref<64xi32, 2>
-        %202 = arith.muli %200, %201 : i32
-        affine.store %202, %95[%arg0] : memref<64xi32, 2>
-      }
+      // affine.for %arg0 = 0 to 64 {
+      //   %200 = affine.load %99[%arg0] : memref<64xi32, 2>
+      //   %201 = affine.load %97[%arg0] : memref<64xi32, 2>
+      //   %202 = arith.muli %200, %201 : i32
+      //   affine.store %202, %95[%arg0] : memref<64xi32, 2>
+      // }
       aie.use_lock(%94, Release, 1)
       aie.use_lock(%96, Release, 0)
       aie.use_lock(%98, Release, 0)
@@ -2754,21 +2621,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%110, Acquire, 0)
-      aie.dma_bd(%111 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%111 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%110, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%108, Acquire, 0)
-      aie.dma_bd(%109 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%109 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%108, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%106, Acquire, 1)
-      aie.dma_bd(%107 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%107 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%106, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -2782,12 +2649,6 @@ module @vecmul_4x4  {
       aie.use_lock(%110, Acquire, 1)
       aie.use_lock(%108, Acquire, 1)
       aie.use_lock(%106, Acquire, 0)
-      affine.for %arg0 = 0 to 64 {
-        %200 = affine.load %111[%arg0] : memref<64xi32, 2>
-        %201 = affine.load %109[%arg0] : memref<64xi32, 2>
-        %202 = arith.muli %200, %201 : i32
-        affine.store %202, %107[%arg0] : memref<64xi32, 2>
-      }
       aie.use_lock(%106, Release, 1)
       aie.use_lock(%108, Release, 0)
       aie.use_lock(%110, Release, 0)
@@ -2807,21 +2668,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%122, Acquire, 0)
-      aie.dma_bd(%123 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%123 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%122, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%120, Acquire, 0)
-      aie.dma_bd(%121 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%121 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%120, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%118, Acquire, 1)
-      aie.dma_bd(%119 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%119 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%118, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -2835,12 +2696,6 @@ module @vecmul_4x4  {
       aie.use_lock(%122, Acquire, 1)
       aie.use_lock(%120, Acquire, 1)
       aie.use_lock(%118, Acquire, 0)
-      affine.for %arg0 = 0 to 64 {
-        %200 = affine.load %123[%arg0] : memref<64xi32, 2>
-        %201 = affine.load %121[%arg0] : memref<64xi32, 2>
-        %202 = arith.muli %200, %201 : i32
-        affine.store %202, %119[%arg0] : memref<64xi32, 2>
-      }
       aie.use_lock(%118, Release, 1)
       aie.use_lock(%120, Release, 0)
       aie.use_lock(%122, Release, 0)
@@ -2861,21 +2716,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%135, Acquire, 0)
-      aie.dma_bd(%136 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%136 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%135, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%133, Acquire, 0)
-      aie.dma_bd(%134 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%134 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%133, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%131, Acquire, 1)
-      aie.dma_bd(%132 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%132 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%131, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -2889,12 +2744,6 @@ module @vecmul_4x4  {
       aie.use_lock(%135, Acquire, 1)
       aie.use_lock(%133, Acquire, 1)
       aie.use_lock(%131, Acquire, 0)
-      affine.for %arg0 = 0 to 64 {
-        %200 = affine.load %136[%arg0] : memref<64xi32, 2>
-        %201 = affine.load %134[%arg0] : memref<64xi32, 2>
-        %202 = arith.muli %200, %201 : i32
-        affine.store %202, %132[%arg0] : memref<64xi32, 2>
-      }
       aie.use_lock(%131, Release, 1)
       aie.use_lock(%133, Release, 0)
       aie.use_lock(%135, Release, 0)
@@ -2914,21 +2763,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%147, Acquire, 0)
-      aie.dma_bd(%148 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%148 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%147, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%145, Acquire, 0)
-      aie.dma_bd(%146 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%146 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%145, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%143, Acquire, 1)
-      aie.dma_bd(%144 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%144 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%143, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -2942,12 +2791,12 @@ module @vecmul_4x4  {
       aie.use_lock(%147, Acquire, 1)
       aie.use_lock(%145, Acquire, 1)
       aie.use_lock(%143, Acquire, 0)
-      affine.for %arg0 = 0 to 64 {
-        %200 = affine.load %148[%arg0] : memref<64xi32, 2>
-        %201 = affine.load %146[%arg0] : memref<64xi32, 2>
-        %202 = arith.muli %200, %201 : i32
-        affine.store %202, %144[%arg0] : memref<64xi32, 2>
-      }
+      // affine.for %arg0 = 0 to 64 {
+      //   %200 = affine.load %148[%arg0] : memref<64xi32, 2>
+      //   %201 = affine.load %146[%arg0] : memref<64xi32, 2>
+      //   %202 = arith.muli %200, %201 : i32
+      //   affine.store %202, %144[%arg0] : memref<64xi32, 2>
+      // }
       aie.use_lock(%143, Release, 1)
       aie.use_lock(%145, Release, 0)
       aie.use_lock(%147, Release, 0)
@@ -2966,21 +2815,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%158, Acquire, 0)
-      aie.dma_bd(%159 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%159 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%158, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%156, Acquire, 0)
-      aie.dma_bd(%157 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%157 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%156, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%154, Acquire, 1)
-      aie.dma_bd(%155 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%155 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%154, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -2994,12 +2843,6 @@ module @vecmul_4x4  {
       aie.use_lock(%158, Acquire, 1)
       aie.use_lock(%156, Acquire, 1)
       aie.use_lock(%154, Acquire, 0)
-      affine.for %arg0 = 0 to 64 {
-        %200 = affine.load %159[%arg0] : memref<64xi32, 2>
-        %201 = affine.load %157[%arg0] : memref<64xi32, 2>
-        %202 = arith.muli %200, %201 : i32
-        affine.store %202, %155[%arg0] : memref<64xi32, 2>
-      }
       aie.use_lock(%154, Release, 1)
       aie.use_lock(%156, Release, 0)
       aie.use_lock(%158, Release, 0)
@@ -3019,21 +2862,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%170, Acquire, 0)
-      aie.dma_bd(%171 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%171 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%170, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%168, Acquire, 0)
-      aie.dma_bd(%169 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%169 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%168, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%166, Acquire, 1)
-      aie.dma_bd(%167 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%167 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%166, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3047,12 +2890,12 @@ module @vecmul_4x4  {
       aie.use_lock(%170, Acquire, 1)
       aie.use_lock(%168, Acquire, 1)
       aie.use_lock(%166, Acquire, 0)
-      affine.for %arg0 = 0 to 64 {
-        %200 = affine.load %171[%arg0] : memref<64xi32, 2>
-        %201 = affine.load %169[%arg0] : memref<64xi32, 2>
-        %202 = arith.muli %200, %201 : i32
-        affine.store %202, %167[%arg0] : memref<64xi32, 2>
-      }
+      // affine.for %arg0 = 0 to 64 {
+      //   %200 = affine.load %171[%arg0] : memref<64xi32, 2>
+      //   %201 = affine.load %169[%arg0] : memref<64xi32, 2>
+      //   %202 = arith.muli %200, %201 : i32
+      //   affine.store %202, %167[%arg0] : memref<64xi32, 2>
+      // }
       aie.use_lock(%166, Release, 1)
       aie.use_lock(%168, Release, 0)
       aie.use_lock(%170, Release, 0)
@@ -3073,21 +2916,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%183, Acquire, 0)
-      aie.dma_bd(%184 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%184 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%183, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%181, Acquire, 0)
-      aie.dma_bd(%182 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%182 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%181, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%179, Acquire, 1)
-      aie.dma_bd(%180 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%180 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%179, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3101,12 +2944,12 @@ module @vecmul_4x4  {
       aie.use_lock(%183, Acquire, 1)
       aie.use_lock(%181, Acquire, 1)
       aie.use_lock(%179, Acquire, 0)
-      affine.for %arg0 = 0 to 64 {
-        %200 = affine.load %184[%arg0] : memref<64xi32, 2>
-        %201 = affine.load %182[%arg0] : memref<64xi32, 2>
-        %202 = arith.muli %200, %201 : i32
-        affine.store %202, %180[%arg0] : memref<64xi32, 2>
-      }
+      // affine.for %arg0 = 0 to 64 {
+      //   %200 = affine.load %184[%arg0] : memref<64xi32, 2>
+      //   %201 = affine.load %182[%arg0] : memref<64xi32, 2>
+      //   %202 = arith.muli %200, %201 : i32
+      //   affine.store %202, %180[%arg0] : memref<64xi32, 2>
+      // }
       aie.use_lock(%179, Release, 1)
       aie.use_lock(%181, Release, 0)
       aie.use_lock(%183, Release, 0)
@@ -3127,21 +2970,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%196, Acquire, 0)
-      aie.dma_bd(%197 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%197 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%196, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%194, Acquire, 0)
-      aie.dma_bd(%195 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%195 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%194, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%192, Acquire, 1)
-      aie.dma_bd(%193 : memref<64xi32, 2>) {len = 64 : i32}
+      aie.dma_bd(%193 : memref<64xi32, 2>)  {len = 64 : i32}
       aie.use_lock(%192, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3155,12 +2998,6 @@ module @vecmul_4x4  {
       aie.use_lock(%196, Acquire, 1)
       aie.use_lock(%194, Acquire, 1)
       aie.use_lock(%192, Acquire, 0)
-      affine.for %arg0 = 0 to 64 {
-        %200 = affine.load %197[%arg0] : memref<64xi32, 2>
-        %201 = affine.load %195[%arg0] : memref<64xi32, 2>
-        %202 = arith.muli %200, %201 : i32
-        affine.store %202, %193[%arg0] : memref<64xi32, 2>
-      }
       aie.use_lock(%192, Release, 1)
       aie.use_lock(%194, Release, 0)
       aie.use_lock(%196, Release, 0)

--- a/runtime/src/iree-amd-aie/aie_runtime/iree_aie_configure.cc
+++ b/runtime/src/iree-amd-aie/aie_runtime/iree_aie_configure.cc
@@ -240,7 +240,7 @@ LogicalResult initializeLock(const AMDAIEDeviceModel &deviceModel,
 }
 
 LogicalResult configureStreamSwitch(const AMDAIEDeviceModel &deviceModel,
-                                    const SwitchBox &tileLoc,
+                                    const TileLoc &tileLoc,
                                     const std::vector<Connect> &connects) {
   auto devInst = const_cast<XAie_DevInst *>(&deviceModel.devInst);
   // FIXME hack for TCT routing
@@ -280,7 +280,7 @@ LogicalResult configureStreamSwitch(const AMDAIEDeviceModel &deviceModel,
 }
 
 LogicalResult configureSwitchPacketMasters(const AMDAIEDeviceModel &deviceModel,
-                                           const SwitchBox &tileLoc,
+                                           const TileLoc &tileLoc,
                                            const StrmSwPortType &destBundle,
                                            uint8_t destChannel,
                                            const std::vector<AMSel> &amSels,
@@ -317,7 +317,7 @@ LogicalResult configureSwitchPacketMasters(const AMDAIEDeviceModel &deviceModel,
 }
 
 LogicalResult configureSwitchPacketSlaves(const AMDAIEDeviceModel &deviceModel,
-                                          const SwitchBox &tileLoc,
+                                          const TileLoc &tileLoc,
                                           const StrmSwPortType &srcBundle,
                                           uint8_t srcChannel,
                                           const AMSel &amsel, uint8_t packetId,

--- a/runtime/src/iree-amd-aie/aie_runtime/iree_aie_configure.h
+++ b/runtime/src/iree-amd-aie/aie_runtime/iree_aie_configure.h
@@ -172,12 +172,12 @@ LogicalResult pushToBdQueueAndEnable(const AMDAIEDeviceModel &deviceModel,
                                      uint8_t bdId, uint32_t repeatCount);
 
 LogicalResult configureStreamSwitch(const AMDAIEDeviceModel &deviceModel,
-                                    const SwitchBox &tileLoc,
+                                    const TileLoc &tileLoc,
                                     const std::vector<Connect> &connects);
 
 /// Configure and enable master ports in switch in packet routing mode.
 LogicalResult configureSwitchPacketMasters(const AMDAIEDeviceModel &deviceModel,
-                                           const SwitchBox &tileLoc,
+                                           const TileLoc &tileLoc,
                                            const StrmSwPortType &destBundle,
                                            uint8_t destChannel,
                                            const std::vector<AMSel> &amSels,
@@ -185,7 +185,7 @@ LogicalResult configureSwitchPacketMasters(const AMDAIEDeviceModel &deviceModel,
 
 /// Configure and enable slave ports in switch in packet routing mode.
 LogicalResult configureSwitchPacketSlaves(const AMDAIEDeviceModel &deviceModel,
-                                          const SwitchBox &tileLoc,
+                                          const TileLoc &tileLoc,
                                           const StrmSwPortType &srcBundle,
                                           uint8_t srcChannel,
                                           const AMSel &amsel, uint8_t packetId,

--- a/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.h
+++ b/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.h
@@ -49,7 +49,7 @@ struct TileLoc {
 
   TileLoc(int col, int row) : col(col), row(row) {}
 
-  TileLoc() = delete;
+  TileLoc() = default;
   // for std::transform
   TileLoc &operator=(const TileLoc &t) = default;
 


### PR DESCRIPTION
Pulls in changes from: https://github.com/Xilinx/mlir-aie/pull/1643:

> Changes on router behaviours: Previously, the router used a two-step process: first finding paths with Dijkstra's algorithm and then allocating channel IDs based on heuristics. Now, channel ID allocation is integrated into Dijkstra's algorithm to consider demand and congestion on individual channels directly.

NOTE: I had to bump the `DEMAND_COEFF` from 1.1 to 1.5 to find a solution for the `unit_vecmul_4x4.mlir` testcase. Not sure whether this makes sense or there might be an underlying issue? cc @Yu-Zhewen