### PR TITLE
[Router] Add packet flow groups for channel sharing

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aie/test/test_congestion0.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/test_congestion0.mlir
@@ -8,18 +8,20 @@
 // CHECK:             %[[VAL_2:.*]] = aie.amsel<2> (0)
 // CHECK:             %[[VAL_3:.*]] = aie.amsel<3> (0)
 // CHECK:             %[[VAL_4:.*]] = aie.masterset(DMA : 0, %[[VAL_0]])
-// CHECK:             %[[VAL_5:.*]] = aie.masterset(DMA : 1, %[[VAL_2]])
-// CHECK:             %[[VAL_6:.*]] = aie.masterset(DMA : 2, %[[VAL_3]])
-// CHECK:             %[[VAL_7:.*]] = aie.masterset(DMA : 3, %[[VAL_1]])
+// CHECK:             %[[VAL_5:.*]] = aie.masterset(DMA : 1, %[[VAL_3]])
+// CHECK:             %[[VAL_6:.*]] = aie.masterset(DMA : 2, %[[VAL_1]])
+// CHECK:             %[[VAL_7:.*]] = aie.masterset(DMA : 3, %[[VAL_2]])
 // CHECK:             aie.packet_rules(NORTH : 0) {
 // CHECK:               aie.rule(31, 0, %[[VAL_0]])
 // CHECK:             }
+// CHECK:             aie.packet_rules(NORTH : 1) {
+// CHECK:               aie.rule(31, 2, %[[VAL_1]])
+// CHECK:             }
 // CHECK:             aie.packet_rules(NORTH : 2) {
-// CHECK:               aie.rule(31, 3, %[[VAL_1]])
+// CHECK:               aie.rule(31, 3, %[[VAL_2]])
 // CHECK:             }
 // CHECK:             aie.packet_rules(NORTH : 3) {
-// CHECK:               aie.rule(31, 1, %[[VAL_2]])
-// CHECK:               aie.rule(31, 2, %[[VAL_3]])
+// CHECK:               aie.rule(31, 1, %[[VAL_3]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_0_2:.*]] = aie.tile(0, 2)
@@ -27,9 +29,11 @@
 // CHECK:             %[[VAL_8:.*]] = aie.amsel<0> (0)
 // CHECK:             %[[VAL_9:.*]] = aie.amsel<1> (0)
 // CHECK:             %[[VAL_10:.*]] = aie.amsel<2> (0)
-// CHECK:             %[[VAL_11:.*]] = aie.masterset(SOUTH : 0, %[[VAL_8]])
-// CHECK:             %[[VAL_12:.*]] = aie.masterset(SOUTH : 2, %[[VAL_10]])
-// CHECK:             %[[VAL_13:.*]] = aie.masterset(SOUTH : 3, %[[VAL_9]])
+// CHECK:             %[[VAL_11:.*]] = aie.amsel<3> (0)
+// CHECK:             %[[VAL_12:.*]] = aie.masterset(SOUTH : 0, %[[VAL_8]])
+// CHECK:             %[[VAL_13:.*]] = aie.masterset(SOUTH : 1, %[[VAL_10]])
+// CHECK:             %[[VAL_14:.*]] = aie.masterset(SOUTH : 2, %[[VAL_11]])
+// CHECK:             %[[VAL_15:.*]] = aie.masterset(SOUTH : 3, %[[VAL_9]])
 // CHECK:             aie.packet_rules(DMA : 0) {
 // CHECK:               aie.rule(31, 0, %[[VAL_8]])
 // CHECK:             }
@@ -37,40 +41,49 @@
 // CHECK:               aie.rule(31, 1, %[[VAL_9]])
 // CHECK:             }
 // CHECK:             aie.packet_rules(NORTH : 2) {
-// CHECK:               aie.rule(31, 2, %[[VAL_9]])
-// CHECK:               aie.rule(31, 3, %[[VAL_10]])
+// CHECK:               aie.rule(31, 2, %[[VAL_10]])
+// CHECK:             }
+// CHECK:             aie.packet_rules(NORTH : 3) {
+// CHECK:               aie.rule(31, 3, %[[VAL_11]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_0_3:.*]] = aie.tile(0, 3)
 // CHECK:           %[[SWITCHBOX_0_3:.*]] = aie.switchbox(%[[TILE_0_3]]) {
-// CHECK:             %[[VAL_14:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_15:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_16:.*]] = aie.masterset(SOUTH : 0, %[[VAL_14]])
-// CHECK:             %[[VAL_17:.*]] = aie.masterset(SOUTH : 2, %[[VAL_15]])
+// CHECK:             %[[VAL_16:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_17:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_18:.*]] = aie.amsel<2> (0)
+// CHECK:             %[[VAL_19:.*]] = aie.masterset(SOUTH : 0, %[[VAL_16]])
+// CHECK:             %[[VAL_20:.*]] = aie.masterset(SOUTH : 2, %[[VAL_17]])
+// CHECK:             %[[VAL_21:.*]] = aie.masterset(SOUTH : 3, %[[VAL_18]])
 // CHECK:             aie.packet_rules(DMA : 0) {
-// CHECK:               aie.rule(31, 1, %[[VAL_14]])
+// CHECK:               aie.rule(31, 1, %[[VAL_16]])
 // CHECK:             }
 // CHECK:             aie.packet_rules(NORTH : 0) {
-// CHECK:               aie.rule(30, 2, %[[VAL_15]])
+// CHECK:               aie.rule(31, 2, %[[VAL_17]])
+// CHECK:             }
+// CHECK:             aie.packet_rules(NORTH : 1) {
+// CHECK:               aie.rule(31, 3, %[[VAL_18]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_0_4:.*]] = aie.tile(0, 4)
 // CHECK:           %[[SWITCHBOX_0_4:.*]] = aie.switchbox(%[[TILE_0_4]]) {
-// CHECK:             %[[VAL_18:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_19:.*]] = aie.masterset(SOUTH : 0, %[[VAL_18]])
+// CHECK:             %[[VAL_22:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_23:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_24:.*]] = aie.masterset(SOUTH : 0, %[[VAL_22]])
+// CHECK:             %[[VAL_25:.*]] = aie.masterset(SOUTH : 1, %[[VAL_23]])
 // CHECK:             aie.packet_rules(DMA : 0) {
-// CHECK:               aie.rule(31, 2, %[[VAL_18]])
+// CHECK:               aie.rule(31, 2, %[[VAL_22]])
 // CHECK:             }
 // CHECK:             aie.packet_rules(NORTH : 0) {
-// CHECK:               aie.rule(31, 3, %[[VAL_18]])
+// CHECK:               aie.rule(31, 3, %[[VAL_23]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_0_5:.*]] = aie.tile(0, 5)
 // CHECK:           %[[SWITCHBOX_0_5:.*]] = aie.switchbox(%[[TILE_0_5]]) {
-// CHECK:             %[[VAL_20:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_21:.*]] = aie.masterset(SOUTH : 0, %[[VAL_20]])
+// CHECK:             %[[VAL_26:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_27:.*]] = aie.masterset(SOUTH : 0, %[[VAL_26]])
 // CHECK:             aie.packet_rules(DMA : 0) {
-// CHECK:               aie.rule(31, 3, %[[VAL_20]])
+// CHECK:               aie.rule(31, 3, %[[VAL_26]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           aie.packet_flow(0) {

--- a/compiler/plugins/target/AMD-AIE/aie/test/test_congestion1.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/test_congestion1.mlir
@@ -18,10 +18,10 @@
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_1:.*]] = aie.switchbox(%[[TILE_0_1]]) {
-// CHECK:             aie.connect<NORTH : 0, DMA : 0>
+// CHECK:             aie.connect<NORTH : 1, DMA : 0>
 // CHECK:             aie.connect<NORTH : 2, DMA : 1>
-// CHECK:             aie.connect<NORTH : 1, DMA : 2>
-// CHECK:             aie.connect<NORTH : 3, DMA : 3>
+// CHECK:             aie.connect<NORTH : 3, DMA : 2>
+// CHECK:             aie.connect<NORTH : 0, DMA : 3>
 // CHECK:             aie.connect<DMA : 0, SOUTH : 1>
 // CHECK:             %[[VAL_2:.*]] = aie.amsel<0> (0)
 // CHECK:             %[[VAL_3:.*]] = aie.masterset(DMA : 4, %[[VAL_2]])
@@ -30,19 +30,19 @@
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_2:.*]] = aie.switchbox(%[[TILE_0_2]]) {
-// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
-// CHECK:             aie.connect<NORTH : 1, SOUTH : 2>
-// CHECK:             aie.connect<NORTH : 0, SOUTH : 1>
-// CHECK:             aie.connect<NORTH : 3, SOUTH : 3>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 0, SOUTH : 2>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 0>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_3:.*]] = aie.switchbox(%[[TILE_0_3]]) {
-// CHECK:             aie.connect<DMA : 0, SOUTH : 1>
-// CHECK:             aie.connect<NORTH : 0, SOUTH : 0>
-// CHECK:             aie.connect<NORTH : 1, SOUTH : 3>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
+// CHECK:             aie.connect<NORTH : 3, SOUTH : 1>
+// CHECK:             aie.connect<NORTH : 2, SOUTH : 3>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_4:.*]] = aie.switchbox(%[[TILE_0_4]]) {
-// CHECK:             aie.connect<DMA : 0, SOUTH : 0>
-// CHECK:             aie.connect<NORTH : 1, SOUTH : 1>
+// CHECK:             aie.connect<DMA : 0, SOUTH : 3>
+// CHECK:             aie.connect<NORTH : 1, SOUTH : 2>
 // CHECK:           }
 // CHECK:           %[[SWITCHBOX_0_5:.*]] = aie.switchbox(%[[TILE_0_5]]) {
 // CHECK:             aie.connect<DMA : 0, SOUTH : 1>

--- a/compiler/plugins/target/AMD-AIE/aie/test/test_pktflow_weight_pusher.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/test_pktflow_weight_pusher.mlir
@@ -26,7 +26,7 @@
 // CHECK:             %[[VAL_7:.*]] = aie.amsel<1> (0)
 // CHECK:             %[[VAL_8:.*]] = aie.masterset(DMA : 1, %[[VAL_6]])
 // CHECK:             %[[VAL_9:.*]] = aie.masterset(WEST : 2, %[[VAL_7]])
-// CHECK:             aie.packet_rules(NORTH : 1) {
+// CHECK:             aie.packet_rules(EAST : 0) {
 // CHECK:               aie.rule(31, 8, %[[VAL_6]])
 // CHECK:             }
 // CHECK:             aie.packet_rules(EAST : 3) {
@@ -37,185 +37,189 @@
 // CHECK:           %[[SWITCHBOX_5_2:.*]] = aie.switchbox(%[[TILE_5_2]]) {
 // CHECK:             %[[VAL_10:.*]] = aie.amsel<0> (0)
 // CHECK:             %[[VAL_11:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_12:.*]] = aie.masterset(DMA : 1, %[[VAL_10]])
-// CHECK:             %[[VAL_13:.*]] = aie.masterset(WEST : 3, %[[VAL_11]])
-// CHECK:             aie.packet_rules(EAST : 1) {
-// CHECK:               aie.rule(31, 12, %[[VAL_10]])
+// CHECK:             %[[VAL_12:.*]] = aie.amsel<2> (0)
+// CHECK:             %[[VAL_13:.*]] = aie.masterset(DMA : 1, %[[VAL_11]])
+// CHECK:             %[[VAL_14:.*]] = aie.masterset(WEST : 0, %[[VAL_10]])
+// CHECK:             %[[VAL_15:.*]] = aie.masterset(WEST : 3, %[[VAL_12]])
+// CHECK:             aie.packet_rules(NORTH : 1) {
+// CHECK:               aie.rule(31, 8, %[[VAL_10]])
+// CHECK:               aie.rule(31, 12, %[[VAL_11]])
 // CHECK:             }
 // CHECK:             aie.packet_rules(EAST : 3) {
-// CHECK:               aie.rule(27, 0, %[[VAL_11]])
+// CHECK:               aie.rule(27, 0, %[[VAL_12]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_2_3:.*]] = aie.tile(2, 3)
 // CHECK:           %[[SWITCHBOX_2_3:.*]] = aie.switchbox(%[[TILE_2_3]]) {
-// CHECK:             %[[VAL_14:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_15:.*]] = aie.masterset(DMA : 1, %[[VAL_14]])
+// CHECK:             %[[VAL_16:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_17:.*]] = aie.masterset(DMA : 1, %[[VAL_16]])
 // CHECK:             aie.packet_rules(NORTH : 2) {
-// CHECK:               aie.rule(31, 1, %[[VAL_14]])
+// CHECK:               aie.rule(31, 1, %[[VAL_16]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_3_3:.*]] = aie.tile(3, 3)
 // CHECK:           %[[SWITCHBOX_3_3:.*]] = aie.switchbox(%[[TILE_3_3]]) {
-// CHECK:             %[[VAL_16:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_17:.*]] = aie.masterset(DMA : 1, %[[VAL_16]])
+// CHECK:             %[[VAL_18:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_19:.*]] = aie.masterset(DMA : 1, %[[VAL_18]])
 // CHECK:             aie.packet_rules(EAST : 2) {
-// CHECK:               aie.rule(31, 5, %[[VAL_16]])
+// CHECK:               aie.rule(31, 5, %[[VAL_18]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_4_3:.*]] = aie.tile(4, 3)
 // CHECK:           %[[SWITCHBOX_4_3:.*]] = aie.switchbox(%[[TILE_4_3]]) {
-// CHECK:             %[[VAL_18:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_19:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_20:.*]] = aie.amsel<2> (0)
-// CHECK:             %[[VAL_21:.*]] = aie.masterset(DMA : 1, %[[VAL_20]])
-// CHECK:             %[[VAL_22:.*]] = aie.masterset(SOUTH : 1, %[[VAL_19]])
-// CHECK:             %[[VAL_23:.*]] = aie.masterset(WEST : 2, %[[VAL_18]])
-// CHECK:             aie.packet_rules(NORTH : 1) {
-// CHECK:               aie.rule(31, 5, %[[VAL_18]])
-// CHECK:             }
-// CHECK:             aie.packet_rules(NORTH : 3) {
-// CHECK:               aie.rule(31, 8, %[[VAL_19]])
+// CHECK:             %[[VAL_20:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_21:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_22:.*]] = aie.masterset(DMA : 1, %[[VAL_20]])
+// CHECK:             %[[VAL_23:.*]] = aie.masterset(WEST : 2, %[[VAL_21]])
+// CHECK:             aie.packet_rules(NORTH : 0) {
 // CHECK:               aie.rule(31, 9, %[[VAL_20]])
+// CHECK:             }
+// CHECK:             aie.packet_rules(NORTH : 1) {
+// CHECK:               aie.rule(31, 5, %[[VAL_21]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_5_3:.*]] = aie.tile(5, 3)
 // CHECK:           %[[SWITCHBOX_5_3:.*]] = aie.switchbox(%[[TILE_5_3]]) {
 // CHECK:             %[[VAL_24:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_25:.*]] = aie.masterset(DMA : 1, %[[VAL_24]])
-// CHECK:             aie.packet_rules(NORTH : 1) {
-// CHECK:               aie.rule(31, 13, %[[VAL_24]])
+// CHECK:             %[[VAL_25:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_26:.*]] = aie.masterset(DMA : 1, %[[VAL_25]])
+// CHECK:             %[[VAL_27:.*]] = aie.masterset(SOUTH : 1, %[[VAL_24]])
+// CHECK:             aie.packet_rules(NORTH : 2) {
+// CHECK:               aie.rule(27, 8, %[[VAL_24]])
+// CHECK:               aie.rule(31, 13, %[[VAL_25]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_2_4:.*]] = aie.tile(2, 4)
 // CHECK:           %[[SWITCHBOX_2_4:.*]] = aie.switchbox(%[[TILE_2_4]]) {
-// CHECK:             %[[VAL_26:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_27:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_28:.*]] = aie.masterset(DMA : 1, %[[VAL_27]])
-// CHECK:             %[[VAL_29:.*]] = aie.masterset(SOUTH : 2, %[[VAL_26]])
+// CHECK:             %[[VAL_28:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_29:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_30:.*]] = aie.masterset(DMA : 1, %[[VAL_29]])
+// CHECK:             %[[VAL_31:.*]] = aie.masterset(SOUTH : 2, %[[VAL_28]])
 // CHECK:             aie.packet_rules(EAST : 1) {
-// CHECK:               aie.rule(31, 1, %[[VAL_26]])
-// CHECK:               aie.rule(31, 2, %[[VAL_27]])
+// CHECK:               aie.rule(31, 1, %[[VAL_28]])
+// CHECK:               aie.rule(31, 2, %[[VAL_29]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_3_4:.*]] = aie.tile(3, 4)
 // CHECK:           %[[SWITCHBOX_3_4:.*]] = aie.switchbox(%[[TILE_3_4]]) {
-// CHECK:             %[[VAL_30:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_31:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_32:.*]] = aie.masterset(DMA : 1, %[[VAL_31]])
-// CHECK:             %[[VAL_33:.*]] = aie.masterset(WEST : 1, %[[VAL_30]])
+// CHECK:             %[[VAL_32:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_33:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_34:.*]] = aie.masterset(DMA : 1, %[[VAL_33]])
+// CHECK:             %[[VAL_35:.*]] = aie.masterset(WEST : 1, %[[VAL_32]])
 // CHECK:             aie.packet_rules(NORTH : 1) {
-// CHECK:               aie.rule(28, 0, %[[VAL_30]])
-// CHECK:               aie.rule(31, 6, %[[VAL_31]])
+// CHECK:               aie.rule(28, 0, %[[VAL_32]])
+// CHECK:               aie.rule(31, 6, %[[VAL_33]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_4_4:.*]] = aie.tile(4, 4)
 // CHECK:           %[[SWITCHBOX_4_4:.*]] = aie.switchbox(%[[TILE_4_4]]) {
-// CHECK:             %[[VAL_34:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_35:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_36:.*]] = aie.amsel<2> (0)
-// CHECK:             %[[VAL_37:.*]] = aie.masterset(DMA : 1, %[[VAL_36]])
-// CHECK:             %[[VAL_38:.*]] = aie.masterset(SOUTH : 1, %[[VAL_34]])
-// CHECK:             %[[VAL_39:.*]] = aie.masterset(SOUTH : 3, %[[VAL_35]])
+// CHECK:             %[[VAL_36:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_37:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_38:.*]] = aie.amsel<2> (0)
+// CHECK:             %[[VAL_39:.*]] = aie.masterset(DMA : 1, %[[VAL_37]])
+// CHECK:             %[[VAL_40:.*]] = aie.masterset(SOUTH : 0, %[[VAL_36]])
+// CHECK:             %[[VAL_41:.*]] = aie.masterset(SOUTH : 1, %[[VAL_38]])
+// CHECK:             aie.packet_rules(NORTH : 0) {
+// CHECK:               aie.rule(31, 9, %[[VAL_36]])
+// CHECK:               aie.rule(31, 10, %[[VAL_37]])
+// CHECK:             }
 // CHECK:             aie.packet_rules(NORTH : 3) {
-// CHECK:               aie.rule(31, 5, %[[VAL_34]])
-// CHECK:               aie.rule(30, 8, %[[VAL_35]])
-// CHECK:               aie.rule(31, 10, %[[VAL_36]])
+// CHECK:               aie.rule(31, 5, %[[VAL_38]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_5_4:.*]] = aie.tile(5, 4)
 // CHECK:           %[[SWITCHBOX_5_4:.*]] = aie.switchbox(%[[TILE_5_4]]) {
-// CHECK:             %[[VAL_40:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_41:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_42:.*]] = aie.masterset(DMA : 1, %[[VAL_41]])
-// CHECK:             %[[VAL_43:.*]] = aie.masterset(SOUTH : 1, %[[VAL_40]])
-// CHECK:             aie.packet_rules(NORTH : 0) {
-// CHECK:               aie.rule(31, 13, %[[VAL_40]])
-// CHECK:               aie.rule(31, 14, %[[VAL_41]])
+// CHECK:             %[[VAL_42:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_43:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_44:.*]] = aie.masterset(DMA : 1, %[[VAL_43]])
+// CHECK:             %[[VAL_45:.*]] = aie.masterset(SOUTH : 2, %[[VAL_42]])
+// CHECK:             aie.packet_rules(EAST : 1) {
+// CHECK:               aie.rule(26, 8, %[[VAL_42]])
+// CHECK:               aie.rule(31, 14, %[[VAL_43]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_2_5:.*]] = aie.tile(2, 5)
 // CHECK:           %[[SWITCHBOX_2_5:.*]] = aie.switchbox(%[[TILE_2_5]]) {
-// CHECK:             %[[VAL_44:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_45:.*]] = aie.masterset(DMA : 1, %[[VAL_44]])
+// CHECK:             %[[VAL_46:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_47:.*]] = aie.masterset(DMA : 1, %[[VAL_46]])
 // CHECK:             aie.packet_rules(EAST : 1) {
-// CHECK:               aie.rule(31, 3, %[[VAL_44]])
+// CHECK:               aie.rule(31, 3, %[[VAL_46]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_3_5:.*]] = aie.tile(3, 5)
 // CHECK:           %[[SWITCHBOX_3_5:.*]] = aie.switchbox(%[[TILE_3_5]]) {
-// CHECK:             %[[VAL_46:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_47:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_48:.*]] = aie.amsel<2> (0)
-// CHECK:             %[[VAL_49:.*]] = aie.masterset(DMA : 1, %[[VAL_48]])
-// CHECK:             %[[VAL_50:.*]] = aie.masterset(SOUTH : 1, %[[VAL_46]])
-// CHECK:             %[[VAL_51:.*]] = aie.masterset(WEST : 1, %[[VAL_47]])
+// CHECK:             %[[VAL_48:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_49:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_50:.*]] = aie.amsel<2> (0)
+// CHECK:             %[[VAL_51:.*]] = aie.masterset(DMA : 1, %[[VAL_50]])
+// CHECK:             %[[VAL_52:.*]] = aie.masterset(SOUTH : 1, %[[VAL_48]])
+// CHECK:             %[[VAL_53:.*]] = aie.masterset(WEST : 1, %[[VAL_49]])
 // CHECK:             aie.packet_rules(EAST : 2) {
-// CHECK:               aie.rule(24, 0, %[[VAL_46]])
-// CHECK:               aie.rule(31, 3, %[[VAL_47]])
-// CHECK:               aie.rule(31, 7, %[[VAL_48]])
+// CHECK:               aie.rule(24, 0, %[[VAL_48]])
+// CHECK:               aie.rule(31, 3, %[[VAL_49]])
+// CHECK:               aie.rule(31, 7, %[[VAL_50]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_4_5:.*]] = aie.tile(4, 5)
 // CHECK:           %[[SWITCHBOX_4_5:.*]] = aie.switchbox(%[[TILE_4_5]]) {
-// CHECK:             %[[VAL_52:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_53:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_54:.*]] = aie.amsel<2> (0)
-// CHECK:             %[[VAL_55:.*]] = aie.masterset(DMA : 1, %[[VAL_54]])
-// CHECK:             %[[VAL_56:.*]] = aie.masterset(SOUTH : 3, %[[VAL_53]])
-// CHECK:             %[[VAL_57:.*]] = aie.masterset(WEST : 2, %[[VAL_52]])
+// CHECK:             %[[VAL_54:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_55:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_56:.*]] = aie.amsel<2> (0)
+// CHECK:             %[[VAL_57:.*]] = aie.amsel<3> (0)
+// CHECK:             %[[VAL_58:.*]] = aie.masterset(DMA : 1, %[[VAL_57]])
+// CHECK:             %[[VAL_59:.*]] = aie.masterset(SOUTH : 0, %[[VAL_56]])
+// CHECK:             %[[VAL_60:.*]] = aie.masterset(SOUTH : 3, %[[VAL_55]])
+// CHECK:             %[[VAL_61:.*]] = aie.masterset(WEST : 2, %[[VAL_54]])
 // CHECK:             aie.packet_rules(EAST : 2) {
-// CHECK:               aie.rule(24, 0, %[[VAL_52]])
-// CHECK:               aie.rule(31, 5, %[[VAL_53]])
+// CHECK:               aie.rule(24, 0, %[[VAL_54]])
+// CHECK:               aie.rule(31, 5, %[[VAL_55]])
 // CHECK:             }
 // CHECK:             aie.packet_rules(EAST : 3) {
-// CHECK:               aie.rule(28, 8, %[[VAL_53]])
-// CHECK:               aie.rule(31, 11, %[[VAL_54]])
+// CHECK:               aie.rule(28, 8, %[[VAL_56]])
+// CHECK:               aie.rule(31, 11, %[[VAL_57]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_5_5:.*]] = aie.tile(5, 5)
 // CHECK:           %[[SWITCHBOX_5_5:.*]] = aie.switchbox(%[[TILE_5_5]]) {
-// CHECK:             %[[VAL_58:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_59:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_60:.*]] = aie.amsel<2> (0)
-// CHECK:             %[[VAL_61:.*]] = aie.amsel<3> (0)
-// CHECK:             %[[VAL_62:.*]] = aie.masterset(DMA : 1, %[[VAL_61]])
-// CHECK:             %[[VAL_63:.*]] = aie.masterset(SOUTH : 0, %[[VAL_60]])
-// CHECK:             %[[VAL_64:.*]] = aie.masterset(WEST : 2, %[[VAL_58]])
-// CHECK:             %[[VAL_65:.*]] = aie.masterset(WEST : 3, %[[VAL_59]])
+// CHECK:             %[[VAL_62:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_63:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_64:.*]] = aie.amsel<2> (0)
+// CHECK:             %[[VAL_65:.*]] = aie.masterset(DMA : 1, %[[VAL_64]])
+// CHECK:             %[[VAL_66:.*]] = aie.masterset(WEST : 2, %[[VAL_62]])
+// CHECK:             %[[VAL_67:.*]] = aie.masterset(WEST : 3, %[[VAL_63]])
 // CHECK:             aie.packet_rules(EAST : 2) {
-// CHECK:               aie.rule(24, 0, %[[VAL_58]])
+// CHECK:               aie.rule(24, 0, %[[VAL_62]])
 // CHECK:             }
 // CHECK:             aie.packet_rules(EAST : 3) {
-// CHECK:               aie.rule(28, 8, %[[VAL_59]])
-// CHECK:               aie.rule(28, 12, %[[VAL_60]])
-// CHECK:               aie.rule(31, 15, %[[VAL_61]])
+// CHECK:               aie.rule(28, 8, %[[VAL_63]])
+// CHECK:               aie.rule(31, 15, %[[VAL_64]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_6_5:.*]] = aie.tile(6, 5)
 // CHECK:           %[[SWITCHBOX_6_5:.*]] = aie.switchbox(%[[TILE_6_5]]) {
-// CHECK:             %[[VAL_66:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_67:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_68:.*]] = aie.amsel<2> (0)
-// CHECK:             %[[VAL_69:.*]] = aie.masterset(SOUTH : 2, %[[VAL_66]])
-// CHECK:             %[[VAL_70:.*]] = aie.masterset(WEST : 2, %[[VAL_67]])
-// CHECK:             %[[VAL_71:.*]] = aie.masterset(WEST : 3, %[[VAL_68]])
+// CHECK:             %[[VAL_68:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_69:.*]] = aie.amsel<1> (0)
+// CHECK:             %[[VAL_70:.*]] = aie.amsel<2> (0)
+// CHECK:             %[[VAL_71:.*]] = aie.amsel<3> (0)
+// CHECK:             %[[VAL_72:.*]] = aie.masterset(SOUTH : 2, %[[VAL_68]])
+// CHECK:             %[[VAL_73:.*]] = aie.masterset(SOUTH : 3, %[[VAL_70]])
+// CHECK:             %[[VAL_74:.*]] = aie.masterset(WEST : 2, %[[VAL_69]])
+// CHECK:             %[[VAL_75:.*]] = aie.masterset(WEST : 3, %[[VAL_71]])
 // CHECK:             aie.packet_rules(DMA : 0) {
-// CHECK:               aie.rule(27, 0, %[[VAL_66]])
-// CHECK:               aie.rule(24, 0, %[[VAL_67]])
+// CHECK:               aie.rule(27, 0, %[[VAL_68]])
+// CHECK:               aie.rule(24, 0, %[[VAL_69]])
 // CHECK:             }
 // CHECK:             aie.packet_rules(EAST : 0) {
-// CHECK:               aie.rule(24, 8, %[[VAL_68]])
+// CHECK:               aie.rule(24, 8, %[[VAL_70]])
+// CHECK:               aie.rule(24, 8, %[[VAL_71]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           %[[TILE_7_5:.*]] = aie.tile(7, 5)
 // CHECK:           %[[SWITCHBOX_7_5:.*]] = aie.switchbox(%[[TILE_7_5]]) {
-// CHECK:             %[[VAL_72:.*]] = aie.amsel<0> (0)
-// CHECK:             %[[VAL_73:.*]] = aie.amsel<1> (0)
-// CHECK:             %[[VAL_74:.*]] = aie.masterset(SOUTH : 0, %[[VAL_73]])
-// CHECK:             %[[VAL_75:.*]] = aie.masterset(WEST : 0, %[[VAL_72]])
+// CHECK:             %[[VAL_76:.*]] = aie.amsel<0> (0)
+// CHECK:             %[[VAL_77:.*]] = aie.masterset(WEST : 0, %[[VAL_76]])
 // CHECK:             aie.packet_rules(DMA : 0) {
-// CHECK:               aie.rule(24, 8, %[[VAL_72]])
-// CHECK:               aie.rule(31, 12, %[[VAL_73]])
+// CHECK:               aie.rule(24, 8, %[[VAL_76]])
 // CHECK:             }
 // CHECK:           }
 // CHECK:           aie.packet_flow(0) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_connection_types.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_connection_types.mlir
@@ -19,7 +19,7 @@
 // PACKET:         %[[OBJ2:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG2]]
 // PACKET:         amdaie.connection(%[[OBJ1]], %[[OBJ0]], connection_type = Packet)
 // PACKET:         amdaie.connection(%[[OBJ0]], %[[OBJ1]], connection_type = Packet)
-// PACKET:         amdaie.connection(%[[OBJ2]], %[[OBJ1]], connection_type = Circuit)
+// PACKET:         amdaie.connection(%[[OBJ2]], %[[OBJ1]], connection_type = Packet)
 
 module {
   func.func @assign_connection_types(%arg0: memref<8x16xi32>, %arg1: memref<1x1x8x16xi32, 1>, %arg2: memref<1x1x8x16xi32, 2>) {


### PR DESCRIPTION
Pulls in changes from: https://github.com/Xilinx/mlir-aie/pull/1694

This fixes deadlock issues with larger matmuls when all connections are made packet connections and therefore enables optional packet routing on all connections.