### PR TITLE
[AIEVec] Allow unit extent dimensions in canonicalize-vector-for-aievec

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
+++ b/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
@@ -11,23 +11,28 @@
 // it compatible with the available vector instructions in AIE architectures
 //===----------------------------------------------------------------------===//
 
-#include <algorithm>
 #include <memory>
 
 #include "AIEVecUtils.h"
 #include "Passes.h"
+#include "llvm/ADT/STLExtras.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Dialect/Affine/Analysis/LoopAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
+#include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
+#include "mlir/Dialect/Vector/Utils/VectorUtils.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
 
 #define DEBUG_TYPE "aievec-canonicalization"
 
@@ -155,6 +160,35 @@ struct ConvertSplatTransferReadToBroadcastPattern
   }
 };
 
+/// Given:
+/// ```
+/// %1 = elTypeChanger %0
+/// %2 = shapeChanger %1
+/// ```
+///
+/// Where 'elTypeChanger' changes the element type, and 'shapeChanger' changes
+/// the shape, suppose we wanted to rewrite this as:
+/// ```
+/// %1 = shapeChanger %0
+/// %2 = elTypeChanger %1
+/// ```
+///
+/// What would the type of %1 be? That is what this function computes.
+VectorType getIntermediateType(Operation *elTypeChanger,
+                               Operation *shapeChanger) {
+  assert(elTypeChanger->getNumOperands() == 1 && "require single operand");
+  assert(shapeChanger->getNumResults() == 1 && "require single result");
+  Value inValue = elTypeChanger->getOperand(0);
+  Value outValue = shapeChanger->getResult(0);
+  auto inType = inValue.getType();
+  auto inShapedType = dyn_cast<ShapedType>(inType);
+  Type elType = inShapedType ? inShapedType.getElementType() : inType;
+  auto outType = dyn_cast<ShapedType>(outValue.getType());
+  assert(outType && "require ShapedTypes");
+  auto newType = VectorType::get(outType.getShape(), elType);
+  return newType;
+}
+
 // This pattern swaps a UnaryOpA followed by UnaryOpB. This pattern can be used
 // to improve pattern matching for mixed-type arithmetic ops, by getting sign
 // extension ops closer to the single-type arithmetic operations.
@@ -168,6 +202,13 @@ struct SwapUnaryOpsPattern : public OpRewritePattern<UnaryOpB> {
 
   SwapUnaryOpsPattern(MLIRContext *context, InferTypeB2AFnTy inferType)
       : OpRewritePattern<UnaryOpB>(context), inferTypeB2A(inferType) {}
+
+  /// Construct with the default InferTypeB2AFnTy function.
+  SwapUnaryOpsPattern(MLIRContext *context)
+      : OpRewritePattern<UnaryOpB>(context),
+        inferTypeB2A([](UnaryOpA aOp, UnaryOpB bOp) -> Type {
+          return getIntermediateType(aOp, bOp);
+        }) {}
 
   LogicalResult matchAndRewrite(UnaryOpB bOp,
                                 PatternRewriter &rewriter) const override {
@@ -196,153 +237,212 @@ struct SwapUnaryOpsPattern : public OpRewritePattern<UnaryOpB> {
   }
 };
 
-static SmallVector<Value> collapseInnerMostDimIndices(PatternRewriter &b,
-                                                      Location loc, int numDims,
-                                                      ValueRange indices,
-                                                      ArrayRef<int64_t> shape,
-                                                      AffineMap layout) {
-  // TODO: Don't assume trivial layout
-  assert(layout.isMinorIdentity() &&
-         "dimension collapse in non-identity layout is not implemented");
-  auto newIdxExpr = b.getAffineDimExpr(numDims - 1);
-  int64_t stride = 1;
-  for (int64_t dim = numDims - 2; dim >= 0; dim--) {
-    stride *= shape[shape.size() - (numDims - dim - 1)];
-    newIdxExpr = newIdxExpr + b.getAffineDimExpr(dim) * stride;
+/// AffineMaps which are 'generalized' minor identities, where the results just
+/// need to be in ascending order. Examples:
+///
+/// (d0, d1, d2) -> (d0, d2)    // return {0,2}
+/// (d0, d1) -> (d0, d1)        // return {0,1}
+/// (d0, d1) -> (d1)            // return {1}
+/// (d0, d1) -> (d0)            // return {0}
+/// (d0, d1) -> (d1, d0)        // failure
+/// (d0, d1) -> (d0 + d1)       // failure
+FailureOr<SmallVector<int64_t>> getDimsOfNonPermutingMap(AffineMap perm) {
+  ArrayRef<AffineExpr> results = perm.getResults();
+  uint64_t nResults = results.size();
+  SmallVector<int64_t> dims;
+  for (uint64_t i = 0; i < nResults; ++i) {
+    if (!isa<AffineDimExpr>(results[i])) return failure();
+    auto nxtDim = cast<AffineDimExpr>(results[i]).getPosition();
+    if (!dims.empty() && (nxtDim <= dims.back())) return failure();
+    dims.push_back(nxtDim);
   }
-  auto newIndexMap = AffineMap::get(numDims, 0, newIdxExpr);
-  Value newInnerMostIdxValue =
-      b.create<affine::AffineApplyOp>(loc, newIndexMap,
-                                      indices.take_back(numDims))
-          .getResult();
-  SmallVector<Value> newIdxRange;
-  for (auto idx : indices.drop_back(numDims)) newIdxRange.push_back(idx);
-  newIdxRange.push_back(newInnerMostIdxValue);
-  return newIdxRange;
+  return dims;
 }
 
-static Value collapseInnerMostShapeDims(PatternRewriter &b, Location loc,
-                                        int numDims, Value val) {
-  auto memRefTy = cast<MemRefType>(val.getType());
-  auto shape = memRefTy.getShape();
-  int64_t newInnerMostDim = std::accumulate(shape.end() - numDims, shape.end(),
-                                            1, std::multiplies<>());
-  SmallVector<int64_t, 4> newShape{shape.begin(), shape.end() - numDims + 1};
-  newShape[shape.size() - numDims] = newInnerMostDim;
-  auto newNumDims = newShape.size();
-  auto ctx = b.getContext();
-  auto newMemRefTy = MemRefType::get(
-      newShape, memRefTy.getElementType(),
-      AffineMap::getMinorIdentityMap(newNumDims, newNumDims, ctx),
-      memRefTy.getMemorySpace());
-  auto reassocIndices =
-      getReassociationIndicesForCollapse(shape, newShape).value();
-  return b
-      .create<memref::CollapseShapeOp>(loc, newMemRefTy, val, reassocIndices)
-      .getResult();
+template <typename TransferOp>
+std::tuple<SmallVector<int64_t>, SmallVector<bool>>
+getUnsqueezedShapeAndInBounds(uint64_t inputRank,
+                              SmallVector<int64_t> oldDimensions,
+                              PatternRewriter &rewriter, TransferOp op) {
+  uint64_t newRank = inputRank - oldDimensions[0];
+  SmallVector<int64_t> newShape(newRank, 1);
+  SmallVector<bool> newInBounds(newRank, true);
+  SmallVector<bool> oldInBounds = op.getInBoundsValues();
+  ArrayRef<int64_t> oldShape = op.getVectorType().getShape();
+  for (auto iter : enumerate(oldDimensions)) {
+    uint64_t oldIndex = iter.index();
+    uint64_t newIndex = iter.value() - oldDimensions[0];
+    assert(oldIndex <= newIndex);
+    newInBounds[newIndex] = oldInBounds[oldIndex];
+    newShape[newIndex] = oldShape[oldIndex];
+  }
+  return {newShape, newInBounds};
 }
 
-// This pattern flattens multidimensional `vector.transfer_read` operations
-// replacing them with a `memref.collapse_shape`, a 1D `vector.transfer_read`,
-// and a `vector.shape_cast`.
-struct FlattenMultDimTransferReadPattern
-    : public OpRewritePattern<vector::TransferReadOp> {
-  using OpRewritePattern<vector::TransferReadOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(vector::TransferReadOp readOp,
-                                PatternRewriter &rewriter) const override {
-    // We can only deal with unmasked transfer ops with an identity permutation
-    // map.
-    if (!readOp.getPermutationMap().isMinorIdentity() || readOp.getMask())
-      return failure();
-    VectorType vectorTy = readOp.getVector().getType();
-    if (vectorTy.getRank() < 2) return failure();
-    // Work only on bufferized reads
-    MemRefType memRefTy = dyn_cast<MemRefType>(readOp.getSource().getType());
-    if (!memRefTy) return failure();
-    auto memRefShape = memRefTy.getShape();
-    auto vecShape = vectorTy.getShape();
-
-    auto newVectorTy =
-        VectorType::get({std::accumulate(vecShape.begin(), vecShape.end(), 1,
-                                         std::multiplies<>())},
-                        vectorTy.getElementType());
-    AffineMap layout = memRefTy.getLayout().getAffineMap();
-    auto newIndices =
-        collapseInnerMostDimIndices(rewriter, readOp.getLoc(), vecShape.size(),
-                                    readOp.getIndices(), memRefShape, layout);
-    auto newSource = collapseInnerMostShapeDims(
-        rewriter, readOp.getLoc(), vecShape.size(), readOp.getSource());
-    auto newVector = rewriter.create<vector::TransferReadOp>(
-        readOp.getLoc(), newVectorTy, newSource, newIndices);
-
-    auto inBoundsArrayAttrOpt = readOp.getInBounds();
-    if (inBoundsArrayAttrOpt) {
-      SmallVector<bool> inBounds =
-          llvm::to_vector(inBoundsArrayAttrOpt.getAsValueRange<BoolAttr>());
-      SmallVector<bool> newInBounds({false});
-      newInBounds[0] = std::all_of(inBounds.begin(), inBounds.end(),
-                                   [](bool v) { return v; });
-      newVector.getProperties().setInBounds(
-          rewriter.getBoolArrayAttr(newInBounds));
-    }
-
-    rewriter.replaceOpWithNewOp<vector::ShapeCastOp>(readOp, vectorTy,
-                                                     newVector);
-
-    return success();
-  }
-};
-
-// This pattern flatten multidimensional `vector.transfer_write` operations
-// replacing them with a `memref.collapse_shape`, a `vector.shape_cast`, and a
-// 1D `vector.transfer_write`,
-struct FlattenMultDimTransferWritePattern
+/// This pattern rewrites a `vector.transfer_write` with a non minor identity
+/// permutation map, with a minor-identity permutation map, if possible. For
+/// example,
+///
+/// ```
+/// #map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+/// vector.transfer_write %v1, %alloc[%c0, %c0, %c0, %c0]
+///    {permutation_map = #map} : vector<4x8xi8>, memref<2x4x1x8xi8>
+/// ```
+///
+/// is rewritten as
+/// ```
+/// #map = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+/// vector.transfer_write %v2, %alloc[%c0, %c0, %c0, %c0]
+///    {permutation_map = #map} : vector<4x1x8xi8>, memref<2x4x1x8xi8>
+/// ```
+///
+/// with the new vector `v2` being a `vector.shape_cast` of `v1`.
+///
+/// This allows other upstream patterns to work on the transfer op, as they
+/// expect minor-identity permutation maps.
+struct ToMinorIdentityTransferWritePattern
     : public OpRewritePattern<vector::TransferWriteOp> {
   using OpRewritePattern<vector::TransferWriteOp>::OpRewritePattern;
 
   LogicalResult matchAndRewrite(vector::TransferWriteOp writeOp,
                                 PatternRewriter &rewriter) const override {
-    // We can only deal with unmasked transfer ops with an identity permutation
-    // map.
-    if (!writeOp.getPermutationMap().isMinorIdentity() || writeOp.getMask())
-      return failure();
-    VectorType vectorTy = cast<VectorType>(writeOp.getVector().getType());
-    if (vectorTy.getRank() < 2) return failure();
-    // Work only on bufferized reads
-    MemRefType memRefTy = dyn_cast<MemRefType>(writeOp.getSource().getType());
-    if (!memRefTy) return failure();
-    auto memRefShape = memRefTy.getShape();
-    auto vecShape = vectorTy.getShape();
+    AffineMap perm = writeOp.getPermutationMap();
 
-    auto newVectorTy =
-        VectorType::get({std::accumulate(vecShape.begin(), vecShape.end(), 1,
-                                         std::multiplies<>())},
-                        vectorTy.getElementType());
-    AffineMap layout = memRefTy.getLayout().getAffineMap();
-    auto newVector = rewriter
-                         .create<vector::ShapeCastOp>(
-                             writeOp.getLoc(), newVectorTy, writeOp.getVector())
-                         .getResult();
-    auto newIndices =
-        collapseInnerMostDimIndices(rewriter, writeOp.getLoc(), vecShape.size(),
-                                    writeOp.getIndices(), memRefShape, layout);
-    auto newSource = collapseInnerMostShapeDims(
-        rewriter, writeOp.getLoc(), vecShape.size(), writeOp.getSource());
+    // Already in target form:
+    if (perm.isMinorIdentity()) return failure();
 
-    auto newOp = rewriter.replaceOpWithNewOp<vector::TransferWriteOp>(
-        writeOp, newVector, newSource, newIndices);
-
-    auto inBoundsArrayAttrOpt = writeOp.getInBounds();
-    if (inBoundsArrayAttrOpt) {
-      SmallVector<bool> inBounds =
-          llvm::to_vector(inBoundsArrayAttrOpt.getAsValueRange<BoolAttr>());
-      SmallVector<bool> newInBounds({false});
-      newInBounds[0] = std::all_of(inBounds.begin(), inBounds.end(),
-                                   [](bool v) { return v; });
-      newOp.getProperties().setInBounds(rewriter.getBoolArrayAttr(newInBounds));
+    FailureOr<SmallVector<int64_t>> maybeDims = getDimsOfNonPermutingMap(perm);
+    if (failed(maybeDims)) {
+      return rewriter.notifyMatchFailure(
+          writeOp, "cannot be expressed with a minor-identity permutation map");
     }
 
+    TypedValue<ShapedType> source = writeOp.getSource();
+
+    auto [newShape, newInBounds] = getUnsqueezedShapeAndInBounds(
+        source.getType().getRank(), maybeDims.value(), rewriter, writeOp);
+
+    VectorType newVectorType =
+        VectorType::get(newShape, writeOp.getVectorType().getElementType());
+
+    Value newVector = rewriter.create<vector::ShapeCastOp>(
+        writeOp.getLoc(), newVectorType, writeOp.getVector());
+
+    MemRefType sourceType = cast<MemRefType>(writeOp.getSource().getType());
+
+    if (!mlir::vector::isContiguousSlice(sourceType, newVectorType))
+      return failure();
+
+    auto newWriteOp = rewriter.replaceOpWithNewOp<vector::TransferWriteOp>(
+        writeOp, newVector, source, writeOp.getIndices());
+
+    newWriteOp.getProperties().setInBounds(
+        rewriter.getBoolArrayAttr(newInBounds));
+
+    assert(newWriteOp.getPermutationMap().isMinorIdentity() &&
+           "Pattern failed to convert to minor identity");
+
+    return success();
+  }
+};
+
+
+/// This pattern rewrites a `vector.transfer_read` with a non minor identity
+/// permutation map, with a minor-identity permutation map, if possible. For
+/// example,
+///
+/// ```
+/// #map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+/// %0 = vector.transfer_read %alloc[%c0, %c0, %c0, %c0], %c0_i8
+///    {in_bounds = [true, true], permutation_map = #map} : memref<2x4x1x8xi8>,
+///    vector<4x8xi8>
+/// ```
+///
+/// is rewritten as
+///
+/// ```
+/// #map = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3)>
+/// %1 = vector.transfer_read %alloc[%c0, %c0, %c0, %c0], %c0_i8
+///   {in_bounds = [true, true, true], permutation_map = #map} :
+///   memref<2x4x1x8xi8>, vector<4x1x8xi8>
+/// %2 = vector.shape_cast %1 : vector<4x1x8xi8> to vector<4x8xi8>
+///   ```
+///
+struct ToMinorIdentityTransferReadPattern
+    : public OpRewritePattern<vector::TransferReadOp> {
+  using OpRewritePattern<vector::TransferReadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::TransferReadOp readOp,
+                                PatternRewriter &rewriter) const override {
+    AffineMap perm = readOp.getPermutationMap();
+    if (perm.isMinorIdentity()) return failure();
+    FailureOr<SmallVector<int64_t>> maybeDims = getDimsOfNonPermutingMap(perm);
+    if (failed(maybeDims)) return failure();
+    auto [newShape, newInBounds] =
+        getUnsqueezedShapeAndInBounds(readOp.getSource().getType().getRank(),
+                                      maybeDims.value(), rewriter, readOp);
+    VectorType newVectorTy =
+        VectorType::get(newShape, readOp.getVectorType().getElementType());
+    MemRefType sourceType = cast<MemRefType>(readOp.getSource().getType());
+    if (!mlir::vector::isContiguousSlice(sourceType, newVectorTy))
+      return failure();
+    auto newReadOp = rewriter.create<vector::TransferReadOp>(
+        readOp.getLoc(), newVectorTy, readOp.getSource(), readOp.getIndices());
+    newReadOp.getProperties().setInBounds(
+        rewriter.getBoolArrayAttr(newInBounds));
+    rewriter.replaceOpWithNewOp<vector::ShapeCastOp>(
+        readOp, readOp.getVector().getType(), newReadOp);
+    return success();
+  }
+};
+
+/// A pattern to drop leading unit dimensions from TransferReads. Converts
+/// ```
+/// %0 = vector.transfer_read %alloc[%c0, %c0, %c0], %c0_i8 {in_bounds = [true, true]} : memref<1x2x8xi8>, vector<1x8xi8>
+/// ```
+///
+/// to
+/// ```
+/// %0 = vector.transfer_read %alloc[%c0, %c0, %c0], %c0_i8 {in_bounds = [true]} : memref<1x2x8xi8>, vector<8xi8>
+/// %1 = vector.shape_cast %0 : vector<8xi8> to vector<1x8xi8>
+/// ```
+struct DropMinorIndentityLeadingDimFromTransferReadPattern
+    : public OpRewritePattern<vector::TransferReadOp> {
+  using OpRewritePattern<vector::TransferReadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::TransferReadOp readOp,
+                                PatternRewriter &rewriter) const override {
+    AffineMap perm = readOp.getPermutationMap();
+    if (!perm.isMinorIdentity()) return failure();
+
+    SmallVector<bool> oldBounds = readOp.getInBoundsValues();
+    VectorType oldVectorType = readOp.getVectorType();
+    ArrayRef<int64_t> oldShape = oldVectorType.getShape();
+
+    SmallVector<bool> newBounds;
+    SmallVector<int64_t> newShape;
+
+    bool leading = true;
+    for (uint64_t i = 0; i < oldShape.size(); ++i) {
+      if (oldShape[i] > 1 || i + 1 == oldShape.size()) leading = false;
+      if (!leading) {
+        newBounds.push_back(oldBounds[i]);
+        newShape.push_back(oldShape[i]);
+      }
+    }
+
+    // Already without leading '1's.
+    if (oldShape.size() == newShape.size()) return failure();
+
+    VectorType newVectorType =
+        VectorType::get(newShape, oldVectorType.getElementType());
+
+    auto newReadOp = rewriter.create<vector::TransferReadOp>(
+        readOp.getLoc(), newVectorType, readOp.getSource(),
+        readOp.getIndices());
+    newReadOp.getProperties().setInBounds(rewriter.getBoolArrayAttr(newBounds));
+    rewriter.replaceOpWithNewOp<vector::ShapeCastOp>(
+        readOp, readOp.getVector().getType(), newReadOp);
     return success();
   }
 };
@@ -393,6 +493,7 @@ struct ExtractTransposeFromContractionOp
     }
 
     int64_t nDim = rhsVecTy.getShape().size();
+
     SmallVector<int64_t> rhsPermutation;
     for (int64_t i = 0; i < nDim - 2; i++) rhsPermutation.push_back(i);
     rhsPermutation.push_back(nDim - 1);
@@ -499,6 +600,14 @@ struct ConvertLeadingUnitDimInsertToReshapePattern
   }
 };
 
+void populateBubbleSignExtensionsLate(RewritePatternSet &patterns) {
+  patterns.add<SwapUnaryOpsPattern<arith::ExtSIOp, vector::BroadcastOp>,
+               SwapUnaryOpsPattern<arith::ExtFOp, vector::BroadcastOp>,
+               SwapUnaryOpsPattern<arith::ExtSIOp, vector::ShapeCastOp>,
+               SwapUnaryOpsPattern<arith::ExtFOp, vector::ShapeCastOp>>(
+      patterns.getContext());
+}
+
 // This pass converts standard vector ops into a subset of `Vector` ops more
 // amenable to being converted to `AIEVec`.
 struct CanonicalizeVectorForAIEVecPass
@@ -519,27 +628,37 @@ struct CanonicalizeVectorForAIEVecPass
   void runOnOperation() override {
     auto op = getOperation();
     MLIRContext *context = &getContext();
-    RewritePatternSet patterns(context);
 
-    patterns.add<ExtractTransposeFromContractionOp,
-                 FlattenMultDimTransferReadPattern,
-                 FlattenMultDimTransferWritePattern,
-                 ConvertLeadingUnitDimInsertToReshapePattern>(context);
 
-    patterns.add<ConvertSplatTransferReadToBroadcastPattern>(context);
+    {
+      // These must run before 'populateVectorBroadcastLoweringPatterns'
+      // so that broadcasts can be matched before conversion to insert.
+      RewritePatternSet patterns(context);
+      populateBubbleSignExtensionsLate(patterns);
+      patterns.add<DropMinorIndentityLeadingDimFromTransferReadPattern>(
+          context);
+      (void)applyPatternsAndFoldGreedily(op, std::move(patterns));
+    }
+    {
+      RewritePatternSet patterns(context);
+      patterns.add<ExtractTransposeFromContractionOp,
+                   ToMinorIdentityTransferReadPattern,
+                   ToMinorIdentityTransferWritePattern,
+                   ConvertLeadingUnitDimInsertToReshapePattern>(context);
+      patterns.add<ConvertSplatTransferReadToBroadcastPattern>(context);
+      mlir::vector::populateFlattenVectorTransferPatterns(patterns);
+      mlir::vector::populateVectorBroadcastLoweringPatterns(patterns);
+      (void)applyPatternsAndFoldGreedily(op, std::move(patterns));
+    }
 
-    patterns.add<SwapUnaryOpsPattern<arith::ExtSIOp, vector::BroadcastOp>>(
-        context, [](arith::ExtSIOp extOp, vector::BroadcastOp bcastOp) -> Type {
-          Type extInElemTy = extOp.getIn().getType();
-          auto extInVecTy = dyn_cast<VectorType>(extInElemTy);
-          if (extInVecTy) extInElemTy = extInVecTy.getElementType();
-          return VectorType::get(bcastOp.getResultVectorType().getShape(),
-                                 extInElemTy);
-        });
-
-    populateVectorBroadcastLoweringPatterns(patterns);
-
-    (void)applyPatternsAndFoldGreedily(op, std::move(patterns));
+    {
+      // These must run after 'populateFlattenVectorTransferPatterns' because
+      // vector.shape_casts are introduced. Merging into a single pass creates
+      // cycles.
+      RewritePatternSet patterns(context);
+      populateBubbleSignExtensionsLate(patterns);
+      (void)applyPatternsAndFoldGreedily(op, std::move(patterns));
+    }
   }
 };
 
@@ -573,10 +692,9 @@ struct DetectNonCanonicalOpsPass
 };
 
 void buildCanonicalizeVectorForAIEVec(OpPassManager &pm) {
-  // Add `Vector` code canonicalization passes
-  // TODO: Add passes to unroll vector with unsupported types
   // TODO: Add passes to split vectors that won't fit in registers
   pm.addPass(createCanonicalizeVectorForAIEVecPass());
+  pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(std::make_unique<DetectNonCanonicalOpsPass>());
 }
 

--- a/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
@@ -154,18 +154,3 @@ func.func @noncontiguous_write(%v: vector<4x8xi8>) {
     vector.transfer_write %v, %alloc[%c0, %c0] : vector<4x8xi8>, memref<4x10xi8>
     return
 }
-
-// -----
-
-// CHECK-LABEL: @unsqueeze_leading_transfer_read_dims(
-// CHECK: transfer_read
-// CHECK-SAME: memref<1x2x8xi8>, vector<8xi8>
-// CHECK: vector.shape_cast
-// CHECK-SAME: vector<8xi8> to vector<1x8xi8>
-func.func @unsqueeze_leading_transfer_read_dims() -> vector<1x8xi8> {
-    %alloc = memref.alloc() : memref<1x2x8xi8>
-    %c0 = arith.constant 0 : index
-    %c0_i8 = arith.constant 0 : i8
-    %0 = vector.transfer_read %alloc[%c0, %c0, %c0], %c0_i8 {in_bounds = [true, true]} : memref<1x2x8xi8>, vector<1x8xi8>
-    return %0 : vector<1x8xi8>
-}

--- a/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
@@ -169,6 +169,3 @@ func.func @unsqueeze_leading_transfer_read_dims() -> vector<1x8xi8> {
     %0 = vector.transfer_read %alloc[%c0, %c0, %c0], %c0_i8 {in_bounds = [true, true]} : memref<1x2x8xi8>, vector<1x8xi8>
     return %0 : vector<1x8xi8>
 }
-
-
-

--- a/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
@@ -12,6 +12,19 @@ func.func @scalar_extsi_to_broadcast_swap(%s: i8) -> vector<32xi32> {
 
 // -----
 
+// CHECK-LABEL: @scalar_extsi_to_shape_cast_swap(
+// CHECK-SAME: %[[SIN:.*]]: vector<16x2xi8>
+func.func @scalar_extsi_to_shape_cast_swap(%s: vector<16x2xi8>) -> vector<32xi32> {
+    // CHECK: %[[SHAPE_CAST:.*]] = vector.shape_cast %[[SIN:.*]] : vector<16x2xi8> to vector<32xi8>
+    // CHECK: %[[EXT:.*]] = arith.extsi %[[SHAPE_CAST]] : vector<32xi8> to vector<32xi32>
+    %0 = arith.extsi %s : vector<16x2xi8> to vector<16x2xi32>
+    %1 = vector.shape_cast %0 : vector<16x2xi32> to vector<32xi32>
+    return %1 : vector<32xi32>
+}
+
+
+// -----
+
 // CHECK-LABEL: @extsi_to_broadcast_swap(
 // CHECK-SAME: %[[VIN:.*]]: vector<8xi8>
 func.func @extsi_to_broadcast_swap(%v: vector<8xi8>) -> vector<4x8xi32> {
@@ -41,3 +54,121 @@ func.func @broadcast_to_insert(%v: vector<8xbf16>) -> vector<1x4x8xbf16> {
     %0 = vector.broadcast %v : vector<8xbf16> to vector<1x4x8xbf16>
     return %0 : vector<1x4x8xbf16>
 }
+
+// -----
+
+// CHECK-LABEL: @contiguous_read_with_unit_extent_dim(
+// CHECK: memref.collapse_shape
+// CHECK-SAME:  memref<2x4x1x8xi8> into memref<2x32xi8>
+// CHECK: vector.transfer_read
+// CHECK-SAME: {in_bounds = [true]} : memref<2x32xi8>, vector<32xi8>
+// CHECK: vector.shape_cast
+// CHECK-SAME: vector<32xi8> to vector<4x8xi8>
+#map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+func.func @contiguous_read_with_unit_extent_dim() -> vector<4x8xi8> {
+    %c0_i8 = arith.constant 0 : i8
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() : memref<2x4x1x8xi8>
+    %0 = vector.transfer_read %alloc[%c0, %c0, %c0, %c0], %c0_i8 {in_bounds = [true, true], permutation_map = #map} : memref<2x4x1x8xi8>, vector<4x8xi8>
+    return %0 : vector<4x8xi8>
+}
+
+// -----
+
+// As above, but this time the dimension 'd2' is of size 2, so the pattern FlattenMultDimTransferReadPattern does not match.
+
+// CHECK-LABEL: @noncontiguous_read_cannot_collapse(
+// CHECK: transfer_read{{.*}} memref<2x4x2x8xi8>
+// CHECK: return
+#map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+func.func @noncontiguous_read_cannot_collapse() -> vector<4x8xi8> {
+    %c0_i8 = arith.constant 0 : i8
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() : memref<2x4x2x8xi8>
+    %0 = vector.transfer_read %alloc[%c0, %c0, %c0, %c0], %c0_i8 {in_bounds = [true, true], permutation_map = #map} : memref<2x4x2x8xi8>, vector<4x8xi8>
+    return %0 : vector<4x8xi8>
+}
+
+// -----
+
+// CHECK-LABEL: @permutation_read_cannot_collapse
+// CHECK-NOT: memref.collapse_shape
+// CHECK-NOT: vector.shape_cast
+// CHECK: return
+
+#map = affine_map<(d0, d1) -> (d1, d0)>
+func.func @permutation_read_cannot_collapse() -> vector<8x8xi8> {
+    %c0_i8 = arith.constant 0 : i8
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() : memref<8x8xi8>
+    %0 = vector.transfer_read %alloc[%c0, %c0], %c0_i8 {in_bounds = [true, true], permutation_map = #map} : memref<8x8xi8>, vector<8x8xi8>
+    return %0 : vector<8x8xi8>
+}
+
+// -----
+
+// CHECK-LABEL: @contiguous_write_with_unit_extent_dim(
+// CHECK-DAG: vector.shape_cast{{.*}} vector<4x8xi8> to vector<32xi8>
+// CHECK-DAG: memref.collapse_shape{{.*}} memref<2x4x1x8xi8> into memref<2x32xi8>
+// CHECK: vector.transfer_write
+// CHECK: return
+#map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+func.func @contiguous_write_with_unit_extent_dim(%v: vector<4x8xi8>) {
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() : memref<2x4x1x8xi8>
+    vector.transfer_write %v, %alloc[%c0, %c0, %c0, %c0] {permutation_map = #map} : vector<4x8xi8>, memref<2x4x1x8xi8>
+    return
+}
+
+// -----
+
+
+// CHECK-LABEL: @contiguous_write_with_unit_extent_dim_2(
+// CHECK: %[[C8:.*]] = arith.constant 8 : index
+// CHECK: %[[C0:.*]] = arith.constant 0 : index
+// CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<2x6x1x8x1xi8>
+// CHECK-DAG: %[[CAST:.*]] = vector.shape_cast %[[V:.*]] : vector<4x8xi8> to vector<32xi8>
+// CHECK-DAG: %[[COLLAPSE:.*]] = memref.collapse_shape %[[ALLOC]]{{.*}}memref<2x6x1x8x1xi8> into memref<2x48xi8>
+// CHECK:       vector.transfer_write %[[CAST]], %[[COLLAPSE]][%[[C0]], %[[C8]]]
+// CHECK-SAME:  {in_bounds = [true]} : vector<32xi8>, memref<2x48xi8>
+// CHECK: return
+
+#map = affine_map<(d0, d1, d2, d3, d4) -> (d1, d3)>
+func.func @contiguous_write_with_unit_extent_dim_2(%v: vector<4x8xi8>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %alloc = memref.alloc() : memref<2x6x1x8x1xi8>
+    vector.transfer_write %v, %alloc[%c0, %c1, %c0, %c0, %c0] {permutation_map = #map} : vector<4x8xi8>, memref<2x6x1x8x1xi8>
+    return
+}
+
+// -----
+
+// CHECK-LABEL: @noncontiguous_write(
+// CHECK-NOT: memref.collapse_shape
+// CHECK-NOT: vector.shape_cast
+// CHECK: return
+func.func @noncontiguous_write(%v: vector<4x8xi8>) {
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() : memref<4x10xi8>
+    vector.transfer_write %v, %alloc[%c0, %c0] : vector<4x8xi8>, memref<4x10xi8>
+    return
+}
+
+// -----
+
+// CHECK-LABEL: @unsqueeze_leading_transfer_read_dims(
+// CHECK: transfer_read
+// CHECK-SAME: memref<1x2x8xi8>, vector<8xi8>
+// CHECK: vector.shape_cast
+// CHECK-SAME: vector<8xi8> to vector<1x8xi8>
+func.func @unsqueeze_leading_transfer_read_dims() -> vector<1x8xi8> {
+    %alloc = memref.alloc() : memref<1x2x8xi8>
+    %c0 = arith.constant 0 : index
+    %c0_i8 = arith.constant 0 : i8
+    %0 = vector.transfer_read %alloc[%c0, %c0, %c0], %c0_i8 {in_bounds = [true, true]} : memref<1x2x8xi8>, vector<1x8xi8>
+    return %0 : vector<1x8xi8>
+}
+
+
+


### PR DESCRIPTION
There's a pass we run `--canonicalize-vector-for-aievec` which (as the name suggests) massages vector dialect operations to make them lowerable to aievec. One of the things the pass does is 'flatten' `vector.transfer_read`s. For example it converts 

```  
%26 = vector.transfer_read %reinterpret_cast_1[%c0, %20, %24, %22, %c0], %cst {in_bounds = [true, true]} : memref<1x3x4x6x8xbf16>, vector<4x8xbf16>
```

which has a rank-2 vector operand to 

```
...
%collapse_shape = memref.collapse_shape %reinterpret_cast_1 [[0], [1], [2], [3, 4]] : memref<1x3x4x6x8xbf16> into memref<1x3x4x48xbf16>
 %27 = vector.transfer_read %collapse_shape[%c0, %20, %24, %26], %cst {in_bounds = [true]} : memref<1x3x4x48xbf16>, vector<32xbf16>
 %28 = vector.shape_cast %27 : vector<32xbf16> to vector<4x8xbf16>
 ```
 
 Subsequent compiler passes fail if there are any `transfer_read`s (or `transfer_write`s) which have a vector operand of rank > 1. 
 
 
With my current convolution pipeline (using the `linalg-fold-unit-extent-dims` pass with `useRankReducingSlices = true` as suggested by @MaheshRavishankar to simplify the compiler by avoiding collapse_shape/expand_shape) we get a `transfer_read` like

```
%61 = vector.transfer_read %reinterpret_cast_3[%c0, %c0, %c0, %c0, %c0], %cst_0 {in_bounds = [true, true], permutation_map = #map} : memref<1x1x4x1x4xf32>, vector<4x4xf32> 
 ```

where 
 ```
#map = affine_map<(d0, d1, d2, d3, d4) -> (d2, d4)>
``` 

Before this PR, the pass `--canonicalize-vector-for-aievec` failed to convert this into a transfer_read with a rank-1 vector. This is because the map `#map` is not a "minor identity" affine map which the pattern previously required. So this PR relaxes the constraint that the map must be a minor identity map, allowing unit dimensions to slip through. 

It uses the upstream pass to flatten reads and writes, and adds a new pattern to make unflatten (unsqueeze) reads and writes whose permutation maps are not minor identity. 

Unfortunately @jsetoain is going to be away for a while, so @makslevental would you mind reviewing this? 