### PR TITLE
[WIP] Enable Temporary Alloc Bufferization pass

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pack_peel_objectfifo_e2e.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pack_peel_objectfifo_e2e.mlir
@@ -32,3 +32,38 @@ func.func @matmul_i32(%lhs: tensor<128x256xi32>, %rhs: tensor<256x128xi32>) -> t
                     outs(%1: tensor<128x128xi32>) -> tensor<128x128xi32>
   return %res : tensor<128x128xi32>
 }
+
+// CHECK-LABEL: hal.executable.export public @matmul_truncf_bf16_bf16_dispatch_0_matmul_128x128x256_bf16xbf16xf32
+
+// CHECK:       aie.device(npu1_4col) {
+// CHECK-DAG:   %[[TILE_0_2:.+]] = aie.tile(0, 2)
+// CHECK-DAG:   %[[TILE_0_3:.+]] = aie.tile(0, 3)
+// CHECK-DAG:   %[[TILE_1_2:.+]] = aie.tile(1, 2)
+// CHECK-DAG:   %[[TILE_1_3:.+]] = aie.tile(1, 3)
+// CHECK-DAG:   %[[TILE_0_0:.+]] = aie.tile(0, 0)
+// CHECK-DAG:   %[[TILE_0_1:.+]] = aie.tile(0, 1)
+// CHECK-DAG:   aie.core(%[[TILE_0_2]])
+// CHECK-DAG:   aie.core(%[[TILE_1_2]])
+// CHECK-DAG:   aie.core(%[[TILE_0_3]])
+// CHECK-DAG:   aie.core(%[[TILE_1_3]])
+// CHECK-DAG:   aie.shim_dma_allocation {{.*}}(MM2S, 0, 0)
+// CHECK-DAG:   aie.shim_dma_allocation {{.*}}(MM2S, 1, 0)
+// CHECK-DAG:   aie.memtile_dma(%[[TILE_0_1]])
+// CHECK-DAG:   aie.mem(%[[TILE_0_2]])
+// CHECK-DAG:   aie.mem(%[[TILE_0_3]])
+// CHECK-DAG:   aie.mem(%[[TILE_1_2]])
+// CHECK-DAG:   aie.mem(%[[TILE_1_3]])
+// CHECK-DAG:   aie.shim_dma_allocation {{.*}}(S2MM, 0, 0)
+// CHECK:       {npu_instructions =
+// CHECK-SAME:   runtime_sequence_name = "matmul_truncf_bf16_bf16_dispatch_0_matmul_128x128x256_bf16xbf16xf32"
+func.func @matmul_truncf_bf16_bf16(%lhs: tensor<128x256xbf16>, %rhs: tensor<256x128xbf16>) -> tensor<128x128xbf16>
+{
+  %cst = arith.constant 0.0 : f32
+  %cst_bf16 = arith.constant 0.0 : bf16
+  %0 = tensor.empty() : tensor<128x128xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<128x128xf32>) -> tensor<128x128xf32>
+  %res = linalg.matmul ins(%lhs, %rhs: tensor<128x256xbf16>, tensor<256x128xbf16>)
+                    outs(%1: tensor<128x128xf32>) -> tensor<128x128xf32>
+  %cast = arith.truncf %res : tensor<128x128xf32> to tensor<128x128xbf16>
+  return %cast : tensor<128x128xbf16>
+}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -612,6 +612,7 @@ void addAMDAIEObjectFifoLoweringPasses(OpPassManager &passManager,
   passManager.addPass(createCanonicalizerPass());
 
   passManager.addPass(createAMDAIEObjFifoBufferizationPass());
+  passManager.addPass(createAMDAIETemporaryAllocBufferizationPass());
 
   addAMDAIEToAIEPasses(passManager);
 


### PR DESCRIPTION
This doesn't enable vectorization on elementwise and just with the temporary buffer -> amdaie.buffer.

I noticed my last local state was enabling vectorization on elementwise because I was trying to test Relu too once "Matmul + truncf" worked hence forgot to disable and went on to add changes to lit tests.

Adding this as WIP because I'll immediately try to add fixes for enabling vectorization on elementwise/Relu - so can just reuse the lit test changes that I added previously.