### PR TITLE
[AMDAIETemporaryAllocBufferization] Bufferize temporary allocs that aren't defined in core

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -584,10 +584,10 @@ def AMDAIETemporaryAllocBufferization :
          `amdaie.logicalobjectfifo.acquire` ->
          `amdaie.logicalobjectfifo.access`.
 
-       We call the directly accessed allocations 'temporary'. The temporary 
+       We call the directly accessed allocations 'temporary'. The temporary
        allocations need to be converted to amdaie.buffer ops, because
-       there is no other support lowering to llvm from memref.allocs in our 
-       stack. The indirectly accessed allocatations, i.e. those with the layering 
+       there is no other support lowering to llvm from memref.allocs in our
+       stack. The indirectly accessed allocatations, i.e. those with the layering
        described above, are handled in pass iree-amdaie-objfifo-bufferization.
   }];
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -572,7 +572,25 @@ def AMDAIESplitLogicalObjFifosForConnectionReuse :
 
 def AMDAIETemporaryAllocBufferization :
     Pass<"iree-amdaie-temporary-alloc-bufferization", ""> {
-  let summary = "Bufferizes temporary alloc buffers into `amdaie.buffer` ops.";
+  let summary = "Convert 'temporary' `memref.alloc` ops to `amdaie.buffer`.";
+  let description = [{
+       Some memref allocations are accessed directly on the core, not going via
+       the layering that is used for streamed inputs, which currently have layering
+       like:
+
+         `memref.alloc` ->
+         `amdaie.logicalobjectfifo.from_memref` ->
+         `amdaie.connection` ->
+         `amdaie.logicalobjectfifo.acquire` ->
+         `amdaie.logicalobjectfifo.access`.
+
+       We call the directly accessed allocations 'temporary'. The temporary 
+       allocations need to be converted to amdaie.buffer ops, because
+       there is no other support lowering to llvm from memref.allocs in our 
+       stack. The indirectly accessed allocatations, i.e. those with the layering 
+       described above, are handled in pass iree-amdaie-objfifo-bufferization.
+  }];
+
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIETemporaryAllocBufferizationPass()";
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/temporary_alloc_bufferization.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/temporary_alloc_bufferization.mlir
@@ -76,3 +76,34 @@ func.func @temp_buffer() {
   }
   return
 }
+
+// -----
+
+// CHECK-LABEL: @temp_buffer_2
+//   CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.*]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[TILE_0:.*]] = amdaie.tile(%[[C0]], %[[C0]])
+//   CHECK-DAG:   %[[BUFFER_0:.*]] = amdaie.buffer(%[[TILE_0]]) : memref<4xi32>
+//   CHECK-DAG:   %[[TILE_1:.*]] = amdaie.tile(%[[C0]], %[[C1]])
+//   CHECK-DAG:   %[[BUFFER_1:.*]] = amdaie.buffer(%[[TILE_1]]) : memref<4xi32>
+//       CHECK:   amdaie.core(%[[TILE_0]]
+//       CHECK:     %[[CAST:.*]] = memref.reinterpret_cast %[[BUFFER_0]]
+//       CHECK:   amdaie.core(%[[TILE_1]]
+//       CHECK:     %[[CAST:.*]] = memref.reinterpret_cast %[[BUFFER_1]]
+func.func @temp_buffer_2(){
+  %alloc = memref.alloc() : memref<4xi32>
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %tile_0 = amdaie.tile(%c0, %c0)
+  %tile_1 = amdaie.tile(%c0, %c1)
+  %core_0 = amdaie.core(%tile_0, in : [], out : []) {
+    %reinterpret_cast = memref.reinterpret_cast %alloc to offset: [0], sizes: [4], strides: [1] : memref<4xi32> to memref<4xi32>
+    amdaie.end
+  }
+  %core_1 = amdaie.core(%tile_1, in : [], out : []) {
+    %reinterpret_cast = memref.reinterpret_cast %alloc to offset: [0], sizes: [4], strides: [1] : memref<4xi32> to memref<4xi32>
+    amdaie.end
+  }
+  memref.dealloc %alloc : memref<4xi32>
+  return
+}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/temporary_alloc_bufferization.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/temporary_alloc_bufferization.mlir
@@ -14,30 +14,20 @@
 //   CHECK-DAG:   %[[BUFFER_0_3_1:.*]] = amdaie.buffer(%[[TILE_0_3]]) : memref<1024xf32, 2 : i32>
 //   CHECK-DAG:   %[[BUFFER_0_2:.*]] = amdaie.buffer(%[[TILE_0_2]]) : memref<1024xf32, 2 : i32>
 //       CHECK:   amdaie.core(%[[TILE_0_2]]
-//   CHECK-NOT:     memref.alloc
 //       CHECK:     %[[CAST:.*]] = memref.reinterpret_cast %[[BUFFER_0_2]]
 //       CHECK:     linalg.fill ins(%{{.*}}) outs(%[[CAST]]
-//   CHECK-NOT:     dealloc
 //       CHECK:     amdaie.end
 //       CHECK:   amdaie.core(%[[TILE_0_3]]
-//   CHECK-NOT:     memref.alloc
 //       CHECK:     %[[CAST:.*]] = memref.reinterpret_cast %[[BUFFER_0_3_1]]
 //       CHECK:     linalg.fill ins(%{{.*}}) outs(%[[CAST]]
-//   CHECK-NOT:     dealloc
-//   CHECK-NOT:     memref.alloc
 //       CHECK:     %[[CAST_1:.*]] = memref.reinterpret_cast %[[BUFFER_0_3_0]]
 //       CHECK:     linalg.fill ins(%{{.*}}) outs(%[[CAST_1]]
-//   CHECK-NOT:     dealloc
 //       CHECK:     amdaie.end
 //       CHECK:   amdaie.core(%[[TILE_1_2]]
-//   CHECK-NOT:     memref.alloc
-//   CHECK-NOT:     memref.alloc
 //       CHECK:     %[[CAST:.*]] = memref.reinterpret_cast %[[BUFFER_1_2_1]]
 //       CHECK:     %[[CAST_1:.*]] = memref.reinterpret_cast %[[BUFFER_1_2_0]]
 //       CHECK:     linalg.fill ins(%{{.*}}) outs(%[[CAST]]
 //       CHECK:     linalg.fill ins(%{{.*}}) outs(%[[CAST_1]]
-//   CHECK-NOT:     dealloc
-//   CHECK-NOT:     dealloc
 //       CHECK:     amdaie.end
 func.func @temp_buffer() {
   amdaie.workgroup {


### PR DESCRIPTION
Update the pass to handle `memref.alloc` in any scope, not just in `amdaie.core`