### PR TITLE
[NpuDmaCpyNdOp/NpuDmaWaitOp] Return optional async token and wait for multiple

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.cpp
@@ -660,11 +660,12 @@ void LogicalObjectFifoRelease::build(OpBuilder &b, mlir::OperationState &result,
 // Build a NpuDmaCpyNdOp with mixed static and dynamic entries and target and
 // source BD IDs.
 void NpuDmaCpyNdOp::build(
-    OpBuilder &b, OperationState &result, Value dma, Value target,
-    ArrayRef<OpFoldResult> targetOffsets, ArrayRef<OpFoldResult> targetSizes,
-    ArrayRef<OpFoldResult> targetStrides, Value targetBdId, Value source,
-    ArrayRef<OpFoldResult> sourceOffsets, ArrayRef<OpFoldResult> sourceSizes,
-    ArrayRef<OpFoldResult> sourceStrides, Value sourceBdId) {
+    OpBuilder &b, OperationState &result, TypeRange resultTypes,
+    Value connection, Value target, ArrayRef<OpFoldResult> targetOffsets,
+    ArrayRef<OpFoldResult> targetSizes, ArrayRef<OpFoldResult> targetStrides,
+    Value targetBdId, Value source, ArrayRef<OpFoldResult> sourceOffsets,
+    ArrayRef<OpFoldResult> sourceSizes, ArrayRef<OpFoldResult> sourceStrides,
+    Value sourceBdId) {
   SmallVector<int64_t> staticTargetOffsets, staticTargetSizes,
       staticTargetStrides;
   SmallVector<int64_t> staticSourceOffsets, staticSourceSizes,
@@ -685,7 +686,7 @@ void NpuDmaCpyNdOp::build(
                              staticSourceSizes);
   dispatchIndexOpFoldResults(sourceStrides, dynamicSourceStrides,
                              staticSourceStrides);
-  build(b, result, b.getIndexType(), dma, target, dynamicTargetOffsets,
+  build(b, result, resultTypes, connection, target, dynamicTargetOffsets,
         dynamicTargetSizes, dynamicTargetStrides, staticTargetOffsets,
         staticTargetSizes, staticTargetStrides, targetBdId, source,
         dynamicSourceOffsets, dynamicSourceSizes, dynamicSourceStrides,
@@ -695,11 +696,12 @@ void NpuDmaCpyNdOp::build(
 
 // Build a NpuDmaCpyNdOp with static entries.
 void NpuDmaCpyNdOp::build(
-    OpBuilder &b, OperationState &result, Value dma, Value target,
-    ArrayRef<int64_t> targetOffsets, ArrayRef<int64_t> targetSizes,
-    ArrayRef<int64_t> targetStrides, mlir::Value targetBdId, Value source,
-    ArrayRef<int64_t> sourceOffsets, ArrayRef<int64_t> sourceSizes,
-    ArrayRef<int64_t> sourceStrides, mlir::Value sourceBdId) {
+    OpBuilder &b, OperationState &result, TypeRange resultTypes,
+    Value connection, Value target, ArrayRef<int64_t> targetOffsets,
+    ArrayRef<int64_t> targetSizes, ArrayRef<int64_t> targetStrides,
+    mlir::Value targetBdId, Value source, ArrayRef<int64_t> sourceOffsets,
+    ArrayRef<int64_t> sourceSizes, ArrayRef<int64_t> sourceStrides,
+    mlir::Value sourceBdId) {
   SmallVector<OpFoldResult> targetOffsetValues = llvm::to_vector<4>(
       llvm::map_range(targetOffsets, [&](int64_t v) -> OpFoldResult {
         return b.getI64IntegerAttr(v);
@@ -724,18 +726,19 @@ void NpuDmaCpyNdOp::build(
       llvm::map_range(sourceStrides, [&](int64_t v) -> OpFoldResult {
         return b.getI64IntegerAttr(v);
       }));
-  build(b, result, dma, target, targetOffsetValues, targetSizeValues,
-        targetStrideValues, targetBdId, source, sourceOffsetValues,
-        sourceSizeValues, sourceStrideValues, sourceBdId);
+  build(b, result, resultTypes, connection, target, targetOffsetValues,
+        targetSizeValues, targetStrideValues, targetBdId, source,
+        sourceOffsetValues, sourceSizeValues, sourceStrideValues, sourceBdId);
 }
 
 // Build a NpuDmaCpyNdOp with dynamic entries.
-void NpuDmaCpyNdOp::build(OpBuilder &b, OperationState &result, Value dma,
-                          Value target, ValueRange targetOffsets,
-                          ValueRange targetSizes, ValueRange targetStrides,
-                          mlir::Value targetBdId, Value source,
-                          ValueRange sourceOffsets, ValueRange sourceSizes,
-                          ValueRange sourceStrides, mlir::Value sourceBdId) {
+void NpuDmaCpyNdOp::build(OpBuilder &b, OperationState &result,
+                          TypeRange resultTypes, Value connection, Value target,
+                          ValueRange targetOffsets, ValueRange targetSizes,
+                          ValueRange targetStrides, mlir::Value targetBdId,
+                          Value source, ValueRange sourceOffsets,
+                          ValueRange sourceSizes, ValueRange sourceStrides,
+                          mlir::Value sourceBdId) {
   SmallVector<OpFoldResult> targetOffsetValues =
       llvm::to_vector<4>(llvm::map_range(
           targetOffsets, [](Value v) -> OpFoldResult { return v; }));
@@ -752,13 +755,20 @@ void NpuDmaCpyNdOp::build(OpBuilder &b, OperationState &result, Value dma,
   SmallVector<OpFoldResult> sourceStrideValues =
       llvm::to_vector<4>(llvm::map_range(
           sourceStrides, [](Value v) -> OpFoldResult { return v; }));
-  build(b, result, dma, target, targetOffsetValues, targetSizeValues,
-        targetStrideValues, targetBdId, source, sourceOffsetValues,
-        sourceSizeValues, sourceStrideValues, sourceBdId);
+  build(b, result, resultTypes, connection, target, targetOffsetValues,
+        targetSizeValues, targetStrideValues, targetBdId, source,
+        sourceOffsetValues, sourceSizeValues, sourceStrideValues, sourceBdId);
 }
 
 void NpuDmaCpyNdOp::print(OpAsmPrinter &p) {
   Operation *op = getOperation();
+  for (OpResult res : getAsyncTokens()) {
+    if (isa<AMDAIE::AsyncTargetTokenType>(res.getType())) {
+      p << " async_target";
+    } else if (isa<AMDAIE::AsyncSourceTokenType>(res.getType())) {
+      p << " async_source";
+    }
+  }
   p << " " << getConnection() << "(";
   if (getTarget()) p << getTarget();
   printDynamicIndexList(p, op, getTargetOffsets(), getTargetStaticOffsets());
@@ -806,6 +816,16 @@ ParseResult NpuDmaCpyNdOp::parse(OpAsmParser &parser, OperationState &result) {
       sourceDynamicSizes, sourceDynamicStrides;
   SmallVector<Type, 1> targetTypes;
   SmallVector<Type, 1> sourceTypes;
+  SmallVector<Type, 1> asyncTokenTypes;
+
+  if (succeeded(parser.parseOptionalKeyword("async_target"))) {
+    asyncTokenTypes.push_back(
+        parser.getBuilder().getType<AMDAIE::AsyncTargetTokenType>());
+  }
+  if (succeeded(parser.parseOptionalKeyword("async_source"))) {
+    asyncTokenTypes.push_back(
+        parser.getBuilder().getType<AMDAIE::AsyncSourceTokenType>());
+  }
 
   if (failed(parser.parseOperand(dma)) || failed(parser.parseLParen()))
     return failure();
@@ -899,6 +919,8 @@ ParseResult NpuDmaCpyNdOp::parse(OpAsmParser &parser, OperationState &result) {
     }
   }
 
+  result.addTypes(asyncTokenTypes);
+
   llvm::copy(
       ArrayRef<int32_t>({1, static_cast<int32_t>(targetOperands.size()),
                          static_cast<int32_t>(targetDynamicOffsets.size()),
@@ -955,8 +977,6 @@ ParseResult NpuDmaCpyNdOp::parse(OpAsmParser &parser, OperationState &result) {
                                     result.operands))) {
     return failure();
   }
-
-  result.addTypes(indexType);
   return success();
 }
 
@@ -970,9 +990,9 @@ DoublyStridedOpInterface NpuDmaCpyNdOp::createDoublyStridedOp(
     ::llvm::SmallVector<OpFoldResult> &newSourceStrides) {
   Location loc = (*this)->getLoc();
   auto newOp = rewriter.create<AMDAIE::NpuDmaCpyNdOp>(
-      loc, getConnection(), getTarget(), newTargetOffsets, newTargetSizes,
-      newTargetStrides, getTargetBdId(), getSource(), newSourceOffsets,
-      newSourceSizes, newSourceStrides, getSourceBdId());
+      loc, getResultTypes(), getConnection(), getTarget(), newTargetOffsets,
+      newTargetSizes, newTargetStrides, getTargetBdId(), getSource(),
+      newSourceOffsets, newSourceSizes, newSourceStrides, getSourceBdId());
   return cast<DoublyStridedOpInterface>(newOp.getOperation());
 }
 
@@ -991,8 +1011,8 @@ struct NpuDmaCpyNdOpReplacementBuilder {
                       ArrayRef<OpFoldResult> srcMixedSizes,
                       ArrayRef<OpFoldResult> srcMixedStrides) {
     rewriter.replaceOpWithNewOp<NpuDmaCpyNdOp>(
-        dmaOp, dmaOp.getConnection(), dmaOp.getTarget(), tgtMixedOffsets,
-        tgtMixedSizes, tgtMixedStrides, dmaOp.getTargetBdId(),
+        dmaOp, dmaOp.getResultTypes(), dmaOp.getConnection(), dmaOp.getTarget(),
+        tgtMixedOffsets, tgtMixedSizes, tgtMixedStrides, dmaOp.getTargetBdId(),
         dmaOp.getSource(), srcMixedOffsets, srcMixedSizes, srcMixedStrides,
         dmaOp.getSourceBdId());
   }
@@ -1148,6 +1168,21 @@ void NpuCircularDmaCpyNdOp::getCanonicalizationPatterns(
   results.add<DoublyStridedFolder<NpuCircularDmaCpyNdOp,
                                   NpuCircularDmaCpyNdOpReplacementBuilder>>(
       context);
+}
+
+//===----------------------------------------------------------------------===//
+// AMDAIE_NpuDmaWaitOp
+//===----------------------------------------------------------------------===//
+
+SmallVector<AMDAIE::NpuDmaCpyNdOp> NpuDmaWaitOp::getDmaOps() {
+  SmallVector<AMDAIE::NpuDmaCpyNdOp> dmaOps;
+  for (Value token : getAsyncTokens()) {
+    if (auto dmaOp =
+            dyn_cast_if_present<AMDAIE::NpuDmaCpyNdOp>(token.getDefiningOp())) {
+      dmaOps.push_back(dmaOp);
+    }
+  }
+  return dmaOps;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -379,8 +379,7 @@ def AMDAIE_ChannelOp: AMDAIE_Op<"channel", [
 //===----------------------------------------------------------------------===//
 
 def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd", [
-      AttrSizedOperandSegments, DoublyStridedOpInterface]>,
-    Results<(outs Index)> {
+      AttrSizedOperandSegments, DoublyStridedOpInterface]> {
   let summary = "The Npu uController's dma operator";
   let description = [{
     The Npu DMA operation represents a strided copy operation with an unlimited
@@ -393,6 +392,16 @@ def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd", [
     source and target `offsets`, `sizes` and `strides`. A special sentinel value
     ShapedType::kDynamic encodes that the corresponding entry has a dynamic value.
 
+    The op can be `async` by specifying one or more `AnyAsyncTokenType` results.
+    Other wait-like operations can use these async tokens to describe a blocking
+    operation on the source or/and target side of this DMA operation.
+    In case of `async_source`, an async token will be returned by this operation
+    when the source DMA port will be done executing.
+    In case of `async_target`, an async token will be returned by this operation
+    when the target DMA port will be done executing.
+    In case of both `async_source` and `async_target`, two tokens will be returned
+    which can be blocked on.
+
     Example:
 
     ```mlir
@@ -401,7 +410,7 @@ def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd", [
       !amdaie.logicalobjectfifo<memref<32x1024xi32>>)
     ...
     amdaie.controlcode {
-      %3 = amdaie.npu.dma_cpy_nd %2([] [] [], [0, 0] [32, 64] [1024, 1])
+      %3 = amdaie.npu.dma_cpy_nd async_source %2([] [] [], [0, 0] [32, 64] [1024, 1])
       ...
     }
     ```
@@ -427,33 +436,35 @@ def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd", [
         Optional<Index>:$source_bd_id
   );
 
+  let results = (outs Variadic<AMDAIE_AnyAsyncTokenType>:$async_tokens);
+
   // Use a custom assembly format because of weird spaces being inserted around 
   // the optional `target` by the default assembly format generator.
   let hasCustomAssemblyFormat = 1;
 
   let builders = [
     // Build a NpuDmaCpyNdOp with mixed static and dynamic entries.
-    OpBuilder<(ins "Value":$dma, "::mlir::Value":$target,
-      "ArrayRef<OpFoldResult>":$target_offsets,
+    OpBuilder<(ins "::mlir::TypeRange":$result_types, "Value":$connection,
+      "::mlir::Value":$target, "ArrayRef<OpFoldResult>":$target_offsets,
       "ArrayRef<OpFoldResult>":$target_sizes,
       "ArrayRef<OpFoldResult>":$target_strides, "::mlir::Value":$target_bd_id,
       "::mlir::Value":$source, "ArrayRef<OpFoldResult>":$source_offsets,
       "ArrayRef<OpFoldResult>":$source_sizes,
       "ArrayRef<OpFoldResult>":$source_strides, "::mlir::Value":$source_bd_id)>,
     // Build a NpuDmaCpyNdOp with static entries.
-    OpBuilder<(ins "Value":$dma, "::mlir::Value":$target,
-      "ArrayRef<int64_t>":$target_offsets, "ArrayRef<int64_t>":$target_sizes,
-      "ArrayRef<int64_t>":$target_strides, "::mlir::Value":$target_bd_id,
-      "::mlir::Value":$source, "ArrayRef<int64_t>":$source_offsets, 
-      "ArrayRef<int64_t>":$source_sizes, "ArrayRef<int64_t>":$source_strides,
-      "::mlir::Value":$source_bd_id)>,
+    OpBuilder<(ins "::mlir::TypeRange":$result_types, "Value":$connection,
+      "::mlir::Value":$target, "ArrayRef<int64_t>":$target_offsets, 
+      "ArrayRef<int64_t>":$target_sizes, "ArrayRef<int64_t>":$target_strides,
+      "::mlir::Value":$target_bd_id, "::mlir::Value":$source,
+      "ArrayRef<int64_t>":$source_offsets, "ArrayRef<int64_t>":$source_sizes,
+      "ArrayRef<int64_t>":$source_strides, "::mlir::Value":$source_bd_id)>,
     // Build a NpuDmaCpyNdOp with dynamic entries.
-    OpBuilder<(ins "Value":$dma, "::mlir::Value":$target,
-      "ValueRange":$target_offsets, "ValueRange":$target_sizes,
-      "ValueRange":$target_strides, "::mlir::Value":$target_bd_id,
-      "::mlir::Value":$source, "ValueRange":$source_offsets,
-      "ValueRange":$source_sizes, "ValueRange":$source_strides, 
-      "::mlir::Value":$source_bd_id)>
+    OpBuilder<(ins "::mlir::TypeRange":$result_types, "Value":$dma,
+      "::mlir::Value":$target, "ValueRange":$target_offsets,
+      "ValueRange":$target_sizes, "ValueRange":$target_strides,
+      "::mlir::Value":$target_bd_id, "::mlir::Value":$source,
+      "ValueRange":$source_offsets, "ValueRange":$source_sizes,
+      "ValueRange":$source_strides, "::mlir::Value":$source_bd_id)>
   ];
 
   let extraClassDeclaration = [{
@@ -702,45 +713,51 @@ def AMDAIE_NpuCircularDmaCpyNdOp: AMDAIE_Op<"npu.circular_dma_cpy_nd", [
 def AMDAIE_NpuDmaWaitOp: AMDAIE_Op<"npu.dma_wait", []> {
   let summary = "Wait for the Npu DMA operation to complete.";
   let description = [{
-    The wait operation will block on the referenced Npu DMA operation to complete
-    execution on the provided `direction`. The `S2MM` direction will block on the
-    destination side of the dma operation, ensuring complete execution. The
-    `MM2S` direction will block on the source side of the dma operation,
-    ensuring that the DMA has successfully started execution, but not
-    guaranteeing that all data has been received on the destination side.
+    The wait operation will block on the referenced dependent ops.
+    
+    If a dependent op returns a `!amdaie.async_token`, this wait op will block
+    on the dependent op having completed execution.
+    If a dependent op returns a `!amdaie.async_source_token`, this wait op will
+    block on the source side of the referenced dependent op having completed
+    execution.
+    If a dependent op returns a `!amdaie.async_target_token`, this wait op will
+    block on the target side of the referenced dependent op having completed
+    execution.
+
+    Being able to block on the source and/or target side separately is useful
+    for copy/dma-like operations that involve multiple physical ports/channels
+    in hardware. In this case, blocking on the source side and/or target side,
+    might be different from blocking on the entire operation.
 
     Example:
 
     ```mlir
-    %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [%c0, %c0] [%c32, %c64] [%c1024, %c1])
-    amdaie.npu.dma_wait(%2, MM2S)
+    %2 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], [%c0, %c0] [%c32, %c64] [%c1024, %c1])
+    amdaie.npu.dma_wait(%2 : !amdaie.async_source_token)
     ```
 
     Here, the `dma_wait` operation will wait until the referenced Npu DMA
-    operation has started execution. On the other hand, the `S2MM` direction can
-    be used to wait on the destination side of the DMA, i.e. until the DMA has
-    finished its write into the target memory:
+    operation has started execution. On the other hand, the 
+    `!amdaie.async_target_token` can be used to wait on the target side of the
+    DMA, i.e. until the DMA has finished its write into the target memory:
 
     ```mlir
-    %2 = amdaie.npu.dma_cpy_nd %0([%c0, %c0] [%c32, %c64] [%c1024, %c1], [] [] [])
-    amdaie.npu.dma_wait(%2, S2MM)
+    %2 = amdaie.npu.dma_cpy_nd async_target %0([%c0, %c0] [%c32, %c64] [%c1024, %c1], [] [] [])
+    amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
     ```
   }];
 
   let arguments = (
-    ins Index:$dma,
-        DMAChannelDir:$direction
+    ins Variadic<AMDAIE_AnyAsyncTokenType>:$async_tokens
   );
 
   let assemblyFormat = [{
-    `(` $dma `,` $direction `)`  attr-dict
+    (`(` $async_tokens^ `:` type($async_tokens) `)`)? attr-dict
   }];
 
   let extraClassDeclaration = [{
-    // Return the Npu DMA operation argument.
-    NpuDmaCpyNdOp getDmaOp() { 
-      return dyn_cast_if_present<NpuDmaCpyNdOp>(getDma().getDefiningOp());
-    }
+    // Return the Npu DMA operation arguments.
+    SmallVector<NpuDmaCpyNdOp> getDmaOps();
   }];
 }
 
@@ -1073,7 +1090,7 @@ def AMDAIE_LogicalObjectFifoPlaceholderOp:
     amdaie.controlcode {
       %obj1 = amdaie.logicalobjectfifo.from_memref %0, {%tile_0_0}
         : memref<1024xi32> -> !amdaie.logicalobjectfifo<memref<1024xi32>>
-      %npu_dma = amdaie.npu.dma_cpy_nd %connection([] [] [], 
+      %npu_dma = amdaie.npu.dma_cpy_nd async_source %connection([] [] [], 
         %obj0[%c0, %c32] [%c32, %c32] [%c32, %c1]) 
         : source_type = !amdaie.logicalobjectfifo<memref<1024xi32>>
       amdaie.end

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIETypes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIETypes.td
@@ -15,6 +15,16 @@ class AMDAIEDialect_Type<string name, string typeMnemonic, list<Trait> traits = 
   let mnemonic = typeMnemonic;
 }
 
+// The types for async tokens which can be returned from async operations. The
+// dedicated types for `source` and `target` can be used to specify on which
+// side of (for example a copy/DMA) operation should be synchronized if there
+// are multiple.
+def AMDAIE_AsyncTokenType : AMDAIEDialect_Type<"AsyncToken", "async_token">;
+def AMDAIE_AsyncSourceTokenType : AMDAIEDialect_Type<"AsyncSourceToken", "async_source_token">;
+def AMDAIE_AsyncTargetTokenType : AMDAIEDialect_Type<"AsyncTargetToken", "async_target_token">;
+def AMDAIE_AnyAsyncTokenType 
+  : AnyTypeOf<[AMDAIE_AsyncTokenType, AMDAIE_AsyncSourceTokenType, AMDAIE_AsyncTargetTokenType]>;
+
 def AMDAIE_LogicalObjectFifoType :
     AMDAIEDialect_Type<"LogicalObjectFifo", "logicalobjectfifo"> {
   let summary = "The logical objectfifo type encapsulating a memref";

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/AMDAIEDmaOpInterfaceTest.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/AMDAIEDmaOpInterfaceTest.cpp
@@ -46,7 +46,7 @@ class DmaOpInterfaceTest : public ::testing::Test {
     auto input =
         rewriter.create<arith::ConstantIndexOp>(rewriter.getUnknownLoc(), 2);
     auto dmaOp = rewriter.create<mlir::iree_compiler::AMDAIE::NpuDmaCpyNdOp>(
-        rewriter.getUnknownLoc(), input, target, targetOffsetsOfr,
+        rewriter.getUnknownLoc(), TypeRange{}, input, target, targetOffsetsOfr,
         targetSizesOfr, targetStridesOfr, nullptr, source, sourceOffsetsOfr,
         sourceSizesOfr, sourceStridesOfr, nullptr);
     std::optional<int64_t> sourceStaticSize = dmaOp.getSourceStaticSize();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/invalid.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/invalid.mlir
@@ -337,7 +337,7 @@ func.func @npu_dma_cpy_nd_invalid_src_offsets() {
   %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
   %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   // expected-error @+1 {{source sizes should have same number of dimensions as source offsets}}
-  %3 = amdaie.npu.dma_cpy_nd %2([%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16, %c1], [%c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c16, %c16, %c1])
+  %3 = amdaie.npu.dma_cpy_nd async_source %2([%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16, %c1], [%c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c16, %c16, %c1])
   return
 }
 
@@ -355,7 +355,7 @@ func.func @npu_dma_cpy_nd_invalid_src_sizes() {
   %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
   %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   // expected-error @+1 {{source sizes should have same number of dimensions as source offsets}}
-  %3 = amdaie.npu.dma_cpy_nd %2([%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16, %c1], [%c0, %c0, %c0, %c0] [%c1, %c8, %c16] [%c128, %c16, %c16, %c1])
+  %3 = amdaie.npu.dma_cpy_nd async_source %2([%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16, %c1], [%c0, %c0, %c0, %c0] [%c1, %c8, %c16] [%c128, %c16, %c16, %c1])
   return
 }
 
@@ -373,7 +373,7 @@ func.func @npu_dma_cpy_nd_invalid_src_strides() {
   %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
   %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   // expected-error @+1 {{source strides should have same number of dimensions as source offsets}}
-  %3 = amdaie.npu.dma_cpy_nd %2([%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16, %c1], [%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c16, %c16])
+  %3 = amdaie.npu.dma_cpy_nd async_source %2([%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16, %c1], [%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c16, %c16])
   return
 }
 
@@ -391,7 +391,7 @@ func.func @npu_dma_cpy_nd_invalid_target_offsets() {
   %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
   %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   // expected-error @+1 {{target sizes should have same number of dimensions as target offsets}}
-  %3 = amdaie.npu.dma_cpy_nd %2([%c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16, %c1], [%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c16, %c16, %c1])
+  %3 = amdaie.npu.dma_cpy_nd async_source %2([%c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16, %c1], [%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c16, %c16, %c1])
   return
 }
 
@@ -409,7 +409,7 @@ func.func @npu_dma_cpy_nd_invalid_target_sizes() {
   %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
   %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   // expected-error @+1 {{target sizes should have same number of dimensions as target offsets}}
-  %3 = amdaie.npu.dma_cpy_nd %2([%c0, %c0, %c0, %c0] [%c1, %c8, %c16] [%c128, %c128, %c16, %c1], [%c0, %c0, %c0, %c0] [%c1, %c8, %c16] [%c128, %c16, %c16, %c1])
+  %3 = amdaie.npu.dma_cpy_nd async_source %2([%c0, %c0, %c0, %c0] [%c1, %c8, %c16] [%c128, %c128, %c16, %c1], [%c0, %c0, %c0, %c0] [%c1, %c8, %c16] [%c128, %c16, %c16, %c1])
   return
 }
 
@@ -427,7 +427,7 @@ func.func @npu_dma_cpy_nd_invalid_target_strides() {
   %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
   %2 = amdaie.dma_cpy_nd(%0[] [] [], %1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   // expected-error @+1 {{target strides should have same number of dimensions as target offsets}}
-  %3 = amdaie.npu.dma_cpy_nd %2([%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16], [%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c16, %c16, %c1])
+  %3 = amdaie.npu.dma_cpy_nd async_source %2([%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c128, %c16], [%c0, %c0, %c0, %c0] [%c1, %c1, %c8, %c16] [%c128, %c16, %c16, %c1])
   return
 }
 
@@ -436,7 +436,7 @@ func.func @npu_dma_cpy_nd_invalid_target_strides() {
 func.func @npu_dma_cpy_nd_negative_target_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   // expected-error @+1 {{expected target offsets to be non-negative, but got -1}}
-  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, -1] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
+  %1 = amdaie.npu.dma_cpy_nd async_source %0([0, 0, 0, -1] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
   return
 }
 
@@ -445,7 +445,7 @@ func.func @npu_dma_cpy_nd_negative_target_offset(%arg0: !amdaie.logicalobjectfif
 func.func @npu_dma_cpy_nd_negative_target_size(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   // expected-error @+1 {{expected target sizes to be non-negative, but got -16}}
-  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, -16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
+  %1 = amdaie.npu.dma_cpy_nd async_source %0([0, 0, 0, 0] [1, 1, 8, -16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
   return
 }
 
@@ -454,7 +454,7 @@ func.func @npu_dma_cpy_nd_negative_target_size(%arg0: !amdaie.logicalobjectfifo<
 func.func @npu_dma_cpy_nd_negative_target_stride(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   // expected-error @+1 {{expected target strides to be non-negative, but got -16}}
-  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, -16, 1], [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
+  %1 = amdaie.npu.dma_cpy_nd async_source %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, -16, 1], [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
   return
 }
 
@@ -463,7 +463,7 @@ func.func @npu_dma_cpy_nd_negative_target_stride(%arg0: !amdaie.logicalobjectfif
 func.func @npu_dma_cpy_nd_negative_source_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   // expected-error @+1 {{expected source offsets to be non-negative, but got -1}}
-  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, -1] [1, 1, 8, 16] [128, 16, 16, 1])
+  %1 = amdaie.npu.dma_cpy_nd async_source %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, -1] [1, 1, 8, 16] [128, 16, 16, 1])
   return
 }
 
@@ -472,7 +472,7 @@ func.func @npu_dma_cpy_nd_negative_source_offset(%arg0: !amdaie.logicalobjectfif
 func.func @npu_dma_cpy_nd_negative_source_size(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   // expected-error @+1 {{expected source sizes to be non-negative, but got -8}}
-  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 1, -8, 16] [128, 16, 16, 1])
+  %1 = amdaie.npu.dma_cpy_nd async_source %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 1, -8, 16] [128, 16, 16, 1])
   return
 }
 
@@ -481,7 +481,7 @@ func.func @npu_dma_cpy_nd_negative_source_size(%arg0: !amdaie.logicalobjectfifo<
 func.func @npu_dma_cpy_nd_negative_source_stride(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   // expected-error @+1 {{expected source strides to be non-negative, but got -16}}
-  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 1, 8, 16] [128, -16, 16, 1])
+  %1 = amdaie.npu.dma_cpy_nd async_source %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 1, 8, 16] [128, -16, 16, 1])
   return
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeNpuDmaCpyNd.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeNpuDmaCpyNd.cpp
@@ -103,9 +103,10 @@ class AMDAIECanonicalizeNpuDmaCpyNdPass
 
       // Replace the npu.dma_cpy_nd with the canonicalized version.
       dmaOp = rewriter.replaceOpWithNewOp<AMDAIE::NpuDmaCpyNdOp>(
-          dmaOp, dmaOp.getConnection(), dmaOp.getTarget(), tgtOffsets, tgtSizes,
-          tgtStrides, dmaOp.getTargetBdId(), dmaOp.getSource(), srcOffsets,
-          srcSizes, srcStrides, dmaOp.getSourceBdId());
+          dmaOp, dmaOp.getResultTypes(), dmaOp.getConnection(),
+          dmaOp.getTarget(), tgtOffsets, tgtSizes, tgtStrides,
+          dmaOp.getTargetBdId(), dmaOp.getSource(), srcOffsets, srcSizes,
+          srcStrides, dmaOp.getSourceBdId());
 
       return WalkResult::advance();
     });

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
@@ -185,16 +185,19 @@ LogicalResult WorkgroupBuilder::buildForDmaCpyNdOp(
       circularDmaTargetOffsets, circularDmaTargetSizes,
       circularDmaTargetStrides, circularDmaSourceOffsets,
       circularDmaSourceSizes, circularDmaSourceStrides);
+  Type ty =
+      !sourceMemSpace
+          ? static_cast<Type>(
+                controlCodeRewriter.getType<AMDAIE::AsyncSourceTokenType>())
+          : static_cast<Type>(
+                controlCodeRewriter.getType<AMDAIE::AsyncTargetTokenType>());
   auto npuDmaCpy = controlCodeRewriter.createAndLookup<AMDAIE::NpuDmaCpyNdOp>(
-      loc, connectionOp.getResult(), npuDmaTarget, npuDmaTargetOffsets,
+      loc, ty, connectionOp.getResult(), npuDmaTarget, npuDmaTargetOffsets,
       npuDmaTargetSizes, npuDmaTargetStrides, /*target_bd_id=*/nullptr,
       npuDmaSource, npuDmaSourceOffsets, npuDmaSourceSizes, npuDmaSourceStrides,
       /*source_bd_id=*/nullptr);
-  DMAChannelDir direction =
-      !sourceMemSpace ? DMAChannelDir::MM2S : DMAChannelDir::S2MM;
   controlCodeRewriter.createAndLookup<AMDAIE::NpuDmaWaitOp>(
-      rewriter.getUnknownLoc(), SmallVector<Type, 1>{}, npuDmaCpy.getResult(),
-      direction);
+      rewriter.getUnknownLoc(), SmallVector<Type, 1>{}, npuDmaCpy.getResult(0));
   rewriter.restoreInsertionPoint(dmaInsertionPoint);
   LLVM_DEBUG(llvm::dbgs() << "workgroupBuild [amdaie.dma_cpy_nd] End\n");
   return success();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
@@ -19,8 +19,8 @@ module {
 // CHECK-DAG:     %[[FROM_MEMREF:.+]] = amdaie.logicalobjectfifo.from_memref %{{.+}}, {%[[TILE_0_0]]} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:         %[[CIRC_DMA:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         amdaie.controlcode
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], MM2S)
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_source_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -35,8 +35,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %from_memref_1 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_0_1} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
       %0 = amdaie.circular_dma_cpy_nd(%from_memref_1[] [] [], %placeholder[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], %from_memref_0[0, 0, 0] [1, 8, 16] [128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
-        amdaie.npu.dma_wait(%1, MM2S)
+        %1 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], %from_memref_0[0, 0, 0] [1, 8, 16] [128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
         amdaie.end
       }
     }
@@ -54,8 +54,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK-DAG:     %[[FROM_MEMREF:.+]] = amdaie.logicalobjectfifo.from_memref %{{.+}}, {%[[TILE_0_0]]} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:         %[[CIRC_DMA:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         amdaie.controlcode
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]](%[[FROM_MEMREF]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]], [] [] [])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CIRC_DMA]](%[[FROM_MEMREF]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]], [] [] [])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -70,8 +70,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %from_memref_1 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_0_1} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
       %0 = amdaie.circular_dma_cpy_nd(%placeholder[] [] [], %from_memref_1[] [] []) : (!amdaie.logicalobjectfifo<memref<8x16xi32>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0(%from_memref_0[0, 0, 0] [1, 8, 16] [128, 16, 1], [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
-        amdaie.npu.dma_wait(%1, S2MM)
+        %1 = amdaie.npu.dma_cpy_nd async_target %0(%from_memref_0[0, 0, 0] [1, 8, 16] [128, 16, 1], [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        amdaie.npu.dma_wait(%1 : !amdaie.async_target_token)
         amdaie.end
       }
     }
@@ -99,12 +99,12 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:         %[[CIRC_DMA_1:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         %[[CIRC_DMA_2:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         amdaie.controlcode
-// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_0]]([] [] [], %[[FROM_MEMREF_0]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
-// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_1]]([] [] [], %[[FROM_MEMREF_1]][0, 0] [8, 16] [16, 1] bd_id = %[[BD_ID_1]])
-// CHECK:           %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_2]]([] [] [], %[[FROM_MEMREF_2]][0] [128] [1] bd_id = %[[BD_ID_2]])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]], MM2S)
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_1]], MM2S)
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_2]], MM2S)
+// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CIRC_DMA_0]]([] [] [], %[[FROM_MEMREF_0]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
+// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CIRC_DMA_1]]([] [] [], %[[FROM_MEMREF_1]][0, 0] [8, 16] [16, 1] bd_id = %[[BD_ID_1]])
+// CHECK:           %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CIRC_DMA_2]]([] [] [], %[[FROM_MEMREF_2]][0] [128] [1] bd_id = %[[BD_ID_2]])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]] : !amdaie.async_source_token)
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_1]] : !amdaie.async_source_token)
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_2]] : !amdaie.async_source_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -128,12 +128,12 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %dma1 = amdaie.circular_dma_cpy_nd(%from_memref_3[] [] [], %placeholder1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       %dma2 = amdaie.circular_dma_cpy_nd(%from_memref_3[] [] [], %placeholder2[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %0 = amdaie.npu.dma_cpy_nd %dma0([] [] [], %from_memref_0[0, 0, 0] [1, 8, 16] [128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
-        %1 = amdaie.npu.dma_cpy_nd %dma1([] [] [], %from_memref_1[0, 0] [8, 16] [16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
-        %2 = amdaie.npu.dma_cpy_nd %dma2([] [] [], %from_memref_2[0] [128] [1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
-        amdaie.npu.dma_wait(%0, MM2S)
-        amdaie.npu.dma_wait(%1, MM2S)
-        amdaie.npu.dma_wait(%2, MM2S)
+        %0 = amdaie.npu.dma_cpy_nd async_source %dma0([] [] [], %from_memref_0[0, 0, 0] [1, 8, 16] [128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %1 = amdaie.npu.dma_cpy_nd async_source %dma1([] [] [], %from_memref_1[0, 0] [8, 16] [16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %2 = amdaie.npu.dma_cpy_nd async_source %dma2([] [] [], %from_memref_2[0] [128] [1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        amdaie.npu.dma_wait(%0 : !amdaie.async_source_token)
+        amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
+        amdaie.npu.dma_wait(%2 : !amdaie.async_source_token)
         amdaie.end
       }
     }
@@ -151,12 +151,12 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK-DAG:     %[[FROM_MEMREF_0:.+]] = amdaie.logicalobjectfifo.from_memref %{{.+}}, {%[[TILE_0_0]]} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:         %[[CIRC_DMA:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         amdaie.controlcode
-// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]], MM2S)
-// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0, 0] [8, 16] [16, 1] bd_id = %[[BD_ID_0]])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_1]], MM2S)
-// CHECK:           %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0] [128] [1] bd_id = %[[BD_ID_0]])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_2]], MM2S)
+// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]] : !amdaie.async_source_token)
+// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0, 0] [8, 16] [16, 1] bd_id = %[[BD_ID_0]])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_1]] : !amdaie.async_source_token)
+// CHECK:           %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0] [128] [1] bd_id = %[[BD_ID_0]])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_2]] : !amdaie.async_source_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -171,12 +171,12 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %from_memref_1 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_0_1} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
       %0 = amdaie.circular_dma_cpy_nd(%from_memref_1[] [] [], %placeholder0[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], %from_memref_0[0, 0, 0] [1, 8, 16] [128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
-        amdaie.npu.dma_wait(%1, MM2S)
-        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], %from_memref_0[0, 0] [8, 16] [16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
-        amdaie.npu.dma_wait(%2, MM2S)
-        %3 = amdaie.npu.dma_cpy_nd %0([] [] [], %from_memref_0[0] [128] [1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
-        amdaie.npu.dma_wait(%3, MM2S)
+        %1 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], %from_memref_0[0, 0, 0] [1, 8, 16] [128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
+        %2 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], %from_memref_0[0, 0] [8, 16] [16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        amdaie.npu.dma_wait(%2 : !amdaie.async_source_token)
+        %3 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], %from_memref_0[0] [128] [1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        amdaie.npu.dma_wait(%3 : !amdaie.async_source_token)
         amdaie.end
       }
     }
@@ -196,12 +196,12 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK-DAG:     %[[FROM_MEMREF_0:.+]] = amdaie.logicalobjectfifo.from_memref %{{.+}}, {%[[TILE_0_0]]} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:         %[[CIRC_DMA:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         amdaie.controlcode
-// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
-// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0, 0] [8, 16] [16, 1] bd_id = %[[BD_ID_1]])
-// CHECK:           %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0] [128] [1] bd_id = %[[BD_ID_2]])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]], MM2S)
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_1]], MM2S)
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_2]], MM2S)
+// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
+// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0, 0] [8, 16] [16, 1] bd_id = %[[BD_ID_1]])
+// CHECK:           %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CIRC_DMA]]([] [] [], %[[FROM_MEMREF_0]][0] [128] [1] bd_id = %[[BD_ID_2]])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]] : !amdaie.async_source_token)
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_1]] : !amdaie.async_source_token)
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_2]] : !amdaie.async_source_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -216,12 +216,12 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %from_memref_1 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_0_1} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
       %0 = amdaie.circular_dma_cpy_nd(%from_memref_1[] [] [], %placeholder0[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], %from_memref_0[0, 0, 0] [1, 8, 16] [128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
-        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], %from_memref_0[0, 0] [8, 16] [16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
-        %3 = amdaie.npu.dma_cpy_nd %0([] [] [], %from_memref_0[0] [128] [1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
-        amdaie.npu.dma_wait(%1, MM2S)
-        amdaie.npu.dma_wait(%2, MM2S)
-        amdaie.npu.dma_wait(%3, MM2S)
+        %1 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], %from_memref_0[0, 0, 0] [1, 8, 16] [128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %2 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], %from_memref_0[0, 0] [8, 16] [16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %3 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], %from_memref_0[0] [128] [1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
+        amdaie.npu.dma_wait(%2 : !amdaie.async_source_token)
+        amdaie.npu.dma_wait(%3 : !amdaie.async_source_token)
         amdaie.end
       }
     }
@@ -252,20 +252,20 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:         %[[CIRC_DMA_1:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         %[[CIRC_DMA_2:.+]] = amdaie.circular_dma_cpy_nd
 // CHECK:         amdaie.controlcode
-// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_0]]([] [] [], %[[FROM_MEMREF_0]][0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1] bd_id = %[[BD_ID_0_0]])
+// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CIRC_DMA_0]]([] [] [], %[[FROM_MEMREF_0]][0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1] bd_id = %[[BD_ID_0_0]])
 // CHECK:           scf.forall (%{{.+}}, %{{.+}}) in (2, 2)
-// CHECK:             %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_1]]([] [] [], %[[FROM_MEMREF_1]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_1_0]])
+// CHECK:             %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CIRC_DMA_1]]([] [] [], %[[FROM_MEMREF_1]][0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_1_0]])
 // CHECK:             scf.for %{{.+}} = %[[C0]] to %[[C6]] step %[[C1]]
-// CHECK:               %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_1]]([] [] [], %[[FROM_MEMREF_1]][0, 0] [1, 128] [128, 1] bd_id = %[[BD_ID_1_1]])
-// CHECK:               %[[NPU_DMA_3:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_0]]([] [] [], %[[FROM_MEMREF_0]][0] [128] [1] bd_id = %[[BD_ID_0_1]])
-// CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_2]], MM2S)
-// CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_3]], MM2S)
-// CHECK:               %[[NPU_DMA_4:.+]] = amdaie.npu.dma_cpy_nd %[[CIRC_DMA_2]]([] [] [], %[[FROM_MEMREF_2]][] [] [] bd_id = %[[BD_ID_2_0]])
-// CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_4]], MM2S)
+// CHECK:               %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CIRC_DMA_1]]([] [] [], %[[FROM_MEMREF_1]][0, 0] [1, 128] [128, 1] bd_id = %[[BD_ID_1_1]])
+// CHECK:               %[[NPU_DMA_3:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CIRC_DMA_0]]([] [] [], %[[FROM_MEMREF_0]][0] [128] [1] bd_id = %[[BD_ID_0_1]])
+// CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_2]] : !amdaie.async_source_token)
+// CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_3]] : !amdaie.async_source_token)
+// CHECK:               %[[NPU_DMA_4:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CIRC_DMA_2]]([] [] [], %[[FROM_MEMREF_2]][] [] [] bd_id = %[[BD_ID_2_0]])
+// CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_4]] : !amdaie.async_source_token)
 // CHECK:             }
-// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA_1]], MM2S)
+// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA_1]] : !amdaie.async_source_token)
 // CHECK:           }
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]], MM2S)
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]] : !amdaie.async_source_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -290,20 +290,20 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %dma1 = amdaie.circular_dma_cpy_nd(%from_memref_3[] [] [], %placeholder1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       %dma2 = amdaie.circular_dma_cpy_nd(%from_memref_3[] [] [], %placeholder2[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %0 = amdaie.npu.dma_cpy_nd %dma0([] [] [], %from_memref_0[0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %0 = amdaie.npu.dma_cpy_nd async_source %dma0([] [] [], %from_memref_0[0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
         scf.forall (%arg4, %arg5) in (2, 2) {
-          %1 = amdaie.npu.dma_cpy_nd %dma1([] [] [], %from_memref_1[0, 0, 0] [1, 8, 16] [128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+          %1 = amdaie.npu.dma_cpy_nd async_source %dma1([] [] [], %from_memref_1[0, 0, 0] [1, 8, 16] [128, 16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
           scf.for %arg6 = %c0 to %c6 step %c1 {
-            %2 = amdaie.npu.dma_cpy_nd %dma1([] [] [], %from_memref_1[0, 0] [1, 128] [128, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
-            %3 = amdaie.npu.dma_cpy_nd %dma0([] [] [], %from_memref_0[0] [128] [1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
-            amdaie.npu.dma_wait(%2, MM2S)
-            amdaie.npu.dma_wait(%3, MM2S)
-            %4 = amdaie.npu.dma_cpy_nd %dma2([] [] [], %from_memref_2[] [] []) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
-            amdaie.npu.dma_wait(%4, MM2S)
+            %2 = amdaie.npu.dma_cpy_nd async_source %dma1([] [] [], %from_memref_1[0, 0] [1, 128] [128, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+            %3 = amdaie.npu.dma_cpy_nd async_source %dma0([] [] [], %from_memref_0[0] [128] [1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+            amdaie.npu.dma_wait(%2 : !amdaie.async_source_token)
+            amdaie.npu.dma_wait(%3 : !amdaie.async_source_token)
+            %4 = amdaie.npu.dma_cpy_nd async_source %dma2([] [] [], %from_memref_2[] [] []) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+            amdaie.npu.dma_wait(%4 : !amdaie.async_source_token)
           }
-          amdaie.npu.dma_wait(%1, MM2S)
+          amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
         }
-        amdaie.npu.dma_wait(%0, MM2S)
+        amdaie.npu.dma_wait(%0 : !amdaie.async_source_token)
         amdaie.end
       }
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_doubly_strided_op.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_doubly_strided_op.mlir
@@ -210,7 +210,7 @@ func.func @dma_cpy_nd_partial_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<m
 // FOLD-SINGLE-DIMS:        amdaie.npu.dma_cpy_nd %[[DMA0]]([] [] [], [] [] [])
 func.func @npu_dma_cpy_nd_source(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 4, 2, 8] [64, 16, 8, 1])
+  amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 4, 2, 8] [64, 16, 8, 1])
   return
 }
 
@@ -221,7 +221,7 @@ func.func @npu_dma_cpy_nd_source(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x1
 // FOLD-SINGLE-DIMS:  amdaie.npu.dma_cpy_nd %{{.+}}([] [] [], [] [] [])
 func.func @npu_dma_cpy_nd_linear_implicit(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 4, 2, 8] [64, 16, 8, 1])
+  amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 0] [1, 4, 2, 8] [64, 16, 8, 1])
   return
 }
 
@@ -233,7 +233,7 @@ func.func @npu_dma_cpy_nd_linear_implicit(%arg0: !amdaie.logicalobjectfifo<memre
 func.func @npu_dma_cpy_nd_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %c16 = arith.constant 16 : index
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 2, 8, 8] [256, 128, %c16, 1], [0, 0, 0, 0] [64, 16, 8, %c16] [128, %c16, %c16, 1])
+  amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [1, 2, 8, 8] [256, 128, %c16, 1], [0, 0, 0, 0] [64, 16, 8, %c16] [128, %c16, %c16, 1])
   return
 }
 
@@ -244,7 +244,7 @@ func.func @npu_dma_cpy_nd_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x1
 // FOLD-SINGLE-DIMS:  amdaie.npu.dma_cpy_nd %{{.+}}([0, 0, 0, 0] [2, 2, 8, 8] [256, 64, 16, 1], [0, 0, 0, 0] [2, 2, 8, 16] [128, 16, 8, 1])
 func.func @npu_dma_cpy_nd_no_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [2, 2, 8, 8] [256, 64, 16, 1], [0, 0, 0, 0] [2, 2, 8, 16] [128, 16, 8, 1])
+  amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [2, 2, 8, 8] [256, 64, 16, 1], [0, 0, 0, 0] [2, 2, 8, 16] [128, 16, 8, 1])
   return
 }
 
@@ -255,7 +255,7 @@ func.func @npu_dma_cpy_nd_no_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x
 // FOLD-SINGLE-DIMS:      amdaie.npu.dma_cpy_nd %{{.+}}([] [] [], [0, 0, 0] [2, 8, 8] [8, 16, 1])
 func.func @npu_dma_cpy_nd_unit(%arg0: !amdaie.logicalobjectfifo<memref<1x1x2x2x4x8xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x2x2x4x8xi32, 1>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>)
-  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0, 0, 0] [1, 1, 2, 2, 4, 8] [128, 128, 64, 32, 8, 1], [0, 0, 0, 0, 0, 0] [1, 1, 2, 2, 4, 8] [128, 128, 8, 64, 16, 1])
+  amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0, 0, 0] [1, 1, 2, 2, 4, 8] [128, 128, 64, 32, 8, 1], [0, 0, 0, 0, 0, 0] [1, 1, 2, 2, 4, 8] [128, 128, 8, 64, 16, 1])
   return
 }
 
@@ -266,7 +266,7 @@ func.func @npu_dma_cpy_nd_unit(%arg0: !amdaie.logicalobjectfifo<memref<1x1x2x2x4
 // FOLD-SINGLE-DIMS:  amdaie.npu.dma_cpy_nd %{{.+}}([] [] [], [] [] [])
 func.func @npu_dma_cpy_nd_unit_between_linear(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [2, 1, 64, 64] [4096, 64, 64, 1], [0, 0, 0, 0] [2, 1, 1, 64] [64, 64, 64, 1])
+  amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [2, 1, 64, 64] [4096, 64, 64, 1], [0, 0, 0, 0] [2, 1, 1, 64] [64, 64, 64, 1])
   return
 }
 
@@ -277,7 +277,7 @@ func.func @npu_dma_cpy_nd_unit_between_linear(%arg0: !amdaie.logicalobjectfifo<m
 // FOLD-SINGLE-DIMS:  amdaie.npu.dma_cpy_nd %{{.+}}([1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
 func.func @npu_dma_cpy_nd_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-  %1 = amdaie.npu.dma_cpy_nd %0([1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
+  amdaie.npu.dma_cpy_nd %0([1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
   return
 }
 
@@ -288,6 +288,6 @@ func.func @npu_dma_cpy_nd_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memre
 // FOLD-SINGLE-DIMS:      amdaie.npu.dma_cpy_nd %{{.+}}([1] [128] [1], [1] [64] [1])
 func.func @npu_dma_cpy_nd_partial_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-  %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 1] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 1] [1, 4, 2, 8] [64, 16, 8, 1])
+  amdaie.npu.dma_cpy_nd %0([0, 0, 0, 1] [1, 1, 8, 16] [128, 128, 16, 1], [0, 0, 0, 1] [1, 4, 2, 8] [64, 16, 8, 1])
   return
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_npu_dma_cpy_nd.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_npu_dma_cpy_nd.mlir
@@ -9,7 +9,7 @@ module {
       %0 = amdaie.connection(%arg1, %arg2) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
       amdaie.controlcode {
          // expected-error @+1 {{'amdaie.npu.dma_cpy_nd' op might have stride=0 in dimension 2, and size>1 in dimension 1. As 1 < 2, this cannot be supported -- the zero stride cannot be moved to the outer-most (slowest) dimension, as required by current AIE architecture.}}
-        %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 32] [1, 32, 2, 32] [128, 64, 0, 1] bd_id = %arg0, [] [] [])
+        amdaie.npu.dma_cpy_nd %0([0, 0, 0, 32] [1, 32, 2, 32] [128, 64, 0, 1] bd_id = %arg0, [] [] [])
         amdaie.end
       }
     }
@@ -28,7 +28,7 @@ module {
       %0 = amdaie.connection(%arg1, %arg2) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
       amdaie.controlcode {
          // expected-error @+1 {{'amdaie.npu.dma_cpy_nd' op might have stride=0 in dimension 1, and size>1 in dimension 0. As 0 < 1, this cannot be supported -- the zero stride cannot be moved to the outer-most (slowest) dimension, as required by current AIE architecture.}}
-        %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 32] [2, 8, 2, 32] [0, 0, 64, 1] bd_id = %arg0, [] [] [])
+        amdaie.npu.dma_cpy_nd %0([0, 0, 0, 32] [2, 8, 2, 32] [0, 0, 64, 1] bd_id = %arg0, [] [] [])
         amdaie.end
       }
     }
@@ -47,7 +47,7 @@ module {
       %0 = amdaie.connection(%arg1, %arg2) : (!amdaie.logicalobjectfifo<memref<2048xi32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1>>)
       amdaie.controlcode {
         // expected-error @+1 {{'amdaie.npu.dma_cpy_nd' op has target in L3, but does not have target addressing. Target addressing is required to canonicalize}}
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [] bd_id = %arg0, [] [] [])
+        amdaie.npu.dma_cpy_nd %0([] [] [] bd_id = %arg0, [] [] [])
         amdaie.end
       }
     }
@@ -69,7 +69,7 @@ module {
       amdaie.controlcode {
         // CHECK: amdaie.npu.dma_cpy_nd
         // CHECK-SAME: [0, 0, 0, 0] [1, 1, 1, 10] [0, 0, 0, 1]
-        %1 = amdaie.npu.dma_cpy_nd %0([0] [10] [1] bd_id = %arg0, [] [] [])
+        amdaie.npu.dma_cpy_nd %0([0] [10] [1] bd_id = %arg0, [] [] [])
         amdaie.end
       }
     }
@@ -93,7 +93,7 @@ module {
       amdaie.controlcode {
         // CHECK: amdaie.npu.dma_cpy_nd
         // CHECK-SAME: [0, 0, 0, 0] [1, 1, 1, 10] [0, 0, 0, 1]
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [] bd_id = %arg0, [0] [10] [1])
+        amdaie.npu.dma_cpy_nd %0([] [] [] bd_id = %arg0, [0] [10] [1])
         amdaie.end
       }
     }
@@ -117,7 +117,7 @@ module {
       amdaie.controlcode {
         // CHECK: amdaie.npu.dma_cpy_nd
         // CHECK-SAME: [3, 1, 2, 4] [10, 1, 1, 12] [0, 100, 200, 300]
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [] bd_id = %arg0, [1, 2, 3, 4] [1, 1, 10, 12] [100, 200, 0, 300])
+        amdaie.npu.dma_cpy_nd %0([] [] [] bd_id = %arg0, [1, 2, 3, 4] [1, 1, 10, 12] [100, 200, 0, 300])
         amdaie.end
       }
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/combine_strided_ops.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/combine_strided_ops.mlir
@@ -6,7 +6,7 @@ module {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
         // expected-error @+1 {{No AMDAIEDevice found in the target attribute configuration}}
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [] [] [])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [] [] [])
         amdaie.end
       }
     }
@@ -32,8 +32,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       %1 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
-        %3 = amdaie.npu.dma_cpy_nd %1([] [] [], [32] [16] [1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
+        amdaie.npu.dma_cpy_nd %1([] [] [], [32] [16] [1])
         amdaie.end
       }
     }
@@ -53,8 +53,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
-        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
         amdaie.end
       }
     }
@@ -74,8 +74,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([0, 32] [16, 32] [64, 1], [] [] [])
-        %2 = amdaie.npu.dma_cpy_nd %0([0, 32] [16, 32] [64, 1], [] [] [])
+        amdaie.npu.dma_cpy_nd %0([0, 32] [16, 32] [64, 1], [] [] [])
+        amdaie.npu.dma_cpy_nd %0([0, 32] [16, 32] [64, 1], [] [] [])
         amdaie.end
       }
     }
@@ -95,8 +95,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0, 0] [8, 16, 8, 16] [8, 32, 8, 1])
-        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0, 32] [8, 16, 8, 16] [8, 32, 8, 1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0, 0] [8, 16, 8, 16] [8, 32, 8, 1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0, 32] [8, 16, 8, 16] [8, 32, 8, 1])
         amdaie.end
       }
     }
@@ -116,8 +116,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [8, 16, 8, 16] [8, 32, 8, 1], [] [] [])
-        %2 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 32] [8, 16, 8, 16] [8, 32, 8, 1], [] [] [])
+        amdaie.npu.dma_cpy_nd %0([0, 0, 0, 0] [8, 16, 8, 16] [8, 32, 8, 1], [] [] [])
+        amdaie.npu.dma_cpy_nd %0([0, 0, 0, 32] [8, 16, 8, 16] [8, 32, 8, 1], [] [] [])
         amdaie.end
       }
     }
@@ -138,9 +138,9 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
-        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0] [8] [1])
-        %3 = amdaie.npu.dma_cpy_nd %0([] [] [], [32] [16] [1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0] [8] [1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [32] [16] [1])
         amdaie.end
       }
     }
@@ -166,11 +166,11 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
         scf.for %arg2 = %c0 to %c6 step %c1 {
-          %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [32] [16] [1])
+          amdaie.npu.dma_cpy_nd %0([] [] [], [32] [16] [1])
         }
-        %3 = amdaie.npu.dma_cpy_nd %0([] [] [], [64] [16] [1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [64] [16] [1])
         amdaie.end
       }
     }
@@ -186,9 +186,9 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 
 // CHECK-LABEL: @no_dims
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
-// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [] [] [])
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION]]([] [] [], [] [] [])
 // CHECK-NOT:   amdaie.npu.dma_cpy_nd
-// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]], MM2S)
+// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_source_token)
 // CHECK-NOT:   amdaie.npu.dma_wait
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -196,10 +196,10 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [] [] [])
-        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [] [] [])
-        amdaie.npu.dma_wait(%1, MM2S)
-        amdaie.npu.dma_wait(%2, MM2S)
+        %1 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], [] [] [])
+        %2 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], [] [] [])
+        amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
+        amdaie.npu.dma_wait(%2 : !amdaie.async_source_token)
         amdaie.end
       }
     }
@@ -219,8 +219,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0] [16, 8, 16] [32, 8, 1])
-        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 32] [16, 8, 16] [32, 8, 1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0] [16, 8, 16] [32, 8, 1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 32] [16, 8, 16] [32, 8, 1])
         amdaie.end
       }
     }
@@ -245,8 +245,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [%c0, %c0, %c0] [%c16, %c8, %c16] [%c32, %c8, %c1])
-        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [%c0, %c0, %c32] [%c16, %c8, %c16] [%c32, %c8, %c1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [%c0, %c0, %c0] [%c16, %c8, %c16] [%c32, %c8, %c1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [%c0, %c0, %c32] [%c16, %c8, %c16] [%c32, %c8, %c1])
         amdaie.end
       }
     }
@@ -266,8 +266,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0] [16, 8, 16] [32, 8, 1])
-        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0, 64] [2, 16, 8, 16] [64, 32, 8, 1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0] [16, 8, 16] [32, 8, 1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0, 64] [2, 16, 8, 16] [64, 32, 8, 1])
         amdaie.end
       }
     }
@@ -283,9 +283,9 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK-DAG:   %[[C6:.+]] = arith.constant 6 : index
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       scf.for %[[ARG2:.+]] = %[[C1]] to %[[C6]] step %[[C2]]
-// CHECK:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, %[[ARG2]], 0] [2, 16, 8, 16] [32, 32, 8, 1])
+// CHECK:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION]]([] [] [], [0, 0, %[[ARG2]], 0] [2, 16, 8, 16] [32, 32, 8, 1])
 // CHECK-NOT:     amdaie.npu.dma_cpy_nd
-// CHECK:         amdaie.npu.dma_wait(%[[NPU_DMA]], MM2S)
+// CHECK:         amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_source_token)
 // CHECK-NOT:     amdaie.npu.dma_wait
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -297,10 +297,10 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
         scf.for %arg2 = %c1 to %c6 step %c2 {
-          %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, %arg2, 0] [16, 8, 16] [32, 8, 1])
-          amdaie.npu.dma_wait(%1, MM2S)
-          %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, %arg2, 32] [16, 8, 16] [32, 8, 1])
-          amdaie.npu.dma_wait(%2, MM2S)
+          %1 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], [0, %arg2, 0] [16, 8, 16] [32, 8, 1])
+          amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
+          %2 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], [0, %arg2, 32] [16, 8, 16] [32, 8, 1])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_source_token)
         }
         amdaie.end
       }
@@ -321,8 +321,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 32] [16, 8, 16] [32, 8, 1], [] [] [])
-        %2 = amdaie.npu.dma_cpy_nd %0([0, 0, 64] [16, 8, 16] [32, 8, 1], [] [] [])
+        amdaie.npu.dma_cpy_nd %0([0, 0, 32] [16, 8, 16] [32, 8, 1], [] [] [])
+        amdaie.npu.dma_cpy_nd %0([0, 0, 64] [16, 8, 16] [32, 8, 1], [] [] [])
         amdaie.end
       }
     }
@@ -342,8 +342,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([0, 0, 32] [16, 8, 16] [32, 8, 1], [] [] [])
-        %2 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, 96] [2, 16, 8, 16] [64, 32, 8, 1], [] [] [])
+        amdaie.npu.dma_cpy_nd %0([0, 0, 32] [16, 8, 16] [32, 8, 1], [] [] [])
+        amdaie.npu.dma_cpy_nd %0([0, 0, 0, 96] [2, 16, 8, 16] [64, 32, 8, 1], [] [] [])
         amdaie.end
       }
     }
@@ -369,8 +369,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([%c0, %c0, %c32] [%c16, %c8, %c16] [%c32, %c8, %c1], [] [] [])
-        %2 = amdaie.npu.dma_cpy_nd %0([%c0, %c0, %c64] [%c16, %c8, %c16] [%c32, %c8, %c1], [] [] [])
+        amdaie.npu.dma_cpy_nd %0([%c0, %c0, %c32] [%c16, %c8, %c16] [%c32, %c8, %c1], [] [] [])
+        amdaie.npu.dma_cpy_nd %0([%c0, %c0, %c64] [%c16, %c8, %c16] [%c32, %c8, %c1], [] [] [])
         amdaie.end
       }
     }
@@ -386,9 +386,9 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK-DAG:   %[[C6:.+]] = arith.constant 6 : index
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       scf.for %[[ARG2:.+]] = %[[C0]] to %[[C6]] step %[[C1]]
-// CHECK:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, %[[ARG2]], 0, 32] [2, 16, 8, 16] [32, 32, 8, 1], [] [] [])
+// CHECK:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION]]([0, %[[ARG2]], 0, 32] [2, 16, 8, 16] [32, 32, 8, 1], [] [] [])
 // CHECK-NOT:     amdaie.npu.dma_cpy_nd
-// CHECK:         amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:         amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_source_token)
 // CHECK-NOT:     amdaie.npu.dma_cpy_nd
 // CHECK-NOT:     amdaie.npu.dma_wait
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
@@ -401,10 +401,10 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
       amdaie.controlcode {
         scf.for %arg2 = %c0 to %c6 step %c1 {
-          %1 = amdaie.npu.dma_cpy_nd %0([%arg2, 0, 32] [16, 8, 16] [32, 8, 1], [] [] [])
-          amdaie.npu.dma_wait(%1, S2MM)
-          %2 = amdaie.npu.dma_cpy_nd %0([%arg2, 0, 64] [16, 8, 16] [32, 8, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %1 = amdaie.npu.dma_cpy_nd async_source %0([%arg2, 0, 32] [16, 8, 16] [32, 8, 1], [] [] [])
+          amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
+          %2 = amdaie.npu.dma_cpy_nd async_source %0([%arg2, 0, 64] [16, 8, 16] [32, 8, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_source_token)
         }
         amdaie.end
       }
@@ -423,7 +423,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // touch the circular DMA in between. Therefore, the wait can be removed.
 // CHECK-LABEL: @wait_after_first
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
-// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [] [] [])
+// CHECK:       amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [] [] [])
 // CHECK-NOT:   amdaie.npu.dma_cpy_nd
 // CHECK-NOT:   amdaie.npu.dma_wait
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
@@ -432,9 +432,9 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [] [] [])
-        amdaie.npu.dma_wait(%1, MM2S)
-        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [] [] [])
+        %1 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], [] [] [])
+        amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
+        amdaie.npu.dma_cpy_nd %0([] [] [], [] [] [])
         amdaie.end
       }
     }
@@ -447,18 +447,18 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // Keep wait after the last NPU DMA operation.
 // CHECK-LABEL: @wait_after_last
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
-// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [] [] [])
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION]]([] [] [], [] [] [])
 // CHECK-NOT:   amdaie.npu.dma_cpy_nd
-// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]], MM2S)
+// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_source_token)
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @wait_after_last(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32>>) {
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [] [] [])
-        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [] [] [])
-        amdaie.npu.dma_wait(%2, MM2S)
+        amdaie.npu.dma_cpy_nd %0([] [] [], [] [] [])
+        %1 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], [] [] [])
+        amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
         amdaie.end
       }
     }
@@ -478,9 +478,9 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
-        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [32] [16] [1])
-        %3 = amdaie.npu.dma_cpy_nd %0([] [] [], [64] [16] [1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [32] [16] [1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [64] [16] [1])
         amdaie.end
       }
     }
@@ -500,9 +500,9 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
-        %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
-        %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 32] [2, 16] [32, 1])
-        %3 = amdaie.npu.dma_cpy_nd %0([] [] [], [96] [16] [1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0, 32] [2, 16] [32, 1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [96] [16] [1])
         amdaie.end
       }
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
@@ -69,10 +69,10 @@ func.func @core() {
 // CHECK:         amdaie.controlcode
 // CHECK:           %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG1]], {} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:           amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([] [] [], [] [] [])
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION]]
 // CHECK-SAME:      [] [] []
 // CHECK-SAME:      %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], MM2S)
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_source_token)
 func.func @dma_cpy_nd_L3_L2(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi32>) {
   %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
   %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
@@ -92,10 +92,10 @@ func.func @dma_cpy_nd_L3_L2(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi
 // CHECK:         amdaie.controlcode
 // CHECK:           %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG1]], {} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
 // CHECK:           amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1], [] [] [])
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION]]
 // CHECK-SAME:      [] [] []
 // CHECK-SAME:      %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], MM2S)
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_source_token)
 func.func @dma_cpy_nd_L3_L2_target_addressing(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi32>) {
   %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
   %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
@@ -115,8 +115,8 @@ func.func @dma_cpy_nd_L3_L2_target_addressing(%arg0: memref<1x1x8x16xi32, 1>, %a
 // CHECK:         amdaie.controlcode
 // CHECK:           %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]], {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
 // CHECK:           amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]](%[[FROMMEMREF1]][] [] [], [] [] [])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]](%[[FROMMEMREF1]][] [] [], [] [] [])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 func.func @dma_cpy_nd_L2_L3(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) {
   %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
   %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
@@ -136,10 +136,10 @@ func.func @dma_cpy_nd_L2_L3(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32,
 // CHECK:         amdaie.controlcode
 // CHECK:           %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]], {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
 // CHECK:           amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]
 // CHECK-SAME:      %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]
 // CHECK-SAME:      [] [] []
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 func.func @dma_cpy_nd_L2_L3_target_addressing(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) {
   %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
   %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
@@ -236,10 +236,10 @@ func.func @for_cores() {
 // CHECK-DAG:       %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]]
 // CHECK:           scf.for %[[ARG:.+]] = %[[C0_1]] to %[[C8_1]] step %[[C1_1]]
 // CHECK:             amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([] [] [], [] [] [])
-// CHECK:             %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]
+// CHECK:             %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION]]
 // CHECK-SAME:        [] [] []
 // CHECK-SAME:        %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, %[[ARG]], 1]
-// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA]], MM2S)
+// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_source_token)
 func.func @for_dma(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
@@ -311,10 +311,10 @@ func.func @forall_cores() {
 // CHECK-DAG:     %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]]
 // CHECK:           scf.forall (%[[ARG0:.*]], %[[ARG1:.*]]) in (2, 2)
 // CHECK:             amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([] [] [], [] [] [])
-// CHECK:             %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]
+// CHECK:             %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION]]
 // CHECK-SAME:        [] [] []
 // CHECK-SAME:        %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, %[[ARG1]], %[[ARG0]], 1]
-// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA]], MM2S)
+// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_source_token)
 func.func @forall_dmas(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) {
   %0 = amdaie.logicalobjectfifo.from_memref %arg0, {} : memref<1x1x8x16xi32> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
   %1 = amdaie.logicalobjectfifo.from_memref %arg1, {} : memref<8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>
@@ -355,12 +355,12 @@ func.func @forall_dmas(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) 
 // CHECK-DAG:       %[[C8_1:.+]] = arith.constant 8 : index
 // CHECK-DAG:       %[[FROMMEMREF1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]]
 // CHECK:           amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([] [] [], [] [] [])
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) 
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], MM2S)
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION]]([] [] [], %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1]) 
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_source_token)
 // CHECK:           scf.for %{{.*}} = %[[C0_1]] to %[[C8_1]] step %[[C1_1]] {
 // CHECK:             amdaie.npu.circular_dma_cpy_nd %[[CONNECTION2]]([] [] [], [] [] [])
-// CHECK:             %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION2]]([] [] [], %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
-// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA_2]], MM2S)
+// CHECK:             %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION2]]([] [] [], %[[FROMMEMREF1]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
+// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA_2]] : !amdaie.async_source_token)
 // CHECK:           }
 func.func @merge_cores(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 2>) {
   %c0 = arith.constant 0 : index
@@ -430,15 +430,15 @@ func.func @merge_cores(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 2>) 
 // CHECK-DAG:       %[[C1_1:.+]] = arith.constant 1 : index
 // CHECK-DAG:       %[[C8_1:.+]] = arith.constant 8 : index
 // CHECK:           amdaie.npu.circular_dma_cpy_nd %[[CONNECTION0]]([] [] [], [] [] [])
-// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION0]]([] [] [], %[[FROMMEMREF0]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]], MM2S)
+// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION0]]([] [] [], %[[FROMMEMREF0]][0, 0, 0, 0] [1, 1, 8, 16] [128, 16, 16, 1])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]] : !amdaie.async_source_token)
 // CHECK:           scf.for %{{.*}} = %[[C0_1]] to %[[C8_1]] step %[[C1_1]]
 // CHECK:             amdaie.npu.circular_dma_cpy_nd %[[CONNECTION1]]([] [] [], [] [] [])
-// CHECK:             %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION1]]([] [] [], %[[FROMMEMREF2]][0, 0, 0, 0] [1, 1, 16, 16] [128, 16, 8, 1])
-// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA_1]], MM2S)
+// CHECK:             %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION1]]([] [] [], %[[FROMMEMREF2]][0, 0, 0, 0] [1, 1, 16, 16] [128, 16, 8, 1])
+// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA_1]] : !amdaie.async_source_token)
 // CHECK:             amdaie.npu.circular_dma_cpy_nd %[[CONNECTION2]]([] [] [], [] [] [])
-// CHECK:             %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION2]]([] [] [], %[[FROMMEMREF4]][0, 0, 0, 0] [1, 1, 32, 16] [128, 16, 8, 1])
-// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA_2]], MM2S)
+// CHECK:             %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION2]]([] [] [], %[[FROMMEMREF4]][0, 0, 0, 0] [1, 1, 32, 16] [128, 16, 8, 1])
+// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA_2]] : !amdaie.async_source_token)
 func.func @complex_example(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 2>, %arg2: memref<1x1x16x16xi32>, %arg3: memref<16x16xi32, 2>, %arg4: memref<1x1x32x16xi32>, %arg5: memref<32x16xi32, 2>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/dma_loop_subsumption.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/dma_loop_subsumption.mlir
@@ -32,8 +32,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg2 = %c1 to %c6 step %c2 {
           %bd_id = amdaie.bd_id(%tile, 0)
-          %2 = amdaie.npu.dma_cpy_nd %0([%arg2] [16] [1] bd_id = %bd_id, [] [] [])
-          %3 = amdaie.npu.dma_cpy_nd %1([%arg2] [16] [1], [] [] [])
+          amdaie.npu.dma_cpy_nd %0([%arg2] [16] [1] bd_id = %bd_id, [] [] [])
+          amdaie.npu.dma_cpy_nd %1([%arg2] [16] [1], [] [] [])
         }
         amdaie.end
       }
@@ -85,13 +85,13 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg2 = %c1 to %c6 step %c2 {
           %4 = affine.apply #map0(%arg2)
-          %5 = amdaie.npu.dma_cpy_nd %0([%4] [16] [1], [] [] [])
+          amdaie.npu.dma_cpy_nd %0([%4] [16] [1], [] [] [])
           %6 = affine.apply #map1(%arg2)
-          %7 = amdaie.npu.dma_cpy_nd %1([%6] [16] [1], [] [] [])
+          amdaie.npu.dma_cpy_nd %1([%6] [16] [1], [] [] [])
           %8 = affine.apply #map2(%arg2)
-          %9 = amdaie.npu.dma_cpy_nd %2([%8] [16] [1], [] [] [])
+          amdaie.npu.dma_cpy_nd %2([%8] [16] [1], [] [] [])
           %10 = affine.apply #map3(%arg2)
-          %11 = amdaie.npu.dma_cpy_nd %3([%10] [16] [1], [] [] [])
+          amdaie.npu.dma_cpy_nd %3([%10] [16] [1], [] [] [])
         }
         amdaie.end
       }
@@ -113,8 +113,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       amdaie.controlcode
 // CHECK:         scf.for %[[ARG2:.+]] = %[[C0]] to %[[C6]] step %[[C1]]
 // CHECK:           %[[APPLY:.+]] = affine.apply #[[$MAP]](%[[ARG2]])
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0, %[[APPLY]]] [1, 1, 8, 16] [128, 128, 16, 1], [] [] [])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, 0, %[[APPLY]]] [1, 1, 8, 16] [128, 128, 16, 1], [] [] [])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -127,8 +127,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg2 = %c0 to %c6 step %c1 {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, %1] [1, 1, 8, 16] [128, 128, 16, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([0, 0, 0, %1] [1, 1, 8, 16] [128, 128, 16, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -150,8 +150,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       amdaie.controlcode
 // CHECK:         scf.for %[[ARG2:.+]] = %[[C0]] to %[[C6]] step %[[C1]]
 // CHECK:           %[[APPLY:.+]] = affine.apply #[[$MAP]](%[[ARG2]])
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0, %[[APPLY]]] [1, 1, 8, 16] [128, 128, 16, 1])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([] [] [], [0, 0, 0, %[[APPLY]]] [1, 1, 8, 16] [128, 128, 16, 1])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -164,8 +164,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg2 = %c0 to %c6 step %c1 {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0, %1] [1, 1, 8, 16] [128, 128, 16, 1])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([] [] [], [0, 0, 0, %1] [1, 1, 8, 16] [128, 128, 16, 1])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -187,8 +187,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       amdaie.controlcode
 // CHECK:         scf.for %[[ARG2:.+]] = %[[C0]] to %[[C6]] step %[[C1]]
 // CHECK:           %[[APPLY:.+]] = affine.apply #[[$MAP]](%[[ARG2]])
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0, %[[APPLY]]] [1, 1, 8, 16] [128, 128, 16, 1], [] [] [])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, 0, %[[APPLY]]] [1, 1, 8, 16] [128, 128, 16, 1], [] [] [])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -201,8 +201,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg2 = %c0 to %c6 step %c1 {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, 0, 0, %1] [1, 1, 8, 16] [128, 128, 16, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([0, 0, 0, %1] [1, 1, 8, 16] [128, 128, 16, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -224,8 +224,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       amdaie.controlcode
 // CHECK:         scf.for %[[ARG2:.+]] = %[[C0]] to %[[C6]] step %[[C1]]
 // CHECK:           %[[APPLY:.+]] = affine.apply #[[$MAP]](%[[ARG2]])
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0, %[[APPLY]]] [1, 1, 8, 16] [128, 128, 16, 1])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([] [] [], [0, 0, 0, %[[APPLY]]] [1, 1, 8, 16] [128, 128, 16, 1])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -238,8 +238,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg2 = %c0 to %c6 step %c1 {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0, %1] [1, 1, 8, 16] [128, 128, 16, 1])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([] [] [], [0, 0, 0, %1] [1, 1, 8, 16] [128, 128, 16, 1])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -261,8 +261,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       amdaie.controlcode
 // CHECK:         scf.for %[[ARG2:.+]] = %[[C0]] to %[[C6]] step %[[C1]]
 // CHECK:           %[[APPLY:.+]] = affine.apply #[[$MAP]](%[[ARG2]])
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, %[[APPLY]]] [1, 8, 16] [128, 16, 1], [] [] [])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, %[[APPLY]]] [1, 8, 16] [128, 16, 1], [] [] [])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -275,8 +275,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg2 = %c0 to %c6 step %c1 {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, 0, %1] [1, 8, 16] [128, 16, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([0, 0, %1] [1, 8, 16] [128, 16, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -298,8 +298,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       amdaie.controlcode
 // CHECK:         scf.for %[[ARG2:.+]] = %[[C0]] to %[[C6]] step %[[C1]]
 // CHECK:           %[[APPLY:.+]] = affine.apply #[[$MAP]](%[[ARG2]])
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, %[[APPLY]]] [1, 8, 16] [128, 16, 1])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([] [] [], [0, 0, %[[APPLY]]] [1, 8, 16] [128, 16, 1])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -312,8 +312,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg2 = %c0 to %c6 step %c1 {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, %1] [1, 8, 16] [128, 16, 1])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([] [] [], [0, 0, %1] [1, 8, 16] [128, 16, 1])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -332,8 +332,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       amdaie.controlcode
 // CHECK:         scf.forall (%[[ARG2:.+]], %[[ARG3:.+]]) in (2, 6)
 // CHECK:           %[[APPLY:.+]] = affine.apply #[[$MAP]](%[[ARG3]])
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, %[[APPLY]]] [1, 8, 16] [128, 16, 1], [] [] [])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, %[[APPLY]]] [1, 8, 16] [128, 16, 1], [] [] [])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -343,8 +343,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.forall (%arg2, %arg3) in (2, 6) {
           %1 = affine.apply #map(%arg3)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, 0, %1] [1, 8, 16] [128, 16, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([0, 0, %1] [1, 8, 16] [128, 16, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -364,10 +364,10 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       amdaie.controlcode
 // CHECK:         scf.for %[[ARG2:.+]] = %[[C0]] to %[[C6]] step %[[C1]]
 // CHECK:           %[[APPLY:.+]] = affine.apply #[[$MAP]](%[[ARG2]])
-// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, %[[APPLY]]] [1, 8, 16] [128, 16, 1], [] [] [])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]], S2MM)
-// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, %[[APPLY]]] [1, 8, 16] [128, 16, 1], [] [] [])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_1]], S2MM)
+// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, %[[APPLY]]] [1, 8, 16] [128, 16, 1], [] [] [])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]] : !amdaie.async_target_token)
+// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, %[[APPLY]]] [1, 8, 16] [128, 16, 1], [] [] [])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_1]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -380,10 +380,10 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg2 = %c0 to %c6 step %c1 {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, 0, %1] [1, 8, 16] [128, 16, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
-          %3 = amdaie.npu.dma_cpy_nd %0([0, 0, %1] [1, 8, 16] [128, 16, 1], [] [] [])
-          amdaie.npu.dma_wait(%3, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([0, 0, %1] [1, 8, 16] [128, 16, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
+          %3 = amdaie.npu.dma_cpy_nd async_target %0([0, 0, %1] [1, 8, 16] [128, 16, 1], [] [] [])
+          amdaie.npu.dma_wait(%3 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -401,10 +401,10 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       amdaie.controlcode
 // CHECK:         scf.forall (%[[ARG2:.+]], %[[ARG3:.+]]) in (2, 6)
 // CHECK:           %[[APPLY:.+]] = affine.apply #[[$MAP]](%[[ARG3]])
-// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, %[[APPLY]]] [1, 8, 16] [128, 16, 1], [] [] [])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]], S2MM)
-// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, %[[APPLY]]] [1, 8, 16] [128, 16, 1], [] [] [])
-// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_1]], S2MM)
+// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, %[[APPLY]]] [1, 8, 16] [128, 16, 1], [] [] [])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]] : !amdaie.async_target_token)
+// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, %[[APPLY]]] [1, 8, 16] [128, 16, 1], [] [] [])
+// CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_1]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -414,10 +414,10 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.forall (%arg2, %arg3) in (2, 6) {
           %1 = affine.apply #map(%arg3)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, 0, %1] [1, 8, 16] [128, 16, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
-          %3 = amdaie.npu.dma_cpy_nd %0([0, 0, %1] [1, 8, 16] [128, 16, 1], [] [] [])
-          amdaie.npu.dma_wait(%3, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([0, 0, %1] [1, 8, 16] [128, 16, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
+          %3 = amdaie.npu.dma_cpy_nd async_target %0([0, 0, %1] [1, 8, 16] [128, 16, 1], [] [] [])
+          amdaie.npu.dma_wait(%3 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -436,7 +436,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       amdaie.controlcode
 // CHECK:         scf.forall (%[[ARG2:.+]], %[[ARG3:.+]]) in (2, 2)
 // CHECK:           %[[APPLY:.+]] = affine.apply #[[$MAP]](%[[ARG3]])
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, %[[APPLY]]] [1024, 64] [128, 1])
+// CHECK:           amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, %[[APPLY]]] [1024, 64] [128, 1])
 #map = affine_map<(d0) -> (d0 * 64)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -446,7 +446,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.forall (%arg2, %arg3) in (2, 2) {
           %1 = affine.apply #map(%arg3)
-          %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, %1] [1024, 64] [128, 1])
+          amdaie.npu.dma_cpy_nd %0([] [] [], [0, %1] [1024, 64] [128, 1])
         }
         amdaie.end
       }
@@ -465,7 +465,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       amdaie.controlcode
 // CHECK:         scf.forall (%[[ARG2:.+]], %[[ARG3:.+]]) in (2, 2)
 // CHECK:           %[[APPLY:.+]] = affine.apply #[[$MAP]](%[[ARG3]])
-// CHECK:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, %[[APPLY]]] [1024, 64] [128, 1], [] [] [])
+// CHECK:           amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, %[[APPLY]]] [1024, 64] [128, 1], [] [] [])
 #map = affine_map<(d0) -> (d0 * 64)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -475,7 +475,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.forall (%arg2, %arg3) in (2, 2) {
           %1 = affine.apply #map(%arg3)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, %1] [1024, 64] [128, 1], [] [] [])
+          amdaie.npu.dma_cpy_nd %0([0, %1] [1024, 64] [128, 1], [] [] [])
         }
         amdaie.end
       }
@@ -494,11 +494,11 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK-DAG:   %[[C64:.+]] = arith.constant 64 : index
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
-// CHECK:         %{{.+}} = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0, 0] [63, 1, 8, 16] [0, 64, 16, 1])
+// CHECK:         amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0, 0] [63, 1, 8, 16] [0, 64, 16, 1])
 // CHECK:         scf.for %{{.+}} = %[[C0]] to %[[C64]] step %[[C1]]
-// CHECK:           %{{.+}} = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0] [1, 8, 16] [128, 16, 1])
+// CHECK:           amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0] [1, 8, 16] [128, 16, 1])
 // CHECK:         }
-// CHECK:         %{{.+}} = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0] [1024, 8, 16] [0, 16, 1])
+// CHECK:         amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0] [1024, 8, 16] [0, 16, 1])
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @exceed_max_size_source(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32>>) {
@@ -512,13 +512,13 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
       amdaie.controlcode {
         scf.for %arg4 = %c0 to %c63 step %c1 {
-          %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0] [1, 8, 16] [64, 16, 1])
+          amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0] [1, 8, 16] [64, 16, 1])
         }
         scf.for %arg5 = %c0 to %c64 step %c1 {
-          %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0] [1, 8, 16] [128, 16, 1])
+          amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0] [1, 8, 16] [128, 16, 1])
         }
         scf.for %arg6 = %c0 to %c1024 step %c1 {
-          %4 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0] [8, 16] [16, 1])
+          amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0] [8, 16] [16, 1])
         }
         amdaie.end
       }
@@ -538,11 +538,11 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK-DAG:   %[[C64:.+]] = arith.constant 64 : index
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
-// CHECK:         %{{.+}} = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0, 0] [63, 1, 8, 16] [0, 64, 16, 1], [] [] [])
+// CHECK:         amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0, 0] [63, 1, 8, 16] [0, 64, 16, 1], [] [] [])
 // CHECK:         scf.for %{{.+}} = %[[C0]] to %[[C64]] step %[[C1]]
-// CHECK:           %{{.+}} = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0] [1, 8, 16] [128, 16, 1], [] [] [])
+// CHECK:           amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0] [1, 8, 16] [128, 16, 1], [] [] [])
 // CHECK:         }
-// CHECK:         %{{.+}} = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0] [1024, 8, 16] [0, 16, 1], [] [] [])
+// CHECK:         amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0] [1024, 8, 16] [0, 16, 1], [] [] [])
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @exceed_max_size_target(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
@@ -556,13 +556,13 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
       amdaie.controlcode {
         scf.for %arg4 = %c0 to %c63 step %c1 {
-          %2 = amdaie.npu.dma_cpy_nd %0([0, 0, 0] [1, 8, 16] [64, 16, 1], [] [] [])
+          amdaie.npu.dma_cpy_nd %0([0, 0, 0] [1, 8, 16] [64, 16, 1], [] [] [])
         }
         scf.for %arg5 = %c0 to %c64 step %c1 {
-          %2 = amdaie.npu.dma_cpy_nd %0([0, 0, 0] [1, 8, 16] [128, 16, 1], [] [] [])
+          amdaie.npu.dma_cpy_nd %0([0, 0, 0] [1, 8, 16] [128, 16, 1], [] [] [])
         }
         scf.for %arg6 = %c0 to %c1024 step %c1 {
-          %4 = amdaie.npu.dma_cpy_nd %0([0, 0] [8, 16] [16, 1], [] [] [])
+          amdaie.npu.dma_cpy_nd %0([0, 0] [8, 16] [16, 1], [] [] [])
         }
         amdaie.end
       }
@@ -582,15 +582,15 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK-DAG:   %[[C32:.+]] = arith.constant 32 : index
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
-// CHECK:         %{{.+}} = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0, 0] [32, 1, 8, 16] [1048576, 64, 16, 1])
+// CHECK:         amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0, 0] [32, 1, 8, 16] [1048576, 64, 16, 1])
 // CHECK:         scf.for %[[ARG5:.+]] = %[[C0]] to %[[C32]] step %[[C1]]
 // CHECK:           %[[APPLY1:.+]] = affine.apply #[[$MAP]](%[[ARG5]])
-// CHECK:           %{{.+}} = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, %[[APPLY1]]] [1, 8, 16] [64, 16, 1])
+// CHECK:           amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, %[[APPLY1]]] [1, 8, 16] [64, 16, 1])
 // CHECK:         }
-// CHECK:         %{{.+}} = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0] [32, 8, 16] [1048576, 16, 1])
+// CHECK:         amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0] [32, 8, 16] [1048576, 16, 1])
 // CHECK:         scf.for %[[ARG7:.+]] = %[[C0]] to %[[C32]] step %[[C1]]
 // CHECK:           %[[APPLY1:.+]] = affine.apply #[[$MAP]](%[[ARG7]])
-// CHECK:           %{{.+}} = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, %[[APPLY1]]] [8, 16] [16, 1])
+// CHECK:           amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, %[[APPLY1]]] [8, 16] [16, 1])
 // CHECK:         }
 #map = affine_map<(d0) -> (d0 * 1048576)>
 #map1 = affine_map<(d0) -> (d0 * 1048577)>
@@ -605,19 +605,19 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg4 = %c0 to %c32 step %c1 {
           %affine1 = affine.apply #map(%arg4)
-          %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, %affine1] [1, 8, 16] [64, 16, 1])
+          amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, %affine1] [1, 8, 16] [64, 16, 1])
         }
         scf.for %arg5 = %c0 to %c32 step %c1 {
           %affine2 = affine.apply #map1(%arg5)
-          %3 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, %affine2] [1, 8, 16] [64, 16, 1])
+          amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, %affine2] [1, 8, 16] [64, 16, 1])
         }
         scf.for %arg6 = %c0 to %c32 step %c1 {
           %affine3 = affine.apply #map(%arg6)
-          %4 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, %affine3] [8, 16] [16, 1])
+          amdaie.npu.dma_cpy_nd %0([] [] [], [0, %affine3] [8, 16] [16, 1])
         }
         scf.for %arg7 = %c0 to %c32 step %c1 {
           %affine4 = affine.apply #map1(%arg7)
-          %5 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, %affine4] [8, 16] [16, 1])
+          amdaie.npu.dma_cpy_nd %0([] [] [], [0, %affine4] [8, 16] [16, 1])
         }
         amdaie.end
       }
@@ -637,15 +637,15 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK-DAG:   %[[C32:.+]] = arith.constant 32 : index
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
-// CHECK:         %{{.+}} = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0, 0] [32, 1, 8, 16] [1048576, 64, 16, 1], [] [] [])
+// CHECK:         amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0, 0] [32, 1, 8, 16] [1048576, 64, 16, 1], [] [] [])
 // CHECK:         scf.for %[[ARG5:.+]] = %[[C0]] to %[[C32]] step %[[C1]]
 // CHECK:           %[[APPLY1:.+]] = affine.apply #[[$MAP]](%[[ARG5]])
-// CHECK:           %{{.+}} = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, %[[APPLY1]]] [1, 8, 16] [64, 16, 1], [] [] [])
+// CHECK:           amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, %[[APPLY1]]] [1, 8, 16] [64, 16, 1], [] [] [])
 // CHECK:         }
-// CHECK:         %{{.+}} = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0] [32, 8, 16] [1048576, 16, 1], [] [] [])
+// CHECK:         amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0] [32, 8, 16] [1048576, 16, 1], [] [] [])
 // CHECK:         scf.for %[[ARG7:.+]] = %[[C0]] to %[[C32]] step %[[C1]]
 // CHECK:           %[[APPLY1:.+]] = affine.apply #[[$MAP]](%[[ARG7]])
-// CHECK:           %{{.+}} = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, %[[APPLY1]]] [8, 16] [16, 1], [] [] [])
+// CHECK:           amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, %[[APPLY1]]] [8, 16] [16, 1], [] [] [])
 // CHECK:         }
 #map = affine_map<(d0) -> (d0 * 1048576)>
 #map1 = affine_map<(d0) -> (d0 * 1048577)>
@@ -660,19 +660,19 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg4 = %c0 to %c32 step %c1 {
           %affine1 = affine.apply #map(%arg4)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, 0, %affine1] [1, 8, 16] [64, 16, 1], [] [] [])
+          amdaie.npu.dma_cpy_nd %0([0, 0, %affine1] [1, 8, 16] [64, 16, 1], [] [] [])
         }
         scf.for %arg5 = %c0 to %c32 step %c1 {
           %affine2 = affine.apply #map1(%arg5)
-          %3 = amdaie.npu.dma_cpy_nd %0([0, 0, %affine2] [1, 8, 16] [64, 16, 1], [] [] [])
+          amdaie.npu.dma_cpy_nd %0([0, 0, %affine2] [1, 8, 16] [64, 16, 1], [] [] [])
         }
         scf.for %arg6 = %c0 to %c32 step %c1 {
           %affine3 = affine.apply #map(%arg6)
-          %4 = amdaie.npu.dma_cpy_nd %0([0, %affine3] [8, 16] [16, 1], [] [] [])
+          amdaie.npu.dma_cpy_nd %0([0, %affine3] [8, 16] [16, 1], [] [] [])
         }
         scf.for %arg7 = %c0 to %c32 step %c1 {
           %affine4 = affine.apply #map1(%arg7)
-          %5 = amdaie.npu.dma_cpy_nd %0([0, %affine4] [8, 16] [16, 1], [] [] [])
+          amdaie.npu.dma_cpy_nd %0([0, %affine4] [8, 16] [16, 1], [] [] [])
         }
         amdaie.end
       }
@@ -692,8 +692,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:     scf.for
-// CHECK:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0, 0] [6, 1, 8, 16] [0, 128, 16, 1], [] [] [])
-// CHECK:         amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, 0, 0] [6, 1, 8, 16] [0, 128, 16, 1], [] [] [])
+// CHECK:         amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -706,8 +706,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg4 = %c0 to %c6 step %c1 {
           %1 = affine.apply #map(%arg4)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, 0, 0] [1, 8, 16] [128, 16, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([0, 0, 0] [1, 8, 16] [128, 16, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -723,8 +723,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:     scf.forall (%{{.+}}, %{{.+}}) in (2, 2)
-// CHECK:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0, 0] [2, 2, 8, 16] [0, 0, 16, 1], [] [] [])
-// CHECK:         amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, 0, 0] [2, 2, 8, 16] [0, 0, 16, 1], [] [] [])
+// CHECK:         amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -734,8 +734,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.forall (%arg2, %arg3) in (2, 2) {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, 0] [8, 16] [16, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([0, 0] [8, 16] [16, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -752,8 +752,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:     scf.forall
 // CHECK-NOT:     scf.for
-// CHECK:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0, 0] [2, 3, 6, 16] [0, 0, 0, 1], [] [] [])
-// CHECK:         amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, 0, 0] [2, 3, 6, 16] [0, 0, 0, 1], [] [] [])
+// CHECK:         amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -767,8 +767,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
         scf.forall (%arg2, %arg3) in (2, 3) {
           scf.for %arg4 = %c0 to %c6 step %c1 {
             %1 = affine.apply #map(%arg4)
-            %2 = amdaie.npu.dma_cpy_nd %0([0] [16] [1], [] [] [])
-            amdaie.npu.dma_wait(%2, S2MM)
+            %2 = amdaie.npu.dma_cpy_nd async_target %0([0] [16] [1], [] [] [])
+            amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
           }
         }
         amdaie.end
@@ -787,8 +787,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:     scf.for
-// CHECK:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, %[[ARG]]] [6, 16] [0, 1], [] [] [])
-// CHECK:         amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, %[[ARG]]] [6, 16] [0, 1], [] [] [])
+// CHECK:         amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @dynamic_non_induction_var_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>, %arg2: index) {
@@ -799,8 +799,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
       amdaie.controlcode {
         scf.for %arg3 = %c0 to %c6 step %c1 {
-          %2 = amdaie.npu.dma_cpy_nd %0([%arg2] [16] [1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([%arg2] [16] [1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -817,7 +817,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:     scf.for
-// CHECK:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0, 0] [4, 1024, 64, 2] [0, 128, 2, 1])
+// CHECK:         amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0, 0] [4, 1024, 64, 2] [0, 128, 2, 1])
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @inter_to_intra_outermost(%arg0: !amdaie.logicalobjectfifo<memref<2048xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<1024x64x2xi32>>) {
@@ -828,7 +828,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<2048xi32, 1>>, !amdaie.logicalobjectfifo<memref<1024x64x2xi32>>)
       amdaie.controlcode {
         scf.for %arg2 = %c0 to %c4 step %c1 {
-          %1 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0] [1024, 64, 2] [128, 2, 1])
+          amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0] [1024, 64, 2] [128, 2, 1])
         }
         amdaie.end
       }
@@ -869,11 +869,11 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg2 = %c0 to %c6 step %c1 {
           %1 = affine.apply #map0(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %dma0([%1] [16] [1], [] [] [])
+          amdaie.npu.dma_cpy_nd %dma0([%1] [16] [1], [] [] [])
           %3 = affine.apply #map1(%arg2)
-          %4 = amdaie.npu.dma_cpy_nd %dma1([%3] [16] [1], [] [] [])
+          amdaie.npu.dma_cpy_nd %dma1([%3] [16] [1], [] [] [])
           %5 = affine.apply #map2(%arg2)
-          %6 = amdaie.npu.dma_cpy_nd %dma2([%5] [16] [1], [] [] [])
+          amdaie.npu.dma_cpy_nd %dma2([%5] [16] [1], [] [] [])
         }
         amdaie.end
       }
@@ -888,8 +888,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:   scf.for
-// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0, 0] [6, 1, 8, 16] [16, 128, 16, 1], [] [] [])
-// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, 0, 0] [6, 1, 8, 16] [16, 128, 16, 1], [] [] [])
+// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -902,8 +902,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg2 = %c0 to %c6 step %c1 {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, 0, %1] [1, 8, 16] [128, 16, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([0, 0, %1] [1, 8, 16] [128, 16, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -918,8 +918,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:   scf.forall
-// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0, 0] [2, 6, 8, 16] [0, 16, 16, 1], [] [] [])
-// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, 0, 0] [2, 6, 8, 16] [0, 16, 16, 1], [] [] [])
+// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (16 * d0)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -929,8 +929,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.forall (%arg2, %arg3) in (2, 6) {
           %1 = affine.apply #map(%arg3)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, %1] [8, 16] [16, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([0, %1] [8, 16] [16, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -945,8 +945,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:   scf.for
-// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0, 0] [6, 1, 8, 16] [16, 128, 16, 1])
-// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([] [] [], [0, 0, 0, 0] [6, 1, 8, 16] [16, 128, 16, 1])
+// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -959,8 +959,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg2 = %c0 to %c6 step %c1 {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, %1] [1, 8, 16] [128, 16, 1])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([] [] [], [0, 0, %1] [1, 8, 16] [128, 16, 1])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -975,8 +975,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:   scf.forall
-// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0, 0] [2, 6, 8, 16] [0, 16, 16, 1])
-// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([] [] [], [0, 0, 0, 0] [2, 6, 8, 16] [0, 16, 16, 1])
+// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -986,8 +986,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.forall (%arg2, %arg3) in (2, 6) {
           %1 = affine.apply #map(%arg3)
-          %2 = amdaie.npu.dma_cpy_nd %0([] [] [], [0, %1] [8, 16] [16, 1])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([] [] [], [0, %1] [8, 16] [16, 1])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -1003,8 +1003,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:   scf.for
-// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0, 0] [6, 6, 8, 16] [256, 16, 16, 1], [] [] [])
-// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, 0, 0] [6, 6, 8, 16] [256, 16, 16, 1], [] [] [])
+// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -1017,8 +1017,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg2 = %c0 to %c6 step %c1 {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([%1, %1] [8, 16] [16, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([%1, %1] [8, 16] [16, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -1033,8 +1033,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:   scf.forall
-// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0, 0] [2, 6, 8, 16] [16, 512, 16, 1], [] [] [])
-// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, 0, 0] [2, 6, 8, 16] [16, 512, 16, 1], [] [] [])
+// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #map1 = affine_map<(d0) -> (d0 * 32)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
@@ -1049,8 +1049,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
         scf.forall (%arg2, %arg3) in (2, 6) {
           %1 = affine.apply #map(%arg2)
           %2 = affine.apply #map1(%arg3)
-          %3 = amdaie.npu.dma_cpy_nd %0([%2, %1] [8, 16] [16, 1], [] [] [])
-          amdaie.npu.dma_wait(%3, S2MM)
+          %3 = amdaie.npu.dma_cpy_nd async_target %0([%2, %1] [8, 16] [16, 1], [] [] [])
+          amdaie.npu.dma_wait(%3 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -1065,8 +1065,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:   scf.for
-// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 16] [3, 16] [32, 1], [] [] [])
-// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 16] [3, 16] [32, 1], [] [] [])
+// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -1079,8 +1079,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg2 = %c1 to %c6 step %c2 {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([%1] [16] [1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([%1] [16] [1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -1095,8 +1095,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:   scf.forall
-// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 32, 32] [5, 4, 8, 16] [48, 1024, 16, 1], [] [] [])
-// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, 32, 32] [5, 4, 8, 16] [48, 1024, 16, 1], [] [] [])
+// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #map1 = affine_map<(d0) -> (d0 * 32)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
@@ -1111,8 +1111,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
         scf.forall (%arg2, %arg3) = (2, 1) to (17, 8) step (3, 2) {
           %1 = affine.apply #map(%arg2)
           %2 = affine.apply #map1(%arg3)
-          %3 = amdaie.npu.dma_cpy_nd %0([%2, %1] [8, 16] [16, 1], [] [] [])
-          amdaie.npu.dma_wait(%3, S2MM)
+          %3 = amdaie.npu.dma_cpy_nd async_target  %0([%2, %1] [8, 16] [16, 1], [] [] [])
+          amdaie.npu.dma_wait(%3 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -1132,8 +1132,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:   scf.forall
 // CHECK-NOT:   scf.for
-// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0, 0] [2, 6, 3, 8] [0, 32, 0, 1], [] [] [])
-// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, 0, 0] [2, 6, 3, 8] [0, 32, 0, 1], [] [] [])
+// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #map1 = affine_map<(d0) -> (d0 * 32)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
@@ -1149,8 +1149,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
           %1 = affine.apply #map(%arg2)
           %2 = affine.apply #map1(%arg3)
           scf.for %arg4 = %c1 to %c6 step %c2 {
-            %3 = amdaie.npu.dma_cpy_nd %0([%2] [8] [1], [] [] [])
-            amdaie.npu.dma_wait(%3, S2MM)
+            %3 = amdaie.npu.dma_cpy_nd async_target %0([%2] [8] [1], [] [] [])
+            amdaie.npu.dma_wait(%3 : !amdaie.async_target_token)
           }
         }
         amdaie.end
@@ -1171,8 +1171,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:   scf.for
-// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0] [6, 16] [1, 1], [] [] [])
-// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0] [6, 16] [1, 1], [] [] [])
+// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @for_with_induction_var_normalized(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
@@ -1183,8 +1183,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
       amdaie.controlcode {
         scf.for %arg2 = %c0 to %c6 step %c1 {
-          %2 = amdaie.npu.dma_cpy_nd %0([%arg2] [16] [1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([%arg2] [16] [1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -1199,8 +1199,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:   scf.for
-// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 1] [3, 16] [2, 1], [] [] [])
-// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 1] [3, 16] [2, 1], [] [] [])
+// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @for_with_induction_var_non_normalized(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
@@ -1211,8 +1211,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
       amdaie.controlcode {
         scf.for %arg2 = %c1 to %c6 step %c2 {
-          %2 = amdaie.npu.dma_cpy_nd %0([%arg2] [16] [1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([%arg2] [16] [1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -1227,8 +1227,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:   scf.forall
-// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0, 0] [17, 8, 8, 16] [1, 16, 16, 1], [] [] [])
-// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, 0, 0] [17, 8, 8, 16] [1, 16, 16, 1], [] [] [])
+// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @forall_with_induction_var_normalized(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
@@ -1236,8 +1236,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
       amdaie.controlcode {
         scf.forall (%arg2, %arg3) in (17, 8) {
-          %3 = amdaie.npu.dma_cpy_nd %0([%arg3, %arg2] [8, 16] [16, 1], [] [] [])
-          amdaie.npu.dma_wait(%3, S2MM)
+          %3 = amdaie.npu.dma_cpy_nd async_target %0([%arg3, %arg2] [8, 16] [16, 1], [] [] [])
+          amdaie.npu.dma_wait(%3 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -1252,8 +1252,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:   scf.forall
-// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 1, 2] [5, 4, 8, 16] [3, 32, 16, 1], [] [] [])
-// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, 1, 2] [5, 4, 8, 16] [3, 32, 16, 1], [] [] [])
+// CHECK:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @forall_with_induction_var_non_normalized(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
@@ -1261,8 +1261,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
       amdaie.controlcode {
         scf.forall (%arg2, %arg3) = (2, 1) to (17, 8) step (3, 2) {
-          %3 = amdaie.npu.dma_cpy_nd %0([%arg3, %arg2] [8, 16] [16, 1], [] [] [])
-          amdaie.npu.dma_wait(%3, S2MM)
+          %3 = amdaie.npu.dma_cpy_nd async_target %0([%arg3, %arg2] [8, 16] [16, 1], [] [] [])
+          amdaie.npu.dma_wait(%3 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -1281,8 +1281,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // OUTER-ZERO-STRIDE:       %[[CONNECTION:.+]] = amdaie.connection
 // OUTER-ZERO-STRIDE:       amdaie.controlcode
 // OUTER-ZERO-STRIDE-NOT:   scf.for
-// OUTER-ZERO-STRIDE:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0] [6, 16] [1, 1], [] [] [])
-// OUTER-ZERO-STRIDE:       amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// OUTER-ZERO-STRIDE:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0] [6, 16] [1, 1], [] [] [])
+// OUTER-ZERO-STRIDE:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @for_outer_zero_stride_sanity_check(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
@@ -1293,8 +1293,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
       amdaie.controlcode {
         scf.for %arg2 = %c0 to %c6 step %c1 {
-          %2 = amdaie.npu.dma_cpy_nd %0([%arg2] [16] [1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([%arg2] [16] [1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -1310,8 +1310,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // OUTER-ZERO-STRIDE:       %[[CONNECTION:.+]] = amdaie.connection
 // OUTER-ZERO-STRIDE:       amdaie.controlcode
 // OUTER-ZERO-STRIDE-NOT:   scf.forall
-// OUTER-ZERO-STRIDE:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 1, 2] [5, 4, 8, 16] [3, 32, 16, 1], [] [] [])
-// OUTER-ZERO-STRIDE:       amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// OUTER-ZERO-STRIDE:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, 1, 2] [5, 4, 8, 16] [3, 32, 16, 1], [] [] [])
+// OUTER-ZERO-STRIDE:       amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @forall_outer_zero_stride_sanity_check(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
@@ -1319,8 +1319,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
       amdaie.controlcode {
         scf.forall (%arg2, %arg3) = (2, 1) to (17, 8) step (3, 2) {
-          %3 = amdaie.npu.dma_cpy_nd %0([%arg3, %arg2] [8, 16] [16, 1], [] [] [])
-          amdaie.npu.dma_wait(%3, S2MM)
+          %3 = amdaie.npu.dma_cpy_nd async_target %0([%arg3, %arg2] [8, 16] [16, 1], [] [] [])
+          amdaie.npu.dma_wait(%3 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -1341,8 +1341,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // OUTER-ZERO-STRIDE:       amdaie.controlcode
 // OUTER-ZERO-STRIDE:         scf.for %[[ARG2:.+]] = %[[C0]] to %[[C6]] step %[[C1]]
 // OUTER-ZERO-STRIDE:           %[[APPLY:.+]] = affine.apply #[[$MAP]](%[[ARG2]])
-// OUTER-ZERO-STRIDE:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, %[[APPLY]]] [1, 8, 16] [0, 16, 1], [] [] [])
-// OUTER-ZERO-STRIDE:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// OUTER-ZERO-STRIDE:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, %[[APPLY]]] [1, 8, 16] [0, 16, 1], [] [] [])
+// OUTER-ZERO-STRIDE:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -1355,8 +1355,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.for %arg2 = %c0 to %c6 step %c1 {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, 0, %1] [1, 8, 16] [0, 16, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([0, 0, %1] [1, 8, 16] [0, 16, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -1374,8 +1374,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // OUTER-ZERO-STRIDE:       amdaie.controlcode
 // OUTER-ZERO-STRIDE:         scf.forall (%[[ARG2:.+]], %[[ARG3:.+]]) in (2, 6)
 // OUTER-ZERO-STRIDE:           %[[APPLY:.+]] = affine.apply #[[$MAP]](%[[ARG3]])
-// OUTER-ZERO-STRIDE:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, %[[APPLY]]] [8, 16] [0, 1], [] [] [])
-// OUTER-ZERO-STRIDE:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// OUTER-ZERO-STRIDE:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, %[[APPLY]]] [8, 16] [0, 1], [] [] [])
+// OUTER-ZERO-STRIDE:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -1385,8 +1385,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.forall (%arg2, %arg3) in (2, 6) {
           %1 = affine.apply #map(%arg3)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, %1] [8, 16] [0, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([0, %1] [8, 16] [0, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -1404,8 +1404,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // OUTER-ZERO-STRIDE:       amdaie.controlcode
 // OUTER-ZERO-STRIDE:         scf.forall (%[[ARG2:.+]], %[[ARG3:.+]]) in (2, 6)
 // OUTER-ZERO-STRIDE:           %[[APPLY:.+]] = affine.apply #[[$MAP]](%[[ARG2]])
-// OUTER-ZERO-STRIDE:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, %[[APPLY]]] [8, 16] [16, 1], [] [] [])
-// OUTER-ZERO-STRIDE:           amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// OUTER-ZERO-STRIDE:           %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, %[[APPLY]]] [8, 16] [16, 1], [] [] [])
+// OUTER-ZERO-STRIDE:           amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -1415,8 +1415,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.forall (%arg2, %arg3) in (2, 6) {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, %1] [8, 16] [16, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([0, %1] [8, 16] [16, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -1432,8 +1432,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // OUTER-ZERO-STRIDE:       %[[CONNECTION:.+]] = amdaie.connection
 // OUTER-ZERO-STRIDE:       amdaie.controlcode
 // OUTER-ZERO-STRIDE-NOT:     scf.forall
-// OUTER-ZERO-STRIDE:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0] [2, 8, 16] [16, 16, 1], [] [] [])
-// OUTER-ZERO-STRIDE:         amdaie.npu.dma_wait(%[[NPU_DMA]], S2MM)
+// OUTER-ZERO-STRIDE:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([0, 0, 0] [2, 8, 16] [16, 16, 1], [] [] [])
+// OUTER-ZERO-STRIDE:         amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_target_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -1443,8 +1443,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.forall (%arg2, %arg3) in (2, 1) {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, %1] [8, 16] [16, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([0, %1] [8, 16] [16, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -1464,8 +1464,8 @@ module {
       amdaie.controlcode {
         scf.forall (%arg2, %arg3) in (2, 1) {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, %1] [8, 16] [16, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_target %0([0, %1] [8, 16] [16, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
         }
         amdaie.end
       }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
@@ -657,7 +657,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
         %5 = amdaie.npu.circular_dma_cpy_nd %4([0] [1024] [1], [] [] [])
         %6 = amdaie.logicalobjectfifo.from_memref %0, {%tile_0_0} : memref<4096xi32> -> !amdaie.logicalobjectfifo<memref<4096xi32>>
         // expected-error @+1 {{'amdaie.npu.dma_cpy_nd' op must have a source BD ID op to lower to the AIE dialect}}
-        %7 = amdaie.npu.dma_cpy_nd %4([] [] [], %6[0, 32] [32, 32] [64, 1]) : source_type = !amdaie.logicalobjectfifo<memref<4096xi32>>
+        amdaie.npu.dma_cpy_nd %4([] [] [], %6[0, 32] [32, 32] [64, 1]) : source_type = !amdaie.logicalobjectfifo<memref<4096xi32>>
         amdaie.end
       }
     }
@@ -695,7 +695,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         %5 = amdaie.npu.circular_dma_cpy_nd %4([0] [1024] [1], [] [] [])
         %6 = amdaie.logicalobjectfifo.from_memref %0, {%tile_0_0} : memref<4096xi32> -> !amdaie.logicalobjectfifo<memref<4096xi32>>
-        %7 = amdaie.npu.dma_cpy_nd %4([] [] [], %6[0, 0, 0, 32] [2, 1, 2, 32] [2, 0, 16, 1] bd_id = %bd_id_0) : source_type = !amdaie.logicalobjectfifo<memref<4096xi32>>
+        amdaie.npu.dma_cpy_nd %4([] [] [], %6[0, 0, 0, 32] [2, 1, 2, 32] [2, 0, 16, 1] bd_id = %bd_id_0) : source_type = !amdaie.logicalobjectfifo<memref<4096xi32>>
         amdaie.end
       }
     }
@@ -757,15 +757,15 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
         %11 = amdaie.npu.circular_dma_cpy_nd %9([] [] [], [0] [2048] [1])
         %12 = amdaie.logicalobjectfifo.from_memref %0, {%tile_0_0} : memref<4096xi32> -> !amdaie.logicalobjectfifo<memref<4096xi32>>
         %13 = amdaie.logicalobjectfifo.from_memref %1, {%tile_0_0} : memref<2048xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
-        %14 = amdaie.npu.dma_cpy_nd %5([] [] [], %12[0, 0, 0, 32] [1, 1, 32, 32] [0, 0, 64, 1] bd_id = %bd_id_0) : source_type = !amdaie.logicalobjectfifo<memref<4096xi32>>
-        amdaie.npu.dma_wait(%14, MM2S)
-        %15 = amdaie.npu.dma_cpy_nd %5([] [] [], %12[0, 0, 0, 0] [1, 1, 1, 2048] [0, 0, 0, 1] bd_id = %bd_id_0) : source_type = !amdaie.logicalobjectfifo<memref<4096xi32>>
-        amdaie.npu.dma_wait(%15, MM2S)
+        %14 = amdaie.npu.dma_cpy_nd async_source %5([] [] [], %12[0, 0, 0, 32] [1, 1, 32, 32] [0, 0, 64, 1] bd_id = %bd_id_0) : source_type = !amdaie.logicalobjectfifo<memref<4096xi32>>
+        amdaie.npu.dma_wait(%14 : !amdaie.async_source_token)
+        %15 = amdaie.npu.dma_cpy_nd async_source %5([] [] [], %12[0, 0, 0, 0] [1, 1, 1, 2048] [0, 0, 0, 1] bd_id = %bd_id_0) : source_type = !amdaie.logicalobjectfifo<memref<4096xi32>>
+        amdaie.npu.dma_wait(%15 : !amdaie.async_source_token)
         scf.forall (%arg0, %arg1) in (2, 1) {
-          %16 = amdaie.npu.dma_cpy_nd %9(%13[0, 0, 0, 32] [1, 1, 32, 32] [0, 0, 64, 1] bd_id = %bd_id_0, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<2048xi32>>
-          amdaie.npu.dma_wait(%16, S2MM)
-          %17 = amdaie.npu.dma_cpy_nd %9(%13[0, 0, 0, 0] [1, 1, 1, 1024] [0, 0, 0, 1] bd_id = %bd_id_0, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<2048xi32>>
-          amdaie.npu.dma_wait(%17, S2MM)
+          %16 = amdaie.npu.dma_cpy_nd async_target %9(%13[0, 0, 0, 32] [1, 1, 32, 32] [0, 0, 64, 1] bd_id = %bd_id_0, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<2048xi32>>
+          amdaie.npu.dma_wait(%16 : !amdaie.async_target_token)
+          %17 = amdaie.npu.dma_cpy_nd async_target %9(%13[0, 0, 0, 0] [1, 1, 1, 1024] [0, 0, 0, 1] bd_id = %bd_id_0, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<2048xi32>>
+          amdaie.npu.dma_wait(%17 : !amdaie.async_target_token)
         }
         amdaie.end
       }
@@ -824,14 +824,14 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
         %11 = amdaie.npu.circular_dma_cpy_nd %9([] [] [], [0] [2048] [1])
         %12 = amdaie.logicalobjectfifo.from_memref %0, {%tile_0_0} : memref<4096xbf16> -> !amdaie.logicalobjectfifo<memref<4096xbf16>>
         %13 = amdaie.logicalobjectfifo.from_memref %1, {%tile_0_0} : memref<2048xf32> -> !amdaie.logicalobjectfifo<memref<2048xf32>>
-        %14 = amdaie.npu.dma_cpy_nd %5([] [] [], %12[0, 0, 1, 2] [1, 2, 32, 16] [0, 16, 32, 1] bd_id = %bd_id_0) : source_type = !amdaie.logicalobjectfifo<memref<4096xbf16>>
-        amdaie.npu.dma_wait(%14, MM2S)
-        %15 = amdaie.npu.dma_cpy_nd %5([] [] [], %12[0, 0, 0, 0] [1, 1, 1, 1024] [0, 0, 0, 1] bd_id = %bd_id_0) : source_type = !amdaie.logicalobjectfifo<memref<4096xbf16>>
-        amdaie.npu.dma_wait(%15, MM2S)
-        %16 = amdaie.npu.dma_cpy_nd %9(%13[0, 0, 0, 32] [1, 1, 32, 32] [0, 0, 64, 1] bd_id = %bd_id_0, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<2048xf32>>
-        amdaie.npu.dma_wait(%16, S2MM)
-        %17 = amdaie.npu.dma_cpy_nd %9(%13[0, 0, 0, 0] [1, 1, 1, 1024] [0, 0, 0, 1] bd_id = %bd_id_0, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<2048xf32>>
-        amdaie.npu.dma_wait(%17, S2MM)
+        %14 = amdaie.npu.dma_cpy_nd async_source %5([] [] [], %12[0, 0, 1, 2] [1, 2, 32, 16] [0, 16, 32, 1] bd_id = %bd_id_0) : source_type = !amdaie.logicalobjectfifo<memref<4096xbf16>>
+        amdaie.npu.dma_wait(%14 : !amdaie.async_source_token)
+        %15 = amdaie.npu.dma_cpy_nd async_source %5([] [] [], %12[0, 0, 0, 0] [1, 1, 1, 1024] [0, 0, 0, 1] bd_id = %bd_id_0) : source_type = !amdaie.logicalobjectfifo<memref<4096xbf16>>
+        amdaie.npu.dma_wait(%15 : !amdaie.async_source_token)
+        %16 = amdaie.npu.dma_cpy_nd async_target %9(%13[0, 0, 0, 32] [1, 1, 32, 32] [0, 0, 64, 1] bd_id = %bd_id_0, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<2048xf32>>
+        amdaie.npu.dma_wait(%16 : !amdaie.async_target_token)
+        %17 = amdaie.npu.dma_cpy_nd async_target %9(%13[0, 0, 0, 0] [1, 1, 1, 1024] [0, 0, 0, 1] bd_id = %bd_id_0, [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<2048xf32>>
+        amdaie.npu.dma_wait(%17 : !amdaie.async_target_token)
         amdaie.end
       }
     }
@@ -1150,8 +1150,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
         %10 = amdaie.npu.circular_dma_cpy_nd %5([0, 0] [64, 64] [32, 1], [] [] [])
         %11 = amdaie.npu.circular_dma_cpy_nd %7([] [] [], [0, 1024] [64, 64] [32, 1])
         %12 = amdaie.logicalobjectfifo.from_memref %0, {%tile} : memref<4096xi32> -> !amdaie.logicalobjectfifo<memref<4096xi32>>
-        %13 = amdaie.npu.dma_cpy_nd %5([] [] [], %12[0, 0, 0, 32] [1, 1, 32, 32] [0, 0, 64, 1] bd_id = %bd_id) : source_type = !amdaie.logicalobjectfifo<memref<4096xi32>>
-        amdaie.npu.dma_wait(%13, MM2S)
+        %13 = amdaie.npu.dma_cpy_nd async_source %5([] [] [], %12[0, 0, 0, 32] [1, 1, 32, 32] [0, 0, 64, 1] bd_id = %bd_id) : source_type = !amdaie.logicalobjectfifo<memref<4096xi32>>
+        amdaie.npu.dma_wait(%13 : !amdaie.async_source_token)
         amdaie.end
       }
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/obj_fifo_bufferization.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/obj_fifo_bufferization.mlir
@@ -46,7 +46,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %1 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_0_0} : memref<1024xi32> -> !amdaie.logicalobjectfifo<memref<1024xi32>, 2>
       %2 = amdaie.connection(%0, %1) : (!amdaie.logicalobjectfifo<memref<1024xi32, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<1024xi32>, 2>)
       amdaie.controlcode {
-        %3 = amdaie.npu.dma_cpy_nd %2([] [] [], [] [] [])
+        amdaie.npu.dma_cpy_nd %2([] [] [], [] [] [])
         amdaie.end
       }
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/remove_memory_space.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/remove_memory_space.mlir
@@ -53,8 +53,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.forall (%arg2, %arg3) in (2, 1) {
           %1 = affine.apply #map(%arg2)
-          %2 = amdaie.npu.dma_cpy_nd %0([0, %1] [8, 16] [16, 1], [] [] [])
-          amdaie.npu.dma_wait(%2, S2MM)
+          %2 = amdaie.npu.dma_cpy_nd async_source %0([0, %1] [8, 16] [16, 1], [] [] [])
+          amdaie.npu.dma_wait(%2 : !amdaie.async_source_token)
         }
         amdaie.end
       }


### PR DESCRIPTION
This PR makes the return type of `AMDAIE::NpuDmaCpyNdOp` optional and more explicit by introducing an `amdaie.async_token` type. The `AMDAIE::NpuDmaWaitOp` will now operate on operands of the async token type . This is consistent with how `gpu.async_token` is used in the GPU dialect. 