### PR TITLE
Run aievec lowering passes in 'main' pipeline

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
+++ b/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
@@ -642,6 +642,7 @@ struct DetectNonCanonicalOpsPass
 };
 
 void buildCanonicalizeVectorForAIEVec(OpPassManager &pm) {
+
   // TODO: Add passes to split vectors that won't fit in registers
   pm.addPass(createCanonicalizeVectorForAIEVecPass());
   pm.addPass(mlir::createCanonicalizerPass());

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pack_peel_air_e2e.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pack_peel_air_e2e.mlir
@@ -18,14 +18,14 @@ func.func @matmul_i8_i32(%lhs: tensor<32x16xi8>, %rhs: tensor<16x32xi8>) -> tens
 
 // -----
 
-func.func @matmul_bf16(%lhs: tensor<16x32xbf16>, %rhs: tensor<32x16xbf16>) -> tensor<16x16xbf16>
+func.func @matmul_bf16(%lhs: tensor<16x32xbf16>, %rhs: tensor<32x16xbf16>) -> tensor<16x16xf32>
 {
-  %cst = arith.constant 0.000000e+00 : bf16
-  %0 = tensor.empty() : tensor<16x16xbf16>
-  %1 = linalg.fill ins(%cst : bf16) outs(%0 : tensor<16x16xbf16>) -> tensor<16x16xbf16>
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : tensor<16x16xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<16x16xf32>) -> tensor<16x16xf32>
   %res = linalg.matmul ins(%lhs, %rhs: tensor<16x32xbf16>, tensor<32x16xbf16>)
-                    outs(%1: tensor<16x16xbf16>) -> tensor<16x16xbf16>
-  return %res : tensor<16x16xbf16>
+                    outs(%1: tensor<16x16xf32>) -> tensor<16x16xf32>
+  return %res : tensor<16x16xf32>
 }
 
 // CHECK-LABEL: hal.executable.export public @matmul_bf16_dispatch_0_matmul_16x16x32_bf16

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -817,6 +817,8 @@ void addMLIRAIELoweringPasses(OpPassManager &passManager) {
     devicePM.addPass(createAMDAIENormalizeAddressSpacesPass());
     devicePM.addPass(createCanonicalizerPass());
   }
+
+  mlir::iree_compiler::aievec::buildConvertVectorToAIEVec(passManager);
 }
 
 // NOTE: this runs on the top-level program module containing all hal.executable

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/disable_vectorization.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/disable_vectorization.mlir
@@ -34,6 +34,6 @@ func.func @mm_in_bf16_out_f32(%lhs: tensor<64x64xbf16>,
   return %res : tensor<64x64xf32>
 }
 
-// CHECK-DISABLED-NOT: vector.contract
-// CHECK-ENABLED: vector.contract
-// CHECK-DEFAULT: vector.contract
+// CHECK-DISABLED-NOT: aievec.matmul
+// CHECK-ENABLED: aievec.matmul
+// CHECK-DEFAULT: aievec.matmul


### PR DESCRIPTION
This PR puts the aievec passes in the main 'IREE' pipeline, rather than running them in aie2xclbin. 

I found the trickiest was figuring out why it didn't "just work" without adding Affine and AIEVec as legal dialects in the pattern target in AMDAIECoreToStandard, So I'd like to refactor that pass soon -- there are too many dialects listed there. I'd also like to throw the final lowering to LLVM over the wall from aie2xclbin too, but that was causing other issues which I'd rather address in another PR. 