### PR TITLE
Temporarily disable double buffering for better performance

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -174,8 +174,7 @@ FailureOr<ParameterSetting> ParameterSetting::create(linalg::LinalgOp linalgOp,
   // the element types of all tensors which need to be allocated in memory
   // simultaneously.
   FailureOr<unsigned> maybeScaleFactor =
-      isObjectFifo ? getTilingScaleFactor(initType.getElementType())
-                   : getTilingScaleFactor(lhsType.getElementType());
+      getTilingScaleFactor(lhsType.getElementType());
   if (failed(maybeScaleFactor)) {
     return linalgOp.emitOpError(
         "does not have the expected bitwidth (64, 32, 16, or 8), could not "

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -48,9 +48,9 @@ def AMDAIEAssignLogicalObjectFifoDepth :
   let options = [
     Option<"l3BufferDepth", "l3-buffer-depth", "int64_t", /*default=*/"1",
       "Set the L3 buffer depth to be used.">,
-    Option<"l2BufferDepth", "l2-buffer-depth", "int64_t", /*default=*/"2",
+    Option<"l2BufferDepth", "l2-buffer-depth", "int64_t", /*default=*/"1",
       "Set the L2 buffer depth to be used.">,
-    Option<"l1BufferDepth", "l1-buffer-depth", "int64_t", /*default=*/"2",
+    Option<"l1BufferDepth", "l1-buffer-depth", "int64_t", /*default=*/"1",
       "Set the L1 buffer depth to be used.">,
   ];
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_logical_objectfifo_depth.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_logical_objectfifo_depth.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-assign-logical-objectfifo-depth)" %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-assign-logical-objectfifo-depth{l3-buffer-depth=1 l2-buffer-depth=2 l1-buffer-depth=2})" %s | FileCheck %s
 // RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-assign-logical-objectfifo-depth{l3-buffer-depth=3 l2-buffer-depth=2 l1-buffer-depth=1})" %s | FileCheck %s --check-prefix=OPTIONS
 
 // CHECK-LABEL: @assign


### PR DESCRIPTION
Temporarily set default buffer depth as 1 for l1/l2 space, and use a larger tile size. This will give much better performance. Will enable it after optimizing double buffering and pipelining.