### PR TITLE
[Testing] Fix bf16->f32 utility to preserve shape of the input

### DIFF
--- a/build_tools/ci/cpu_comparison/input_generator.py
+++ b/build_tools/ci/cpu_comparison/input_generator.py
@@ -69,7 +69,7 @@ def convert_bf16_to_f32(bfloat16_array):
     bit of info on the mantissa/exponent manipulation.
     """
     v0 = bfloat16_array.astype(np.uint32) << 16
-    return np.frombuffer(v0.tobytes(), dtype=np.float32)
+    return np.frombuffer(v0.tobytes(), dtype=np.float32).reshape(bfloat16_array.shape)
 
 
 def generate_bfloat16_data(num_values, lower_bound, upper_bound, rng):

--- a/build_tools/ci/cpu_comparison/test_input_generator.py
+++ b/build_tools/ci/cpu_comparison/test_input_generator.py
@@ -12,4 +12,3 @@ def test_conversion():
     c = convert_bf16_to_f32(np.array(b))
     assert np.allclose(c, expected, 0, 0)
 
-test_conversion()

--- a/build_tools/ci/cpu_comparison/test_input_generator.py
+++ b/build_tools/ci/cpu_comparison/test_input_generator.py
@@ -6,8 +6,10 @@ def test_conversion():
     """
     Check that float(bfloat(a)) is (almost) a.
     """
-    expected = np.array([1.5, 3.125, -1.5, -32.0, 0.0, -3.125], dtype=np.float32)
-    a = np.array([1.5, 3.14, -1.5, -32, 0, -3.14], np.float32)
+    expected = np.array([1.5, 3.125, -1.5, -32.0, 0.0, -3.125], dtype=np.float32).reshape([2,3])
+    a = np.array([1.5, 3.14, -1.5, -32, 0, -3.14], np.float32).reshape([2,3])
     b = [convert_f32_to_bf16(x) for x in a]
     c = convert_bf16_to_f32(np.array(b))
     assert np.allclose(c, expected, 0, 0)
+
+test_conversion()


### PR DESCRIPTION
-- This commit adds a quick fix for bf16->f32 utility to preserve the shape of the input.
-- Without this the utility is linearizing the input which causes issues during comparison.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>