### PR TITLE
[CombineStridedOps] Add a combinable case

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETemporaryAllocBufferization.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETemporaryAllocBufferization.cpp
@@ -48,7 +48,6 @@ LogicalResult bufferizeTemporaryMemrefs(Operation *parentOp) {
     });
   }
 
-
   // Note: we don't erase allocs/deallocs, we leave this for canonicalization.
 
   return success();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIEDmaUtilsTest.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIEDmaUtilsTest.cpp
@@ -111,6 +111,8 @@ TEST_F(AccessPatternCombinationTest, CombinableAccessPatterns) {
   EXPECT_TRUE(checkAreAccessPatternsCombinable({0, 2, 0}, {16, 16, 32},
                                                {32, 64, 1}, {0, 2, 32},
                                                {16, 16, 32}, {32, 64, 1}, 4));
+  EXPECT_TRUE(checkAreAccessPatternsCombinable({32, 0}, {64, 64}, {128, 1},
+                                               {96, 0}, {32, 64}, {128, 1}, 4));
   // size(A) > size(B)
   EXPECT_TRUE(checkAreAccessPatternsCombinable(
       {0, 0, 0}, {2, 16, 32}, {32, 64, 1}, {0, 64}, {16, 32}, {64, 1}, 4));
@@ -168,6 +170,12 @@ TEST_F(AccessPatternCombinationTest, NonCombinableAccessPatterns) {
       {0, 0}, {16, 32}, {64, 1}, {0, 0, 96}, {2, 16, 32}, {32, 64, 1}, 4));
   EXPECT_FALSE(checkAreAccessPatternsCombinable(
       {0, 0}, {16, 32}, {64, 1}, {0, 1, 0}, {2, 16, 32}, {32, 64, 1}, 4));
+
+  // size(A) == size(B) Incompatible offset
+  EXPECT_FALSE(checkAreAccessPatternsCombinable(
+      {32, 0}, {64, 64}, {128, 1}, {32, 0}, {32, 64}, {128, 1}, 4));
+  EXPECT_FALSE(checkAreAccessPatternsCombinable(
+      {32, 0}, {32, 64}, {128, 1}, {96, 0}, {64, 64}, {128, 1}, 4));
 }
 
 TEST_F(AccessPatternCombinationTest, CombineAccessPatterns) {
@@ -197,6 +205,8 @@ TEST_F(AccessPatternCombinationTest, CombineAccessPatterns) {
   checkCombineAccessPatterns({8, 0, 0}, {16, 8, 16}, {16, 8, 1}, {40, 0, 0},
                              {16, 8, 16}, {16, 8, 1}, {0, 8, 0, 0},
                              {2, 16, 8, 16}, {512, 16, 8, 1}, 4);
+  checkCombineAccessPatterns({32, 0}, {64, 64}, {128, 1}, {96, 0}, {32, 64},
+                             {128, 1}, {32, 0}, {96, 64}, {128, 1}, 4);
   // size(A) > size(B)
   checkCombineAccessPatterns({0, 0}, {2, 32}, {64, 1}, {128}, {32}, {1}, {0, 0},
                              {3, 32}, {64, 1}, 3);
@@ -255,6 +265,10 @@ TEST_F(AccessPatternCombinationTest, FailCombineAccessPatterns) {
                              {3, 32}, {64, 1}, 3, false);
   checkCombineAccessPatterns({0}, {32}, {1}, {0, 96}, {2, 32}, {64, 1}, {0, 0},
                              {3, 32}, {64, 1}, 3, false);
+
+  // size(A) == size(B) Incompatible offset
+  checkCombineAccessPatterns({32, 0}, {32, 64}, {128, 1}, {96, 0}, {64, 64},
+                             {128, 1}, {32, 0}, {96, 64}, {128, 1}, 4, false);
 }
 
 }  // namespace

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/combine_strided_ops.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/combine_strided_ops.mlir
@@ -230,6 +230,28 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 
 // -----
 
+// CHECK-LABEL: @combine_source_same_dims_diff_sizes
+// CHECK:       %[[CONNECTION:.+]] = amdaie.connection
+// CHECK:       amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0] [128, 64] [128, 1])
+// CHECK-NOT:   amdaie.npu.dma_cpy_nd
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @combine_source_same_dims_diff_sizes(%arg0: !amdaie.logicalobjectfifo<memref<2048xi32, 1 : i32>>, %arg1: !amdaie.logicalobjectfifo<memref<128x128xi32>>) {
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<2048xi32, 1 : i32>>, !amdaie.logicalobjectfifo<memref<128x128xi32>>)
+      amdaie.controlcode {
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0] [32, 64] [128, 1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [32, 0] [64, 64] [128, 1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [96, 0] [32, 64] [128, 1])
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
 // CHECK-LABEL: @combine_source_values
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0, 0] [2, 16, 8, 16] [32, 32, 8, 1])
@@ -323,6 +345,28 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         amdaie.npu.dma_cpy_nd %0([0, 0, 32] [16, 8, 16] [32, 8, 1], [] [] [])
         amdaie.npu.dma_cpy_nd %0([0, 0, 64] [16, 8, 16] [32, 8, 1], [] [] [])
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @combine_target_same_dims_diff_sizes
+// CHECK:       %[[CONNECTION:.+]] = amdaie.connection
+// CHECK:       amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0] [128, 64] [128, 1], [] [] [])
+// CHECK-NOT:   amdaie.npu.dma_cpy_nd
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @combine_target_same_dims_diff_sizes(%arg0: !amdaie.logicalobjectfifo<memref<2048xi32, 1 : i32>>, %arg1: !amdaie.logicalobjectfifo<memref<128x128xi32>>) {
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<2048xi32, 1 : i32>>, !amdaie.logicalobjectfifo<memref<128x128xi32>>)
+      amdaie.controlcode {
+        amdaie.npu.dma_cpy_nd %0([0, 0] [32, 64] [128, 1], [] [] [])
+        amdaie.npu.dma_cpy_nd %0([32, 0] [64, 64] [128, 1], [] [] [])
+        amdaie.npu.dma_cpy_nd %0([96, 0] [32, 64] [128, 1], [] [] [])
         amdaie.end
       }
     }


### PR DESCRIPTION
This PR adds a corner case for strided op combination. With this PR, the following strides ops:

```
48 = amdaie.npu.dma_cpy_nd %8([] [] [], %31[0, %45] [32, 64] [128, 1]) : source_type = !amdaie.logicalobjectfifo<memref<16384xi32>>
%49 = amdaie.npu.dma_cpy_nd %8([] [] [], %31[32, %45] [96, 64] [128, 1]) : source_type = !amdaie.logicalobjectfifo<memref<16384xi32>>
```

can be combined as 

`%48 = amdaie.npu.dma_cpy_nd %8([] [] [], %31[0, %45] [128, 64] [128, 1]) : source_type = !amdaie.logicalobjectfifo<memref<16384xi32>>
`

Addressed review comments https://github.com/nod-ai/iree-amd-aie/pull/826#discussion_r1792561366.