### PR TITLE
[XRT-LITE] add ability to configure NPU power mode

### DIFF
--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -796,6 +796,7 @@ fi
 # note this will not actually show any devices because --xrt_lite_n_core_rows --xrt_lite_n_core_cols are not passed
 # which i have omitted to make the conditional slightly more succinct
 if [[ $($IREE_INSTALL_DIR/bin/iree-benchmark-module --dump_devices | grep xrt-lite) ]]; then
+
   $IREE_INSTALL_DIR/bin/iree-benchmark-module \
     --module=$OUTPUT_DIR/mm_test1_bf16_f32_m64_n64_k64.vmfb \
     --function=matmul_64x64_64xbf16_ \
@@ -804,7 +805,25 @@ if [[ $($IREE_INSTALL_DIR/bin/iree-benchmark-module --dump_devices | grep xrt-li
     --device=xrt-lite \
     --benchmark_repetitions=10 \
     --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS \
-    --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS
+    --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS \
+
+  # TURBO POWER!!!!!!!!!!!!!!!!!
+  set +o pipefail
+  sudo -nv 2>&1 && has_sudo="true" || has_sudo="false"
+  set -o pipefail
+  if [ has_sudo == "true" ]; then
+    sudo $IREE_INSTALL_DIR/bin/iree-benchmark-module \
+      --module=$OUTPUT_DIR/mm_test1_bf16_f32_m64_n64_k64.vmfb \
+      --function=matmul_64x64_64xbf16_ \
+      --input=64x64xbf16 \
+      --input=64x64xbf16 \
+      --device=xrt-lite \
+      --benchmark_repetitions=10 \
+      --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS \
+      --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS \
+      --xrt_lite_power_mode=turbo
+  fi
+
 fi
 
 echo "$MATMUL_TESTS_RUN matmul tests run!"

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/api.h
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/api.h
@@ -7,12 +7,14 @@
 #ifndef IREE_AMD_AIE_DRIVER_XRT_LITE_API_H_
 #define IREE_AMD_AIE_DRIVER_XRT_LITE_API_H_
 
+#include "iree-amd-aie/driver/xrt-lite/shim/linux/kmq/amdxdna_accel.h"
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
 
 struct iree_hal_xrt_lite_device_params {
   int32_t n_core_rows;
   int32_t n_core_cols;
+  iree_string_view_t power_mode;
 };
 
 IREE_API_EXPORT void iree_hal_xrt_lite_device_options_initialize(

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/device.h
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/device.h
@@ -25,6 +25,7 @@ struct iree_hal_xrt_lite_device {
   // should come last; see the definition of total_size below in
   // iree_hal_xrt_lite_device_create
   iree_string_view_t identifier;
+  iree_string_view_t power_mode;
 
   iree_hal_xrt_lite_device(const iree_hal_xrt_lite_device_params* options,
                            iree_allocator_t host_allocator);

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/device.h
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/device.h
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <map>
 
+#include "amdxdna_accel.h"
 #include "fence.h"
 #include "xrt_mem.h"
 
@@ -33,6 +34,7 @@ struct device {
   uint32_t n_cols;
 
   device(uint32_t n_rows, uint32_t n_cols);
+  device(uint32_t n_rows, uint32_t n_cols, amdxdna_power_mode_type power_mode);
   ~device();
 
   std::unique_ptr<bo> import_bo(int ehdl) const;
@@ -58,12 +60,18 @@ struct device {
   void write_aie_reg(uint16_t col, uint16_t row, uint32_t reg_addr,
                      uint32_t reg_val);
 
+  // TODO(max): hide amdxdna_accel enums so they don't leak
+  amdxdna_power_mode_type get_power_mode() const;
+  void set_power_mode(amdxdna_power_mode_type mode) const;
+
   std::unique_ptr<fence_handle> create_fence(fence_handle::access_mode);
   std::unique_ptr<fence_handle> import_fence(pid_t, int);
 };
 
 std::string read_sysfs(const std::string &filename);
 std::filesystem::path find_npu_device();
+std::string stringify_amdxdna_power_mode_type(
+    amdxdna_power_mode_type power_mode);
 
 }  // namespace shim_xdna
 

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/hwctx.cpp
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/hwctx.cpp
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <cstring>
 
+#include "amdxdna_accel.h"
 #include "bo.h"
 #include "hwq.h"
 #include "shim_debug.h"

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/hwctx.h
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/hwctx.h
@@ -6,7 +6,6 @@
 
 #include <map>
 
-#include "amdxdna_accel.h"
 #include "device.h"
 
 namespace shim_xdna {
@@ -54,8 +53,7 @@ struct hw_ctx {
          std::unique_ptr<hw_q> q, const std::vector<uint8_t> &pdi,
          const std::string &cu_name, uint32_t n_rows, uint32_t n_cols);
   hw_ctx(device &dev, const std::vector<uint8_t> &pdi,
-         const std::string &cu_name,
-         uint32_t n_rows, uint32_t n_cols,
+         const std::string &cu_name, uint32_t n_rows, uint32_t n_cols,
          const std::map<std::string, uint32_t> &qos = {});
   ~hw_ctx();
   // no copying


### PR DESCRIPTION
Notes

1. This needs `sudo`;
   - if you want to run the whole `run_matmul_test.sh` script under `sudo` and you have env variables you need to do `sudo -E`;
2. I remembered this can actually be done using `xrt-smi` with something like 
    ```
    sudo /opt/xilinx/xrt/bin/xrt-smi configure -d 0000:c5:00.1 --pmode turbo
    ```
    Still maybe this is useful to expose directly here so that `xrt-smi` isn't required in the env.

Using the added test I got these results:

## Default

```
-----------------------------------------------------------------------------------------------------------------
Benchmark                                                       Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------------------------
BM_matmul_64x64_64xbf16_/process_time/real_time              1.61 ms        0.671 ms          456 items_per_second=620.987/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.56 ms        0.641 ms          456 items_per_second=643.073/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.59 ms        0.648 ms          456 items_per_second=630.323/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.62 ms        0.653 ms          456 items_per_second=616.069/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.59 ms        0.646 ms          456 items_per_second=629.755/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.57 ms        0.644 ms          456 items_per_second=635.695/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.58 ms        0.641 ms          456 items_per_second=633.842/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.57 ms        0.639 ms          456 items_per_second=636.084/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.59 ms        0.642 ms          456 items_per_second=630.571/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.58 ms        0.648 ms          456 items_per_second=633/s
BM_matmul_64x64_64xbf16_/process_time/real_time_mean         1.59 ms        0.648 ms           10 items_per_second=630.94/s
BM_matmul_64x64_64xbf16_/process_time/real_time_median       1.58 ms        0.645 ms           10 items_per_second=631.786/s
BM_matmul_64x64_64xbf16_/process_time/real_time_stddev      0.019 ms        0.009 ms           10 items_per_second=7.68176/s
BM_matmul_64x64_64xbf16_/process_time/real_time_cv           1.23 %          1.42 %            10 items_per_second=1.22%
```

## Turbo

```
-----------------------------------------------------------------------------------------------------------------
Benchmark                                                       Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------------------------
BM_matmul_64x64_64xbf16_/process_time/real_time              1.57 ms        0.652 ms          433 items_per_second=638.857/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.55 ms        0.651 ms          433 items_per_second=644.931/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.57 ms        0.650 ms          433 items_per_second=638.939/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.57 ms        0.644 ms          433 items_per_second=638.037/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.57 ms        0.664 ms          433 items_per_second=635.318/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.58 ms        0.663 ms          433 items_per_second=631.421/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.54 ms        0.648 ms          433 items_per_second=650.474/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.54 ms        0.646 ms          433 items_per_second=649.22/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.56 ms        0.669 ms          433 items_per_second=642.177/s
BM_matmul_64x64_64xbf16_/process_time/real_time              1.60 ms        0.660 ms          433 items_per_second=623.584/s
BM_matmul_64x64_64xbf16_/process_time/real_time_mean         1.56 ms        0.655 ms           10 items_per_second=639.296/s
BM_matmul_64x64_64xbf16_/process_time/real_time_median       1.57 ms        0.652 ms           10 items_per_second=638.898/s
BM_matmul_64x64_64xbf16_/process_time/real_time_stddev      0.020 ms        0.009 ms           10 items_per_second=8.09723/s
BM_matmul_64x64_64xbf16_/process_time/real_time_cv           1.27 %          1.31 %            10 items_per_second=1.27%
```

Higher `items_per_second` is better (I'm pretty sure?).

So for `BM_matmul_64x64_64xbf16_/process_time/real_time_mean` we get `630.94/s` under `default` vs. `639.296/s` under `turbo`, but with `stddev=8.09723` it's basically the same. So I'm not sure what the effect should be :shrug:. 

Note at least one of the things it's doing is enabling/disabling clock gating:

```
[13486.742867] amdxdna:aie2_pm_set_mode:90: amdxdna 0000:c5:00.1: Changing power mode from 0 to 4
[13486.742869] amdxdna:aie2_pm_clock_gating:27: amdxdna 0000:c5:00.1: Disable clock gating, 1 type(s)
...
[13493.313651] amdxdna:aie2_pm_set_mode:90: amdxdna 0000:c5:00.1: Changing power mode from 4 to 0
[13493.313653] amdxdna:aie2_pm_clock_gating:27: amdxdna 0000:c5:00.1: Enable clock gating, 1 type(s)
```

(via `dmesg`).

EDIT: 

I did this test with a debug build - maybe in a release build there's a difference 🤷‍♂️