### PR TITLE
Bump mlir-air to 24cb14e6d2233e819a5455928e4237ef319e6fc8

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/DecomposeLinalgExtPackUnPackToAIR.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/DecomposeLinalgExtPackUnPackToAIR.cpp
@@ -230,7 +230,7 @@ FailureOr<LowerPackUnPackResult> lowerUnPack(
       } else {
         readSizes.push_back(rewriter.getIndexAttr(srcShape[i]));
       }
-      if (srcShape[i] != 1) readShape.push_back(srcShape[i]);
+      readShape.push_back(srcShape[i]);
     }
 
     auto mixedTiles = unPackOp.getMixedTiles();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pack_to_air.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pack_to_air.mlir
@@ -79,9 +79,9 @@ func.func @func4() {
 // CHECK: scf.parallel (%[[ARG0:.*]], %[[ARG1:.*]], %[[ARG2:.*]]) = 
 // CHECK: %[[SUBVIEW0:.*]] = memref.subview %[[ALLOC0]][%[[ARG0]], %[[ARG1]], %[[ARG2]]] [1, 8, 64] [1, 1, 1] : memref<32x8x64xf32> to memref<1x8x64xf32, strided<[512, 64, 1], offset: ?>>
 // CHECK: %[[ALLOC1:.*]] = memref.alloc() : memref<1x1x1x8x64xf32, 1>
-// CHECK: %[[SUBVIEW1:.*]] = memref.subview %[[ALLOC1]][0, 0, 0, 0, 0] [1, 1, 1, 8, 64] [1, 1, 1, 1, 1] : memref<1x1x1x8x64xf32, 1> to memref<8x64xf32, 1>
-// CHECK: %[[TRANSPOSE0:.*]] = memref.transpose %[[SUBVIEW1]] (d0, d1) -> (d0, d1) : memref<8x64xf32, 1> to memref<8x64xf32, strided<[64, 1]>, 1>
-// CHECK: air.dma_memcpy_nd (%[[SUBVIEW0]][] [] [], %[[TRANSPOSE0]][] [] []) : (memref<1x8x64xf32, strided<[512, 64, 1], offset: ?>>, memref<8x64xf32, strided<[64, 1]>, 1>)
+// CHECK: %[[SUBVIEW1:.*]] = memref.subview %[[ALLOC1]][0, 0, 0, 0, 0] [1, 1, 1, 8, 64] [1, 1, 1, 1, 1] : memref<1x1x1x8x64xf32, 1> to memref<1x8x64xf32, 1>
+// CHECK: %[[TRANSPOSE0:.*]] = memref.transpose %[[SUBVIEW1]] (d0, d1, d2) -> (d0, d1, d2) : memref<1x8x64xf32, 1> to memref<1x8x64xf32, strided<[512, 64, 1]>, 1>
+// CHECK: air.dma_memcpy_nd (%[[SUBVIEW0]][] [] [], %[[TRANSPOSE0]][] [] []) : (memref<1x8x64xf32, strided<[512, 64, 1], offset: ?>>, memref<1x8x64xf32, strided<[512, 64, 1]>, 1>)
 
 func.func @func5() {
   %c0 = arith.constant 0 : index

--- a/tests/test_matmul.py
+++ b/tests/test_matmul.py
@@ -62,10 +62,7 @@ simple_matmul_test_params = list(
 )
 
 xfails = [
-    (8, 512, 8, T.i32, T.i32, "air", "pad-pack", 1),
-    (8, 512, 16, T.i32, T.i32, "air", "pad-pack", 1),
-    (16, 512, 8, T.i32, T.i32, "air", "pad-pack", 1),
-    (16, 512, 16, T.i32, T.i32, "air", "pad-pack", 1),
+    # currently there are no xfails
 ]
 
 for x in xfails:


### PR DESCRIPTION
- Convolution with `air` pipeline now works once again.
- In MLIR-AIR, we now have a ukernel for vectorized i8 conv2d (https://github.com/Xilinx/mlir-air/blob/main/test/xrt/14_conv2d_i8_extern_vec/aie.py), following the new convolution tiling recipe in iree-amd-aie.