### PR TITLE
[Vectorization][ObjectFifo] Enable larger Matmul + Truncf

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -795,6 +795,29 @@ class MatmulSet(TestSet):
             output_type=get_output_type(test_name),
         )
 
+        # Large shape Matmul + Truncf
+        generate_matmul_test(test_name, template_name, 128, 128, 256, "bf16", "f32")
+        identity_mat = np.eye(128, dtype=np.float32)
+        ones = np.ones(128 * 128, dtype=np.float32).reshape([128, 128])
+        lhs = ones * 101
+        rhs = identity_mat * 3
+        input_args = generate_inputs(test_name, output_dir, 1, {1: lhs, 2: rhs})
+        aie_vs_baseline(
+            config,
+            test_name,
+            input_args,
+            ones * 302,  # exected output
+            use_ukernel=False,
+            tile_pipeline="pack-peel",
+            lower_to_aie_pipeline="objectFifo",
+            function_name=None,
+            seed=1,
+            rtol=0,
+            atol=0,
+            n_repeats=1,
+            output_type=get_output_type(test_name),
+        )
+
 
 class SmokeSet(TestSet):
     def __init__(self):

--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -795,7 +795,7 @@ class MatmulSet(TestSet):
             output_type=get_output_type(test_name),
         )
 
-        # Large shape Matmul + Truncf
+        # 128x128x256 shape test of Matmul + Truncf
         generate_matmul_test(test_name, template_name, 128, 128, 256, "bf16", "f32")
         identity_mat = np.eye(128, dtype=np.float32)
         lhs_ones = np.ones(128 * 256, dtype=np.float32).reshape([128, 256])

--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -798,15 +798,17 @@ class MatmulSet(TestSet):
         # Large shape Matmul + Truncf
         generate_matmul_test(test_name, template_name, 128, 128, 256, "bf16", "f32")
         identity_mat = np.eye(128, dtype=np.float32)
-        ones = np.ones(128 * 128, dtype=np.float32).reshape([128, 128])
-        lhs = ones * 101
-        rhs = identity_mat * 3
+        lhs_ones = np.ones(128 * 256, dtype=np.float32).reshape([128, 256])
+        rhs_ones = np.ones(256 * 128, dtype=np.float32).reshape([256, 128])
+        out_ones = np.ones(128 * 128, dtype=np.float32).reshape([128, 128])
+        lhs = lhs_ones * 2
+        rhs = rhs_ones * 3
         input_args = generate_inputs(test_name, output_dir, 1, {1: lhs, 2: rhs})
         aie_vs_baseline(
             config,
             test_name,
             input_args,
-            ones * 302,  # exected output
+            out_ones * 1536,  # exected output
             use_ukernel=False,
             tile_pipeline="pack-peel",
             lower_to_aie_pipeline="objectFifo",

--- a/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
+++ b/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
@@ -320,13 +320,13 @@ struct CanonicalizeTrivialReadAccessSubviewOpPattern
         }))
       return failure();
     SmallVector<Value> newIndices;
-    for (OpFoldResult x : subViewOp.getMixedOffsets()) {
+    for (OpFoldResult offset : subViewOp.getMixedOffsets()) {
       Value indexVal;
-      if (auto attr = dyn_cast<Attribute>(x)) {
+      if (auto attr = dyn_cast<Attribute>(offset)) {
         indexVal = rewriter.create<arith::ConstantIndexOp>(
             readOp.getLoc(), cast<IntegerAttr>(attr).getInt());
       } else {
-        indexVal = cast<Value>(x);
+        indexVal = cast<Value>(offset);
       }
       newIndices.push_back(indexVal);
     }
@@ -353,13 +353,13 @@ struct CanonicalizeTrivialWriteAccessSubviewOpPattern
         }))
       return failure();
     SmallVector<Value> newIndices;
-    for (OpFoldResult x : subViewOp.getMixedOffsets()) {
+    for (OpFoldResult offset : subViewOp.getMixedOffsets()) {
       Value indexVal;
-      if (auto attr = dyn_cast<Attribute>(x)) {
+      if (auto attr = dyn_cast<Attribute>(offset)) {
         indexVal = rewriter.create<arith::ConstantIndexOp>(
             writeOp.getLoc(), cast<IntegerAttr>(attr).getInt());
       } else {
-        indexVal = cast<Value>(x);
+        indexVal = cast<Value>(offset);
       }
       newIndices.push_back(indexVal);
     }

--- a/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
+++ b/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
@@ -30,6 +30,7 @@
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
 #include "mlir/Dialect/Vector/Utils/VectorUtils.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
@@ -302,6 +303,73 @@ class FlattenContiguousRowMajorTransferWritePattern
 };
 
 }  // namespace copied_from_mlir
+
+struct CanonicalizeTrivialReadAccessSubviewOpPattern
+    : public OpRewritePattern<vector::TransferReadOp> {
+  using OpRewritePattern<vector::TransferReadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::TransferReadOp readOp,
+                                PatternRewriter &rewriter) const override {
+    auto subViewOp = dyn_cast_if_present<memref::SubViewOp>(
+        readOp.getSource().getDefiningOp());
+    if (!subViewOp) return failure();
+    if (!llvm::all_of(readOp.getIndices(), [](Value val) {
+          IntegerAttr attr;
+          if (!matchPattern(val, m_Constant(&attr))) return false;
+          return attr.getInt() == 0;
+        }))
+      return failure();
+    SmallVector<Value> newIndices;
+    for (OpFoldResult x : subViewOp.getMixedOffsets()) {
+      Value indexVal;
+      if (auto attr = dyn_cast<Attribute>(x)) {
+        indexVal = rewriter.create<arith::ConstantOp>(readOp.getLoc(),
+                                                      cast<IntegerAttr>(attr));
+      } else {
+        indexVal = cast<Value>(x);
+      }
+      newIndices.push_back(indexVal);
+    }
+    rewriter.replaceOpWithNewOp<vector::TransferReadOp>(
+        readOp, readOp.getType(), subViewOp.getSource(), newIndices,
+        readOp.getPadding(), readOp.getInBoundsValues());
+    return success();
+  }
+};
+
+struct CanonicalizeTrivialWriteAccessSubviewOpPattern
+    : public OpRewritePattern<vector::TransferWriteOp> {
+  using OpRewritePattern<vector::TransferWriteOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::TransferWriteOp writeOp,
+                                PatternRewriter &rewriter) const override {
+    auto subViewOp = dyn_cast_if_present<memref::SubViewOp>(
+        writeOp.getSource().getDefiningOp());
+    if (!subViewOp) return failure();
+    if (!llvm::all_of(writeOp.getIndices(), [](Value val) {
+          IntegerAttr attr;
+          if (!matchPattern(val, m_Constant(&attr))) return false;
+          return attr.getInt() == 0;
+        }))
+      return failure();
+    SmallVector<Value> newIndices;
+    for (OpFoldResult x : subViewOp.getMixedOffsets()) {
+      Value indexVal;
+      if (auto attr = dyn_cast<Attribute>(x)) {
+        indexVal = rewriter.create<arith::ConstantOp>(writeOp.getLoc(),
+                                                      cast<IntegerAttr>(attr));
+      } else {
+        indexVal = cast<Value>(x);
+      }
+      newIndices.push_back(indexVal);
+    }
+    rewriter.create<vector::TransferWriteOp>(
+        writeOp.getLoc(), writeOp.getVector(), subViewOp.getSource(),
+        newIndices, writeOp.getInBoundsValues());
+    rewriter.eraseOp(writeOp);
+    return success();
+  }
+};
 
 static bool isGemmBTransposedContractionOp(vector::ContractionOp op) {
   if (op.getKind() != vector::CombiningKind::ADD) return false;
@@ -892,6 +960,12 @@ struct CanonicalizeVectorForAIEVecPass
     auto op = getOperation();
     MLIRContext *context = &getContext();
 
+    {
+      RewritePatternSet patterns(context);
+      patterns.add<CanonicalizeTrivialReadAccessSubviewOpPattern,
+                   CanonicalizeTrivialWriteAccessSubviewOpPattern>(context);
+      (void)applyPatternsAndFoldGreedily(op, std::move(patterns));
+    }
     {
       // These must run before 'populateVectorBroadcastLoweringPatterns'
       // so that broadcasts can be matched before conversion to insert.

--- a/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
+++ b/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
@@ -323,8 +323,8 @@ struct CanonicalizeTrivialReadAccessSubviewOpPattern
     for (OpFoldResult x : subViewOp.getMixedOffsets()) {
       Value indexVal;
       if (auto attr = dyn_cast<Attribute>(x)) {
-        indexVal = rewriter.create<arith::ConstantOp>(readOp.getLoc(),
-                                                      cast<IntegerAttr>(attr));
+        indexVal = rewriter.create<arith::ConstantIndexOp>(
+            readOp.getLoc(), cast<IntegerAttr>(attr).getInt());
       } else {
         indexVal = cast<Value>(x);
       }
@@ -356,8 +356,8 @@ struct CanonicalizeTrivialWriteAccessSubviewOpPattern
     for (OpFoldResult x : subViewOp.getMixedOffsets()) {
       Value indexVal;
       if (auto attr = dyn_cast<Attribute>(x)) {
-        indexVal = rewriter.create<arith::ConstantOp>(writeOp.getLoc(),
-                                                      cast<IntegerAttr>(attr));
+        indexVal = rewriter.create<arith::ConstantIndexOp>(
+            writeOp.getLoc(), cast<IntegerAttr>(attr).getInt());
       } else {
         indexVal = cast<Value>(x);
       }

--- a/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
@@ -171,6 +171,7 @@ func.func @arith_truncf(%inp: vector<2x3xf32>) -> vector<2x3xbf16> {
 
 // CHECK-LABEL: @trivial_read_access
 // CHECK-SAME:  (%[[ARG0:.*]]: memref<4x8x4x8xbf16, strided<[256, 32, 8, 1]>>)
+// CHECK-NOT:     memref.subview
 // CHECK:         %[[COLLAPSE_SHAPE:.*]] = memref.collapse_shape %[[ARG0]]
 // CHECK-SAME:        into memref<1024xbf16, strided<[1]>>
 // CHECK:         %[[READ:.*]] = vector.transfer_read %[[COLLAPSE_SHAPE]]
@@ -190,6 +191,7 @@ func.func @trivial_read_access(%arg0: memref<4x8x4x8xbf16, strided<[256, 32, 8, 
 // CHECK-LABEL: @trivial_write_access
 // CHECK-SAME:  (%[[ARG0:.*]]: memref<8x8x4x4xf32, strided<[128, 16, 4, 1]>>,
 // CHECK-SAME:   %[[ARG1:.*]]: vector<1x1x4x4xf32>)
+// CHECK-NOT:       memref.subview
 // CHECK:           %[[COLLAPSE_SHAPE:.*]] = memref.collapse_shape %[[ARG0]]
 // CHECK-SAME:          : memref<8x8x4x4xf32, strided<[128, 16, 4, 1]>> into memref<1024xf32, strided<[1]>>
 // CHECK:           %[[SHAPE_CAST:.*]] = vector.shape_cast %[[ARG1]]

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
     "matmul_pack_peel_objectfifo.mlir"
     "matmul_pack_peel_objectfifo_e2e.mlir"
     "matmul_pad_pack_air_e2e.mlir"
+    "matmul_elementwise_pack_peel_objectfifo_e2e.mlir"
     "xdna_oplib_plugin.mlir"
   TOOLS
     ${IREE_LLD_TARGET}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_elementwise_pack_peel_objectfifo_e2e.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_elementwise_pack_peel_objectfifo_e2e.mlir
@@ -1,0 +1,34 @@
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources --iree-amdaie-target-device=npu1_4col %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-lower-to-aie-pipeline=objectFifo --iree-amdaie-tile-pipeline=pack-peel --split-input-file | FileCheck %s
+
+// CHECK-LABEL: hal.executable.export public @matmul_truncf_bf16_dispatch_0_matmul_128x128x256_bf16
+// CHECK:       aie.device(npu1_4col) {
+// CHECK-DAG:   %[[TILE_0_2:.+]] = aie.tile(0, 2)
+// CHECK-DAG:   %[[TILE_0_3:.+]] = aie.tile(0, 3)
+// CHECK-DAG:   %[[TILE_1_2:.+]] = aie.tile(1, 2)
+// CHECK-DAG:   %[[TILE_1_3:.+]] = aie.tile(1, 3)
+// CHECK-DAG:   %[[TILE_0_0:.+]] = aie.tile(0, 0)
+// CHECK-DAG:   %[[TILE_0_1:.+]] = aie.tile(0, 1)
+// CHECK-DAG:   aie.core(%[[TILE_0_2]])
+// CHECK-DAG:   aie.core(%[[TILE_1_2]])
+// CHECK-DAG:   aie.core(%[[TILE_0_3]])
+// CHECK-DAG:   aie.core(%[[TILE_1_3]])
+// CHECK-DAG:   aie.shim_dma_allocation {{.*}}(MM2S, 0, 0)
+// CHECK-DAG:   aie.shim_dma_allocation {{.*}}(MM2S, 1, 0)
+// CHECK-DAG:   aie.memtile_dma(%[[TILE_0_1]])
+// CHECK-DAG:   aie.mem(%[[TILE_0_2]])
+// CHECK-DAG:   aie.mem(%[[TILE_0_3]])
+// CHECK-DAG:   aie.mem(%[[TILE_1_2]])
+// CHECK-DAG:   aie.mem(%[[TILE_1_3]])
+// CHECK-DAG:   aie.shim_dma_allocation {{.*}}(S2MM, 0, 0)
+// CHECK:       {npu_instructions =
+// CHECK-SAME:   runtime_sequence_name = "matmul_truncf_bf16_dispatch_0_matmul_128x128x256_bf16xbf16xf32"
+func.func @matmul_truncf_bf16(%lhs: tensor<128x256xbf16>, %rhs: tensor<256x128xbf16>) -> tensor<128x128xbf16>
+{
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = tensor.empty() : tensor<128x128xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<128x128xf32>) -> tensor<128x128xf32>
+  %res = linalg.matmul ins(%lhs, %rhs: tensor<128x256xbf16>, tensor<256x128xbf16>)
+                    outs(%1: tensor<128x128xf32>) -> tensor<128x128xf32>
+  %cast = arith.truncf %res : tensor<128x128xf32> to tensor<128x128xbf16>
+  return %cast : tensor<128x128xbf16>
+}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -567,6 +567,10 @@ void addAMDAIEObjectFifoLoweringPasses(OpPassManager &passManager,
   {
     // Vectorization passes
     OpPassManager &funcPassManager = passManager.nest<func::FuncOp>();
+    enableVectorizationPasses =
+        (useTilePipeline == TilePassPipeline::ConvDecomposePipeline)
+            ? false
+            : enableVectorizationPasses;
     appendVectorizationToPipeline(funcPassManager, enableVectorizationPasses);
   }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -284,9 +284,6 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
     funcPassManager.addPass(createAMDAIELowerToUKernelsPass(options));
   }
 
-  // Vectorization passes
-  appendVectorizationToPipeline(funcPassManager, enableVectorizationPasses);
-
   // Comprehensive bufferization
   addAMDAIEBufferizePasses(funcPassManager, useTilePipeline);
   funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
@@ -518,7 +515,8 @@ void buildAMDAIETransformPassPipeline(
   modulePassManager.addPass(createLowerUKernelOpsToCallsPass());
   if (useLowerToAIEPipeline == LowerToAIEPassPipeline::ObjectFifo) {
     addAMDAIEObjectFifoLoweringPasses(modulePassManager, enablePacketFlow,
-                                      useTilePipeline);
+                                      useTilePipeline,
+                                      enableVectorizationPasses);
   } else if (useLowerToAIEPipeline == LowerToAIEPassPipeline::AIR) {
     addMLIRAIRLoweringPasses(modulePassManager, device, useTilePipeline,
                              matmulElementwiseFusion);
@@ -539,7 +537,8 @@ void buildAMDAIETransformPassPipeline(
 
 void addAMDAIEObjectFifoLoweringPasses(OpPassManager &passManager,
                                        bool enablePacketFlow,
-                                       TilePassPipeline useTilePipeline) {
+                                       TilePassPipeline useTilePipeline,
+                                       bool enableVectorizationPasses) {
   passManager.addPass(createEraseHALDescriptorTypeFromMemRefPass());
   passManager.addPass(memref::createFoldMemRefAliasOpsPass());
 
@@ -564,6 +563,13 @@ void addAMDAIEObjectFifoLoweringPasses(OpPassManager &passManager,
 
   passManager.addPass(createAMDAIENormalizeLoopBoundsPass());
   passManager.addPass(createAMDAIEInsertCoresPass());
+
+  {
+    // Vectorization passes
+    OpPassManager &funcPassManager = passManager.nest<func::FuncOp>();
+    appendVectorizationToPipeline(funcPassManager, enableVectorizationPasses);
+  }
+
   passManager.addPass(createAMDAIELocalizeLogicalObjectFifoPass());
   passManager.addPass(createCSEPass());
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -474,9 +474,6 @@ void addConvDecomposePassPipeline(OpPassManager &funcPassManager,
   LinalgFoldUnitExtentDimsPassOptions opts;
   opts.useRankReducingSlices = true;
   funcPassManager.addPass(mlir::createLinalgFoldUnitExtentDimsPass(opts));
-
-  // Vectorization passes
-  appendVectorizationToPipeline(funcPassManager, enableVectorizationPasses);
   funcPassManager.addPass(createCanonicalizerPass());
 
   // Comprehensive bufferization
@@ -519,7 +516,8 @@ void buildAMDAIETransformPassPipeline(
                                       enableVectorizationPasses);
   } else if (useLowerToAIEPipeline == LowerToAIEPassPipeline::AIR) {
     addMLIRAIRLoweringPasses(modulePassManager, device, useTilePipeline,
-                             matmulElementwiseFusion);
+                             matmulElementwiseFusion,
+                             enableVectorizationPasses);
   } else {
     assert(
         false &&
@@ -567,6 +565,7 @@ void addAMDAIEObjectFifoLoweringPasses(OpPassManager &passManager,
   {
     // Vectorization passes
     OpPassManager &funcPassManager = passManager.nest<func::FuncOp>();
+    // FIXME(newling) https://github.com/nod-ai/iree-amd-aie/issues/820
     enableVectorizationPasses =
         (useTilePipeline == TilePassPipeline::ConvDecomposePipeline)
             ? false
@@ -682,10 +681,21 @@ void addMLIRAIELoweringPasses(OpPassManager &pm) {
 // for details.
 void addMLIRAIRLoweringPasses(OpPassManager &passManager, AMDAIEDevice device,
                               TilePassPipeline useTilePipeline,
-                              bool matmulElementwiseFusion) {
+                              bool matmulElementwiseFusion,
+                              bool enableVectorizationPasses) {
   // Add passes for preparing for lowering to MLIR-AIR
   passManager.addPass(createEraseHALDescriptorTypeFromMemRefPass());
   passManager.addPass(memref::createFoldMemRefAliasOpsPass());
+  {
+    // Vectorization passes
+    OpPassManager &funcPassManager = passManager.nest<func::FuncOp>();
+    // FIXME(newling) https://github.com/nod-ai/iree-amd-aie/issues/820
+    enableVectorizationPasses =
+        (useTilePipeline == TilePassPipeline::ConvDecomposePipeline)
+            ? false
+            : enableVectorizationPasses;
+    appendVectorizationToPipeline(funcPassManager, enableVectorizationPasses);
+  }
   passManager.addPass(createAMDAIEBridgeToAIRPass());
 
   // Running canonicalization for all pipelines here results in failures.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -567,11 +567,6 @@ void addAMDAIEObjectFifoLoweringPasses(OpPassManager &passManager,
   {
     // Vectorization passes
     OpPassManager &funcPassManager = passManager.nest<func::FuncOp>();
-    // FIXME(newling) https://github.com/nod-ai/iree-amd-aie/issues/820
-    enableVectorizationPasses =
-        (useTilePipeline == TilePassPipeline::ConvDecomposePipeline)
-            ? false
-            : enableVectorizationPasses;
     appendVectorizationToPipeline(funcPassManager, enableVectorizationPasses);
   }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -561,6 +561,8 @@ void addAMDAIEObjectFifoLoweringPasses(OpPassManager &passManager,
 
   passManager.addPass(createAMDAIENormalizeLoopBoundsPass());
   passManager.addPass(createAMDAIEInsertCoresPass());
+  if (useTilePipeline != TilePassPipeline::ConvDecomposePipeline)
+    passManager.addPass(createAMDAIELinalgFunctionOutliningPass());
 
   {
     // Vectorization passes

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -24,7 +24,8 @@ void addAMDAIEObjectFifoLoweringPasses(OpPassManager &passManager,
 /// currently the default passes used for lowering after IREEs tiling.
 void addMLIRAIRLoweringPasses(OpPassManager &passManager, AMDAIEDevice device,
                               TilePassPipeline useTilePipeline,
-                              bool matmulElementwiseFusion);
+                              bool matmulElementwiseFusion,
+                              bool enableVectorizationPasses);
 
 /// Add lowering passes from MLIR-AIE. This is
 /// currently the default passes used for lowering from AIE dialect.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -17,7 +17,8 @@ namespace mlir::iree_compiler::AMDAIE {
 /// Add passes to lower to AIE objectFifos.
 void addAMDAIEObjectFifoLoweringPasses(OpPassManager &passManager,
                                        bool enablePacketFlow,
-                                       TilePassPipeline useTilePipeline);
+                                       TilePassPipeline useTilePipeline,
+                                       bool enableVectorizationPasses);
 
 /// Add passes to lower from MLIR-AIR through AIE. This is
 /// currently the default passes used for lowering after IREEs tiling.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
@@ -45,7 +45,6 @@ iree_lit_test_suite(
     "hoist_for_affine_apply.mlir"
     "hoist_logical_obj_fifo.mlir"
     "insert_cores.mlir"
-    "insert_loops_for_vectorization.mlir"
     "localize_logical_objectfifo.mlir"
     "lower_func_args.mlir"
     "lower_to_aie.mlir"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
@@ -45,6 +45,7 @@ iree_lit_test_suite(
     "hoist_for_affine_apply.mlir"
     "hoist_logical_obj_fifo.mlir"
     "insert_cores.mlir"
+    "insert_loops_for_vectorization.mlir"
     "localize_logical_objectfifo.mlir"
     "lower_func_args.mlir"
     "lower_to_aie.mlir"


### PR DESCRIPTION
-- This PR adds the following pieces to enable working of larger Matmul + Truncf.
1. Updates `insert-loops-for-vectorization` to work on bufferized inputs, collapse unit dimensions and coalesce the generated loops for tiling.
2. Makes the pipeline as `IREEComprehensiveBufferization` -> `insert-cores` -> `insert-loops-for-vectorization` -> `vectorization`.
3. Creates and adds a new pass `function-outlining` - which is invoked right after `insert-cores` pass.
4. Adds two canonicalization patterns that canonicalizes away trivial read/write access patterns to enable other dependent canonicalizations in `aievec`.
5. Adds e2e CI test for 128x128x256 Matmul + Truncf bf16 -> bf16.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>