### PR TITLE
Bump driver dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ git \
 The above avoids cloning entire repo histories for submodules, and skips a few, currently, unused, 
 submodules that are nested in IREE.
 
+### Dependencies
+
+#### For Linux
+
+Build and install `xdna-driver`, use commit `59f1d62`:
+
+```
+git clone git@github.com:amd/xdna-driver.git
+cd <root-of-source-tree>
+# get code for submodules
+git checkout 59f1d62
+git submodule update --init --recursive
+```
+
+Follow the instructions to build and install the driver module: https://github.com/amd/xdna-driver.
+
 ## Building (along with IREE)
 
 ### Just show me the CMake

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/amdxdna_accel.h
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/amdxdna_accel.h
@@ -89,6 +89,7 @@ struct amdxdna_qos_info {
  * @mem_size: Size of AIE tile memory.
  * @umq_doorbell: Returned offset of doorbell associated with UMQ.
  * @handle: Returned hardware context handle.
+ * @pad: Structure padding.
  */
 struct amdxdna_drm_create_hwctx {
   __u64 ext;
@@ -101,12 +102,13 @@ struct amdxdna_drm_create_hwctx {
   __u32 mem_size;
   __u32 umq_doorbell;
   __u32 handle;
+  __u32 pad;
 };
 
 /**
  * struct amdxdna_drm_destroy_hwctx - Destroy hardware context.
  * @handle: Hardware context handle.
- * @pad: MBZ.
+ * @pad: Structure padding.
  */
 struct amdxdna_drm_destroy_hwctx {
   __u32 handle;
@@ -115,9 +117,9 @@ struct amdxdna_drm_destroy_hwctx {
 
 /**
  * struct amdxdna_cu_config - configuration for one CU
- * @cu_bo: CU configuration buffer bo handle
- * @cu_func: Functional of a CU
- * @pad: MBZ
+ * @cu_bo: CU configuration buffer bo handle.
+ * @cu_func: Function of a CU.
+ * @pad: Structure padding.
  */
 struct amdxdna_cu_config {
   __u32 cu_bo;
@@ -128,9 +130,9 @@ struct amdxdna_cu_config {
 /**
  * struct amdxdna_hwctx_param_config_cu - configuration for CUs in hardware
  * context
- * @num_cus: Number of CUs to configure
- * @pad: MBZ
- * @cu_configs: Array of CU configurations of struct amdxdna_cu_config
+ * @num_cus: Number of CUs to configure.
+ * @pad: Structure padding.
+ * @cu_configs: Array of CU configurations of struct amdxdna_cu_config.
  */
 struct amdxdna_hwctx_param_config_cu {
   __u16 num_cus;
@@ -153,7 +155,8 @@ enum amdxdna_drm_config_hwctx_param {
  * @param_val: A structure specified by the param_type struct member.
  * @param_val_size: Size of the parameter buffer pointed to by the param_val.
  *		    If param_val is not a pointer, driver can ignore this.
- *
+ * @pad: Structure padding.
+ * 
  * Note: if the param_val is a pointer pointing to a buffer, the maximum size
  * of the buffer is 4KiB(PAGE_SIZE).
  */
@@ -184,17 +187,16 @@ enum amdxdna_bo_type {
 /**
  * struct amdxdna_drm_create_bo - Create a buffer object.
  * @flags: Buffer flags. MBZ.
- * @type: Buffer type.
  * @vaddr: User VA of buffer if applied. MBZ.
  * @size: Size in bytes.
+ * @type: Buffer type.
  * @handle: Returned DRM buffer object handle.
  */
 struct amdxdna_drm_create_bo {
   __u64 flags;
-  __u32 type;
-  __u32 _pad;
   __u64 vaddr;
   __u64 size;
+  __u32 type;
   __u32 handle;
 };
 
@@ -203,6 +205,7 @@ struct amdxdna_drm_create_bo {
  * @ext: MBZ.
  * @ext_flags: MBZ.
  * @handle: DRM buffer object handle.
+ * @pad: Structure padding.
  * @map_offset: Returned DRM fake offset for mmap().
  * @vaddr: Returned user VA of buffer. 0 in case user needs mmap().
  * @xdna_addr: Returned XDNA device virtual address.
@@ -211,7 +214,7 @@ struct amdxdna_drm_get_bo_info {
   __u64 ext;
   __u64 ext_flags;
   __u32 handle;
-  __u32 _pad;
+  __u32 pad;
   __u64 map_offset;
   __u64 vaddr;
   __u64 xdna_addr;
@@ -245,8 +248,8 @@ enum amdxdna_cmd_type {
  * @ext_flags: MBZ.
  * @hwctx: Hardware context handle.
  * @type: One of command type in enum amdxdna_cmd_type.
- * @cmd_handles: Array of command handles or the command handle itself in case
- * of just one.
+ * @cmd_handles: Array of command handles or the command handle itself
+ *               in case of just one.
  * @args: Array of arguments for all command handles.
  * @cmd_count: Number of command handles in the cmd_handles array.
  * @arg_count: Number of arguments in the args array.
@@ -281,8 +284,8 @@ struct amdxdna_drm_wait_cmd {
 
 /**
  * struct amdxdna_drm_query_aie_status - Query the status of the AIE hardware
- * @buffer: The user space buffer that will return the AIE status
- * @buffer_size: The size of the user space buffer
+ * @buffer: The user space buffer that will return the AIE status.
+ * @buffer_size: The size of the user space buffer.
  * @cols_filled: A bitmap of AIE columns whose data has been returned in the
  * buffer.
  */
@@ -294,8 +297,8 @@ struct amdxdna_drm_query_aie_status {
 
 /**
  * struct amdxdna_drm_query_aie_version - Query the version of the AIE hardware
- * @major: The major version number
- * @minor: The minor version number
+ * @major: The major version number.
+ * @minor: The minor version number.
  */
 struct amdxdna_drm_query_aie_version {
   __u32 major; /* out */
@@ -310,7 +313,7 @@ struct amdxdna_drm_query_aie_version {
  * @dma_channel_count: The number of dma channels.
  * @lock_count: The number of locks.
  * @event_reg_count: The number of events.
- * @pad: MBZ.
+ * @pad: Structure padding.
  */
 struct amdxdna_drm_query_aie_tile_metadata {
   __u16 row_count;
@@ -346,7 +349,7 @@ struct amdxdna_drm_query_aie_metadata {
  * struct amdxdna_drm_query_clock - Metadata for a clock
  * @name: The clock name.
  * @freq_mhz: The clock frequency.
- * @pad: MBZ.
+ * @pad: Structure padding.
  */
 struct amdxdna_drm_query_clock {
   __u8 name[16];
@@ -377,9 +380,9 @@ enum amdxdna_sensor_type { AMDXDNA_SENSOR_TYPE_POWER };
  * @status: The sensor status.
  * @units: The sensor units.
  * @unitm: Translates value member variables into the correct unit via (pow(10,
- * unitm) * value)
- * @type: The sensor type from enum amdxdna_sensor_type
- * @pad: MBZ.
+ * unitm) * value).
+ * @type: The sensor type from enum amdxdna_sensor_type.
+ * @pad: Structure padding.
  */
 struct amdxdna_drm_query_sensor {
   __u8 label[64];
@@ -399,6 +402,7 @@ struct amdxdna_drm_query_sensor {
  * @context_id: The ID for this context.
  * @start_col: The starting column for the partition assigned to this context.
  * @num_col: The number of columns in the partition assigned to this context.
+ * @pad: Structure padding.
  * @pid: The Process ID of the process that created this context.
  * @command_submissions: The number of commands submitted to this context.
  * @command_completions: The number of commands completed by this context.
@@ -406,7 +410,7 @@ struct amdxdna_drm_query_sensor {
  * partition.
  * @preemptions: The number of times this context has been preempted by another
  * context in the same partition.
- * @pad: MBZ.
+ * @errors: The errors for this context.
  */
 struct amdxdna_drm_query_hwctx {
   __u32 context_id;

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/bo.cpp
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/bo.cpp
@@ -19,9 +19,10 @@ namespace {
 uint32_t alloc_drm_bo(const shim_xdna::pdev &dev, amdxdna_bo_type type,
                       size_t size) {
   amdxdna_drm_create_bo cbo = {
-      .type = static_cast<uint32_t>(type),
+      .flags = 0,
       .vaddr = reinterpret_cast<uintptr_t>(nullptr),
       .size = size,
+      .type = static_cast<uint32_t>(type),
   };
   dev.ioctl(DRM_IOCTL_AMDXDNA_CREATE_BO, &cbo);
   return cbo.handle;


### PR DESCRIPTION
Pulls in changes from https://github.com/amd/xdna-driver/commit/6d187619e67bf85c694649dc14a1d0465c587091 to make `xrt-lite` work with the latest driver kernel module (see README in changes).

I will need to bump the driver modules on the CI runners to get this PR passing.