### PR TITLE
Towards vectorized convolution (first PR)

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
+++ b/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
@@ -40,16 +40,11 @@ namespace mlir::iree_compiler::aievec {
 
 namespace copied_from_mlir {
 
-/// This code is copied from MLIR. It adds a single-line change to 2 Patterns,
-/// FlattenContiguousRowMajorTransferReadPattern and
-/// FlattenContiguousRowMajorTransferWritePattern. This change allows the
-/// memrefs of the transfer operations be flattened to a 1D memrefs, so not just
-/// the vectors are flattened. TODO(newling) consider upstreaming to reduce code
-/// dup.
-///
-/// If this flag is false, then the patterns are exactly the same as the
-/// original MLIR patterns.
-const static bool flatten_memref = true;
+/// This code is copied from MLIR. It adds a single-line change in 2 patterns,
+/// FlattenContiguousRowMajorTransfer[Read|Write]Pattern. The change allows the
+/// memrefs of the transfer operations to be flattened to 1D memrefs, ie not
+/// only the vectors are flattened. TODO(newling) consider upstreaming to reduce
+/// code dup.
 
 /// Creates a memref.collapse_shape collapsing all inner dimensions of the
 /// input starting at `firstDimToCollapse`.
@@ -167,8 +162,8 @@ class FlattenContiguousRowMajorTransferReadPattern
     // TODO(newling) This is the one line which changes from the original
     // MLIR function. Upstream this as an option to flatten the memref (and
     // not just the vector).
-    int64_t firstDimToCollapse =
-        flatten_memref ? 0 : sourceType.getRank() - vectorType.getRank();
+    // int64_t firstDimToCollapse = sourceType.getRank() - vectorType.getRank();
+    int64_t firstDimToCollapse = 0;
 
     // 1. Collapse the source memref
     Value collapsedSource =
@@ -257,8 +252,8 @@ class FlattenContiguousRowMajorTransferWritePattern
     // TODO(newling) This is the one line which changes from the original
     // MLIR function. Upstream this as an option to flatten the memref (and
     // not just the vector).
-    int64_t firstDimToCollapse =
-        flatten_memref ? 0 : sourceType.getRank() - vectorType.getRank();
+    // int64_t firstDimToCollapse = sourceType.getRank() - vectorType.getRank();
+    int64_t firstDimToCollapse = 0;
 
     // 1. Collapse the source memref
     Value collapsedSource =

--- a/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
@@ -59,9 +59,9 @@ func.func @broadcast_to_insert(%v: vector<8xbf16>) -> vector<1x4x8xbf16> {
 
 // CHECK-LABEL: @contiguous_read_with_unit_extent_dim(
 // CHECK: memref.collapse_shape
-// CHECK-SAME:  memref<2x4x1x8xi8> into memref<2x32xi8>
+// CHECK-SAME:  memref<2x4x1x8xi8> into memref<64xi8>
 // CHECK: vector.transfer_read
-// CHECK-SAME: {in_bounds = [true]} : memref<2x32xi8>, vector<32xi8>
+// CHECK-SAME: {in_bounds = [true]} : memref<64xi8>, vector<32xi8>
 // CHECK: vector.shape_cast
 // CHECK-SAME: vector<32xi8> to vector<4x8xi8>
 #map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
@@ -109,7 +109,7 @@ func.func @permutation_read_cannot_collapse() -> vector<8x8xi8> {
 
 // CHECK-LABEL: @contiguous_write_with_unit_extent_dim(
 // CHECK-DAG: vector.shape_cast{{.*}} vector<4x8xi8> to vector<32xi8>
-// CHECK-DAG: memref.collapse_shape{{.*}} memref<2x4x1x8xi8> into memref<2x32xi8>
+// CHECK-DAG: memref.collapse_shape{{.*}} memref<2x4x1x8xi8> into memref<64xi8>
 // CHECK: vector.transfer_write
 // CHECK: return
 #map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
@@ -125,12 +125,11 @@ func.func @contiguous_write_with_unit_extent_dim(%v: vector<4x8xi8>) {
 
 // CHECK-LABEL: @contiguous_write_with_unit_extent_dim_2(
 // CHECK: %[[C8:.*]] = arith.constant 8 : index
-// CHECK: %[[C0:.*]] = arith.constant 0 : index
 // CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<2x6x1x8x1xi8>
 // CHECK-DAG: %[[CAST:.*]] = vector.shape_cast %[[V:.*]] : vector<4x8xi8> to vector<32xi8>
-// CHECK-DAG: %[[COLLAPSE:.*]] = memref.collapse_shape %[[ALLOC]]{{.*}}memref<2x6x1x8x1xi8> into memref<2x48xi8>
-// CHECK:       vector.transfer_write %[[CAST]], %[[COLLAPSE]][%[[C0]], %[[C8]]]
-// CHECK-SAME:  {in_bounds = [true]} : vector<32xi8>, memref<2x48xi8>
+// CHECK-DAG: %[[COLLAPSE:.*]] = memref.collapse_shape %[[ALLOC]]{{.*}}memref<2x6x1x8x1xi8> into memref<96xi8>
+// CHECK:       vector.transfer_write %[[CAST]], %[[COLLAPSE]][%[[C8]]]
+// CHECK-SAME:  {in_bounds = [true]} : vector<32xi8>, memref<96xi8>
 // CHECK: return
 
 #map = affine_map<(d0, d1, d2, d3, d4) -> (d1, d3)>

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -633,6 +633,8 @@ void addAMDAIEObjectFifoLoweringPasses(OpPassManager &passManager,
 }
 
 void addMLIRAIELoweringPasses(OpPassManager &pm) {
+  mlir::iree_compiler::aievec::buildConvertVectorToAIEVec(pm);
+
   {
     OpPassManager &devicePM = pm.nest<xilinx::AIE::DeviceOp>();
     devicePM.addPass(createCanonicalizerPass());
@@ -652,8 +654,6 @@ void addMLIRAIELoweringPasses(OpPassManager &pm) {
     devicePM.addPass(createAMDAIENormalizeAddressSpacesPass());
     devicePM.addPass(createCanonicalizerPass());
   }
-
-  mlir::iree_compiler::aievec::buildConvertVectorToAIEVec(pm);
 
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());


### PR DESCRIPTION
This PR does 2 things:

1) moves aievec lowering **_before_** scf-to-cf, because computing the alignment information needed to support convolution vectorizion in cf is more difficult than in scf. 

2) Makes flattening of `transfer_read` ops more "aggressive". Large c&p from upstream MLIR here, sorry. Read on for more info. 

The current convolution workflow ends up with core code to load from the input image that looks like:

```
scf.for %arg1 = %c0 to %c3 step %c1 {
  scf.for %arg2 = %c0 to %c3 step %c1 {
    scf.for %arg3 = %c0 to %c4 step %c1 {
      %0 = vector.transfer_read 
         %reinterpret_cast_54[%c0, %arg1, %arg3, %arg2, %c0], %cst 
         {in_bounds = [true, true]} : memref<1x3x4x6x8xbf16>, vector<4x8xbf16>
      ... 
    }
  }
}
```

What is the alignment of the transfer_read above? In other words, what is the highest multiple of 2 that divides the offset of the transfer_read for all values of %arg1, %arg2, and %arg3? It is 16 bytes (consider %arg2=1).

This small alignment is a problem for the AIE instruction set, and without a change to the IR, the transfer_read will lower to inefficient, scalar code. Actually it's currently even worse than that -- it isn't correctly scalarized and we see numerical errors for basic convolutions unless we disable vectorization (slack peano channel discussion). We need 32 byte alignment. 

The solution that the aievec dialect/project has hit upon is implemented in the following pattern: https://github.com/Xilinx/mlir-aie/blob/9fe5fb5386dbf087aca9bfba3815cd5bfa56d80d/lib/Dialect/AIEVec/Transforms/VectorToVectorConversions.cpp#L119


The pattern converts an unaligned transfer_read into an aligned transfer_read of twice the length, followed by a vector.extract_strided_slice operation. For our convolution example, we therefore want to transfer_read a vector of 64 bf16 elements, and then extract the 32 bf16 elements that we actually want.

Clearly, a `transfer_read` of 64 elements from something of type `memref<1x3x4x6x8xbf16>` is not possible (because 6*8 = 48, which does not divide 64). We need some flattening.  After running  the upstream `FlattenContiguousRowMajorTransfer` pass, the memref is flattened as follows: 


```
scf.for %arg1 = %c0 to %c3 step %c1 {
  scf.for %arg2 = %c0 to %c3 step %c1 {
    scf.for %arg3 = %c0 to %c4 step %c1 {
      %collapse_shape = memref.collapse_shape %reinterpret_cast_54 [[0], [1], [2], [3, 4]] : memref<1x3x4x6x8xbf16> into memref<1x3x4x48xbf16>
      %0 = affine.apply affine_map<()[s0] -> (s0 * 8)>()[%arg2]
      %1 = vector.transfer_read %collapse_shape[%c0, %arg1, %arg3, %0], %cst {in_bounds = [true]} : memref<1x3x4x48xbf16>, vector<32xbf16>
      ...
    }
  }
}
```

but this is still insufficient, as the innermost dimension 48 still does not divide 64. This PR therefore makes the flattening more aggressive, so that we get IR like:

```
scf.for %arg1 = %c0 to %c3 step %c1 {
  scf.for %arg2 = %c0 to %c3 step %c1 {
    scf.for %arg3 = %c0 to %c4 step %c1 {
      %collapse_shape = memref.collapse_shape %reinterpret_cast_51 [[0, 1, 2, 3, 4]] : memref<1x3x4x6x8xbf16> into memref<576xbf16>
      %0 = affine.apply affine_map<()[s0, s1, s2] -> (s0 * 192 + s1 * 48 + s2 * 8)>()[%arg1, %arg3, %arg2]
      %1 = vector.transfer_read %collapse_shape[%0], %cst {in_bounds = [true]} : memref<576xbf16>, vector<32xbf16>
    }
  }
}
```

With IR like this we will be able to perform the aievec trick linked to above (future PR). 

