### PR TITLE
[aievec] ShiftOp folder 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aievec/AIEVecOps.td
+++ b/compiler/plugins/target/AMD-AIE/aievec/AIEVecOps.td
@@ -49,6 +49,8 @@ def AIEVec_ShiftOp:
     have the same number of lanes and element types.
     `$result = shift($lhs, $rhs, $shift)`
   }];
+
+  let hasFolder = 1;
 }
 
 def AIEVec_ExtOp:

--- a/compiler/plugins/target/AMD-AIE/aievec/test/fold-ops.mlir
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/fold-ops.mlir
@@ -1,0 +1,34 @@
+// RUN: iree-opt %s --canonicalize -split-input-file | FileCheck %s
+
+// -----
+
+// CHECK-LABEL: @test_fold_shift_zero(%arg0:
+// CHECK: return %arg0
+func.func @test_fold_shift_zero(%arg0: vector<32xbf16>, %arg1: vector<32xbf16>) -> vector<32xbf16> {
+  %c0_i32 = arith.constant 0 : i32
+  %0 = aievec.shift %arg0, %arg1, %c0_i32 {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+  return %0 : vector<32xbf16>
+}
+
+// -----
+
+// CHECK-LABEL: @test_fold_shift_partial(%arg0:
+// CHECK: %[[SHIFT:.*]] = aievec.shift
+// CHECK: return %[[SHIFT]]
+func.func @test_fold_shift_partial(%arg0: vector<32xbf16>, %arg1: vector<32xbf16>) -> vector<32xbf16> {
+  %c1_i32 = arith.constant 1 : i32
+  %0 = aievec.shift %arg0, %arg1, %c1_i32 {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+  return %0 : vector<32xbf16>
+}
+
+// -----
+
+// CHECK-LABEL: @test_fold_shift_zero(%arg0: vector<32xbf16>, %arg1: vector<32xbf16>)
+// CHECK: return %arg1
+func.func @test_fold_shift_zero(%arg0: vector<32xbf16>, %arg1: vector<32xbf16>) -> vector<32xbf16> {
+  %c64_i32 = arith.constant 64 : i32
+  %0 = aievec.shift %arg0, %arg1, %c64_i32 {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+  return %0 : vector<32xbf16>
+}
+
+// -----


### PR DESCRIPTION
ShiftOp has 2 64 byte vector operands, and 1 64 byte vector result. The result is a concatenation of the N upper bytes from the first operand, and the 64 - N lower bytes from the second operand. This folder considers the special cases where N = 0 and N = 64, when it is possible to just return one of the operands directly. 

https://www.xilinx.com/htmldocs/xilinx2024_1/aiengine_ml_intrinsics/intrinsics/group__intr__gpvectorop__shift.html#gaa83afc81114a5e0d3aebea1e973248bc