### PR TITLE
Add hardware-aware canonicalization

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDmaOpInterface.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDmaOpInterface.td
@@ -48,6 +48,30 @@ def DoublyStridedOpInterface : OpInterface<"DoublyStridedOpInterface"> {
 
   let methods = [
     InterfaceMethod<
+      /*desc=*/"Return the optional target memory space attribute.",
+      /*retTy=*/"std::optional<::mlir::Attribute>",
+      /*methodName=*/"getTargetMemorySpace",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return $_op.getTargetMemorySpace();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/"Return the optional target memory space as an integer (0 for "
+               "global memory).",
+      /*retTy=*/"std::optional<uint8_t>",
+      /*methodName=*/"getTargetMemorySpaceAsUInt",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        std::optional<::mlir::Attribute> memSpace = getTargetMemorySpace();
+        if (!memSpace) return std::nullopt;
+        return memSpace.value() ? 
+          cast<::mlir::IntegerAttr>(memSpace.value()).getInt() : 0;
+      }]
+    >,
+    InterfaceMethod<
       /*desc=*/"Return the dynamic target offsets.",
       /*retTy=*/"::mlir::OperandRange",
       /*methodName=*/"getTargetOffsets",
@@ -175,6 +199,30 @@ def DoublyStridedOpInterface : OpInterface<"DoublyStridedOpInterface"> {
       /*defaultImplementation=*/[{
         return detail::getTargetStaticSize(
           ::mlir::cast<DoublyStridedOpInterface>($_op.getOperation()));
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/"Return the optional source memory space attribute.",
+      /*retTy=*/"std::optional<::mlir::Attribute>",
+      /*methodName=*/"getSourceMemorySpace",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return $_op.getSourceMemorySpace();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/"Return the optional source memory space as an integer (0 for global "
+               "memory).",
+      /*retTy=*/"std::optional<uint8_t>",
+      /*methodName=*/"getSourceMemorySpaceAsUInt",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        std::optional<::mlir::Attribute> memSpace = getSourceMemorySpace();
+        if (!memSpace) return std::nullopt;
+        return memSpace.value() ? 
+          cast<::mlir::IntegerAttr>(memSpace.value()).getInt() : 0;
       }]
     >,
     InterfaceMethod<
@@ -348,51 +396,6 @@ def DoublyStridedCopyOpInterface : OpInterface<"DoublyStridedCopyOpInterface",
     specifies source and target indirectly via a referenced DMA operation.
   }];
   let cppNamespace = "mlir::iree_compiler::AMDAIE";
-
-  let methods = [
-    InterfaceMethod<
-      /*desc=*/"Return the source memory space attribute.",
-      /*retTy=*/"::mlir::Attribute",
-      /*methodName=*/"getSourceMemorySpace",
-      /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/[{
-        return $_op.getSourceMemorySpace();
-      }]
-    >,
-    InterfaceMethod<
-      /*desc=*/"Return the source memory space as an integer (0 for global "
-               "memory).",
-      /*retTy=*/"uint8_t",
-      /*methodName=*/"getSourceMemorySpaceAsUInt",
-      /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/[{
-        return $_op.getSourceMemorySpaceAsUInt();
-      }]
-    >,
-    InterfaceMethod<
-      /*desc=*/"Return the target memory space attribute.",
-      /*retTy=*/"::mlir::Attribute",
-      /*methodName=*/"getTargetMemorySpace",
-      /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/[{
-        return $_op.getTargetMemorySpace();
-      }]
-    >,
-    InterfaceMethod<
-      /*desc=*/"Return the target memory space as an integer (0 for global "
-               "memory).",
-      /*retTy=*/"uint8_t",
-      /*methodName=*/"getTargetMemorySpaceAsUInt",
-      /*args=*/(ins),
-      /*methodBody=*/"",
-      /*defaultImplementation=*/[{
-        return $_op.getTargetMemorySpaceAsUInt();
-      }]
-    >,
-  ];
 }
 
 #endif // IREE_AMDAIE_DIALECT_DMAOPINTERFACE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -529,17 +529,9 @@ def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd", [
     }
 
     // Return the source memory space as an attribute.
-    Attribute getSourceMemorySpace() {
+    std::optional<Attribute> getSourceMemorySpace() {
       return cast<LogicalObjectFifoType>(getConnectionOp().getSourceType())
         .getMemorySpace();
-    }
-
-    // Helper method to return the source memory space as an integer. If no 
-    // memory space attribute, this indicates a global memory space and we
-    // return 0. Else cast the memory space attribute to an integer. 
-    uint8_t getSourceMemorySpaceAsUInt() {
-      Attribute memSpace = getSourceMemorySpace();
-      return memSpace ? cast<IntegerAttr>(memSpace).getInt() : 0;
     }
 
     // Return the target memref type. This is retrieved using information from
@@ -550,17 +542,9 @@ def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd", [
     }
 
     // Return the target memory space as an attribute.
-    Attribute getTargetMemorySpace() {
+    std::optional<Attribute> getTargetMemorySpace() {
       return cast<LogicalObjectFifoType>(getConnectionOp().getTargetType())
         .getMemorySpace();
-    }
-
-    // Helper method to return the target memory space as an integer. If no
-    // memory space attribute, this indicates a global memory space and we
-    // return 0. Else cast the memory space attribute to an integer. 
-    uint8_t getTargetMemorySpaceAsUInt() {
-      Attribute memSpace = getTargetMemorySpace();
-      return memSpace ? cast<IntegerAttr>(memSpace).getInt() : 0;
     }
 
     BdIdOp getSourceBdIdOp() {
@@ -840,17 +824,9 @@ def AMDAIE_NpuCircularDmaCpyNdOp: AMDAIE_Op<"npu.circular_dma_cpy_nd", [
     }
 
     // Return the source memory space as an attribute.
-    Attribute getSourceMemorySpace() {
+    std::optional<Attribute> getSourceMemorySpace() {
       return cast<LogicalObjectFifoType>(getConnectionOp().getSourceType())
         .getMemorySpace();
-    }
-
-    // Helper method to return the source memory space as an integer. If no 
-    // memory space attribute, this indicates a global memory space and we
-    // return 0. Else cast the memory space attribute to an integer. 
-    uint8_t getSourceMemorySpaceAsUInt() {
-      Attribute memSpace = getSourceMemorySpace();
-      return memSpace ? cast<IntegerAttr>(memSpace).getInt() : 0;
     }
 
     // Return the target memref type. This is retrieved using information from
@@ -861,17 +837,9 @@ def AMDAIE_NpuCircularDmaCpyNdOp: AMDAIE_Op<"npu.circular_dma_cpy_nd", [
     }
 
     // Return the target memory space as an attribute.
-    Attribute getTargetMemorySpace() {
+    std::optional<Attribute> getTargetMemorySpace() {
       return cast<LogicalObjectFifoType>(getConnectionOp().getTargetType())
         .getMemorySpace();
-    }
-
-    // Helper method to return the target memory space as an integer. If no
-    // memory space attribute, this indicates a global memory space and we
-    // return 0. Else cast the memory space attribute to an integer. 
-    uint8_t getTargetMemorySpaceAsUInt() {
-      Attribute memSpace = getTargetMemorySpace();
-      return memSpace ? cast<IntegerAttr>(memSpace).getInt() : 0;
     }
 
     // A utility to create a new doubly strided operation from this one with a
@@ -1513,28 +1481,12 @@ class AMDAIE_DmaCpyNdBaseOp<string mnemonic, list<Trait> traits = []> :
     LogicalObjectFifoFromMemrefOp getSourceObjectFifo();
     LogicalObjectFifoFromMemrefOp getTargetObjectFifo();
 
-    Attribute getSourceMemorySpace() {
+    std::optional<Attribute> getSourceMemorySpace() {
       return cast<LogicalObjectFifoType>(getSourceType()).getMemorySpace();
     }
 
-    /// Helper method to return the source memory space as an integer. If no 
-    /// memory space attribute exists, this indicates a global memory space and
-    /// we return 0. Else we cast the memory space attribute to an integer. 
-    uint8_t getSourceMemorySpaceAsUInt() {
-      Attribute memSpace = getSourceMemorySpace();
-      return memSpace ? cast<IntegerAttr>(memSpace).getInt() : 0;
-    }
-
-    Attribute getTargetMemorySpace() {
+    std::optional<Attribute> getTargetMemorySpace() {
       return cast<LogicalObjectFifoType>(getTargetType()).getMemorySpace();
-    }
-
-    /// Helper method to return the target memory space as an integer. If no
-    /// memory space attribute exists, this indicates a global memory space and
-    /// we return 0. Else we cast the memory space attribute to an integer.
-    uint8_t getTargetMemorySpaceAsUInt() {
-      Attribute memSpace = getTargetMemorySpace();
-      return memSpace ? cast<IntegerAttr>(memSpace).getInt() : 0;
     }
     
     // A utility to create a new doubly strided operation from this one with a

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeDoublyStridedOp.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeDoublyStridedOp.cpp
@@ -6,12 +6,14 @@
 
 #include "iree-amd-aie/IR/AMDAIEDialect.h"
 #include "iree-amd-aie/Transforms/AMDAIEDmaUtils.h"
+#include "iree-amd-aie/Transforms/AMDAIEUtils.h"
 #include "iree-amd-aie/Transforms/Passes.h"
 #include "iree-amd-aie/Transforms/Transforms.h"
+#include "iree-amd-aie/aie_runtime/iree_aie_runtime.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
-#define DEBUG_TYPE "iree-amdaie-canonicalize-doubly-strided-dma"
+#define DEBUG_TYPE "iree-amdaie-canonicalize-doubly-strided-op"
 
 namespace mlir::iree_compiler::AMDAIE {
 
@@ -19,9 +21,17 @@ namespace {
 
 /// Recognize linear accesses across multiple DMA access dimensions and fold
 /// them.
-struct FoldDmaOpLinearDims
+class FoldDmaOpLinearDims
     : public OpInterfaceRewritePattern<AMDAIE::DoublyStridedOpInterface> {
   using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
+
+ public:
+  FoldDmaOpLinearDims(
+      MLIRContext *ctx,
+      std::optional<std::reference_wrapper<const AMDAIEDeviceModel>>
+          deviceModel = std::nullopt)
+      : OpInterfaceRewritePattern<AMDAIE::DoublyStridedOpInterface>(ctx),
+        deviceModel(deviceModel) {}
 
   LogicalResult matchAndRewrite(AMDAIE::DoublyStridedOpInterface op,
                                 PatternRewriter &rewriter) const override {
@@ -34,14 +44,30 @@ struct FoldDmaOpLinearDims
     SmallVector<OpFoldResult> targetStrides = op.getTargetMixedStrides();
     SmallVector<OpFoldResult> newSourceOffsets, newSourceSizes,
         newSourceStrides, newTargetOffsets, newTargetSizes, newTargetStrides;
+    SmallVector<int64_t> maxSourceSizes, maxTargetSizes;
+    if (deviceModel) {
+      std::optional<uint8_t> sourceMemSpace = op.getSourceMemorySpaceAsUInt();
+      std::optional<uint8_t> targetMemSpace = op.getTargetMemorySpaceAsUInt();
+      if (!sourceMemSpace || !targetMemSpace) {
+        return rewriter.notifyMatchFailure(
+            op,
+            "expected a source and target memory space for hardware aware "
+            "linear dimension folding");
+      }
+      AMDAIE::DmaDimConfig dmaDimConfig(
+          deviceModel.value(), sourceMemSpace.value(), targetMemSpace.value());
+      maxSourceSizes = dmaDimConfig.getMaxSizes<CopyOpOperateOn::Source>();
+      maxTargetSizes = dmaDimConfig.getMaxSizes<CopyOpOperateOn::Target>();
+    }
     LogicalResult sourceRes = foldLinearDims(
         op.getContext(), sourceOffsets, sourceSizes, sourceStrides,
-        newSourceOffsets, newSourceSizes, newSourceStrides);
+        newSourceOffsets, newSourceSizes, newSourceStrides, maxSourceSizes);
     LogicalResult targetRes = foldLinearDims(
         op.getContext(), targetOffsets, targetSizes, targetStrides,
-        newTargetOffsets, newTargetSizes, newTargetStrides);
+        newTargetOffsets, newTargetSizes, newTargetStrides, maxTargetSizes);
     if (failed(sourceRes) && failed(targetRes)) {
-      return failure();
+      return rewriter.notifyMatchFailure(
+          op, "neither a source nor a target change");
     }
 
     rewriter.setInsertionPointAfter(op);
@@ -51,6 +77,11 @@ struct FoldDmaOpLinearDims
     rewriter.replaceOp(op, newDoublyStridedOp.getOperation());
     return success();
   }
+
+ private:
+  /// If the device model is set, this rewriter will use the device model to
+  /// keep hardware stride/size limitations into account.
+  std::optional<std::reference_wrapper<const AMDAIEDeviceModel>> deviceModel;
 };
 
 /// Fold single dimension linear accesses and make them implicit.
@@ -140,8 +171,21 @@ void AMDAIECanonicalizeDoublyStridedOpPass::runOnOperation() {
   Operation *parentOp = getOperation();
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
-
-  populateCanonicalizeDoublyStridedOpPatterns(patterns, foldSingleDims);
+  std::optional<AMDAIEDeviceModel> deviceModel;
+  if (hardwareAware) {
+    auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(parentOp);
+    std::optional<AMDAIEDevice> maybeDevice = getConfigAMDAIEDevice(targetAttr);
+    if (!maybeDevice.has_value()) {
+      parentOp->emitOpError(
+          "hardware-aware canonicalization is enabled, but op has no "
+          "AMDAIEDevice "
+          "in the target attribute configuration");
+      return signalPassFailure();
+    }
+    deviceModel = AMDAIE::getDeviceModel(maybeDevice.value());
+  }
+  populateCanonicalizeDoublyStridedOpPatterns(patterns, foldSingleDims,
+                                              deviceModel);
   if (failed(applyPatternsAndFoldGreedily(parentOp, std::move(patterns)))) {
     parentOp->emitOpError(
         "failed to canonicalize doubly strided DMA operations");
@@ -151,10 +195,13 @@ void AMDAIECanonicalizeDoublyStridedOpPass::runOnOperation() {
 
 }  // namespace
 
-void populateCanonicalizeDoublyStridedOpPatterns(RewritePatternSet &patterns,
-                                                 bool foldSingleDims) {
+void populateCanonicalizeDoublyStridedOpPatterns(
+    RewritePatternSet &patterns, bool foldSingleDims,
+    std::optional<std::reference_wrapper<const AMDAIEDeviceModel>>
+        deviceModel) {
   patterns.add<FoldDmaOpUnitDims>(patterns.getContext());
-  patterns.add<FoldDmaOpLinearDims>(patterns.getContext());
+  patterns.add<FoldDmaOpLinearDims>(patterns.getContext(),
+                                    std::move(deviceModel));
   if (foldSingleDims) {
     patterns.add<FoldDmaOpSingleDims>(patterns.getContext());
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeNpuDmaCpyNd.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeNpuDmaCpyNd.cpp
@@ -61,7 +61,9 @@ class AMDAIECanonicalizeNpuDmaCpyNdPass
       // If the source is in L3, then canonicalize the source addressing.
       // 1) Pad to the correct rank
       // 2) Move the zero stride (if any) to the outer-most (slowest) dim.
-      if (dmaOp.getSourceMemorySpaceAsUInt() == 0) {
+      std::optional<uint8_t> sourceMemSpace =
+          dmaOp.getSourceMemorySpaceAsUInt();
+      if (sourceMemSpace && sourceMemSpace.value() == 0) {
         if (!dmaOp.hasSourceAddressing()) {
           dmaOp.emitOpError()
               << "has source in L3, but does not have source addressing. "
@@ -80,7 +82,9 @@ class AMDAIECanonicalizeNpuDmaCpyNdPass
         bubble(srcStrides, swapIndex);
       }
 
-      if (dmaOp.getTargetMemorySpaceAsUInt() == 0) {
+      std::optional<uint8_t> targetMemSpace =
+          dmaOp.getTargetMemorySpaceAsUInt();
+      if (targetMemSpace && targetMemSpace.value() == 0) {
         if (!dmaOp.hasTargetAddressing()) {
           dmaOp.emitOpError()
               << "has target in L3, but does not have target addressing. "

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECombineStridedOps.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECombineStridedOps.cpp
@@ -62,7 +62,8 @@ struct CombineStridedOps
       // Find next NPU DMA op.
       Block::iterator begin = std::next(npuDmaOp->getIterator());
       block->walk(begin, block->end(), [&](AMDAIE::NpuDmaCpyNdOp other) {
-        if (npuDmaOp.getConnection() != other.getConnection()) return WalkResult::advance();
+        if (npuDmaOp.getConnection() != other.getConnection())
+          return WalkResult::advance();
         Block *otherBlock = other->getBlock();
         if (!otherBlock) return WalkResult::advance();
         if (otherBlock != block) return WalkResult::interrupt();
@@ -71,10 +72,16 @@ struct CombineStridedOps
         return WalkResult::interrupt();
       });
 
-      uint8_t sourceMemspaceInt = npuDmaOp.getSourceMemorySpaceAsUInt();
-      uint8_t targetMemspaceInt = npuDmaOp.getTargetMemorySpaceAsUInt();
-      AMDAIE::DmaDimConfig dmaDimConfig(deviceModel, sourceMemspaceInt,
-                                        targetMemspaceInt);
+      std::optional<uint8_t> sourceMemspaceInt =
+          npuDmaOp.getSourceMemorySpaceAsUInt();
+      std::optional<uint8_t> targetMemspaceInt =
+          npuDmaOp.getTargetMemorySpaceAsUInt();
+      if (!sourceMemspaceInt || !targetMemspaceInt) {
+        return rewriter.notifyMatchFailure(
+            npuDmaOp, "expected a source and target memory space");
+      }
+      AMDAIE::DmaDimConfig dmaDimConfig(deviceModel, sourceMemspaceInt.value(),
+                                        targetMemspaceInt.value());
       sourceMaxNbDims = dmaDimConfig.sourceMaxNbDims;
       targetMaxNbDims = dmaDimConfig.targetMaxNbDims;
     } else {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDistributeCoresAndObjectFifos.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDistributeCoresAndObjectFifos.cpp
@@ -183,17 +183,23 @@ class AMDAIEUnrollLocalLoops : public OpRewritePattern<scf::ForOp> {
         return WalkResult::advance();
       }
 
-      uint8_t sourceMemspace = dmaOp.getSourceMemorySpaceAsUInt();
-      uint8_t targetMemspace = dmaOp.getTargetMemorySpaceAsUInt();
+      std::optional<uint8_t> sourceMemspace =
+          dmaOp.getSourceMemorySpaceAsUInt();
+      std::optional<uint8_t> targetMemspace =
+          dmaOp.getTargetMemorySpaceAsUInt();
+      if (!sourceMemspace || !targetMemspace) {
+        dmaOp.emitOpError() << "expected a source and target memory space";
+        return WalkResult::interrupt();
+      }
       if (std::is_same<Iterator, ForwardIterator>::value &&
           !dependencies.contains(dmaOp.getSourceObjectFifo()) &&
-          sourceMemspace < targetMemspace) {
+          sourceMemspace.value() < targetMemspace.value()) {
         rewriter.moveOpBefore(dmaOp, forOp);
         hoistHappened = true;
         return WalkResult::advance();
       } else if (std::is_same<Iterator, ReverseIterator>::value &&
                  !dependencies.contains(dmaOp.getTargetObjectFifo()) &&
-                 sourceMemspace > targetMemspace) {
+                 sourceMemspace.value() > targetMemspace.value()) {
         rewriter.moveOpAfter(dmaOp, forOp);
         hoistHappened = true;
         return WalkResult::advance();
@@ -244,9 +250,15 @@ class AMDAIEUnrollLocalLoops : public OpRewritePattern<scf::ForOp> {
       for (auto it = loopBodyBlock->begin(); it != std::next(srcBlockEnd);
            it++) {
         if (auto dmaOp = dyn_cast<AMDAIE::DmaCpyNdOp>(*it)) {
-          uint8_t sourceMemSpaceInt = dmaOp.getSourceMemorySpaceAsUInt();
-          uint8_t targetMemSpaceInt = dmaOp.getTargetMemorySpaceAsUInt();
-          if (targetMemSpaceInt > sourceMemSpaceInt) {
+          std::optional<uint8_t> sourceMemSpaceInt =
+              dmaOp.getSourceMemorySpaceAsUInt();
+          std::optional<uint8_t> targetMemSpaceInt =
+              dmaOp.getTargetMemorySpaceAsUInt();
+          if (!sourceMemSpaceInt || !targetMemSpaceInt) {
+            return rewriter.notifyMatchFailure(
+                dmaOp, "expected a source and target memory space");
+          }
+          if (targetMemSpaceInt.value() > sourceMemSpaceInt.value()) {
             AMDAIE::LogicalObjectFifoFromMemrefOp target =
                 dmaOp.getTargetObjectFifo();
             rewriter.setInsertionPoint(target);
@@ -254,7 +266,7 @@ class AMDAIEUnrollLocalLoops : public OpRewritePattern<scf::ForOp> {
                 dyn_cast_if_present<AMDAIE::LogicalObjectFifoFromMemrefOp>(
                     rewriter.clone(*dmaOp.getTarget().getDefiningOp()));
             operandMap.map(target.getOutput(), cloneOp.getOutput());
-          } else if (sourceMemSpaceInt > targetMemSpaceInt) {
+          } else if (sourceMemSpaceInt.value() > targetMemSpaceInt.value()) {
             AMDAIE::LogicalObjectFifoFromMemrefOp source =
                 dmaOp.getSourceObjectFifo();
             rewriter.setInsertionPoint(source);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaComposition.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaComposition.cpp
@@ -39,24 +39,23 @@ void AMDAIEDmaCompositionPass::runOnOperation() {
   Operation *parentOp = getOperation();
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
-  {
-    auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(parentOp);
-    std::optional<AMDAIEDevice> maybeDevice = getConfigAMDAIEDevice(targetAttr);
-    if (!maybeDevice) {
-      parentOp->emitOpError()
-          << "has no AMDAIEDevice in the target attribute configuration. This "
-             "device-specific information is required to determine when loops "
-             "can be subsumed into DMA operations, and must be attached to a "
-             "containing ModuleOp.";
-      return signalPassFailure();
-    }
-    AMDAIE::AMDAIEDeviceModel deviceModel =
-        AMDAIE::getDeviceModel(maybeDevice.value());
-    populateDmaLoopSubsumptionPattern(patterns, std::move(deviceModel),
-                                      onlyZeroStrideOnOuterDim);
+  auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(parentOp);
+  std::optional<AMDAIEDevice> maybeDevice = getConfigAMDAIEDevice(targetAttr);
+  if (!maybeDevice) {
+    parentOp->emitOpError()
+        << "has no AMDAIEDevice in the target attribute configuration. This "
+           "device-specific information is required to determine when loops "
+           "can be subsumed into DMA operations, and must be attached to a "
+           "containing ModuleOp.";
+    return signalPassFailure();
   }
+  AMDAIE::AMDAIEDeviceModel deviceModel =
+      AMDAIE::getDeviceModel(maybeDevice.value());
+  populateDmaLoopSubsumptionPattern(patterns, deviceModel,
+                                    onlyZeroStrideOnOuterDim);
   populateStridedOpCombinationPattern(patterns);
-  populateCanonicalizeDoublyStridedOpPatterns(patterns, false);
+  populateCanonicalizeDoublyStridedOpPatterns(patterns, false, deviceModel);
+
   if (failed(applyPatternsAndFoldGreedily(parentOp, std::move(patterns)))) {
     parentOp->emitOpError("failed to compose strided operations");
     return signalPassFailure();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaUtils.cpp
@@ -264,43 +264,68 @@ LogicalResult foldLinearDims(MLIRContext *ctx,
                              const SmallVector<OpFoldResult> &strides,
                              SmallVector<OpFoldResult> &newOffsets,
                              SmallVector<OpFoldResult> &newSizes,
-                             SmallVector<OpFoldResult> &newStrides) {
+                             SmallVector<OpFoldResult> &newStrides,
+                             ArrayRef<int64_t> maxSizes) {
+  assert(offsets.size() == sizes.size() && offsets.size() == strides.size() &&
+         "expected same number of offsets, sizes and strides");
   bool foldableLinearDimsFound = false;
+  if (offsets.size() == 0) return success(foldableLinearDimsFound);
 
-  if (offsets.size() == 0) {
-    return success(foldableLinearDimsFound);
-  }
+  // As the new offsets/sizes/strides are created in reverse order, reverse the
+  // maxSizes as well for easy comparison.
+  SmallVector<int64_t> maxSizesReversed(maxSizes);
+  std::reverse(maxSizesReversed.begin(), maxSizesReversed.end());
 
-  newOffsets.push_back(offsets[0]);
-  newStrides.push_back(strides[0]);
-  newSizes.push_back(sizes[0]);
+  std::optional<SmallVector<int64_t>> staticSizes = getConstantIntValues(sizes);
+  std::optional<SmallVector<int64_t>> staticStrides =
+      getConstantIntValues(strides);
+  if (!staticSizes || !staticStrides) return failure();
+  SmallVector<int64_t> staticSizeVals = staticSizes.value();
+  SmallVector<int64_t> staticStrideVals = staticStrides.value();
 
-  for (int i = 1; i < offsets.size(); i++) {
+  newOffsets.push_back(offsets[offsets.size() - 1]);
+  newStrides.push_back(strides[strides.size() - 1]);
+  newSizes.push_back(sizes[sizes.size() - 1]);
+
+  for (int i = offsets.size() - 2; i >= 0; i--) {
     // Conditions for folding a dim.
-    // 1. size(i) x stride(i) == stride(i-1), with this we can have new
-    // size(i-1) = size(i-1) * size(i), stride(i-1) = stride(i) and then fold
-    // away the i dimension
-    // 2. Offset(i-1) = 0. This is required because we are dropping the offset
-    // of the i-1 dimension and doing offset(i-1) = offset(i)
-    int vecSize = newOffsets.size();
-    if (isConstantIntValue(newOffsets[vecSize - 1], 0) &&
-        getConstantIndexOrAssert(sizes[i]) *
-                getConstantIndexOrAssert(strides[i]) ==
-            getConstantIndexOrAssert(newStrides[vecSize - 1])) {
+    // 1. Offsets[i] == 0.This is required because we are dropping the offset
+    // of the i dimension and keep newOffets[-1]
+    // 2. newSizes[-1] x newStrides[-1] == strides[i]. With this we can have
+    // newSizes[-1] = sizes[i] * newSizes[-1] , and then fold away the i
+    // dimension
+    // 3. sizes[i] * newSizes[-1] <= maxSizes[newSizes.size() - 1], IF max
+    // constraints are provided. This allows hardware constraints to be
+    // provided.
+    size_t vecSize = newOffsets.size();
+    int64_t newStride = staticStrideVals[i];
+    int64_t newSize = staticSizeVals[i];
+    int64_t prevStride = getConstantIndexOrAssert(newStrides[vecSize - 1]);
+    int64_t prevSize = getConstantIndexOrAssert(newSizes[vecSize - 1]);
+    int64_t dimExtent = prevStride * prevSize;
+    // Fail if max constraints are provided, but the newly created
+    // offsets/sizes/strides start exceeding the number of provide max
+    // constraints as this will result in undefined behaviour.
+    if (maxSizesReversed.size() > 0 && vecSize > maxSizesReversed.size())
+      return failure();
+    bool fitsMaxConstraint =
+        maxSizesReversed.size() == 0 ||
+        newSize * prevSize <= maxSizesReversed[vecSize - 1];
+    if (fitsMaxConstraint && isConstantIntValue(offsets[i], 0) &&
+        dimExtent == newStride) {
       foldableLinearDimsFound = true;
-      int vecSize = newOffsets.size();
-      newOffsets[vecSize - 1] = offsets[i];
-      newStrides[vecSize - 1] = strides[i];
-      newSizes[vecSize - 1] = getAsIndexOpFoldResult(
-          ctx, getConstantIndexOrAssert(sizes[i]) *
-                   getConstantIndexOrAssert(newSizes[vecSize - 1]));
-
+      newSizes[vecSize - 1] = getAsIndexOpFoldResult(ctx, newSize * prevSize);
       continue;
     }
     newOffsets.push_back(offsets[i]);
     newStrides.push_back(strides[i]);
     newSizes.push_back(sizes[i]);
   }
+
+  // Reverse as the new offsets/sizes/strides were created in reverse order.
+  std::reverse(newOffsets.begin(), newOffsets.end());
+  std::reverse(newSizes.begin(), newSizes.end());
+  std::reverse(newStrides.begin(), newStrides.end());
   return success(foldableLinearDimsFound);
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -105,7 +105,9 @@ def AMDAIECanonicalizeDoublyStridedOp :
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIECanonicalizeDoublyStridedOpPass()";
   let options = [
     Option<"foldSingleDims", "fold-single-dims", "bool", /*default=*/"false",
-      "Whether to fold single strided dimensions and make then implicit.">
+      "Whether to fold single strided dimensions and make then implicit.">,
+    Option<"hardwareAware", "hardware-aware", "bool", /*default=*/"true",
+      "Whether the canonicalization should be hardware-aware.">
   ];
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Transforms.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Transforms.h
@@ -39,14 +39,18 @@ LogicalResult normalizeLoopBounds(RewriterBase &rewriter, scf::ForOp forOp);
 LogicalResult normalizeLoopBounds(RewriterBase &rewriter,
                                   scf::ForallOp forallOp);
 
-/// Populate patterns that canonicalize doubly strided DMA operations.
-void populateCanonicalizeDoublyStridedOpPatterns(RewritePatternSet &patterns,
-                                                 bool foldSingleDims);
+/// Populate patterns that canonicalize doubly strided DMA operations. If an
+/// optional device model is provided, it will be used to perform hardware-aware
+/// canonicalization.
+void populateCanonicalizeDoublyStridedOpPatterns(
+    RewritePatternSet &patterns, bool foldSingleDims,
+    std::optional<std::reference_wrapper<const AMDAIEDeviceModel>> deviceModel =
+        std::nullopt);
 
 /// Populate patterns that subsume loops iterations into DMA access patterns.
-void populateDmaLoopSubsumptionPattern(RewritePatternSet &patterns,
-                                       AMDAIE::AMDAIEDeviceModel &&deviceModel,
-                                       bool onlyZeroStrideOnOuterDim);
+void populateDmaLoopSubsumptionPattern(
+    RewritePatternSet &patterns, const AMDAIE::AMDAIEDeviceModel &deviceModel,
+    bool onlyZeroStrideOnOuterDim);
 
 /// Populate patterns that combine strided ops in the same block.
 void populateStridedOpCombinationPattern(RewritePatternSet &patterns);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     "bridge_to_air.mlir"
     "bufferize_to_allocation.mlir"
     "canonicalize_doubly_strided_op.mlir"
+    "canonicalize_doubly_strided_op_hardware_aware.mlir"
     "canonicalize_npu_dma_cpy_nd.mlir"
     "combine_strided_ops.mlir"
     "connection_to_flow.mlir"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_doubly_strided_op.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_doubly_strided_op.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-canonicalize-doubly-strided-op,canonicalize))" -allow-unregistered-dialect %s | FileCheck %s
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-canonicalize-doubly-strided-op{fold-single-dims=true},canonicalize))" -allow-unregistered-dialect %s | FileCheck %s --check-prefix=FOLD-SINGLE-DIMS
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-canonicalize-doubly-strided-op{hardware-aware=false},canonicalize))" -allow-unregistered-dialect %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-canonicalize-doubly-strided-op{fold-single-dims=true hardware-aware=false},canonicalize))" -allow-unregistered-dialect %s | FileCheck %s --check-prefix=FOLD-SINGLE-DIMS
 
 // Verify that source and target of `amdaie.circular_dma_cpy_nd` is still correct after canonicalization.
 //

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_doubly_strided_op_hardware_aware.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_doubly_strided_op_hardware_aware.mlir
@@ -1,0 +1,53 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-amdaie-canonicalize-doubly-strided-op{hardware-aware=true}))" --split-input-file -allow-unregistered-dialect --verify-diagnostics %s | FileCheck %s
+
+
+module {
+  // expected-error @+1 {{hardware-aware canonicalization is enabled, but op has no AMDAIEDevice in the target attribute configuration}}
+  func.func @no_device(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+    %0 = amdaie.circular_dma_cpy_nd(%arg0[0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[0, 0, 0, 0] [1, 4, 2, 8] [64, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+    "iree.keep"(%0) : (index) -> ()
+    return
+  }
+}
+
+// -----
+
+// CHECK-LABEL:    func.func @dma_cpy_nd_fold
+// CHECK:          amdaie.dma_cpy_nd(%{{.+}}[0] [128] [1], %{{.+}}[0] [64] [1])
+// CHECK:          amdaie.dma_cpy_nd(%{{.+}}[0] [512] [1], %{{.+}}[0] [512] [1])
+// CHECK:          amdaie.dma_cpy_nd(%{{.+}}[0, 0] [512, 512] [256, 1], %{{.+}}[0, 0] [512, 512] [256, 1])
+// CHECK:          amdaie.dma_cpy_nd(%{{.+}}[0, 0, 0, 0] [32, 16, 8, 512] [128, 1024, 256, 1], %{{.+}}[0, 0, 0, 0] [32, 16, 8, 512] [128, 1024, 256, 1])
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @dma_cpy_nd_fold(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+    %0 = amdaie.dma_cpy_nd(%arg0[0, 0, 0, 0] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[0, 0, 0, 0] [1, 4, 2, 8] [64, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+    "iree.keep"(%0) : (index) -> ()
+    %1 = amdaie.dma_cpy_nd(%arg0[0, 0] [2, 256] [256, 1], %arg1[0, 0] [2, 256] [256, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+    "iree.keep"(%1) : (index) -> ()
+    %2 = amdaie.dma_cpy_nd(%arg0[0, 0, 0] [128, 4, 512] [1024, 256, 1], %arg1[0, 0, 0] [128, 4, 512] [1024, 256, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+    "iree.keep"(%2) : (index) -> ()
+    %3 = amdaie.dma_cpy_nd(%arg0[0, 0, 0, 0, 0] [4, 8, 16, 8, 512] [1024, 128, 1024, 256, 1], %arg1[0, 0, 0, 0, 0] [4, 8, 16, 8, 512] [1024, 128, 1024, 256, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+    "iree.keep"(%3) : (index) -> ()
+    return
+  }
+}
+
+// -----
+
+// Maxes for npu1 are [63, 1023, 1023, 1023].
+// CHECK-LABEL:    func.func @dma_cpy_nd_no_fold
+// CHECK:          amdaie.dma_cpy_nd(%{{.+}}[0, 0] [2, 512] [512, 1], %{{.+}}[0, 0] [2, 512] [512, 1])
+// CHECK:          amdaie.dma_cpy_nd(%{{.+}}[0, 0, 0] [128, 8, 512] [2048, 256, 1], %{{.+}}[0, 0, 0] [128, 8, 512] [2048, 256, 1])
+// CHECK:          amdaie.dma_cpy_nd(%{{.+}}[0, 0, 0, 0, 0] [8, 8, 16, 8, 512] [1024, 128, 1024, 256, 1], %{{.+}}[0, 0, 0, 0, 0] [8, 8, 16, 8, 512] [1024, 128, 1024, 256, 1])
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @dma_cpy_nd_no_fold(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+    %0 = amdaie.dma_cpy_nd(%arg0[0, 0] [2, 512] [512, 1], %arg1[0, 0] [2, 512] [512, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+    "iree.keep"(%0) : (index) -> ()
+    %1 = amdaie.dma_cpy_nd(%arg0[0, 0, 0] [128, 8, 512] [2048, 256, 1], %arg1[0, 0, 0] [128, 8, 512] [2048, 256, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+    "iree.keep"(%1) : (index) -> ()
+    %2 = amdaie.dma_cpy_nd(%arg0[0, 0, 0, 0, 0] [8, 8, 16, 8, 512] [1024, 128, 1024, 256, 1], %arg1[0, 0, 0, 0, 0] [8, 8, 16, 8, 512] [1024, 128, 1024, 256, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+    "iree.keep"(%2) : (index) -> ()
+    return
+  }
+}


### PR DESCRIPTION
Canonicalization of the offsets/strides/sizes in doubly-strided operations, like DMA ops, can lead to overflow of the number of available bits in the hardware buffer descriptor fields. This PR adds logic to the `AMDAIECanonicalizeDoublyStridedOpPass` to not canonicalize if it would lead to such an overflow.

Note that there is more work to be done on avoiding overflow of available hardware bits and making it more robust, which is not addressed in this PR:
- Using aie-rt's transaction data structure and APIs to generate the control code transaction instead of the manual transaction creation we're currently doing: https://github.com/nod-ai/iree-amd-aie/blob/20867183c610ec870344d074c4be78e0aaac1515/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlCodeToTransaction.cpp#L33. As aie-rt has a lot of checks and will throw errors if hardware field bits are exceeded, this will make the flow way more robust, in the sense that errors will be thrown instead of hard-to-debug silent overflows, leading to hangs or numerical errors.
- A pass that can decanonicalize offset/strides/sizes access patterns, for example if available bits are already exceeded before canonicalization, for example when strides/sizes are derived from the `pack` operations. Note that this should typically not happen, but in general DMA ops could be create that exceed hardware limits and a decanonicalization transformation would let the flow handle more cases.