### PR TITLE
[Strix][KernelDispatch][Ukernel] Enable Matmul intrinsics for Strix

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/CMakeLists.txt
@@ -13,6 +13,7 @@ iree_lit_test_suite(
     "matmul_pack_peel_air_e2e.mlir"
     "matmul_pack_peel_objectfifo.mlir"
     "matmul_pack_peel_objectfifo_e2e.mlir"
+    "matmul_pack_peel_objectfifo_ukernel_e2e.mlir"
     "matmul_pad_pack_air_e2e.mlir"
     "matmul_elementwise_pack_peel_objectfifo_e2e.mlir"
     "xdna_oplib_plugin.mlir"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pack_peel_objectfifo_ukernel_e2e.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pack_peel_objectfifo_ukernel_e2e.mlir
@@ -1,0 +1,59 @@
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources --iree-amdaie-enable-ukernels=all %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-lower-to-aie-pipeline=objectFifo --iree-amdaie-tile-pipeline=pack-peel --split-input-file | FileCheck %s --check-prefix=PHOENIX
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources --iree-amdaie-target-device=npu4 --iree-amdaie-enable-ukernels=all %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-target-device=npu4 --iree-amdaie-lower-to-aie-pipeline=objectFifo --iree-amdaie-tile-pipeline=pack-peel --split-input-file | FileCheck %s --check-prefix=STRIX
+
+// PHOENIX-LABEL: hal.executable.export public @matmul_dispatch_0_matmul_128x128x256_bf16xbf16xf32
+// PHOENIX:       aie.device(npu1_4col) {
+// PHOENIX-DAG:   @matmul_bf16_bf16_f32_32x32x32_4x8x4
+// PHOENIX-DAG:   %[[TILE_0_2:.+]] = aie.tile(0, 2)
+// PHOENIX-DAG:   %[[TILE_0_3:.+]] = aie.tile(0, 3)
+// PHOENIX-DAG:   %[[TILE_1_2:.+]] = aie.tile(1, 2)
+// PHOENIX-DAG:   %[[TILE_1_3:.+]] = aie.tile(1, 3)
+// PHOENIX-DAG:   %[[TILE_0_0:.+]] = aie.tile(0, 0)
+// PHOENIX-DAG:   %[[TILE_0_1:.+]] = aie.tile(0, 1)
+// PHOENIX-DAG:   aie.core(%[[TILE_0_2]])
+// PHOENIX-DAG:   aie.core(%[[TILE_1_2]])
+// PHOENIX-DAG:   aie.core(%[[TILE_0_3]])
+// PHOENIX-DAG:   aie.core(%[[TILE_1_3]])
+// PHOENIX-DAG:   aie.shim_dma_allocation {{.*}}(MM2S, 0, 0)
+// PHOENIX-DAG:   aie.shim_dma_allocation {{.*}}(MM2S, 1, 0)
+// PHOENIX-DAG:   aie.memtile_dma(%[[TILE_0_1]])
+// PHOENIX-DAG:   aie.mem(%[[TILE_0_2]])
+// PHOENIX-DAG:   aie.mem(%[[TILE_0_3]])
+// PHOENIX-DAG:   aie.mem(%[[TILE_1_2]])
+// PHOENIX-DAG:   aie.mem(%[[TILE_1_3]])
+// PHOENIX-DAG:   aie.shim_dma_allocation {{.*}}(S2MM, 0, 0)
+// PHOENIX:       {npu_instructions =
+// PHOENIX-SAME:   runtime_sequence_name = "matmul_dispatch_0_matmul_128x128x256_bf16xbf16xf32"
+
+// STRIX-LABEL: hal.executable.export public @matmul_dispatch_0_matmul_128x128x256_bf16xbf16xf32
+// STRIX:       aie.device(npu4) {
+// STRIX-DAG:   @matmul_bf16_bf16_f32_32x32x32_8x8x8
+// STRIX-DAG:   %[[TILE_0_2:.+]] = aie.tile(0, 2)
+// STRIX-DAG:   %[[TILE_0_3:.+]] = aie.tile(0, 3)
+// STRIX-DAG:   %[[TILE_1_2:.+]] = aie.tile(1, 2)
+// STRIX-DAG:   %[[TILE_1_3:.+]] = aie.tile(1, 3)
+// STRIX-DAG:   %[[TILE_0_0:.+]] = aie.tile(0, 0)
+// STRIX-DAG:   %[[TILE_0_1:.+]] = aie.tile(0, 1)
+// STRIX-DAG:   aie.core(%[[TILE_0_2]])
+// STRIX-DAG:   aie.core(%[[TILE_1_2]])
+// STRIX-DAG:   aie.core(%[[TILE_0_3]])
+// STRIX-DAG:   aie.core(%[[TILE_1_3]])
+// STRIX-DAG:   aie.shim_dma_allocation {{.*}}(MM2S, 0, 0)
+// STRIX-DAG:   aie.shim_dma_allocation {{.*}}(MM2S, 1, 0)
+// STRIX-DAG:   aie.memtile_dma(%[[TILE_0_1]])
+// STRIX-DAG:   aie.mem(%[[TILE_0_2]])
+// STRIX-DAG:   aie.mem(%[[TILE_0_3]])
+// STRIX-DAG:   aie.mem(%[[TILE_1_2]])
+// STRIX-DAG:   aie.mem(%[[TILE_1_3]])
+// STRIX-DAG:   aie.shim_dma_allocation {{.*}}(S2MM, 0, 0)
+// STRIX:       {npu_instructions =
+// STRIX-SAME:   runtime_sequence_name = "matmul_dispatch_0_matmul_128x128x256_bf16xbf16xf32"
+func.func @matmul(%lhs: tensor<128x256xbf16>, %rhs: tensor<256x128xbf16>) -> tensor<128x128xf32>
+{
+  %cst = arith.constant 0.0 : f32
+  %0 = tensor.empty() : tensor<128x128xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<128x128xf32>) -> tensor<128x128xf32>
+  %res = linalg.matmul ins(%lhs, %rhs: tensor<128x256xbf16>, tensor<256x128xbf16>)
+                    outs(%1: tensor<128x128xf32>) -> tensor<128x128xf32>
+  return %res : tensor<128x128xf32>
+}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAddLoweringStrategy.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAddLoweringStrategy.cpp
@@ -67,7 +67,7 @@ void AMDAIELoweringStrategyPass::runOnOperation() {
   for (auto funcOp : moduleOp.getOps<FunctionOpInterface>()) {
     // Set the strategy with default heuristics.
     if (failed(initAIELaunchConfig(funcOp, usePassPipeline,
-                                   useLowerToAIEPipeline))) {
+                                   useLowerToAIEPipeline, targetDevice))) {
       funcOp.emitOpError("failed to have a lowering configuration set for it.");
       return signalPassFailure();
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
@@ -103,9 +103,8 @@ FailureOr<uint32_t> getAIEMacNumElements(Type inputType, Type outputType) {
   return failure();
 }
 
-FailureOr<std::array<uint32_t, 3>> getAIEMatmulInstructionSize(Type elTypeLhs,
-                                                               Type elTypeRhs,
-                                                               Type elTypeAcc) {
+FailureOr<std::array<uint32_t, 3>> getAIEMatmulInstructionSize(
+    Type elTypeLhs, Type elTypeRhs, Type elTypeAcc, AMDAIEDevice targetDevice) {
   bool allFloatingPoint = isa<FloatType>(elTypeLhs) &&
                           isa<FloatType>(elTypeRhs) &&
                           isa<FloatType>(elTypeAcc);
@@ -123,7 +122,13 @@ FailureOr<std::array<uint32_t, 3>> getAIEMatmulInstructionSize(Type elTypeLhs,
 
   if (allFloatingPoint) {
     if (nBitsLhs == 16 && nBitsRhs == 16 && nBitsAcc == 32) {
-      return std::array<uint32_t, 3>{4, 4, 8};
+      if (targetDevice == AMDAIEDevice::npu4) {
+        // Strix intrinsics.
+        return std::array<uint32_t, 3>{8, 8, 8};
+      } else {
+        // Phoenix intrinsics.
+        return std::array<uint32_t, 3>{4, 4, 8};
+      }
     }
     // There is only 1 floating point case in the table (handled above).
     return failure();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
@@ -54,9 +54,9 @@ int64_t getConstantIndexOrAssert(OpFoldResult ofr);
 // This first line says that if 'lhs' is an i8 tensor, 'rhs' is an i4 tensor
 // and 'accumulator' is an i32 tensor, then there is an AIE instruction for
 // matmul with m = 4, n = 8, k = 16.
-FailureOr<std::array<uint32_t, 3>> getAIEMatmulInstructionSize(Type elTypeLhs,
-                                                               Type elTypeRhs,
-                                                               Type elTypeAcc);
+FailureOr<std::array<uint32_t, 3>> getAIEMatmulInstructionSize(
+    Type elTypeLhs, Type elTypeRhs, Type elTypeAcc,
+    AMDAIEDevice targetDevice = AMDAIEDevice::npu1_4col);
 
 // Return the AIE instruction size (m, n, k) for the integer types with
 // bitwidths nBitsLhs, nBitsRhs, and nBitsAcc. Based on the table above.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/CMakeLists.txt
@@ -122,6 +122,7 @@ iree_cc_library(
     iree::compiler::Utils
     iree-amd-aie::aie_runtime::iree_aie_runtime_static
     iree-amd-aie::aie_runtime::Utils
+    iree-amd-aie::aie_runtime::AMDAIEEnums
     iree::target::amd-aie::IR::AMDAIEDialect
     iree::target::amd-aie::aie::AIEDialectIR
     iree::target::amd-aie::aie::AIEPasses

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -27,7 +27,7 @@ using detail::findLargestFactor;
 namespace {
 
 FailureOr<std::array<uint32_t, 3>> getMatmulInstructionSize(
-    linalg::LinalgOp op) {
+    linalg::LinalgOp op, AMDAIEDevice targetDevice) {
   auto getElementType = [](Value v) {
     return cast<ShapedType>(v.getType()).getElementType();
   };
@@ -39,17 +39,19 @@ FailureOr<std::array<uint32_t, 3>> getMatmulInstructionSize(
   auto elTypeRhs = getElementType(op->getOperand(1));
   auto elTypeAcc = getElementType(op->getResult(0));
 
-  return getAIEMatmulInstructionSize(elTypeLhs, elTypeRhs, elTypeAcc);
+  return getAIEMatmulInstructionSize(elTypeLhs, elTypeRhs, elTypeAcc,
+                                     targetDevice);
 }
 
 FailureOr<std::array<uint32_t, 3>> getPackedSize(linalg::LinalgOp linalgOp,
                                                  uint64_t M, uint64_t N,
-                                                 uint64_t K) {
+                                                 uint64_t K,
+                                                 AMDAIEDevice targetDevice) {
   // Depending on the operand/result element types, there might be a specific
   // vector instruction size that must be used on AIE. Some types do not have
   // vector instructions, for example if operands are 32-bit types.
   FailureOr<std::array<uint32_t, 3>> maybeInstructionSize =
-      getMatmulInstructionSize(linalgOp);
+      getMatmulInstructionSize(linalgOp, targetDevice);
 
   // Operand/result element types do not have vector instructions. In this case,
   // try for a packing of 4x4x8, but if the tensor dimensions M, N, and K are
@@ -95,7 +97,8 @@ class ParameterSetting {
   }
 
   static FailureOr<ParameterSetting> create(linalg::LinalgOp linalgOp,
-                                            bool isPackPeel, bool isObjectFifo);
+                                            bool isPackPeel, bool isObjectFifo,
+                                            AMDAIEDevice targetDevice);
 
   uint32_t getM0() const { return M0; }
   uint32_t getN0() const { return N0; }
@@ -142,9 +145,9 @@ class ParameterSetting {
   uint32_t k1Pack;
 };
 
-FailureOr<ParameterSetting> ParameterSetting::create(linalg::LinalgOp linalgOp,
-                                                     bool isPackPeel,
-                                                     bool isObjectFifo) {
+FailureOr<ParameterSetting> ParameterSetting::create(
+    linalg::LinalgOp linalgOp, bool isPackPeel, bool isObjectFifo,
+    AMDAIEDevice targetDevice) {
   auto initType =
       llvm::cast<ShapedType>(linalgOp.getDpsInitOperand(0)->get().getType());
   ArrayRef<int64_t> initShape = initType.getShape();
@@ -184,7 +187,7 @@ FailureOr<ParameterSetting> ParameterSetting::create(linalg::LinalgOp linalgOp,
 
   unsigned scaleFactor = maybeScaleFactor.value();
 
-  auto maybePackedSize = getPackedSize(linalgOp, M, N, K);
+  auto maybePackedSize = getPackedSize(linalgOp, M, N, K, targetDevice);
   if (failed(maybePackedSize)) return failure();
   auto [m1Pack, n1Pack, k1Pack] = maybePackedSize.value();
 
@@ -315,11 +318,12 @@ static SmallVector<int64_t> setInnerPermB(bool isMatmulTransposeB) {
 
 static LogicalResult setRootConfigForPackPeelPipeline(
     mlir::FunctionOpInterface entryPointFn, linalg::LinalgOp linalgOp,
-    LowerToAIEPassPipeline useLowerToAIEPipeline, bool isMatmulTransposeB) {
+    LowerToAIEPassPipeline useLowerToAIEPipeline, bool isMatmulTransposeB,
+    AMDAIEDevice targetDevice) {
   bool isObjectFifo =
       useLowerToAIEPipeline == LowerToAIEPassPipeline::ObjectFifo;
-  auto maybePackPeelTiling =
-      ParameterSetting::create(linalgOp, /*isPackPeel=*/true, isObjectFifo);
+  auto maybePackPeelTiling = ParameterSetting::create(
+      linalgOp, /*isPackPeel=*/true, isObjectFifo, targetDevice);
   if (failed(maybePackPeelTiling)) return failure();
   auto packPeelTiling = maybePackPeelTiling.value();
 
@@ -415,9 +419,9 @@ static LogicalResult setRootConfigForPackPeelPipeline(
 
 static LogicalResult setRootConfigForPadPackPipeline(
     mlir::FunctionOpInterface entryPointFn, linalg::LinalgOp linalgOp,
-    bool isMatmulTransposeB) {
+    bool isMatmulTransposeB, AMDAIEDevice targetDevice) {
   auto maybePadPackTiling = ParameterSetting::create(
-      linalgOp, /*isPackPeel=*/false, /*isObjectFifo=*/false);
+      linalgOp, /*isPackPeel=*/false, /*isObjectFifo=*/false, targetDevice);
   if (failed(maybePadPackTiling)) return failure();
   auto padPackTiling = maybePadPackTiling.value();
 
@@ -471,11 +475,12 @@ static LogicalResult setRootConfigForPadPackPipeline(
 //===----------------------------------------------------------------------===//
 
 static LogicalResult setRootConfigForConvDecomposePipeline(
-    mlir::FunctionOpInterface entryPointFn, linalg::LinalgOp linalgOp) {
+    mlir::FunctionOpInterface entryPointFn, linalg::LinalgOp linalgOp,
+    AMDAIEDevice targetDevice) {
   MLIRContext *context = entryPointFn.getContext();
 
   FailureOr<std::array<uint32_t, 3>> maybeInstructionSize =
-      getMatmulInstructionSize(linalgOp);
+      getMatmulInstructionSize(linalgOp, targetDevice);
   int64_t OW = 4;
   int64_t OC = 4;
   int64_t IC = 8;
@@ -683,13 +688,14 @@ static bool isMatmulTransposeB(linalg::GenericOp genericOp) {
 /// transposition.
 static LogicalResult setTransposeLikeOpRootConfig(
     mlir::FunctionOpInterface entryPointFn, linalg::LinalgOp linalgOp,
-    TilePassPipeline passPipeline,
-    LowerToAIEPassPipeline useLowerToAIEPipeline) {
+    TilePassPipeline passPipeline, LowerToAIEPassPipeline useLowerToAIEPipeline,
+    AMDAIEDevice targetDevice) {
   if (passPipeline == TilePassPipeline::PackPeelPipeline)
-    return setRootConfigForPackPeelPipeline(entryPointFn, linalgOp,
-                                            useLowerToAIEPipeline, true);
+    return setRootConfigForPackPeelPipeline(
+        entryPointFn, linalgOp, useLowerToAIEPipeline, true, targetDevice);
   else if (passPipeline == TilePassPipeline::PadPackPipeline)
-    return setRootConfigForPadPackPipeline(entryPointFn, linalgOp, true);
+    return setRootConfigForPadPackPipeline(entryPointFn, linalgOp, true,
+                                           targetDevice);
   return linalgOp.emitError(
       "Unhandled pass pipeline in setTransposeLikeOpRootConfig.");
 }
@@ -698,16 +704,18 @@ static LogicalResult setTransposeLikeOpRootConfig(
 // Root Configurations
 //===----------------------------------------------------------------------===//
 
-static LogicalResult setRootConfig(
-    mlir::FunctionOpInterface entryPointFn, linalg::GenericOp genericOp,
-    TilePassPipeline passPipeline,
-    LowerToAIEPassPipeline useLowerToAIEPipeline) {
+static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
+                                   linalg::GenericOp genericOp,
+                                   TilePassPipeline passPipeline,
+                                   LowerToAIEPassPipeline useLowerToAIEPipeline,
+                                   AMDAIEDevice targetDevice) {
   assert(!getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(genericOp) &&
          "expected lowering_config is not set");
 
   if (isMatmulTransposeB(genericOp) &&
-      succeeded(setTransposeLikeOpRootConfig(
-          entryPointFn, genericOp, passPipeline, useLowerToAIEPipeline))) {
+      succeeded(
+          setTransposeLikeOpRootConfig(entryPointFn, genericOp, passPipeline,
+                                       useLowerToAIEPipeline, targetDevice))) {
     return success();
   }
 
@@ -716,16 +724,18 @@ static LogicalResult setRootConfig(
 
 /// Sets the lowering configuration for dispatch region with root op that
 /// implements the contraction operation interface.
-static LogicalResult setRootConfig(
-    mlir::FunctionOpInterface entryPointFn,
-    linalg::ContractionOpInterface contractionOp, TilePassPipeline passPipeline,
-    LowerToAIEPassPipeline useLowerToAIEPipeline) {
+static LogicalResult setRootConfig(mlir::FunctionOpInterface entryPointFn,
+                                   linalg::ContractionOpInterface contractionOp,
+                                   TilePassPipeline passPipeline,
+                                   LowerToAIEPassPipeline useLowerToAIEPipeline,
+                                   AMDAIEDevice targetDevice) {
   assert(!getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(contractionOp) &&
          "expected lowering_config is not set");
   auto linalgOp = cast<linalg::LinalgOp>(contractionOp.getOperation());
   if (isa<linalg::MatmulTransposeBOp>(linalgOp)) {
     if (succeeded(setTransposeLikeOpRootConfig(
-            entryPointFn, linalgOp, passPipeline, useLowerToAIEPipeline))) {
+            entryPointFn, linalgOp, passPipeline, useLowerToAIEPipeline,
+            targetDevice))) {
       return success();
     }
     return failure();
@@ -745,31 +755,34 @@ static LogicalResult setRootConfig(
   // logic. Also, need a flag to experiment between pad based and pack based
   // approach which will have different tile sizes and pass pipelines
   if (passPipeline == TilePassPipeline::PackPeelPipeline)
-    return setRootConfigForPackPeelPipeline(entryPointFn, linalgOp,
-                                            useLowerToAIEPipeline, false);
+    return setRootConfigForPackPeelPipeline(
+        entryPointFn, linalgOp, useLowerToAIEPipeline, false, targetDevice);
   if (passPipeline == TilePassPipeline::PadPackPipeline)
-    return setRootConfigForPadPackPipeline(entryPointFn, linalgOp, false);
+    return setRootConfigForPadPackPipeline(entryPointFn, linalgOp, false,
+                                           targetDevice);
   return linalgOp.emitError("Unhandled pass pipeline in setRootConfig.");
 }
 
 static LogicalResult setConvRootConfig(mlir::FunctionOpInterface entryPointFn,
                                        linalg::ConvolutionOpInterface convOp,
-                                       TilePassPipeline passPipeline) {
+                                       TilePassPipeline passPipeline,
+                                       AMDAIEDevice targetDevice) {
   assert(!getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(convOp) &&
          "expected lowering_config is not set");
   auto linalgOp = cast<linalg::LinalgOp>(convOp.getOperation());
 
   // Current tiling strategy is based on llvm-cpu ConvTileAndDecomposeExpert.
   if (passPipeline == TilePassPipeline::ConvDecomposePipeline)
-    return setRootConfigForConvDecomposePipeline(entryPointFn, linalgOp);
+    return setRootConfigForConvDecomposePipeline(entryPointFn, linalgOp,
+                                                 targetDevice);
   return linalgOp.emitError("Unhandled pass pipeline in setConvRootConfig.");
 }
 
 /// Redirects to methods that set the configuration based on operation type.
 static LogicalResult setRootConfigImpl(
     mlir::FunctionOpInterface entryPointFn, Operation *op,
-    TilePassPipeline passPipeline,
-    LowerToAIEPassPipeline useLowerToAIEPipeline) {
+    TilePassPipeline passPipeline, LowerToAIEPassPipeline useLowerToAIEPipeline,
+    AMDAIEDevice targetDevice) {
   auto setRootConfigFn = [&](Operation *op) -> LogicalResult {
     return TypeSwitch<Operation *, LogicalResult>(op)
         // TODO (nmeshram): This is very limited for now, plan is to
@@ -779,15 +792,16 @@ static LogicalResult setRootConfigImpl(
         .Case<linalg::Conv2DNhwcHwcfOp, linalg::Conv2DNchwFchwOp,
               linalg::Conv2DNhwcHwcfQOp, linalg::DepthwiseConv2DNhwcHwcOp>(
             [&](auto op) {
-              return setConvRootConfig(entryPointFn, op, passPipeline);
+              return setConvRootConfig(entryPointFn, op, passPipeline,
+                                       targetDevice);
             })
         .Case<linalg::GenericOp>([&](auto op) {
           return setRootConfig(entryPointFn, op, passPipeline,
-                               useLowerToAIEPipeline);
+                               useLowerToAIEPipeline, targetDevice);
         })
         .Case<linalg::ContractionOpInterface>([&](auto op) {
           return setRootConfig(entryPointFn, op, passPipeline,
-                               useLowerToAIEPipeline);
+                               useLowerToAIEPipeline, targetDevice);
         })
         .Default([&](Operation *op) { return success(); });
   };
@@ -797,8 +811,8 @@ static LogicalResult setRootConfigImpl(
 /// Sets the translation information to use for a dispatch region.
 static LogicalResult setTranslationInfoAndRootConfig(
     mlir::FunctionOpInterface entryPointFn, ArrayRef<Operation *> computeOps,
-    TilePassPipeline passPipeline,
-    LowerToAIEPassPipeline useLowerToAIEPipeline) {
+    TilePassPipeline passPipeline, LowerToAIEPassPipeline useLowerToAIEPipeline,
+    AMDAIEDevice targetDevice) {
   // Make sure that lowering_config is not preset on any compute ops.
   for (auto computeOp : computeOps) {
     if (getLoweringConfig<IREE::Codegen::LoweringConfigAttr>(computeOp))
@@ -814,7 +828,7 @@ static LogicalResult setTranslationInfoAndRootConfig(
     return entryPointFn.emitError("Case with no root ops not yet supported.");
 
   if (failed(setRootConfigImpl(entryPointFn, rootOperation, passPipeline,
-                               useLowerToAIEPipeline)))
+                               useLowerToAIEPipeline, targetDevice)))
     return failure();
   return success();
 }
@@ -823,9 +837,10 @@ static LogicalResult setTranslationInfoAndRootConfig(
 // Entry Point
 //===----------------------------------------------------------------------===//
 
-LogicalResult initAIELaunchConfig(
-    FunctionOpInterface funcOp, TilePassPipeline passPipeline,
-    LowerToAIEPassPipeline useLowerToAIEPipeline) {
+LogicalResult initAIELaunchConfig(FunctionOpInterface funcOp,
+                                  TilePassPipeline passPipeline,
+                                  LowerToAIEPassPipeline useLowerToAIEPipeline,
+                                  AMDAIEDevice targetDevice) {
   if (getTranslationInfo(funcOp)) return success();
 
   // TODO (nmeshram): Need a default pipeline for control flow cases.
@@ -834,7 +849,8 @@ LogicalResult initAIELaunchConfig(
 
   SmallVector<Operation *> computeOps = getComputeOps(funcOp);
   if (failed(setTranslationInfoAndRootConfig(funcOp, computeOps, passPipeline,
-                                             useLowerToAIEPipeline)))
+                                             useLowerToAIEPipeline,
+                                             targetDevice)))
     return failure();
 
   // The root configuration setting introduces `tensor.dim` operations.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
@@ -7,6 +7,7 @@
 #ifndef IREE_AMD_AIE_TRANSFORMS_KERNELDISPATCH_H_
 #define IREE_AMD_AIE_TRANSFORMS_KERNELDISPATCH_H_
 
+#include "iree-amd-aie/aie_runtime/AMDAIEEnums.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 
@@ -29,6 +30,8 @@ enum class TilePassPipeline {
   None
 };
 
+enum class AMDAIEDevice : uint32_t;
+
 /// Enum for types of loop peeling.
 enum class PeelingType { First, Last, FirstLast };
 
@@ -37,7 +40,8 @@ enum class BufferizeOperand { InputOutput, Input, Output, DefOp };
 
 LogicalResult initAIELaunchConfig(FunctionOpInterface funcOp,
                                   TilePassPipeline usePassPipeline,
-                                  LowerToAIEPassPipeline useLowerToAIEPipeline);
+                                  LowerToAIEPassPipeline useLowerToAIEPipeline,
+                                  AMDAIEDevice targetDevice);
 
 }  // namespace mlir::iree_compiler::AMDAIE
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -497,6 +497,7 @@ void buildAMDAIETransformPassPipeline(
     AMDAIELoweringStrategyOptions options;
     options.usePassPipeline = useTilePipeline;
     options.useLowerToAIEPipeline = useLowerToAIEPipeline;
+    options.targetDevice = device;
     modulePassManager.addPass(createAMDAIELoweringStrategyPass(options));
   }
   modulePassManager.addPass(createLowerExecutableUsingTransformDialectPass());

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -687,11 +687,6 @@ void addMLIRAIRLoweringPasses(OpPassManager &passManager, AMDAIEDevice device,
   {
     // Vectorization passes
     OpPassManager &funcPassManager = passManager.nest<func::FuncOp>();
-    // FIXME(newling) https://github.com/nod-ai/iree-amd-aie/issues/820
-    enableVectorizationPasses =
-        (useTilePipeline == TilePassPipeline::ConvDecomposePipeline)
-            ? false
-            : enableVectorizationPasses;
     appendVectorizationToPipeline(funcPassManager, enableVectorizationPasses);
   }
   passManager.addPass(createAMDAIEBridgeToAIRPass());

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -417,6 +417,16 @@ def AMDAIELoweringStrategy :
                    "Use the IREE lowering to objectFifos"),
         clEnumValN(mlir::iree_compiler::AMDAIE::LowerToAIEPassPipeline::AIR, "air",
                    "Use the IREE lowering through AIR")
+      )}]>,
+    Option<"targetDevice", "target-device",
+      "mlir::iree_compiler::AMDAIE::AMDAIEDevice",
+      /*default=*/"mlir::iree_compiler::AMDAIE::AMDAIEDevice::npu1_4col",
+      "AIE device to target",
+      [{::llvm::cl::values(
+        clEnumValN(mlir::iree_compiler::AMDAIE::AMDAIEDevice::npu1_4col, "phoenix",
+                   "Compile for Phoenix"),
+        clEnumValN(mlir::iree_compiler::AMDAIE::AMDAIEDevice::npu4, "strix",
+                   "Compile for Strix")
       )}]>
   ];
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_ukernel.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_ukernel.mlir
@@ -295,3 +295,48 @@ func.func @zero_fill_matmul_elmwise(%arg0 : tensor<8x16x4x8xbf16>, %arg1 : tenso
 // CHECK: linalg.generic
 // CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel", "parallel"]
 // CHECK: return
+
+// -----
+
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_arch = "chip-tbd", ukernels = "all"}>
+#map = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d0, d3, d5)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d3, d4)>
+module {
+  func.func @generic_matmul_bf16bf16f32_pack_peel_objectfifo(
+      %arg0: tensor<1x1x4x4x8x8xbf16>, %arg1: tensor<1x1x4x4x8x8xbf16>,
+      %arg2: tensor<1x1x4x4x8x8xf32>) -> tensor<1x1x4x4x8x8xf32> attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+    %0 = linalg.generic {
+        indexing_maps = [
+            affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d2, d5, d3, d6, d8)>,
+            affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d2, d1, d4, d5, d8, d7)>,
+            affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d4, d3, d6, d7)>
+        ],
+        iterator_types = [
+          "parallel", "parallel", "reduction",
+          "parallel", "parallel", "reduction",
+          "parallel", "parallel", "reduction"
+        ]
+      } ins(%arg0, %arg1 : tensor<1x1x4x4x8x8xbf16>, tensor<1x1x4x4x8x8xbf16>)
+        outs(%arg2 : tensor<1x1x4x4x8x8xf32>) {
+        ^bb0(%in: bf16, %in_0: bf16, %out: f32):
+          %1 = arith.extf %in : bf16 to f32
+          %2 = arith.extf %in_0 : bf16 to f32
+          %3 = arith.mulf %1, %2 : f32
+          %4 = arith.addf %out, %3 : f32
+          linalg.yield %4 : f32
+      } -> tensor<1x1x4x4x8x8xf32>
+    return %0 : tensor<1x1x4x4x8x8xf32>
+  }
+}
+//      CHECK: func @generic_matmul_bf16bf16f32_pack_peel_objectfifo(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<1x1x4x4x8x8xbf16>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<1x1x4x4x8x8xbf16>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<1x1x4x4x8x8xf32>)
+//  CHECK-NOT:   linalg.generic
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "matmul_bf16_bf16_f32_32x32x32_8x8x8"
+// CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
+// CHECK-SAME:       outs(%[[ARG2]] :
+// CHECK-SAME:       fn_def_attrs {link_with = "{{.*}}mm.o"}
+// CHECK-SAME:       strided_outer_dims(0)
+//      CHECK:   return %[[MICRO_KERNEL]]

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo.mlir
@@ -1,7 +1,11 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-amdaie-lowering-strategy{use-pass-pipeline=pack-peel use-lower-to-aie-pipeline=objectFifo})' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-amdaie-lowering-strategy{use-pass-pipeline=pack-peel use-lower-to-aie-pipeline=objectFifo target-device=phoenix})' %s | FileCheck %s --check-prefix=PHOENIX
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-amdaie-lowering-strategy{use-pass-pipeline=pack-peel use-lower-to-aie-pipeline=objectFifo target-device=strix})' %s | FileCheck %s --check-prefix=STRIX
 
-// CHECK-{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
-// CHECK-{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+// PHOENIX-{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
+// PHOENIX-{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+
+// STRIX-{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
+// STRIX-{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 8, 8, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
   <storage_buffer>,
@@ -18,7 +22,8 @@ module {
     %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 128], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<256x128xbf16>> -> tensor<256x128xbf16>
     %5 = tensor.empty() : tensor<128x128xf32>
     %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<128x128xf32>) -> tensor<128x128xf32>
-    // CHECK:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig}
+    // PHOENIX:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig}
+    // STRIX:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig}
     %7 = linalg.matmul ins(%3, %4 : tensor<128x256xbf16>, tensor<256x128xbf16>) outs(%6 : tensor<128x128xf32>) -> tensor<128x128xf32>
     flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [128, 128], strides = [1, 1] : tensor<128x128xf32> -> !flow.dispatch.tensor<writeonly:tensor<128x128xf32>>
     return
@@ -27,8 +32,8 @@ module {
 
 // -----
 
-// CHECK-{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
-// CHECK-{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+// PHOENIX-{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
+// PHOENIX-{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
   <storage_buffer>,
@@ -45,7 +50,7 @@ module {
     %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 128], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<256x128xi32>> -> tensor<256x128xi32>
     %5 = tensor.empty() : tensor<128x128xi32>
     %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<128x128xi32>) -> tensor<128x128xi32>
-    // CHECK:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig}
+    // PHOENIX:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig}
     %7 = linalg.matmul ins(%3, %4 : tensor<128x256xi32>, tensor<256x128xi32>) outs(%6 : tensor<128x128xi32>) -> tensor<128x128xi32>
     flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [128, 128], strides = [1, 1] : tensor<128x128xi32> -> !flow.dispatch.tensor<writeonly:tensor<128x128xi32>>
     return
@@ -54,8 +59,8 @@ module {
 
 // -----
 
-// CHECK-{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
-// CHECK-{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+// PHOENIX-{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
+// PHOENIX-{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
   <storage_buffer>,
@@ -72,7 +77,7 @@ module {
     %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 128], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<256x128xi8>> -> tensor<256x128xi8>
     %5 = tensor.empty() : tensor<128x128xi32>
     %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<128x128xi32>) -> tensor<128x128xi32>
-    // CHECK:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig}
+    // PHOENIX:  linalg.matmul {lowering_config = #config, packing_config = #packingConfig}
     %7 = linalg.matmul ins(%3, %4 : tensor<128x256xi8>, tensor<256x128xi8>) outs(%6 : tensor<128x128xi32>) -> tensor<128x128xi32>
     flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [128, 128], strides = [1, 1] : tensor<128x128xi32> -> !flow.dispatch.tensor<writeonly:tensor<128x128xi32>>
     return
@@ -81,8 +86,8 @@ module {
 
 // -----
 
-// CHECK-{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[1, 64, 64], [0, 0, 0, 1], [0, 1, 1, 0, 0, 0, 0]]>
-// CHECK-{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [0, 32, 32, 32], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1, 2]]}, {packedSizes = [0, 0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 2, 4, 3], [0, 1, 2, 4, 3], [0, 1, 2, 4, 3]]}]>
+// PHOENIX-{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[1, 64, 64], [0, 0, 0, 1], [0, 1, 1, 0, 0, 0, 0]]>
+// PHOENIX-{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [0, 32, 32, 32], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1, 2]]}, {packedSizes = [0, 0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 2, 4, 3], [0, 1, 2, 4, 3], [0, 1, 2, 4, 3]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
   <storage_buffer>,
@@ -99,7 +104,7 @@ module {
     %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [1, 256, 128], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x256x128xi32>> -> tensor<1x256x128xi32>
     %5 = tensor.empty() : tensor<1x128x128xi32>
     %6 = linalg.fill ins(%c0_i32 : i32) outs(%5 : tensor<1x128x128xi32>) -> tensor<1x128x128xi32>
-    // CHECK:  linalg.batch_matmul {lowering_config = #config, packing_config = #packingConfig}
+    // PHOENIX:  linalg.batch_matmul {lowering_config = #config, packing_config = #packingConfig}
     %7 = linalg.batch_matmul ins(%3, %4 : tensor<1x128x256xi32>, tensor<1x256x128xi32>) outs(%6 : tensor<1x128x128xi32>) -> tensor<1x128x128xi32>
     flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0], sizes = [1, 128, 128], strides = [1, 1, 1] : tensor<1x128x128xi32> -> !flow.dispatch.tensor<writeonly:tensor<1x128x128xi32>>
     return


### PR DESCRIPTION
-- This commit enables Matmul intrinsics for Strix bf16xbf16xf32 ukernel.
-- This is an initial PR whose scope is only to generate correct target intrinsics
    based on whether we target 'phoenix' (default) or 'strix'.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>