### PR TITLE
[Testing] Make it possible to run individual tests 

### DIFF
--- a/build_tools/ci/cpu_comparison/convolution_template/convolution_generator.py
+++ b/build_tools/ci/cpu_comparison/convolution_template/convolution_generator.py
@@ -185,6 +185,9 @@ func.func @f_conv(%arg0: ${input_tensor_type},
         self.subbed = regex.sub(lambda m: str(replace[m.group(0)[2:-1]]), base_string)
         print(self.subbed)
 
+        self.params = replace
+        self.params["conv_type"] = conv_type
+
     def __str__(self):
         return self.subbed
 

--- a/build_tools/ci/cpu_comparison/matmul_template/matmul_generator.py
+++ b/build_tools/ci/cpu_comparison/matmul_template/matmul_generator.py
@@ -3,7 +3,7 @@ import re
 import os
 
 
-def generate_matmul_test(output_fn, input_fn, m, n, k, lhs_rhs_type, acc_type, b=0):
+def generate_matmul_test(output_fn, input_fn, m, n, k, lhs_rhs_type, output_type, b=0):
     """
     Generate mlir file (output_fn) from the template file (input_fn).
     """
@@ -13,12 +13,12 @@ def generate_matmul_test(output_fn, input_fn, m, n, k, lhs_rhs_type, acc_type, b
     replace["N"] = n
     replace["K"] = k
     replace["TYPE1"] = lhs_rhs_type
-    replace["TYPE2"] = acc_type
+    replace["TYPE2"] = output_type
 
     replace["B"] = b  # This is only used for batch matmul
-    accl_is_int = acc_type[0] == "i"
-    replace["ZERO"] = 0 if accl_is_int else 0.0
-    replace["ADD"] = "arith.addi" if accl_is_int else "arith.addf"
+    output_is_int = output_type[0] == "i"
+    replace["ZERO"] = 0 if output_is_int else 0.0
+    replace["ADD"] = "arith.addi" if output_is_int else "arith.addf"
 
     key_map = map(lambda s: "${" + s + "}", replace.keys())
     key_map_escaped = map(re.escape, key_map)

--- a/build_tools/ci/cpu_comparison/matmul_template/matmul_generator.py
+++ b/build_tools/ci/cpu_comparison/matmul_template/matmul_generator.py
@@ -3,7 +3,7 @@ import re
 import os
 
 
-def generate_matmul_test(output_fn, input_fn, m, n, k, lhs_rhs_type, output_type, b=0):
+def generate_matmul_test(output_fn, input_fn, m, n, k, lhs_rhs_type, acc_type, b=0):
     """
     Generate mlir file (output_fn) from the template file (input_fn).
     """
@@ -13,12 +13,12 @@ def generate_matmul_test(output_fn, input_fn, m, n, k, lhs_rhs_type, output_type
     replace["N"] = n
     replace["K"] = k
     replace["TYPE1"] = lhs_rhs_type
-    replace["TYPE2"] = output_type
+    replace["TYPE2"] = acc_type
 
     replace["B"] = b  # This is only used for batch matmul
-    output_is_int = output_type[0] == "i"
-    replace["ZERO"] = 0 if output_is_int else 0.0
-    replace["ADD"] = "arith.addi" if output_is_int else "arith.addf"
+    acc_is_int = acc_type[0] == "i"
+    replace["ZERO"] = 0 if acc_is_int else 0.0
+    replace["ADD"] = "arith.addi" if acc_is_int else "arith.addf"
 
     key_map = map(lambda s: "${" + s + "}", replace.keys())
     key_map_escaped = map(re.escape, key_map)

--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -32,6 +32,7 @@ def run_conv_test(config, filename, n_repeats):
         lower_to_aie_pipeline="objectFifo",
         n_repeats=n_repeats,
     )
+    # Return True to indicate that the test ran.
     return True
 
 
@@ -49,11 +50,11 @@ class ConvolutionFromTemplate:
         self.labels = ["Convolution"]
 
     def run(self, config):
-        # Generate the mlir file
+        # Generate MLIR file:
         output_dir = config.output_dir
         filename = output_dir / f"{self.name}.mlir"
         self.generator.write_to_file(filename)
-        # Perform numerical comparison between AIE and CPU
+        # Perform numerical comparison between AIE and CPU:
         return run_conv_test(config, filename, n_repeats=2)
 
 
@@ -85,7 +86,6 @@ class MultipleDispatches:
 
 
 class BaseMatmul:
-
     def __init__(self, M, N, K, input_type, output_type):
         self.labels = []
         self.M = M


### PR DESCRIPTION
After this PR it is possible to run individual tests. 

```
./run.py --help 
```

Prints
```
...
  --tests TESTS         A comma-separated list of test names or sets to run. Available test sets: BatchMatmul, Convolution, ConvolutionNHWCQ, Matmul, MatmulFullBias, MatmulThinBias, MatmulTruncf, MultipleDispatches, UKernel, VanillaMatmul, All. Available individual tests: batch_matmul_1_128_128_256_bf16_f32, batch_matmul_1_128_128_256_i32_i32,
                        batch_matmul_2_64_64_64_bf16_f32, batch_matmul_2_64_64_64_i32_i32, conv_2d_nhwc_hwcf_2_14_bf16_f32, conv_2d_nhwc_hwcf_2_14_i32_i32, conv_2d_nhwc_hwcf_2_14_i8_i32, convolution_nhwc_q, depthwise_conv_2d_nhwc_hwc_1_14_i32_i32, matmul_f32_8_4_8, matmul_f32_8_8_4, matmul_full_bias_128_128_256_i32_i32,
                        matmul_thin_bias_1024_1024_512_bf16_f32_ukernel0, matmul_thin_bias_1024_1024_512_bf16_f32_ukernel1, matmul_truncf_128_256_bf16_f32, matmul_truncf_8_8_bf16_f32, two_matmul_switching, vanilla_matmul_32_32_64_bf16_f32.
...
```

So you can do `./run.py --tests=batch_matmul_1_128_128_256_bf16_f32 ... ` for example, to run just the one test. But you can also do `./run.py --tests=Matmul ...` to run all tests with matmuls. I think this is a better design for debugging. 