### PR TITLE
[aievec] Don't add alignment ops if already aligned 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aievec/test/align-transfer-reads.mlir
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/align-transfer-reads.mlir
@@ -164,7 +164,7 @@ func.func @test_i8_128bytes(%arg0: index) -> vector<128xi8> {
 // -----
 
 // If a `transfer_read` is already aligned, then the IR should be unchanged.
-// This tests sheck alignments of
+// This test check alignments of
 //  - 16 bytes (insufficient alignment, 16%32 != 0)
 //  - 32 bytes (sufficient alignment, 32%32 == 0)
 //  - 48 bytes (insufficient alignment, 48%32 != 0)


### PR DESCRIPTION
I've checked that the IR of a matmul (32x32x64 bf16) is now unchanged by this alignment pass. This this PR, there were aievec.ext ops remaining in the IR after this pass for matmuls. So I'm confident this resolves https://github.com/nod-ai/iree-amd-aie/issues/882

