### PR TITLE
Uncompiled file: remove or fix cmake? 

### DIFF
--- a/runtime/src/iree-amd-aie/driver/xrt-lite/cts/matmul_dispatch_test.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/cts/matmul_dispatch_test.cc
@@ -119,6 +119,9 @@ TEST_F(MatMulDispatchTest, SubmitEmpty) {
 TEST_P(MatMulDispatchTest, DispatchMatmul) {
   PrepareMatmulExecutable();
 
+  EXPECT_TRUE(false);
+  actually this doesn't even get compiled 
+
   // Create input buffer.
   constexpr iree_device_size_t WIDTH = 32;
   constexpr iree_device_size_t M = WIDTH, K = WIDTH, N = WIDTH;


### PR DESCRIPTION
@makslevental please advise 

Background: I/we want to make a semi-standalone cpp file which doesn't use XRT for benchmarking kernels, ie something we can get CI without hacking print statements in https://github.com/nod-ai/iree-amd-aie/blob/9b0582f3cc7e04b9f1747e115e2ee43225ab77f0/runtime/src/iree-amd-aie/driver/xrt-lite/direct_command_buffer.cc#L193 with which we can monitor matmul performance. This file looks like the right direction (or does it?)