### PR TITLE
Invasively print kernel execution time, percolate to CI output

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -126,7 +126,7 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           submodules: false # not required for testbench
-          
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -143,7 +143,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-          
+
       - name: Create venv and install dependencies
         run: |
           python -m venv .venv
@@ -172,6 +172,24 @@ jobs:
             --reset-npu-between-runs -v \
             --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS \
             --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS
+
+      - name : Performance benchmarks
+
+        run: |
+          source .venv/bin/activate
+          python build_tools/ci/cpu_comparison/run.py \
+            test_aie_vs_cpu \
+            $PWD/iree-install \
+            $PWD/llvm-aie \
+            --vitis-dir /opt/Xilinx/Vitis/2024.2 \
+            --target_device "npu1_4col" \
+            --reset-npu-between-runs -v \
+            --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS \
+            --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS \
+            --tests=Performance > performance.log
+
+          python build_tools/ci/cpu_comparison/performance_summarizer.py \
+            performance.log
 
       - name: E2E correctness matmul test
         run: |
@@ -218,7 +236,7 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           submodules: false # not required for testbench
-          
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -233,7 +251,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-          
+
       - name: Create venv and install dependencies
         run: |
           python -m venv .venv

--- a/build_tools/build_test_cpp.sh
+++ b/build_tools/build_test_cpp.sh
@@ -58,7 +58,7 @@ echo '{
     "include": [
         "build_tools/cmake/presets/all.json"
     ]
-}' > $iree_dir/CMakeUserPresets.json 
+}' > $iree_dir/CMakeUserPresets.json
 
 cd $iree_dir
 CMAKE_ARGS=(
@@ -81,6 +81,7 @@ CMAKE_ARGS=(
   -DIREE_INPUT_TORCH=OFF
   -DCMAKE_OBJECT_PATH_MAX=4096
   -DIREE_CMAKE_PLUGIN_PATHS="$repo_root"
+  -DIREE_AMDAIE_TIME_KERNEL=1
 )
 
 PEANO_INSTALL_DIR=${PEANO_INSTALL_DIR:-""}

--- a/build_tools/ci/cpu_comparison/performance_summarizer.py
+++ b/build_tools/ci/cpu_comparison/performance_summarizer.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 The IREE Authors
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 2:
+        print("Usage: python3 performance_summarizer.py <path_to_log_file>")
+        sys.exit(1)
+    path = sys.argv[1]
+    with open(path, "r") as f:
+        lines = f.readlines()
+    print("============================")
+    for line in lines:
+        if "Run #1" in line:
+            print(line.split()[-1])
+        if "IREE_AMDAIE" in line:
+            print(line)
+            print("\n")
+    print("============================")

--- a/build_tools/ci/cpu_comparison/performance_summarizer.py
+++ b/build_tools/ci/cpu_comparison/performance_summarizer.py
@@ -17,5 +17,4 @@ if __name__ == "__main__":
             print(line.split()[-1])
         if "IREE_AMDAIE" in line:
             print(line)
-            print("\n")
     print("============================")

--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -163,11 +163,20 @@ class VanillaMatmul(BaseMatmul):
     """
 
     def __init__(
-        self, M, N, K, input_type, acc_type, use_ukernel, run_on_target=["npu1_4col"]
+        self,
+        M,
+        N,
+        K,
+        input_type,
+        acc_type,
+        use_ukernel,
+        run_on_target=["npu1_4col"],
+        additional_labels=[],
     ):
         super().__init__(M, N, K, input_type, acc_type, run_on_target)
         self.name = f"vanilla_matmul_{M}_{N}_{K}_{input_type}_{acc_type}"
         self.labels.append("VanillaMatmul")
+        self.labels += additional_labels
         self.use_ukernel = use_ukernel
 
     def _execute(self, config):
@@ -983,10 +992,23 @@ class Tests:
             )
         )
         self.register(VanillaMatmul(32, 32, 64, "bf16", "f32", use_ukernel=False))
+
         # TODO: Failure is expected for the 128x128 case we don't yet understand why.
         self.register(
             VanillaMatmul(
                 64, 64, 64, "bf16", "f32", use_ukernel=True, run_on_target=["npu4"]
+            )
+        )
+
+        self.register(
+            VanillaMatmul(
+                512,
+                512,
+                4096,
+                "bf16",
+                "f32",
+                use_ukernel=False,
+                additional_labels=["Performance"],
             )
         )
 

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/CMakeLists.txt
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/CMakeLists.txt
@@ -7,6 +7,14 @@
 
 iree_add_all_subdirs()
 
+option(IREE_AMDAIE_TIME_KERNEL "Time and print the kernel execution time" OFF)
+if(IREE_AMDAIE_TIME_KERNEL)
+  add_compile_definitions(IREE_AMDAIE_TIME_KERNEL)
+  message(STATUS "[IREE_AMDAIE] will time and print kernel execution")
+else()
+  message(STATUS "[IREE_AMDAIE] won't print the kernel execution time")
+endif()
+
 iree_register_external_hal_driver(
   NAME
     xrt-lite


### PR DESCRIPTION
![{4C086AF3-4CB3-4F77-960C-ABEC14FCC4E6}](https://github.com/user-attachments/assets/888fccaf-17fb-4983-8db1-6ab1f44bfc78)

I'll remove some spacing, but above is where you can see the kernel execution time in the CI logs. 

Alternatives considered:

1) Suggestion here: https://github.com/nod-ai/iree-amd-aie/pull/892#discussion_r1838636704 very nearly worked, but it resulted in large amounts of trace information being written to terminal, which I was worried would swamp the CI logs. Played around with `IREE_TRACING_CONSOLE_FILE` but not really designed for this. 

2) Tried tracy, but there is no simple text file dumped with tracy (as far as I can tell) so this didn't work 

3) Tried making a standalone test based on https://github.com/nod-ai/iree-amd-aie/blob/main/runtime/src/iree-amd-aie/driver/xrt/cts/matmul_dispatch_test.cc but this got more complicated than I could handle. 

FWIW running the m=n=512 k=4096 matmul in a loop (ie having warm up runs) does not effect the time to run the kernel, at least that is what I've observed. 

If we're brave we can use the execution time as a threshold above which the test fails (thoughts on this?)

We could also create an artifact and upload these numbers to table and make nice plots of our progress (although I'd prefer someone more experienced with this stuff to take over from me)