### PR TITLE
Revert "Increase the K tile size in L1 for matmul ops"

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/mm.cc
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/mm.cc
@@ -307,8 +307,8 @@ extern "C" {
 
 #define matmul_vectorized_c_func(lhs_ctype_in, lhs_mlir_type_in,                                             \
                                  rhs_ctype_in, rhs_mlir_type_in,                                             \
-                                 acc_ctype_out, acc_mlir_type_out, M, N, K, r, s, t)                         \
-  void matmul_##lhs_mlir_type_in##_##rhs_mlir_type_in##_##acc_mlir_type_out##_##M##x##N##x##K##_##r##x##s##x##t( \
+                                 acc_ctype_out, acc_mlir_type_out, M, K, N, r, s, t)                         \
+  void matmul_##lhs_mlir_type_in##_##rhs_mlir_type_in##_##acc_mlir_type_out##_##M##x##K##x##N##_##r##x##s##x##t( \
       lhs_ctype_in *a_in, unsigned offsetA, rhs_ctype_in *b_in, unsigned offsetB,                            \
       acc_ctype_out *c_out, unsigned offsetC) {                                                              \
     matmul_vectorized_##r##x##s##x##t##_##lhs_mlir_type_in##_##rhs_mlir_type_in##_##acc_mlir_type_out<       \
@@ -321,7 +321,6 @@ extern "C" {
   }
 
 matmul_combos(matmul_vectorized_c_func, 32, 32, 32)
-matmul_combos(matmul_vectorized_c_func, 32, 32, 64)
 matmul_combos(matmul_vectorized_c_func, 64, 64, 64)
 
 zero_fill_combos(zero_vectorized_c_func, 32, 32)

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pack_peel_objectfifo_ukernel_e2e.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pack_peel_objectfifo_ukernel_e2e.mlir
@@ -3,7 +3,7 @@
 
 // PHOENIX-LABEL: hal.executable.export public @matmul_dispatch_0_matmul_128x128x256_bf16xbf16xf32
 // PHOENIX:       aie.device(npu1_4col) {
-// PHOENIX-DAG:   @matmul_bf16_bf16_f32_32x32x64_4x8x4
+// PHOENIX-DAG:   @matmul_bf16_bf16_f32_32x32x32_4x8x4
 // PHOENIX-DAG:   %[[TILE_0_2:.+]] = aie.tile(0, 2)
 // PHOENIX-DAG:   %[[TILE_0_3:.+]] = aie.tile(0, 3)
 // PHOENIX-DAG:   %[[TILE_1_2:.+]] = aie.tile(1, 2)
@@ -27,7 +27,7 @@
 
 // STRIX-LABEL: hal.executable.export public @matmul_dispatch_0_matmul_128x128x256_bf16xbf16xf32
 // STRIX:       aie.device(npu4) {
-// STRIX-DAG:   @matmul_bf16_bf16_f32_32x32x64_8x8x8
+// STRIX-DAG:   @matmul_bf16_bf16_f32_32x32x32_8x8x8
 // STRIX-DAG:   %[[TILE_0_2:.+]] = aie.tile(0, 2)
 // STRIX-DAG:   %[[TILE_0_3:.+]] = aie.tile(0, 3)
 // STRIX-DAG:   %[[TILE_1_2:.+]] = aie.tile(1, 2)

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.cpp
@@ -263,21 +263,6 @@ bool isMatmulProducerOfElementwise(linalg::LinalgOp linalgOp) {
   return false;
 }
 
-/// Utility to identify if `linalgOp` is a matmul operation with an elementwise
-/// op downstream in its computation tree.
-bool isElementwiseConsumerOfMatmul(linalg::LinalgOp linalgOp) {
-  if (!isa<linalg::MatmulOp>(linalgOp) && !isMatmul(linalgOp)) {
-    return false;
-  }
-  for (Operation *userOp : linalgOp->getUsers()) {
-    auto linalgUser = dyn_cast<linalg::LinalgOp>(userOp);
-    if (linalgUser && isElementwise(linalgUser)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 std::string utohexstr(uint32_t value, size_t width, bool header,
                       bool lowercase) {
   std::string res = "";

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEUtils.h
@@ -58,10 +58,6 @@ bool isMatmulInDefChain(Value operand);
 /// matmul-like op upstream in its computation tree.
 bool isMatmulProducerOfElementwise(linalg::LinalgOp linalgOp);
 
-/// Utility to identify if `linalgOp` is a matmul operation with an elementwise
-/// op downstream in its computation tree.
-bool isElementwiseConsumerOfMatmul(linalg::LinalgOp linalgOp);
-
 /// Utility to convert a `uint32_t` value into a hex string.
 std::string utohexstr(uint32_t value, size_t width, bool header = true,
                       bool lowercase = false);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -229,16 +229,7 @@ FailureOr<ParameterSetting> ParameterSetting::create(
     // the second level of inner pack size (vector instruction size).
     uint32_t m0Pack = (M0 / 2) % m1Pack == 0 ? (M0 / 2) : M0;
     uint32_t n0Pack = (N0 / 2) % n1Pack == 0 ? (N0 / 2) : N0;
-
-    // For matmul ops, make the most use of L1 memory by scaling the K tiling
-    // dimension. For AIR pipeline, the tile sizes are already reaching maximum
-    // when taking elementwise op into account, so don't scale it.
-    // TODO: (vivian) Develop a better way to select tile sizes to make the most
-    // use of L1 memory while taking all factors (double buffer, elementwise
-    // memory usage, lhs/rhs element type etc) into account.
-    uint32_t kPackScale =
-        (isElementwiseConsumerOfMatmul(linalgOp) && !isObjectFifo) ? 1 : 2;
-    uint32_t k0Pack = findLargestFactor(K, kPackScale * maxL1Size);
+    uint32_t k0Pack = findLargestFactor(K, maxL1Size);
 
     return ParameterSetting{M0,     N0,     K0,     M1,     N1,     K1,
                             m0Pack, n0Pack, k0Pack, m1Pack, n1Pack, k1Pack};

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy.mlir
@@ -190,7 +190,7 @@ builtin.module {
 // -----
 
 // CHECK-PACK-PEEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
-// CHECK-PACK-PEEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 64], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+// CHECK-PACK-PEEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
   <storage_buffer>,
@@ -217,7 +217,7 @@ builtin.module {
 // -----
 
 // CHECK-PACK-PEEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[44, 128], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
-// CHECK-PACK-PEEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [44, 64, 128], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+// CHECK-PACK-PEEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [44, 64, 64], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[1, 0]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
   <storage_buffer>,
@@ -245,7 +245,7 @@ module {
 // CHECK-PAD-PACK{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128], [0, 0, 256], [32, 32], [0, 0, 4]]>
 // CHECK-PAD-PACK{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [0, 1], [0, 1]], outerPerm = [[1, 0], [1, 0], [1, 0]]}]>
 // CHECK-PACK-PEEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
-// CHECK-PACK-PEEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 64], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[0, 1]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [0, 1], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+// CHECK-PACK-PEEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [1], unpackEmpty = [false], innerPerm = [[0, 1]], outerPerm = [[0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [0, 1], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
   <storage_buffer>,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo_npu1.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo_npu1.mlir
@@ -3,7 +3,7 @@
 // CHECK:       #config = #iree_codegen.lowering_config<tile_sizes = [
 // CHECK-SAME:                [64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]
 // CHECK-SAME:            ]>
-// CHECK:       #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 64], transposePackIndices = [1], unpackEmpty = [false],
+// CHECK:       #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [1], unpackEmpty = [false],
 // CHECK-SAME:                      innerPerm = [
 // CHECK-SAME:                              [1, 0]
 // CHECK-SAME:                   ], outerPerm = [
@@ -39,10 +39,11 @@ module {
 
 // -----
 
+
 // CHECK:       #config = #iree_codegen.lowering_config<tile_sizes = [
 // CHECK-SAME:                [64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]
 // CHECK-SAME:            ]>
-// CHECK:       #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 64], transposePackIndices = [1], unpackEmpty = [false],
+// CHECK:       #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [1], unpackEmpty = [false],
 // CHECK-SAME:                      innerPerm = [
 // CHECK-SAME:                              [1, 0]
 // CHECK-SAME:                   ], outerPerm = [
@@ -78,10 +79,11 @@ module {
 
 // -----
 
+
 // CHECK:       #config = #iree_codegen.lowering_config<tile_sizes = [
 // CHECK-SAME:                [64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]
 // CHECK-SAME:            ]>
-// CHECK:       #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 64], transposePackIndices = [1], unpackEmpty = [false],
+// CHECK:       #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [1], unpackEmpty = [false],
 // CHECK-SAME:                      innerPerm = [
 // CHECK-SAME:                              [1, 0]
 // CHECK-SAME:                   ], outerPerm = [
@@ -117,10 +119,11 @@ module {
 
 // -----
 
+
 // CHECK:       #config = #iree_codegen.lowering_config<tile_sizes = [
 // CHECK-SAME:                [1, 64, 64], [0, 0, 0, 1], [0, 1, 1, 0, 0, 0, 0]
 // CHECK-SAME:            ]>
-// CHECK:       #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [0, 32, 32, 64], transposePackIndices = [1], unpackEmpty = [false],
+// CHECK:       #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [0, 32, 32, 32], transposePackIndices = [1], unpackEmpty = [false],
 // CHECK-SAME:                      innerPerm = [
 // CHECK-SAME:                              [1, 0]
 // CHECK-SAME:                   ], outerPerm = [

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo_npu4.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo_npu4.mlir
@@ -3,7 +3,7 @@
 // CHECK:       #config = #iree_codegen.lowering_config<tile_sizes = [
 // CHECK-SAME:                [64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]
 // CHECK-SAME:            ]>
-// CHECK:       #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 64], transposePackIndices = [1], unpackEmpty = [false],
+// CHECK:       #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [1], unpackEmpty = [false],
 // CHECK-SAME:                      innerPerm = [
 // CHECK-SAME:                              [1, 0]
 // CHECK-SAME:                   ], outerPerm = [


### PR DESCRIPTION
Reverts nod-ai/iree-amd-aie#846, which somehow leads to a bit regression for vectorization path on ToM, although it wasn't causing regression when I tried it with HEAD @ 13d20252d4743ab7b6816572fbcb9aefbb7ffe7a.