### PR TITLE
Fix bug in PushToQueue address generation

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlCodeToTransaction.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlCodeToTransaction.cpp
@@ -93,10 +93,10 @@ class TransactionBuilder {
     uint32_t addr =
         direction == AMDAIE::DMAChannelDir::MM2S ? 0x1D214 : 0x1D204;
     if (channel == 1) addr += 0x8;
-    if (col && row) {
-      addr |= ((col & 0xff) << colShift) | ((row & 0xff) << rowShift) |
-              (addr & 0xFFFFF);
-    }
+    // TODO(jornt): use aie-rt's transaction serializer instead to avoid these
+    // indiscrepancies between this file and aie-rt.
+    addr = ((col & 0xff) << colShift) | ((row & 0xff) << rowShift) |
+           (addr & 0xFFFFF);
     uint32_t value = 0;
     value |= bdId & 0xF;
     value |= (repeatCount & 0xFF) << 16;

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/controlcode_to_transaction.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/controlcode_to_transaction.mlir
@@ -100,7 +100,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       0x00000028
 // CHECK:       0x00000000
 // CHECK:       0x00000000
-// CHECK:       0x0001D21C
+// CHECK:       0x0601D21C
 // CHECK:       0x00000000
 // CHECK:       0x803F0002
 // CHECK:       0x00000018
@@ -127,7 +127,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       0x00000038
 // CHECK:       0x00000000
 // CHECK:       0x00000000
-// CHECK:       0x0001D214
+// CHECK:       0x0401D214
 // CHECK:       0x00000000
 // CHECK:       0x80FF000F
 // CHECK:       0x00000018


### PR DESCRIPTION
The address generation for the `PushToQueue` op is incorrect for `column != 0` and `row == 0` as the condition `col && row` is not true. There is not need for this condition and the base tile address can always be computed as `((col & 0xff) << colShift) | ((row & 0xff) << rowShift)`, see:  https://github.com/Xilinx/aie-rt/blob/3fdf8d8d9a7a2abcd8df76155f950680607eac8a/driver/src/common/xaie_helper.h#L159

Note that we don't see this issue in main right now and this is prefetching an issue that's occurring on 4x4.