### PR TITLE
[DistributeL1Allocations] Fix logic for conv and correctly propagate errors

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDistributeL1Allocations.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDistributeL1Allocations.cpp
@@ -57,7 +57,7 @@ MemRefType getDistributedType(memref::AllocOp alloc,
       // that if a subview has an offset which is not a constant and not a
       // thread id, it's not 'distributing'.
       Operation::operand_range offsets = subview.getOffsets();
-      int nIndVars {0};
+      int nIndVars{0};
       for (Value offset : offsets) {
         bool isConst = matchPattern(offset, m_Constant());
         bool isIndVar = llvm::is_contained(indVars, offset);
@@ -99,8 +99,6 @@ SmallVector<Value> substitute(Container toUpdate,
 /// smaller memory. This is ultimately needed because cores can't operate on
 /// one shared L1 memory.
 LogicalResult distributeLocalMemory(ModuleOp moduleOp) {
-
-
   FailureOr<DenseSet<Value>> maybeIndVars = getThreadIndVars(moduleOp);
   if (failed(maybeIndVars)) return failure();
   const DenseSet<Value> &indVars = maybeIndVars.value();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDistributeL1Allocations.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDistributeL1Allocations.cpp
@@ -101,7 +101,6 @@ SmallVector<Value> substitute(Container toUpdate,
 LogicalResult distributeLocalMemory(ModuleOp moduleOp) {
 
 
-  // llvm::errs() << "Module is \n\n" << moduleOp << "\n\n";
   FailureOr<DenseSet<Value>> maybeIndVars = getThreadIndVars(moduleOp);
   if (failed(maybeIndVars)) return failure();
   const DenseSet<Value> &indVars = maybeIndVars.value();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/distribute_l1_allocations.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/distribute_l1_allocations.mlir
@@ -92,14 +92,16 @@ func.func @non_distributing_subview(%index : index) {
 
 // -----
 
-// Example where the subview type is a complete view of the alloc: unchanged IR
+// Example where the subview type is a complete view of the alloc: unchanged IR.
 
 // CHECK-LABEL: @complete_view_subview
-// CHECK: %[[ALLOC:.+]] = memref.alloc() : memref<4xbf16, 2>
-// CHECK: scf.forall (%[[ARG0:.+]]) in (4) {
-// CHECK: %[[C0_BF16:.+]] = arith.constant
-// CHECK: %[[SUBVIEW:.+]] = memref.subview
-// CHECK-SAME: %[[ALLOC]][0] [4] [1] : memref<4xbf16, 2> to memref<4xbf16, 2>
+// CHECK-NEXT: memref.alloc
+// CHECK-NEXT: scf.forall
+// CHECK-NEXT:    arith.constant
+// CHECK-NEXT:    memref.subview
+// CHECK-NEXT:    linalg.fill
+// CHECK-NEXT: mapping = [#gpu.thread<x>]
+// CHECK-NEXT: return
 
 func.func @complete_view_subview() {
   %alloc = memref.alloc() : memref<4xbf16, 2>
@@ -110,7 +112,3 @@ func.func @complete_view_subview() {
   } {mapping = [#gpu.thread<x>]}
   return
 }
-
-
-
-

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/distribute_l1_allocations.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/distribute_l1_allocations.mlir
@@ -90,4 +90,27 @@ func.func @non_distributing_subview(%index : index) {
 }
 
 
+// -----
+
+// Example where the subview type is a complete view of the alloc: unchanged IR
+
+// CHECK-LABEL: @complete_view_subview
+// CHECK: %[[ALLOC:.+]] = memref.alloc() : memref<4xbf16, 2>
+// CHECK: scf.forall (%[[ARG0:.+]]) in (4) {
+// CHECK: %[[C0_BF16:.+]] = arith.constant
+// CHECK: %[[SUBVIEW:.+]] = memref.subview
+// CHECK-SAME: %[[ALLOC]][0] [4] [1] : memref<4xbf16, 2> to memref<4xbf16, 2>
+
+func.func @complete_view_subview() {
+  %alloc = memref.alloc() : memref<4xbf16, 2>
+  scf.forall (%arg0) in (4) {
+    %c0_bf16 = arith.constant 0.000000e+00 : bf16
+    %subview = memref.subview %alloc[0] [4] [1] : memref<4xbf16, 2> to memref<4xbf16, 2>
+    linalg.fill ins(%c0_bf16 : bf16) outs(%subview : memref<4xbf16, 2>)
+  } {mapping = [#gpu.thread<x>]}
+  return
+}
+
+
+
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/distribute_l1_allocations.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/distribute_l1_allocations.mlir
@@ -95,13 +95,13 @@ func.func @non_distributing_subview(%index : index) {
 // Example where the subview type is a complete view of the alloc: unchanged IR.
 
 // CHECK-LABEL: @complete_view_subview
-// CHECK-NEXT: memref.alloc
-// CHECK-NEXT: scf.forall
-// CHECK-NEXT:    arith.constant
-// CHECK-NEXT:    memref.subview
-// CHECK-NEXT:    linalg.fill
-// CHECK-NEXT: mapping = [#gpu.thread<x>]
-// CHECK-NEXT: return
+// CHECK-NEXT:   memref.alloc() : memref<4xbf16, 2>
+// CHECK-NEXT:   scf.forall
+// CHECK-NEXT:      arith.constant
+// CHECK-NEXT:      memref.subview
+// CHECK-NEXT:      linalg.fill
+// CHECK-NEXT:   mapping = [#gpu.thread<x>]
+// CHECK-NEXT:   return
 
 func.func @complete_view_subview() {
   %alloc = memref.alloc() : memref<4xbf16, 2>


### PR DESCRIPTION
There was what appeared to be a false positive error in CI. i.e. an op emits an error somewhere, but the end-to-end numerical test still passes:

![{7764D0FA-0A0A-44F6-8247-7F984C7C5EC5}](https://github.com/user-attachments/assets/af8471de-700d-420a-97e7-1afb07a56f5d)

I tracked this down and fixed it. 2 things: 

1) error wasn't being propagated all the way to the signal pass failure
2) the convolution tiling doesn't use the approach where L1 result tensors are initially of shape <4x4x*> and then distributed to tensors of shape <1x1x*> but the logic wasn't quite right and it was trying to do this for conv. 

1 was hiding 2, causing default behaviour which just happened to work. 