### PR TITLE
[Experiment, do not review] Function outlining tracker

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -1103,13 +1103,22 @@ class Tests:
             (4096, 512, 512, False),
             (4096, 512, 512, True),
         ]:
-            self.register(
+            for add_outlining in [True, False]:
+                suffix = ""
+                additional_flags = []
+                if add_outlining:
+                    suffix = "outlining"
+                    additional_flags = ["--iree-amdaie-enable-function-outlining"]
+
+                self.register(
                 VanillaMatmul(
                     M,
                     N,
                     K,
                     "bf16",
                     "f32",
+                    aie_compilation_flags=additional_flags,
+                    name_suffix=suffix,
                     additional_labels=["Performance"],
                     use_ukernel=use_ukernel,
                     n_repeats=2,

--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -1111,19 +1111,19 @@ class Tests:
                     additional_flags = ["--iree-amdaie-enable-function-outlining"]
 
                 self.register(
-                VanillaMatmul(
-                    M,
-                    N,
-                    K,
-                    "bf16",
-                    "f32",
-                    aie_compilation_flags=additional_flags,
-                    name_suffix=suffix,
-                    additional_labels=["Performance"],
-                    use_ukernel=use_ukernel,
-                    n_repeats=2,
+                    VanillaMatmul(
+                        M,
+                        N,
+                        K,
+                        "bf16",
+                        "f32",
+                        aie_compilation_flags=additional_flags,
+                        name_suffix=suffix,
+                        additional_labels=["Performance"],
+                        use_ukernel=use_ukernel,
+                        n_repeats=2,
+                    )
                 )
-            )
 
         # MultipleDispatches tests:
         for name in ["two_matmul_switching", "matmul_f32_8_8_4", "matmul_f32_8_4_8"]:


### PR DESCRIPTION
In this run, I've run all benchmark tests with and without function outlining. 

As previous observations suggests, outlining dramatically effects the non-ukernel flow, but has no effect on the ukernel flow. 

![{D56EDFAA-BC49-4771-A6C1-B4BF6F1C599B}](https://github.com/user-attachments/assets/defbddb1-7276-4038-afe7-97d07128477f)

