### PR TITLE
[Test] run.py make file dir absolute

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -1202,7 +1202,7 @@ def all_tests(
         raise RuntimeError(f"'{iree_install_dir}' is not a directory.")
     iree_compile_exe = find_executable(iree_install_dir, "iree-compile")
     iree_run_exe = find_executable(iree_install_dir, "iree-run-module")
-    file_dir = Path(__file__).parent
+    file_dir = Path(os.path.dirname(os.path.abspath(__file__)))
 
     config = TestConfig(
         output_dir,


### PR DESCRIPTION
Changes the file dir variable to contain an absolute path. The relative path gives me issue locally, for example: `build_tools/ci/cpu_comparison/matmul_template/matmul_truncf_MxK_KxN.mlir` not found when I run with:

```
python3 build_tools/ci/cpu_comparison/run.py \
  test_aie_vs_cpu \
  ../iree-build/ \
  path-to-llvm-aie \
  --vitis-dir path-to-vitis \
  --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS \
  --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS \
  --tests "All" \
  --target_device "npu1_4col" \
  -v
```