### PR TITLE
[CI] Refactor tests with chess 

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -160,36 +160,6 @@ jobs:
           echo "XRT_LITE_N_CORE_ROWS=$(python build_tools/ci/amdxdna_driver_utils/amdxdna_ioctl.py --num-rows)" >> $GITHUB_ENV
           echo "XRT_LITE_N_CORE_COLS=$(python build_tools/ci/amdxdna_driver_utils/amdxdna_ioctl.py --num-cols)" >> $GITHUB_ENV
 
-      - name : E2E comparison of AIE to llvm-cpu
-        run: |
-          source .venv/bin/activate
-          python build_tools/ci/cpu_comparison/run.py \
-            test_aie_vs_cpu \
-            $PWD/iree-install \
-            $PWD/llvm-aie \
-            --vitis-dir /opt/Xilinx/Vitis/2024.2 \
-            --target_device "npu1_4col" \
-            --reset-npu-between-runs -v \
-            --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS \
-            --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS
-
-      - name : Performance benchmarks
-
-        run: |
-          source .venv/bin/activate
-          python build_tools/ci/cpu_comparison/run.py \
-            test_aie_vs_cpu \
-            $PWD/iree-install \
-            $PWD/llvm-aie \
-            --vitis-dir /opt/Xilinx/Vitis/2024.2 \
-            --target_device "npu1_4col" \
-            --reset-npu-between-runs -v \
-            --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS \
-            --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS \
-            --tests=Performance > performance.log
-
-          python build_tools/ci/cpu_comparison/performance_summarizer.py \
-            performance.log
 
       - name: E2E correctness matmul test
         run: |
@@ -201,8 +171,40 @@ jobs:
           bash build_tools/ci/run_matmul_test.sh \
             test_matmuls \
             iree-install \
-            $PWD/llvm-aie \
-            /opt/Xilinx/Vitis/2024.2
+            $PWD/llvm-aie
+
+
+      - name : E2E comparison of AIE to llvm-cpu
+        run: |
+          sudo prlimit -lunlimited --pid $$
+          source .venv/bin/activate
+          python build_tools/ci/cpu_comparison/run.py \
+            test_aie_vs_cpu \
+            $PWD/iree-install \
+            --peano_dir=$PWD/llvm-aie \
+            --vitis_dir=/opt/Xilinx/Vitis/2024.2 \
+            --target_device="npu1_4col" \
+            --reset_npu_between_runs -v \
+            --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS \
+            --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS
+
+      - name : Performance benchmarks
+        run: |
+          source .venv/bin/activate
+          python build_tools/ci/cpu_comparison/run.py \
+            test_aie_vs_cpu \
+            $PWD/iree-install \
+            --peano_dir=$PWD/llvm-aie \
+            --vitis_dir=/opt/Xilinx/Vitis/2024.2 \
+            --target_device="npu1_4col" \
+            --reset_npu_between_runs -v \
+            --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS \
+            --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS \
+            --tests=Performance > performance.log
+
+          python build_tools/ci/cpu_comparison/performance_summarizer.py \
+            performance.log
+
 
       - name: XRT-LITE tests
         run: |
@@ -264,11 +266,9 @@ jobs:
           python build_tools/ci/cpu_comparison/run.py \
             test_aie_vs_cpu \
             $PWD/iree-install \
-            /opt/xilinx/Vitis/2024.2 \
-            --vitis-dir /opt/xilinx/Vitis/2024.2 \
-            --target_device "npu4" \
-            --use_chess "1" \
-            --reset-npu-between-runs \
+            --vitis_dir=/opt/xilinx/Vitis/2024.2 \
+            --target_device="npu4" \
+            --reset_npu_between_runs \
             --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS \
             --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS \
             -v

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -190,6 +190,6 @@ jobs:
           python build_tools/ci/cpu_comparison/run.py \
             /c/test_aie_vs_cpu \
             $PWD/iree-install \
-            $PWD/llvm-aie -v \
-            --target_device "npu1_4col" \
-            --device-hal=xrt
+            --peano_dir=$PWD/llvm-aie -v \
+            --target_device="npu1_4col" \
+            --device_hal=xrt

--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -103,7 +103,7 @@ class BaseTest(ABC):
             return False
 
         # If use_chess=1, and config has not provided a valid
-        # path to vitis, then don't run the test. The asymettry between 
+        # path to vitis, then don't run the test. The asymmetry between 
         # logic for peano and chess is because we don't expect everyone 
         # running this script to have chess (currently Windows CI for example
         # does not). 
@@ -1182,6 +1182,7 @@ class Tests:
                 )
             )
 
+        # ukernel test for AIR pad-pack pipeline
         self.register(
             Matmul(
                 256,
@@ -1217,6 +1218,7 @@ class Tests:
                 )
             )
 
+        # chess test
         self.register(
             Matmul(
                 32,
@@ -1230,6 +1232,7 @@ class Tests:
             )
         )
 
+        # chess test with ukernel
         self.register(
             Matmul(
                 64,

--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -102,15 +102,19 @@ class BaseTest(ABC):
         if config.target_device not in self.run_on_target:
             return False
 
+        # If use_chess=1, and config has not provided a valid
+        # path to vitis, then don't run the test. The asymettry between 
+        # logic for peano and chess is because we don't expect everyone 
+        # running this script to have chess (currently Windows CI for example
+        # does not). 
+        if self.use_chess and not config.vitis_dir:
+            return False
+
         # If use_chess=0, and config has not provided a valid
         # path to peano, then bail: a path to peano must be provided.
         if not self.use_chess and not config.peano_dir:
             raise RuntimeError("Peano path not provided, and use_chess=False")
 
-        # If use_chess=1, and config has not provided a valid
-        # path to vitis, then bail: a path to vitis must be provided.
-        if self.use_chess and not config.vitis_dir:
-            raise RuntimeError("Vitis path not provided, and use_chess=True")
 
         # Call into test-specific code to run the test.
         return self._execute(config)

--- a/build_tools/ci/run_all_runtime_tests.sh
+++ b/build_tools/ci/run_all_runtime_tests.sh
@@ -43,8 +43,7 @@ $this_dir/cpu_comparison/run.py \
 $this_dir/run_matmul_test.sh \
   $this_dir/test_matmuls \
   $IREE_INSTALL_DIR \
-  $PEANO_INSTALL_DIR \
-  $VITIS_DIR
+  $PEANO_INSTALL_DIR
 
 pytest -rv --capture=tee-sys $src_dir/tests \
   --peano-install-dir=$PEANO_INSTALL_DIR \


### PR DESCRIPTION
- Make flag usage consistent (use_this_format instead of this-format uniformly)
- Simplify run_matmul_tests.sh -- remove all peano/vitis/ukernel path testing, move all these tests to run.py 
- Make the use_chess flag test specific, rather that a global config flag 
- Change `VanillaMatmul` label to just `Matmul`