### PR TITLE
[SplitLogicalObjFifos] Generalize splitting analysis and enable pass in pipeline

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELogicalObjFifoSplittingUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELogicalObjFifoSplittingUtils.h
@@ -16,26 +16,20 @@ LogicalResult splitLogicalObjectFifoForElementwiseOp(
     IRRewriter &rewriter, SmallVector<AMDAIE::DmaCpyNdOp> &l2ToL1DmaOps,
     MLIRContext *context);
 
-/// Utility to get the split dimension and factor given a L2 objectFifo op.
-LogicalResult getSplitDimAndFactorFromObjFifo(
-    AMDAIE::LogicalObjectFifoFromMemrefOp op, int64_t &splitDim,
-    int64_t &splitFactor);
+/// Split a logical objectFifo on the provided split dimension with the
+/// specified splitting factor. If no split factor is provided, the logical
+/// objectFifo will be split on the size of the dimension being split.
+LogicalResult splitLogicalObjectFifo(
+    IRRewriter &rewriter, AMDAIE::LogicalObjectFifoFromMemrefOp op,
+    size_t splitDim = 0, std::optional<size_t> splitFactor = std::nullopt);
 
-/// Utility to get the split dimension and factor from a L3->L2 dma op.
-LogicalResult getSplitDimAndFactorFromDma(AMDAIE::DmaCpyNdOp op,
-                                          int64_t &splitDim,
-                                          int64_t &splitFactor,
-                                          int64_t &splitDimInL2Dma);
-
-/// Split L2 space input and output logical objectFifos.
-LogicalResult splitLogicalObjectFifo(IRRewriter &rewriter,
-                                     AMDAIE::LogicalObjectFifoFromMemrefOp op,
-                                     int64_t splitDim, int64_t splitFactor);
-
-/// Split DmaCpyNd ops between L2 and L3 memory spaces.
-LogicalResult splitDoublyStridedOp(IRRewriter &rewriter, AMDAIE::DmaCpyNdOp op,
-                                   int64_t splitDim, int64_t splitFactor,
-                                   int64_t splitDimInL2Dma);
+/// Split doubly strided operations on a source and target split dimension with
+/// the provided split factor. If no split factor is provided, the doubly
+/// strided operation will be split on the size of the dimension being split.
+LogicalResult splitDoublyStridedOp(
+    IRRewriter &rewriter, AMDAIE::DoublyStridedOpInterface op,
+    size_t sourceSplitDim = 0, size_t targetSplitDim = 0,
+    std::optional<size_t> splitFactor = std::nullopt);
 
 }  // namespace mlir::iree_compiler::AMDAIE
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIESplitLogicalObjFifos.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIESplitLogicalObjFifos.cpp
@@ -15,6 +15,138 @@ namespace mlir::iree_compiler::AMDAIE {
 
 namespace {
 
+/// Utility struct to represent DMA split information.
+struct DmaSplitInfo {
+  size_t sourceSplitDim{0};
+  size_t targetSplitDim{0};
+};
+
+using DmaObjFifoPairT =
+    std::pair<AMDAIE::DmaCpyNdOp, AMDAIE::LogicalObjectFifoFromMemrefOp>;
+
+/// Find the logical objectFifo and DMA source/target splitting dimensions for
+/// each DMA and objectFifo pair.
+///
+/// Each pair is handled in the following way:
+/// First, compute the objectFifo splitting dimension as the last non-unit shape
+/// dimension. Afterwards, depending on which logical objectFifo is being
+/// split on, find the outermost dimension in either the source or
+/// target access pattern that has:
+/// - stride == sizeAfterSplit
+/// - size != 1
+/// This is the splitting dimension to be used on the respective side of the DMA
+/// operation. Then, calculate the product size of that side of the DMA
+/// operation after the splitting dimension and use it to calculate the
+/// splitting dimension on the other side as the first dimension from the back
+/// that has product size larger than the other side's product size after
+/// splitting because that's the number of elements that should be
+/// produced/consumed on the respective sides before splitting.
+LogicalResult collectSplittingDims(
+    const SmallVector<DmaObjFifoPairT> &dmaObjFifoPairs,
+    DenseMap<AMDAIE::DmaCpyNdOp, DmaSplitInfo> &dmaSplitInfoMap,
+    DenseMap<AMDAIE::LogicalObjectFifoFromMemrefOp, size_t>
+        &objFifoSplitDimMap) {
+  for (auto [dmaOp, objFifo] : dmaObjFifoPairs) {
+    LLVM_DEBUG(llvm::dbgs() << "dmaOp: " << dmaOp << "\n");
+    LLVM_DEBUG(llvm::dbgs() << "objFifo: " << objFifo << "\n");
+    ArrayRef<int64_t> memrefShape = objFifo.getMemrefType().getShape();
+    if (llvm::any_of(memrefShape, [](int64_t size) {
+          return ShapedType::isDynamic(size);
+        })) {
+      return objFifo.emitOpError()
+             << "can't find a valid split dimension for dynamic sizes memref";
+    }
+    auto iter = std::find_if(memrefShape.begin(), memrefShape.end(),
+                             [](int64_t size) { return size > 1; });
+    size_t objFifoSplitDim = std::distance(memrefShape.begin(), iter);
+    // If all dimensions are unit (1), no splitting can be done, so continue to
+    // the next pair.
+    if (objFifoSplitDim >= memrefShape.size()) continue;
+    int64_t sizeAfterSplit =
+        std::accumulate(memrefShape.begin() + objFifoSplitDim + 1,
+                        memrefShape.end(), 1, std::multiplies<>());
+
+    size_t sourceSplitDim{0};
+    size_t targetSplitDim{0};
+    if (dmaOp.getTargetObjectFifo() == objFifo) {
+      std::optional<SmallVector<int64_t>> targetSizes =
+          getConstantIntValues(dmaOp.getTargetMixedSizes());
+      std::optional<SmallVector<int64_t>> targetStrides =
+          getConstantIntValues(dmaOp.getTargetMixedStrides());
+      std::optional<SmallVector<int64_t>> sourceSizes =
+          getConstantIntValues(dmaOp.getSourceMixedSizes());
+      if (!targetSizes.has_value() || !targetStrides.has_value() ||
+          !sourceSizes.has_value()) {
+        return dmaOp.emitOpError() << "has unsupported dynamic target strides "
+                                      "or sizes or source sizes";
+      }
+      for (auto iter : llvm::enumerate(
+               llvm::zip(targetSizes.value(), targetStrides.value()))) {
+        int64_t size = std::get<0>(iter.value());
+        int64_t stride = std::get<1>(iter.value());
+        if (stride == sizeAfterSplit && size != 1) {
+          targetSplitDim = iter.index();
+          break;
+        }
+      }
+      int64_t targetSizeAfterSplit =
+          std::accumulate(targetSizes.value().begin() + targetSplitDim + 1,
+                          targetSizes.value().end(), 1, std::multiplies<>());
+      SmallVector<int64_t> sourceProductSizes = sourceSizes.value();
+      std::partial_sum(sourceProductSizes.rbegin(), sourceProductSizes.rend(),
+                       sourceProductSizes.rbegin(), std::multiplies<int64_t>());
+      for (int idx = sourceProductSizes.size() - 1; idx > 0; idx--) {
+        if (sourceProductSizes[idx] > targetSizeAfterSplit) {
+          sourceSplitDim = idx;
+          break;
+        }
+      }
+    } else if (dmaOp.getSourceObjectFifo() == objFifo) {
+      // Find outermost dimension in the access pattern that has stride ==
+      // sizeAfterSplit and size != 1.
+      std::optional<SmallVector<int64_t>> sourceSizes =
+          getConstantIntValues(dmaOp.getSourceMixedSizes());
+      std::optional<SmallVector<int64_t>> sourceStrides =
+          getConstantIntValues(dmaOp.getSourceMixedStrides());
+      std::optional<SmallVector<int64_t>> targetSizes =
+          getConstantIntValues(dmaOp.getTargetMixedSizes());
+      if (!sourceSizes.has_value() || !sourceStrides.has_value() ||
+          !targetSizes.has_value()) {
+        return dmaOp.emitOpError() << "has unsupported dynamic source strides "
+                                      "or sizes or target sizes";
+      }
+      for (auto iter : llvm::enumerate(
+               llvm::zip(sourceSizes.value(), sourceStrides.value()))) {
+        int64_t size = std::get<0>(iter.value());
+        int64_t stride = std::get<1>(iter.value());
+        if (stride == sizeAfterSplit && size != 1) {
+          sourceSplitDim = iter.index();
+          break;
+        }
+      }
+      int64_t sourceRemainderSize =
+          std::accumulate(sourceSizes.value().begin() + sourceSplitDim + 1,
+                          sourceSizes.value().end(), 1, std::multiplies<>());
+      SmallVector<int64_t> targetProductSizes = targetSizes.value();
+      std::partial_sum(targetProductSizes.rbegin(), targetProductSizes.rend(),
+                       targetProductSizes.rbegin(), std::multiplies<int64_t>());
+      for (int idx = targetProductSizes.size() - 1; idx > 0; idx--) {
+        if (targetProductSizes[idx] > sourceRemainderSize) {
+          targetSplitDim = idx;
+          break;
+        }
+      }
+    }
+    LLVM_DEBUG(llvm::dbgs() << "sourceSplitDim: " << sourceSplitDim << "\n");
+    LLVM_DEBUG(llvm::dbgs() << "targetSplitDim: " << targetSplitDim << "\n");
+    LLVM_DEBUG(llvm::dbgs() << "objFifoSplitDim: " << objFifoSplitDim << "\n");
+    DmaSplitInfo dmaSplitInfo = {sourceSplitDim, targetSplitDim};
+    dmaSplitInfoMap[dmaOp] = std::move(dmaSplitInfo);
+    objFifoSplitDimMap[objFifo] = objFifoSplitDim;
+  }
+  return success();
+}
+
 class AMDAIESplitLogicalObjFifosPass
     : public impl::AMDAIESplitLogicalObjFifosBase<
           AMDAIESplitLogicalObjFifosPass> {
@@ -34,6 +166,7 @@ void AMDAIESplitLogicalObjFifosPass::runOnOperation() {
 
   // Walk and collect all dma ops between L3 and L2.
   SmallVector<AMDAIE::DmaCpyNdOp> l3L2DmaOps;
+  SmallVector<DmaObjFifoPairT> dmaObjFifoPairs;
   WalkResult res = moduleOp->walk([&](AMDAIE::DmaCpyNdOp op) {
     std::optional<uint8_t> sourceMemSpace = op.getSourceMemorySpaceAsUInt();
     std::optional<uint8_t> targetMemSpace = op.getTargetMemorySpaceAsUInt();
@@ -41,61 +174,43 @@ void AMDAIESplitLogicalObjFifosPass::runOnOperation() {
       op.emitOpError() << "expected a source and target memory space";
       return WalkResult::interrupt();
     }
-    if ((sourceMemSpace.value() == 1 && targetMemSpace.value() == 0) ||
-        (sourceMemSpace.value() == 0 && targetMemSpace.value() == 1)) {
-      l3L2DmaOps.push_back(op);
+    if (sourceMemSpace.value() == 1 && targetMemSpace.value() == 0) {
+      dmaObjFifoPairs.push_back({op, op.getSourceObjectFifo()});
+    } else if (sourceMemSpace.value() == 0 && targetMemSpace.value() == 1) {
+      dmaObjFifoPairs.push_back({op, op.getTargetObjectFifo()});
     }
     return WalkResult::advance();
   });
   if (res.wasInterrupted()) return signalPassFailure();
 
-  // Split the dma ops of L3->L2 / L2->L3.
-  for (AMDAIE::DmaCpyNdOp dmaOp : l3L2DmaOps) {
-    int64_t splitDim = -1;
-    int64_t splitFactor = -1;
-    int64_t splitDimInL2Dma = -1;
-    if (failed(getSplitDimAndFactorFromDma(dmaOp, splitDim, splitFactor,
-                                           splitDimInL2Dma))) {
-      LLVM_DEBUG(llvm::dbgs()
-                 << "Failed to get split dimension and factor from " << dmaOp
-                 << " \n");
-      return signalPassFailure();
-    }
+  // Collect the split dimensions for all DMA and ojectFifo pairs.
+  DenseMap<AMDAIE::DmaCpyNdOp, DmaSplitInfo> dmaSplitInfoMap;
+  DenseMap<AMDAIE::LogicalObjectFifoFromMemrefOp, size_t> objFifoSplitDimMap;
+  if (failed(collectSplittingDims(dmaObjFifoPairs, dmaSplitInfoMap,
+                                  objFifoSplitDimMap))) {
+    return signalPassFailure();
+  }
 
-    // No need to split with the following conditions.
-    if (splitDim < 0 || splitDimInL2Dma < 0 || splitFactor <= 1) continue;
-
-    if (failed(splitDoublyStridedOp(rewriter, dmaOp, splitDim, splitFactor,
-                                    splitDimInL2Dma))) {
+  /// Split the DMA and objectFifo ops based on the calcuated splitting
+  /// dimensions.
+  for (auto &&[dmaOp, dmaSplitInfo] : dmaSplitInfoMap) {
+    auto stridedOp =
+        cast<AMDAIE::DoublyStridedOpInterface>(dmaOp.getOperation());
+    if (failed(splitDoublyStridedOp(rewriter, stridedOp,
+                                    dmaSplitInfo.sourceSplitDim,
+                                    dmaSplitInfo.targetSplitDim))) {
       LLVM_DEBUG(llvm::dbgs()
-                 << "Failed to perform splitting of doubly strided op");
+                 << "Failed to perform splitting of the DMA op: " << dmaOp);
       return signalPassFailure();
     }
   }
-
-  // Walk and split input and output objectfifos in L2 memory space.
-  res = moduleOp->walk([&](AMDAIE::LogicalObjectFifoFromMemrefOp op) {
-    if (op.getMemorySpaceAsUInt() != 1) return WalkResult::skip();
-    int64_t splitDim = -1;
-    int64_t splitFactor = -1;
-    if (failed(getSplitDimAndFactorFromObjFifo(op, splitDim, splitFactor))) {
-      LLVM_DEBUG(llvm::dbgs()
-                 << "Failed to get split dimension and factor from " << op
-                 << " \n");
-      return WalkResult::interrupt();
-    }
-
-    // No need to split with the following conditions.
-    if (splitDim < 0 || splitFactor <= 1) return WalkResult::skip();
-
-    if (failed(splitLogicalObjectFifo(rewriter, op, splitDim, splitFactor))) {
+  for (auto &&[objFifo, splitDim] : objFifoSplitDimMap) {
+    if (failed(splitLogicalObjectFifo(rewriter, objFifo, splitDim))) {
       LLVM_DEBUG(llvm::dbgs()
                  << "Failed to perform splitting of objectFifo op");
-      return WalkResult::interrupt();
+      return signalPassFailure();
     }
-    return WalkResult::advance();
-  });
-  if (res.wasInterrupted()) return signalPassFailure();
+  }
 }
 
 }  // namespace

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -602,6 +602,9 @@ void addAMDAIEObjectFifoLoweringPasses(
   passManager.addPass(createCanonicalizerPass());
 
   passManager.addPass(createAMDAIESplitLogicalObjFifosForConnectionReusePass());
+  // Currently, SplitLogicalObjFifos pass only works for matmul-like ops.
+  if (useTilePipeline == TilePassPipeline::PackPeelPipeline)
+    passManager.addPass(createAMDAIESplitLogicalObjFifosPass());
   passManager.addPass(createCSEPass());
   passManager.addPass(createCanonicalizerPass());
 


### PR DESCRIPTION
Generalizes the logical objectFifo splitting analysis to find a source, target and objectFifo splitting dimensions. Enables to pass to demonstrate correct functionality on all tests and especially batch matmul.