### PR TITLE
Add direction to physport to separate source and destination ports

### DIFF
--- a/runtime/src/iree-amd-aie/aie_runtime/iree_aie_router.cc
+++ b/runtime/src/iree-amd-aie/aie_runtime/iree_aie_router.cc
@@ -486,7 +486,8 @@ std::optional<std::map<PathEndPoint, SwitchSettings>> Router::findPaths(
           auto curr = endPoint;
           // trace backwards until a vertex already processed is reached
           while (!processed.count(curr)) {
-            auto &sb = impl->graph[std::make_pair(preds[curr].tileLoc, curr.tileLoc)];
+            auto &sb =
+                impl->graph[std::make_pair(preds[curr].tileLoc, curr.tileLoc)];
             size_t i =
                 std::distance(sb.srcPorts.begin(),
                               std::find(sb.srcPorts.begin(), sb.srcPorts.end(),
@@ -870,7 +871,8 @@ FailureOr<std::tuple<MasterSetsT, SlaveAMSelsT>> emitPacketRoutingConfiguration(
   MasterSetsT mastersets;
   for (const auto &[physPort, ports] : masterAMSels) {
     for (Port port : ports) {
-      mastersets[PhysPort{physPort.first, port}].push_back(physPort.second);
+      mastersets[PhysPort{physPort.first, port, PhysPort::Direction::DST}]
+          .push_back(physPort.second);
     }
   }
 
@@ -882,6 +884,14 @@ FailureOr<std::tuple<MasterSetsT, SlaveAMSelsT>> emitPacketRoutingConfiguration(
 /// ============================= BEGIN ==================================
 /// ================== stringification utils =============================
 /// ======================================================================
+
+std::string to_string(const PhysPort::Direction &direction) {
+  switch (direction) {
+    STRINGIFY_ENUM_CASE(PhysPort::Direction::SRC)
+    STRINGIFY_ENUM_CASE(PhysPort::Direction::DST)
+  }
+  llvm::report_fatal_error("Unhandled PhysPortDirection case");
+}
 
 std::string to_string(const SwitchSetting &setting) {
   return "SwitchSetting(" +
@@ -913,7 +923,7 @@ std::string to_string(const SwitchSettings &settings) {
 STRINGIFY_2TUPLE_STRUCT(Port, bundle, channel)
 STRINGIFY_2TUPLE_STRUCT(Connect, src, dst)
 STRINGIFY_2TUPLE_STRUCT(PathEndPoint, tileLoc, port)
-STRINGIFY_2TUPLE_STRUCT(PhysPort, tileLoc, port)
+STRINGIFY_3TUPLE_STRUCT(PhysPort, tileLoc, port, direction)
 STRINGIFY_2TUPLE_STRUCT(PhysPortAndID, physPort, id)
 
 BOTH_OSTREAM_OPS_FORALL_ROUTER_TYPES(OSTREAM_OP_DEFN, BOTH_OSTREAM_OP)

--- a/runtime/src/iree-amd-aie/aie_runtime/iree_aie_router.h
+++ b/runtime/src/iree-amd-aie/aie_runtime/iree_aie_router.h
@@ -23,7 +23,8 @@ struct Port {
 
   // mlir-air legacy
   Port() : bundle(), channel() {}
-  Port(StrmSwPortType b, int c) : bundle(b), channel(c) {}
+  Port(StrmSwPortType b, int c)
+      : bundle(b), channel(c) {}
   typedef std::tuple<StrmSwPortType, int> TupleType;
   Port(TupleType t) : Port(std::get<0>(t), std::get<1>(t)) {}
   operator TupleType() const { return {bundle, channel}; }
@@ -109,12 +110,16 @@ bool existsPathToDest(const SwitchSettings &settings, TileLoc currTile,
                       int finalDestChannel);
 
 struct PhysPort {
+  enum Direction { SRC, DST };
   TileLoc tileLoc;
   Port port;
-  PhysPort(TileLoc t, Port p) : tileLoc(t), port(p) {}
-  using TupleType = std::tuple<TileLoc, Port>;
-  PhysPort(TupleType t) : PhysPort(std::get<0>(t), std::get<1>(t)) {}
-  operator TupleType() const { return {tileLoc, port}; }
+  Direction direction;
+  PhysPort(TileLoc t, Port p, Direction direction)
+      : tileLoc(t), port(p), direction(direction) {}
+  using TupleType = std::tuple<TileLoc, Port, Direction>;
+  PhysPort(TupleType t)
+      : PhysPort(std::get<0>(t), std::get<1>(t), std::get<2>(t)) {}
+  operator TupleType() const { return {tileLoc, port, direction}; }
   TUPLE_LIKE_STRUCT_RELATIONAL_OPS(PhysPort)
 };
 
@@ -166,7 +171,9 @@ TO_STRINGS(TO_STRING_DECL)
   _(OSTREAM_OP_, mlir::iree_compiler::AMDAIE::Port)          \
   _(OSTREAM_OP_, mlir::iree_compiler::AMDAIE::SwitchSetting) \
   _(OSTREAM_OP_, mlir::iree_compiler::AMDAIE::PhysPort)      \
-  _(OSTREAM_OP_, mlir::iree_compiler::AMDAIE::PhysPortAndID)
+  _(OSTREAM_OP_, mlir::iree_compiler::AMDAIE::PhysPortAndID) \
+  _(OSTREAM_OP_, mlir::iree_compiler::AMDAIE::PhysPort::Direction)
+
 
 BOTH_OSTREAM_OPS_FORALL_ROUTER_TYPES(OSTREAM_OP_DECL, BOTH_OSTREAM_OP)
 

--- a/runtime/src/iree-amd-aie/aie_runtime/test/test_amsel_generator.cc
+++ b/runtime/src/iree-amd-aie/aie_runtime/test/test_amsel_generator.cc
@@ -16,8 +16,9 @@ std::pair<uint8_t, uint8_t> amsel(uint8_t a, uint8_t msel) {
 TEST(AMSelGeneratorTest, TileNotInitialized) {
   AMSelGenerator generator;
   TileLoc tileLoc(0, 1);
-  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}}, 0};
-  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}}, 0};
+  PhysPortAndID src1 = {
+      {{0, 1}, {StrmSwPortType::SOUTH, 0}, PhysPort::Direction::SRC}, 0};
+  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}, PhysPort::Direction::DST}, 0};
   EXPECT_TRUE(failed(generator.addConnection(tileLoc, src1, {dst1})));
 }
 
@@ -25,8 +26,8 @@ TEST(AMSelGeneratorTest, NoArbitersNoMSels) {
   AMSelGenerator generator;
   TileLoc tileLoc(0, 1);
   generator.initTileIfNotExists(tileLoc, 0, 0);
-  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}}, 0};
-  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}}, 0};
+  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}, PhysPort::Direction::SRC}, 0};
+  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}, PhysPort::Direction::DST}, 0};
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src1, {dst1})));
   EXPECT_TRUE(failed(generator.solve()));
 }
@@ -35,8 +36,8 @@ TEST(AMSelGeneratorTest, NoArbiters) {
   AMSelGenerator generator;
   TileLoc tileLoc(0, 1);
   generator.initTileIfNotExists(tileLoc, 0, 4);
-  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}}, 0};
-  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}}, 0};
+  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}, PhysPort::Direction::SRC}, 0};
+  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}, PhysPort::Direction::DST}, 0};
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src1, {dst1})));
   EXPECT_TRUE(failed(generator.solve()));
 }
@@ -45,8 +46,8 @@ TEST(AMSelGeneratorTest, NoMSels) {
   AMSelGenerator generator;
   TileLoc tileLoc(0, 1);
   generator.initTileIfNotExists(tileLoc, 6, 0);
-  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}}, 0};
-  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}}, 0};
+  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}, PhysPort::Direction::SRC}, 0};
+  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}, PhysPort::Direction::DST}, 0};
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src1, {dst1})));
   EXPECT_TRUE(failed(generator.solve()));
 }
@@ -55,19 +56,19 @@ TEST(AMSelGeneratorTest, SingleSrcSingleDst) {
   AMSelGenerator generator;
   TileLoc tileLoc(0, 1);
   generator.initTileIfNotExists(tileLoc, 6, 4);
-  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}}, 0};
-  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}}, 0};
+  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}, PhysPort::Direction::SRC}, 0};
+  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}, PhysPort::Direction::DST}, 0};
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src1, {dst1})));
   EXPECT_TRUE(succeeded(generator.solve()));
   EXPECT_EQ(generator.getAMSel(tileLoc, src1).value(), amsel(0, 0));
   for (int i = 1; i < 6; i++) {
-    PhysPortAndID src2 = {{{0, 1}, {StrmSwPortType::SOUTH, i}}, i};
-    PhysPortAndID dst2 = {{{0, 1}, {StrmSwPortType::NORTH, i}}, i};
+    PhysPortAndID src2 = {{{0, 1}, {StrmSwPortType::SOUTH, i}, PhysPort::Direction::SRC}, i};
+    PhysPortAndID dst2 = {{{0, 1}, {StrmSwPortType::NORTH, i}, PhysPort::Direction::DST}, i};
     EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src2, {dst2})));
   }
   EXPECT_TRUE(succeeded(generator.solve()));
   for (int i = 0; i < 6; i++) {
-    PhysPortAndID src = {{{0, 1}, {StrmSwPortType::SOUTH, i}}, i};
+    PhysPortAndID src = {{{0, 1}, {StrmSwPortType::SOUTH, i}, PhysPort::Direction::SRC}, i};
     EXPECT_EQ(generator.getAMSel(tileLoc, src).value(), amsel(i, 0));
   }
 }
@@ -79,13 +80,13 @@ TEST(AMSelGeneratorTest, SingleSrcSingleDstSamePorts) {
   TileLoc tileLoc(0, 1);
   generator.initTileIfNotExists(tileLoc, 6, 4);
   for (int i = 0; i < 6; i++) {
-    PhysPortAndID src = {{{0, 1}, {StrmSwPortType::SOUTH, 0}}, i};
-    PhysPortAndID dst = {{{0, 1}, {StrmSwPortType::NORTH, 0}}, i};
+    PhysPortAndID src = {{{0, 1}, {StrmSwPortType::SOUTH, 0}, PhysPort::Direction::SRC}, i};
+    PhysPortAndID dst = {{{0, 1}, {StrmSwPortType::NORTH, 0}, PhysPort::Direction::DST}, i};
     EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src, {dst})));
   }
   EXPECT_TRUE(succeeded(generator.solve()));
   for (int i = 0; i < 6; i++) {
-    PhysPortAndID src = {{{0, 1}, {StrmSwPortType::SOUTH, 0}}, i};
+    PhysPortAndID src = {{{0, 1}, {StrmSwPortType::SOUTH, 0}, PhysPort::Direction::SRC}, i};
     EXPECT_EQ(generator.getAMSel(tileLoc, src).value(), amsel(0, 0));
   }
 }
@@ -94,15 +95,15 @@ TEST(AMSelGeneratorTest, SingleSrcMultiDst) {
   AMSelGenerator generator;
   TileLoc tileLoc(0, 1);
   generator.initTileIfNotExists(tileLoc, 6, 4);
-  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}}, 0};
-  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}}, 0};
-  PhysPortAndID dst2 = {{{0, 1}, {StrmSwPortType::EAST, 0}}, 0};
+  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}, PhysPort::Direction::SRC}, 0};
+  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}, PhysPort::Direction::DST}, 0};
+  PhysPortAndID dst2 = {{{0, 1}, {StrmSwPortType::EAST, 0}, PhysPort::Direction::DST}, 0};
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src1, {dst1, dst2})));
   EXPECT_TRUE(succeeded(generator.solve()));
   EXPECT_EQ(generator.getAMSel(tileLoc, src1).value(), amsel(0, 0));
-  PhysPortAndID src2 = {{{0, 1}, {StrmSwPortType::SOUTH, 1}}, 1};
-  PhysPortAndID dst3 = {{{0, 1}, {StrmSwPortType::NORTH, 1}}, 1};
-  PhysPortAndID dst4 = {{{0, 1}, {StrmSwPortType::EAST, 1}}, 1};
+  PhysPortAndID src2 = {{{0, 1}, {StrmSwPortType::SOUTH, 1}, PhysPort::Direction::SRC}, 1};
+  PhysPortAndID dst3 = {{{0, 1}, {StrmSwPortType::NORTH, 1}, PhysPort::Direction::DST}, 1};
+  PhysPortAndID dst4 = {{{0, 1}, {StrmSwPortType::EAST, 1}, PhysPort::Direction::DST}, 1};
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src2, {dst3, dst4})));
   EXPECT_TRUE(succeeded(generator.solve()));
   EXPECT_EQ(generator.getAMSel(tileLoc, src2).value(), amsel(1, 0));
@@ -113,19 +114,19 @@ TEST(AMSelGeneratorTest, MultiSrcSingleDst) {
   TileLoc tileLoc(0, 1);
   generator.initTileIfNotExists(tileLoc, 6, 4);
   // Reuse msels for multiple sources.
-  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}}, 0};
-  PhysPortAndID src2 = {{{0, 1}, {StrmSwPortType::SOUTH, 1}}, 0};
-  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}}, 0};
+  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}, PhysPort::Direction::SRC}, 0};
+  PhysPortAndID src2 = {{{0, 1}, {StrmSwPortType::SOUTH, 1}, PhysPort::Direction::SRC}, 0};
+  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}, PhysPort::Direction::DST}, 0};
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src1, {dst1})));
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src2, {dst1})));
   EXPECT_TRUE(succeeded(generator.solve()));
   EXPECT_EQ(generator.getAMSel(tileLoc, src1).value(), amsel(0, 0));
   EXPECT_EQ(generator.getAMSel(tileLoc, src2).value(), amsel(0, 0));
-  PhysPortAndID src3 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}}, 1};
-  PhysPortAndID src4 = {{{0, 1}, {StrmSwPortType::EAST, 0}}, 1};
-  PhysPortAndID src5 = {{{0, 1}, {StrmSwPortType::EAST, 1}}, 1};
-  PhysPortAndID src6 = {{{0, 1}, {StrmSwPortType::EAST, 2}}, 1};
-  PhysPortAndID dst2 = {{{0, 1}, {StrmSwPortType::NORTH, 1}}, 0};
+  PhysPortAndID src3 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}, PhysPort::Direction::SRC}, 1};
+  PhysPortAndID src4 = {{{0, 1}, {StrmSwPortType::EAST, 0}, PhysPort::Direction::SRC}, 1};
+  PhysPortAndID src5 = {{{0, 1}, {StrmSwPortType::EAST, 1}, PhysPort::Direction::SRC}, 1};
+  PhysPortAndID src6 = {{{0, 1}, {StrmSwPortType::EAST, 2}, PhysPort::Direction::SRC}, 1};
+  PhysPortAndID dst2 = {{{0, 1}, {StrmSwPortType::NORTH, 1}, PhysPort::Direction::DST}, 0};
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src3, {dst2})));
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src4, {dst2})));
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src5, {dst2})));
@@ -143,23 +144,23 @@ TEST(AMSelGeneratorTest, MultiSrcMultiDst) {
   AMSelGenerator generator;
   TileLoc tileLoc(0, 1);
   generator.initTileIfNotExists(tileLoc, 6, 4);
-  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}}, 0};
-  PhysPortAndID src2 = {{{0, 1}, {StrmSwPortType::SOUTH, 1}}, 1};
-  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}}, 0};
-  PhysPortAndID dst2 = {{{0, 1}, {StrmSwPortType::NORTH, 1}}, 0};
-  PhysPortAndID dst3 = {{{0, 1}, {StrmSwPortType::NORTH, 1}}, 1};
-  PhysPortAndID dst4 = {{{0, 1}, {StrmSwPortType::NORTH, 2}}, 1};
+  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}, PhysPort::Direction::SRC}, 0};
+  PhysPortAndID src2 = {{{0, 1}, {StrmSwPortType::SOUTH, 1}, PhysPort::Direction::SRC}, 1};
+  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}, PhysPort::Direction::DST}, 0};
+  PhysPortAndID dst2 = {{{0, 1}, {StrmSwPortType::NORTH, 1}, PhysPort::Direction::DST}, 0};
+  PhysPortAndID dst3 = {{{0, 1}, {StrmSwPortType::NORTH, 1}, PhysPort::Direction::DST}, 1};
+  PhysPortAndID dst4 = {{{0, 1}, {StrmSwPortType::NORTH, 2}, PhysPort::Direction::DST}, 1};
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src1, {dst1, dst2})));
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src2, {dst3, dst4})));
   EXPECT_TRUE(succeeded(generator.solve()));
   EXPECT_EQ(generator.getAMSel(tileLoc, src1).value(), amsel(0, 0));
   EXPECT_EQ(generator.getAMSel(tileLoc, src2).value(), amsel(0, 1));
-  PhysPortAndID src3 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}}, 2};
-  PhysPortAndID src4 = {{{0, 1}, {StrmSwPortType::SOUTH, 1}}, 3};
-  PhysPortAndID dst5 = {{{0, 1}, {StrmSwPortType::WEST, 0}}, 2};
-  PhysPortAndID dst6 = {{{0, 1}, {StrmSwPortType::WEST, 1}}, 2};
-  PhysPortAndID dst7 = {{{0, 1}, {StrmSwPortType::WEST, 0}}, 3};
-  PhysPortAndID dst8 = {{{0, 1}, {StrmSwPortType::WEST, 2}}, 3};
+  PhysPortAndID src3 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}, PhysPort::Direction::SRC}, 2};
+  PhysPortAndID src4 = {{{0, 1}, {StrmSwPortType::SOUTH, 1}, PhysPort::Direction::SRC}, 3};
+  PhysPortAndID dst5 = {{{0, 1}, {StrmSwPortType::WEST, 0}, PhysPort::Direction::DST}, 2};
+  PhysPortAndID dst6 = {{{0, 1}, {StrmSwPortType::WEST, 1}, PhysPort::Direction::DST}, 2};
+  PhysPortAndID dst7 = {{{0, 1}, {StrmSwPortType::WEST, 0}, PhysPort::Direction::DST}, 3};
+  PhysPortAndID dst8 = {{{0, 1}, {StrmSwPortType::WEST, 2}, PhysPort::Direction::DST}, 3};
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src3, {dst5, dst6})));
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src4, {dst7, dst8})));
   EXPECT_TRUE(succeeded(generator.solve()));
@@ -173,14 +174,14 @@ TEST(AMSelGeneratorTest, ReuseArbiters) {
   AMSelGenerator generator;
   TileLoc tileLoc(0, 1);
   generator.initTileIfNotExists(tileLoc, 1, 4);
-  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}}, 0};
-  PhysPortAndID src2 = {{{0, 1}, {StrmSwPortType::SOUTH, 1}}, 1};
-  PhysPortAndID src3 = {{{0, 1}, {StrmSwPortType::SOUTH, 2}}, 2};
-  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}}, 0};
-  PhysPortAndID dst2 = {{{0, 1}, {StrmSwPortType::NORTH, 1}}, 0};
-  PhysPortAndID dst3 = {{{0, 1}, {StrmSwPortType::NORTH, 2}}, 1};
-  PhysPortAndID dst4 = {{{0, 1}, {StrmSwPortType::NORTH, 3}}, 1};
-  PhysPortAndID dst5 = {{{0, 1}, {StrmSwPortType::NORTH, 4}}, 2};
+  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}, PhysPort::Direction::SRC}, 0};
+  PhysPortAndID src2 = {{{0, 1}, {StrmSwPortType::SOUTH, 1}, PhysPort::Direction::SRC}, 1};
+  PhysPortAndID src3 = {{{0, 1}, {StrmSwPortType::SOUTH, 2}, PhysPort::Direction::SRC}, 2};
+  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}, PhysPort::Direction::DST}, 0};
+  PhysPortAndID dst2 = {{{0, 1}, {StrmSwPortType::NORTH, 1}, PhysPort::Direction::DST}, 0};
+  PhysPortAndID dst3 = {{{0, 1}, {StrmSwPortType::NORTH, 2}, PhysPort::Direction::DST}, 1};
+  PhysPortAndID dst4 = {{{0, 1}, {StrmSwPortType::NORTH, 3}, PhysPort::Direction::DST}, 1};
+  PhysPortAndID dst5 = {{{0, 1}, {StrmSwPortType::NORTH, 4}, PhysPort::Direction::DST}, 2};
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src1, {dst1, dst2})));
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src2, {dst3, dst4})));
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src3, {dst5})));
@@ -194,16 +195,31 @@ TEST(AMSelGeneratorTest, ReuseArbitersFailure) {
   AMSelGenerator generator;
   TileLoc tileLoc(0, 1);
   generator.initTileIfNotExists(tileLoc, 1, 2);
-  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}}, 0};
-  PhysPortAndID src2 = {{{0, 1}, {StrmSwPortType::SOUTH, 1}}, 1};
-  PhysPortAndID src3 = {{{0, 1}, {StrmSwPortType::SOUTH, 2}}, 2};
-  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}}, 0};
-  PhysPortAndID dst2 = {{{0, 1}, {StrmSwPortType::NORTH, 1}}, 1};
-  PhysPortAndID dst3 = {{{0, 1}, {StrmSwPortType::NORTH, 2}}, 2};
+  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::SOUTH, 0}, PhysPort::Direction::SRC}, 0};
+  PhysPortAndID src2 = {{{0, 1}, {StrmSwPortType::SOUTH, 1}, PhysPort::Direction::SRC}, 1};
+  PhysPortAndID src3 = {{{0, 1}, {StrmSwPortType::SOUTH, 2}, PhysPort::Direction::SRC}, 2};
+  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}, PhysPort::Direction::DST}, 0};
+  PhysPortAndID dst2 = {{{0, 1}, {StrmSwPortType::NORTH, 1}, PhysPort::Direction::DST}, 1};
+  PhysPortAndID dst3 = {{{0, 1}, {StrmSwPortType::NORTH, 2}, PhysPort::Direction::DST}, 2};
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src1, {dst1})));
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src2, {dst2})));
   EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src3, {dst3})));
   EXPECT_TRUE(failed(generator.solve()));
+}
+
+TEST(AMSelGeneratorTest, DifferentDirections) {
+  AMSelGenerator generator;
+  TileLoc tileLoc(0, 1);
+  generator.initTileIfNotExists(tileLoc, 6, 4);
+  PhysPortAndID src1 = {{{0, 1}, {StrmSwPortType::DMA, 0}, PhysPort::Direction::SRC}, 0};
+  PhysPortAndID dst1 = {{{0, 1}, {StrmSwPortType::NORTH, 0}, PhysPort::Direction::DST}, 0};
+  PhysPortAndID src2 = {{{0, 1}, {StrmSwPortType::NORTH, 0}, PhysPort::Direction::SRC}, 0};
+  PhysPortAndID dst2 = {{{0, 1}, {StrmSwPortType::DMA, 0}, PhysPort::Direction::DST}, 0};
+  EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src1, {dst1})));
+  EXPECT_TRUE(succeeded(generator.addConnection(tileLoc, src2, {dst2})));
+  EXPECT_TRUE(succeeded(generator.solve()));
+  EXPECT_EQ(generator.getAMSel(tileLoc, src1).value(), amsel(0, 0));
+  EXPECT_EQ(generator.getAMSel(tileLoc, src2).value(), amsel(1, 0));
 }
 
 }  // namespace mlir::iree_compiler::AMDAIE


### PR DESCRIPTION
One of two PRs needed to fix the packet routing issue for 4x4: https://github.com/nod-ai/iree-amd-aie/pull/920

Adds a direction field to the `PhysPort` struct to distinguish between ports on the source and destination side of a switch box. This avoids that they are being recognized as the same port while assigning amsel values. See the testcase being added.