### PR TITLE
[NFC] Remove terminal printing during IREE build

### DIFF
--- a/runtime/src/iree-amd-aie/driver/xrt-lite/cts/CMakeLists.txt
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/cts/CMakeLists.txt
@@ -55,7 +55,6 @@ iree_bytecode_module(
     --iree-amd-aie-vitis-install-dir=${VITIS_DIR}
     --iree-amd-aie-enable-chess=$<BOOL:${USE_CHESS}>
     --iree-amdaie-device-hal=xrt-lite
-    --iree-amd-aie-show-invoked-commands
     --iree-hal-memoization=false
     --iree-hal-indirect-command-buffers=false
   PUBLIC


### PR DESCRIPTION
We have a test which runs iree-compile at IREE compile time, and it prints alot of stuff to terminal because it has a specific flag enabled. This PR lowers the verbosity by removing the flag 

i.e. when you run `ninja` or `make` in the terminal you see: 

```
Run:  ... cts/module_amdaie_fb_amdaie_pdi_fb/core_1_4.elf -v

Succeeded in totalTime 0.000000e+00 [s]. Exit code=0
clang version 19.0.0 (https://github.com/Xilinx/llvm-aie 562ccea2c9b29e68756e2ae5fe3c22e764e40f20)
Target: aie2-none-unknown-elf
Thread model: posix
... ule_amdaie_fb_amdaie_pdi_fb/core_1_4.elf

```
now removed. 