### PR TITLE
[NFC] Improve directory structure for test generated files

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -279,10 +279,6 @@ LogicalResult AIETargetBackend::serializeExecutable(
     IREE::HAL::ExecutableVariantOp variantOp, OpBuilder &executableBuilder) {
   ModuleOp moduleOp = variantOp.getInnerModule();
 
-  std::string basename =
-      llvm::join_items("_", serOptions.dumpBaseName, variantOp.getName());
-  sanitizeForBootgen(basename);
-
   FailureOr<SmallString<128>> maybeWorkDir;
   // If a path for intermediates has been specified, assume it is common for
   // all executables compiling in parallel, and so create an
@@ -290,7 +286,6 @@ LogicalResult AIETargetBackend::serializeExecutable(
   // separate.
   if (!serOptions.dumpIntermediatesPath.empty()) {
     SmallString<128> workDir{serOptions.dumpIntermediatesPath};
-    llvm::sys::path::append(workDir, basename);
     if (auto ecode = llvm::sys::fs::create_directories(workDir)) {
       return moduleOp.emitError()
              << "failed to create working directory " << workDir


### PR DESCRIPTION
Before, certain files were overwritten between tests, if the dispatch operation was the same. Now, no files are overwritten. Each test now has a subdirectory containing all its files (and no further subdirectories). i.e. now it is something like

```
output_dir
├── conv_2d_nhwc_hwcf_2_14_bf16_f32
│   ├── aie_cdo_elfs.bin
│   ├── aie_cdo_enable.bin
│   ├── aie_cdo_init.bin
...
│   ├── module_f_conv_dispatch_0_amdaie_pdi_fb_benchmark.mlir
│   └── module_f_conv_dispatch_0.mlir
├── conv_2d_nhwc_hwcf_2_14_i32_i32
│   ├── aie_cdo_elfs.bin
...  ...
└── depthwise_conv_2d_nhwc_hwc_1_14_i32_i32
    ├── aie_cdo_elfs.bin
    ├── aie_cdo_enable.bin
    ├── aie_cdo_init.bin
    ├── configured_module_f_conv_dispatch_0.mlir
    ├── core_0_2.elf
     ...
    └── module_f_conv_dispatch_0.mlir
```

Motivation: I'm running a set of tests and comparing the outputs, but the outputs are overwriting each other so I need to run each test separately, choosing a different output dir each time 