### PR TITLE
[AssignTiles] Generalize pass to use LogicalObjFifoInterface and CopyOpInterface

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.h
@@ -8,6 +8,7 @@
 #define IREE_COMPILER_AMDAIE_LOGICALOBJFIFOOPINTERFACE_H_
 
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/CopyOpInterface.h"
 
 namespace mlir::iree_compiler::AMDAIE {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.td
@@ -97,7 +97,20 @@ def LogicalObjFifoOpInterface : OpInterface<"LogicalObjFifoOpInterface"> {
       /*defaultImplementation=*/[{
         return $_op.getTiles();
       }]
-    >
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
+        A utility to replace this logical objectFifo operation with a new one with new tiles. 
+      }],
+      /*retTy=*/"::llvm::FailureOr<::mlir::iree_compiler::AMDAIE::LogicalObjFifoOpInterface>",
+      /*methodName=*/"replaceWithNewTiles",
+      /*args=*/(ins "::mlir::RewriterBase &":$rewriter,
+                    "::mlir::ValueRange":$tiles),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return $_op.replaceWithNewTiles(rewriter, tiles);
+      }]
+    >,
   ];
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.cpp
@@ -613,6 +613,14 @@ LogicalResult LogicalObjectFifoFromBuffersOp::verify() {
   return success();
 }
 
+FailureOr<LogicalObjFifoOpInterface>
+LogicalObjectFifoFromBuffersOp::replaceWithNewTiles(
+    ::mlir::RewriterBase &rewriter, ::mlir::ValueRange tiles) {
+  // NOTE(jornt): This can potentially be implemented by updating the buffer's
+  // tiles.
+  return (*this).emitOpError() << "doesn't support tile replacement";
+}
+
 //===----------------------------------------------------------------------===//
 // AMDAIE_LogicalObjectFifoFromMemrefOp
 //===----------------------------------------------------------------------===//
@@ -665,6 +673,17 @@ LogicalResult LogicalObjectFifoFromMemrefOp::canonicalize(
   return success();
 }
 
+FailureOr<LogicalObjFifoOpInterface>
+LogicalObjectFifoFromMemrefOp::replaceWithNewTiles(
+    ::mlir::RewriterBase &rewriter, ::mlir::ValueRange tiles) {
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(getOperation());
+  auto newOp =
+      rewriter.replaceOpWithNewOp<AMDAIE::LogicalObjectFifoFromMemrefOp>(
+          *this, getType(), getMemref(), tiles);
+  return cast<LogicalObjFifoOpInterface>(newOp.getOperation());
+}
+
 LogicalResult LogicalObjectFifoFromMemrefOp::verify() {
   // Check whether the tile arguments are all of type AMDAIE::TileOp
   if (llvm::all_of(getTiles(), [](Value result) {
@@ -673,6 +692,21 @@ LogicalResult LogicalObjectFifoFromMemrefOp::verify() {
     return success();
   }
   return failure();
+}
+
+//===----------------------------------------------------------------------===//
+// AMDAIE_LogicalObjectFifoPlaceholderOp
+//===----------------------------------------------------------------------===//
+
+FailureOr<LogicalObjFifoOpInterface>
+LogicalObjectFifoPlaceholderOp::replaceWithNewTiles(
+    ::mlir::RewriterBase &rewriter, ::mlir::ValueRange tiles) {
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(getOperation());
+  auto newOp =
+      rewriter.replaceOpWithNewOp<AMDAIE::LogicalObjectFifoPlaceholderOp>(
+          *this, getType(), tiles);
+  return cast<LogicalObjFifoOpInterface>(newOp.getOperation());
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -1143,7 +1143,8 @@ def AMDAIE_LogicalObjectFifoAcquire:
 
 def AMDAIE_LogicalObjectFifoFromBuffersOp
     : AMDAIE_Op<"logicalobjectfifo.from_buffers", 
-    [LogicalObjFifoOpInterface, Pure, AttrSizedOperandSegments]> {
+    [DeclareOpInterfaceMethods<LogicalObjFifoOpInterface, ["replaceWithNewTiles"]>,
+     Pure, AttrSizedOperandSegments]> {
   let summary = "Create a logical objectFifo from a set of buffers";
   let description = [{
     Creates a logical objectFifo which encapsulates a set of memref `buffers`.
@@ -1220,7 +1221,8 @@ def AMDAIE_LogicalObjectFifoFromBuffersOp
 
 def AMDAIE_LogicalObjectFifoFromMemrefOp
     : AMDAIE_Op<"logicalobjectfifo.from_memref", 
-    [LogicalObjFifoOpInterface, Pure]> {
+    [DeclareOpInterfaceMethods<LogicalObjFifoOpInterface, ["replaceWithNewTiles"]>, 
+     Pure]> {
   let summary = "Create a logical objectFifo from a memref";
   let description = [{
     Creates a logical objectFifo which encapsulates a memref. The logical objectFifo
@@ -1294,7 +1296,8 @@ def AMDAIE_LogicalObjectFifoFromMemrefOp
 
 def AMDAIE_LogicalObjectFifoPlaceholderOp: 
     AMDAIE_Op<"logicalobjectfifo.placeholder", [
-      LogicalObjFifoOpInterface, Pure]> {
+      DeclareOpInterfaceMethods<LogicalObjFifoOpInterface, ["replaceWithNewTiles"]>,
+      Pure]> {
   let summary = "A placeholder for a logical objectFifo.";
   let description = [{
     Represents a placeholder for a logical objectFifo. The actual logical

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignTiles.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignTiles.cpp
@@ -317,7 +317,7 @@ LogicalResult assignNonLocalTiles(RewriterBase &rewriter, Operation *op,
                                   const AMDAIEDeviceModel &deviceModel) {
   MLIRContext *context = rewriter.getContext();
   if (failed(clearNonLocalTiles(rewriter, op)))
-    return op->emitOpError() << "failed to clear non-local tile assigments";
+    return op->emitOpError() << "failed to clear non-local tile assignments";
 
   // Find and fill the tile candidates.
   RewritePatternSet fillTilePatterns(context);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_tiles.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_tiles.mlir
@@ -16,7 +16,7 @@ module {
 
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 // expected-error @+2 {{non-local tile assignment failed}}
-// expected-error @+1 {{failed to clear non-local tile assigments}}
+// expected-error @+1 {{failed to clear non-local tile assignments}}
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @logicalobjectfifo_from_buffers_error() {
     %c0 = arith.constant 0 : index

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_tiles.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_tiles.mlir
@@ -14,6 +14,41 @@ module {
 
 // -----
 
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+// expected-error @+2 {{non-local tile assignment failed}}
+// expected-error @+1 {{failed to clear non-local tile assigments}}
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @logicalobjectfifo_from_buffers_error() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %alloc_1 = memref.alloc() : memref<2048xi32, 2>
+    amdaie.workgroup {
+      %tile_0_1 = amdaie.tile(%c0, %c1)
+      %tile_0_2 = amdaie.tile(%c0, %c2)
+      %buffer = amdaie.buffer(%tile_0_1) : memref<2048xi32, 1>
+      %lock = amdaie.lock(%tile_0_1(0), 2)
+      %lock_1 = amdaie.lock(%tile_0_1(1), 0)
+      // expected-error @+2 {{could not replace its tiles}}
+      // expected-error @+1 {{op doesn't support tile replacement}}
+      %0 = amdaie.logicalobjectfifo.from_buffers({%buffer}, {%lock}, {%lock_1}) : memref<2048xi32, 1> -> !amdaie.logicalobjectfifo<memref<2048xi32, 1>>
+      %1 = amdaie.logicalobjectfifo.from_memref %alloc_1, {} : memref<2048xi32, 2> -> !amdaie.logicalobjectfifo<memref<2048xi32, 2>>
+      %2 = amdaie.dma_cpy_nd(%1[] [] [], %0[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32, 2>>, !amdaie.logicalobjectfifo<memref<2048xi32, 1>>)
+      %3 = amdaie.core(%tile_0_2, in : [], out : []) {
+        %4 = amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<2048xi32, 2>> -> memref<2048xi32, 2>
+        amdaie.end
+      }
+      amdaie.controlcode {
+        amdaie.end
+      }
+    }
+    memref.dealloc %alloc_1 : memref<2048xi32, 2>
+    return
+  }
+}
+
+// -----
+
 // Test assignment of L1 objFifos based on the cores where they are used.
 // CHECK-LABEL: @assign_local_tiles
 // CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
@@ -239,6 +274,42 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       }
     }
     memref.dealloc %alloc : memref<2048xi32>
+    memref.dealloc %alloc_1 : memref<2048xi32, 2>
+    return
+  }
+}
+
+// -----
+
+// Test assignment of L3 placeholder objFifos based on L1 assignments.
+// CHECK-LABEL: @assign_placeholder_l3_l1_tiles
+// CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG:   %[[C2:.*]] = arith.constant 2 : index
+// CHECK-DAG:   %[[ALLOC_1:.*]] = memref.alloc() : memref<2048xi32, 2>
+// CHECK:       amdaie.workgroup
+// CHECK-DAG:     %[[TILE_0_0:.*]] = amdaie.tile(%[[C0]], %[[C0]])
+// CHECK-DAG:     %[[TILE_0_2:.*]] = amdaie.tile(%[[C0]], %[[C2]])
+// CHECK-DAG:     amdaie.logicalobjectfifo.placeholder{%[[TILE_0_0]]}
+// CHECK-DAG:     amdaie.logicalobjectfifo.from_memref %[[ALLOC_1]], {%[[TILE_0_2]]}
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @assign_placeholder_l3_l1_tiles() {
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : index
+    %alloc_1 = memref.alloc() : memref<2048xi32, 2>
+    amdaie.workgroup {
+      %tile_0_2 = amdaie.tile(%c0, %c2)
+      %0 = amdaie.logicalobjectfifo.placeholder{} : !amdaie.logicalobjectfifo<memref<2048xi32>>
+      %1 = amdaie.logicalobjectfifo.from_memref %alloc_1, {} : memref<2048xi32, 2> -> !amdaie.logicalobjectfifo<memref<2048xi32, 2>>
+      %2 = amdaie.dma_cpy_nd(%1[] [] [], %0[] [] []) : (!amdaie.logicalobjectfifo<memref<2048xi32, 2>>, !amdaie.logicalobjectfifo<memref<2048xi32>>)
+      %3 = amdaie.core(%tile_0_2, in : [], out : []) {
+        %4 = amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<2048xi32, 2>> -> memref<2048xi32, 2>
+        amdaie.end
+      }
+      amdaie.controlcode {
+        amdaie.end
+      }
+    }
     memref.dealloc %alloc_1 : memref<2048xi32, 2>
     return
   }


### PR DESCRIPTION
Generalize `AMDAIEAssignTiles` to use `LogicalObjFifoInterface` and `CopyOpInterface` where possible. This allows this pass to be moved around more within the pass pipeline.