### PR TITLE
[CI] don't disable threading in compiler

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -696,7 +696,6 @@ def generate_aie_vmfb(
         "--iree-scheduling-optimize-bindings=false",
         "--iree-hal-memoization=false",
         "--iree-hal-indirect-command-buffers=false",
-        f"--mlir-disable-threading",
         "--mlir-elide-resource-strings-if-larger=10",
     ]
 


### PR DESCRIPTION
I think we should be testing we threading on, so that if we do introduce something which doesn't work with multiple threads we'll know about it immediately. 