### PR TITLE
Changes needed to enable outlining by default 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELinalgFunctionOutlining.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELinalgFunctionOutlining.cpp
@@ -50,7 +50,7 @@ Type getTypeWithoutLayout(Type type) {
 static FailureOr<func::FuncOp> outline(IRRewriter &rewriter, ModuleOp moduleOp,
                                        linalg::LinalgOp computeOp,
                                        const std::string &funcName) {
-  //  // Form outlined FunctionType.
+  // Form outlined FunctionType.
   SmallVector<Type> inputTypes;
   inputTypes.reserve(computeOp->getOperands().size());
   for (const auto &operand : computeOp->getOperands()) {
@@ -64,7 +64,7 @@ static FailureOr<func::FuncOp> outline(IRRewriter &rewriter, ModuleOp moduleOp,
   auto funcType =
       FunctionType::get(rewriter.getContext(), inputTypes, /*outputTypes=*/{});
 
-  // Form outlined FuncSignature
+  // Form outlined FuncSignature.
   rewriter.setInsertionPointToStart(moduleOp.getBody());
   auto func =
       rewriter.create<func::FuncOp>(moduleOp.getLoc(), funcName, funcType);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELinalgFunctionOutlining.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELinalgFunctionOutlining.cpp
@@ -4,11 +4,11 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree-amd-aie/IR/AMDAIEOps.h"
 #include "iree-amd-aie/Transforms/AMDAIEUtils.h"
 #include "iree-amd-aie/Transforms/Passes.h"
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVMPass.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Linalg/Transforms/Hoisting.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
@@ -20,31 +20,49 @@ namespace mlir::iree_compiler::AMDAIE {
 
 namespace {
 
-/// Utility to check if the linalg op is a known op we know we want to be able
-/// to outline.
-static bool mustOutline(linalg::LinalgOp linalgOp) {
-  return isMatmul(linalgOp) || isElementwise(linalgOp);
+/// Return true if the strides of `memrefType` are contiguous.
+bool isContiguousMemRef(MemRefType memrefType) {
+  ArrayRef<int64_t> shape = memrefType.getShape();
+  SmallVector<int64_t, 4> strides;
+  int64_t offset;
+  if (failed(getStridesAndOffset(memrefType, strides, offset))) return false;
+  int64_t expectedStride = 1;
+  for (int i = shape.size() - 1; i >= 0; --i) {
+    if (shape[i] == ShapedType::kDynamic) return false;
+    if (strides[i] != expectedStride) return false;
+    expectedStride *= shape[i];
+  }
+  return true;
 }
 
-/// Utility to check if the linalg op is a known op we know should not be
-/// outlined.
-static bool mustNotOutline(linalg::LinalgOp linalgOp) {
-  return isa<linalg::CopyOp, linalg::FillOp>(linalgOp);
+/// If `type` is a contiguous memref, return an equivalent memref without any
+/// layout attribute. Otherwise, return nullptr.
+Type getIdentityLayoutType(Type type) {
+  auto memRefType = dyn_cast<MemRefType>(type);
+  if (!memRefType) return {};
+  if (!isContiguousMemRef(memRefType)) return {};
+  return MemRefType::get(memRefType.getShape(), memRefType.getElementType(),
+                         MemRefLayoutAttrInterface{},
+                         memRefType.getMemorySpace());
 }
 
 /// Utility to outline the linalg compute op.
-static FailureOr<func::FuncOp> outlinedToAFunction(
-    IRRewriter &rewriter, ModuleOp moduleOp, linalg::LinalgOp computeOp,
-    std::string outlineFuncName) {
-  if (auto outlinedFuncOp = dyn_cast_if_present<func::FuncOp>(
-          moduleOp.lookupSymbol(outlineFuncName))) {
-    return outlinedFuncOp;
-  }
-
+static FailureOr<func::FuncOp> outline(IRRewriter &rewriter, ModuleOp moduleOp,
+                                       linalg::LinalgOp computeOp,
+                                       const std::string &outlineFuncName) {
   // Form outlined FunctionType.
   SmallVector<Type> inputTypes = llvm::map_to_vector(
-      computeOp.getDpsInputs(), [](Value v) { return v.getType(); });
-  for (Value val : computeOp.getDpsInits()) inputTypes.push_back(val.getType());
+      computeOp.getDpsInputs(),
+      [&](Value v) { return getIdentityLayoutType(v.getType()); });
+
+  for (Value val : computeOp.getDpsInits())
+    inputTypes.push_back(getIdentityLayoutType(val.getType()));
+
+  // If any of the input types is not set, return failure.
+  if (llvm::any_of(inputTypes, [](Type t) { return !t; }))
+    return computeOp.emitOpError(
+        "has inputs with types that aren't compatible with outlining");
+
   auto outlinedFuncType =
       FunctionType::get(rewriter.getContext(), inputTypes, /*outputTypes=*/{});
 
@@ -78,16 +96,76 @@ static FailureOr<func::FuncOp> outlinedToAFunction(
   return outlinedFunc;
 }
 
+/// Utility to check if the linalg op is one we know should not be outlined.
+static bool mustNotOutline(linalg::LinalgOp linalgOp) {
+  return isa<linalg::CopyOp, linalg::FillOp>(linalgOp);
+  // TODO(newling) not all remaining ops should be outlined, not even all
+  // remaining matmuls: below some threshold on size (m*n*k) it's not worth
+  // outlining (function call overhead).
+};
+
 class AMDAIELinalgFunctionOutliningPass
     : public impl::AMDAIELinalgFunctionOutliningBase<
           AMDAIELinalgFunctionOutliningPass> {
  public:
   AMDAIELinalgFunctionOutliningPass() = default;
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<AMDAIEDialect, linalg::LinalgDialect>();
+    registry.insert<linalg::LinalgDialect>();
   }
 
   void runOnOperation() override;
+
+ private:
+  // Used for unique-ifing the outlined function names.
+  unsigned outlineCounter = 0;
+
+  DenseMap<Operation *, func::FuncOp> computeOpToOutlinedFuncMap;
+
+  static std::string getSpecializedName(linalg::LinalgOp computeOp) {
+    // Will result in a function name like `generic_matmul_2_outlined`:
+    if (isMatmul(computeOp)) return "_matmul_";
+    // Will result in a function name like `generic_elementwise_2_outlined`:
+    if (isElementwise(computeOp)) return "_elementwise_";
+    // Will result in a function name like `generic_2_outlined`:
+    return "_";
+  }
+
+  std::string generateFuncName(linalg::LinalgOp computeOp) {
+    std::string name = computeOp->getName().stripDialect().str() +
+                       getSpecializedName(computeOp) +
+                       std::to_string(outlineCounter) + "_outlined";
+    ++outlineCounter;
+    return name;
+  }
+
+  FailureOr<func::FuncOp> retrieveOrCreate(IRRewriter &rewriter,
+                                           ModuleOp moduleOp,
+                                           linalg::LinalgOp computeOp) {
+    // Check if the compute op is equivalent to a previously outlined compute
+    // op. If it is, retrieve and return the function generated for the previous
+    // compute op.
+    for (auto &[op, funcOp] : computeOpToOutlinedFuncMap) {
+      if (OperationEquivalence::isEquivalentTo(
+              computeOp.getOperation(), op,
+              OperationEquivalence::ignoreValueEquivalence, /*flags=*/nullptr,
+              OperationEquivalence::IgnoreLocations)) {
+        return funcOp;
+      }
+    }
+
+    std::string outlineFuncName = generateFuncName(computeOp);
+    while (moduleOp.lookupSymbol(outlineFuncName)) {
+      outlineFuncName = generateFuncName(computeOp);
+    }
+
+    FailureOr<func::FuncOp> maybeFuncOp =
+        outline(rewriter, moduleOp, computeOp, outlineFuncName);
+
+    if (succeeded(maybeFuncOp))
+      computeOpToOutlinedFuncMap[computeOp] = maybeFuncOp.value();
+
+    return maybeFuncOp;
+  }
 };
 
 void AMDAIELinalgFunctionOutliningPass::runOnOperation() {
@@ -95,58 +173,37 @@ void AMDAIELinalgFunctionOutliningPass::runOnOperation() {
   MLIRContext *context = &getContext();
   IRRewriter rewriter(context);
 
-  unsigned uniqueOutlinedMatmul = 0;
-  unsigned uniqueOutlinedElementwise = 0;
-  DenseMap<Operation *, std::string> computeOpToOutlinedFuncMap;
   SmallVector<Operation *> toBeErased;
-  moduleOp.walk([&](linalg::LinalgOp computeOp) {
-    if (mustNotOutline(computeOp)) {
-      return WalkResult::skip();
-    } else if (!mustOutline(computeOp)) {
-      computeOp->emitOpError() << "unsupported linalg op for outlining";
-      return WalkResult::interrupt();
-    }
-    // Form outlined function name for matmul/elementwise compute ops.
-    std::string outlineFuncName = "";
-    // Check if the compute op is equivalent to a previously outlined compute
-    // op. If yes, we replace the `outlineFuncName` of the current compute op to
-    // be same as the previous equivalent outlined compute op in order to lookup
-    // the Symbol table.
-    for (auto &[op, funcName] : computeOpToOutlinedFuncMap) {
-      if (OperationEquivalence::isEquivalentTo(
-              computeOp.getOperation(), op,
-              OperationEquivalence::ignoreValueEquivalence, /*flags=*/nullptr,
-              OperationEquivalence::IgnoreLocations)) {
-        outlineFuncName = funcName;
-        break;
+  WalkResult walkResult = moduleOp.walk([&](linalg::LinalgOp computeOp) {
+    if (mustNotOutline(computeOp)) return WalkResult::skip();
+
+    FailureOr<func::FuncOp> maybeFuncOp =
+        retrieveOrCreate(rewriter, moduleOp, computeOp);
+    if (failed(maybeFuncOp)) return WalkResult::interrupt();
+    func::FuncOp outlinedFuncOp = maybeFuncOp.value();
+
+    // Create a call into the outlined function. The operands of the compute op
+    // might need to be cast to a different type to match the outlined function.
+    {
+      SmallVector<Value> castOperands;
+      castOperands.reserve(computeOp->getOperands().size());
+      rewriter.setInsertionPoint(computeOp);
+      Location loc = computeOp.getLoc();
+      for (auto iter : llvm::enumerate(computeOp->getOperands())) {
+        Type type = outlinedFuncOp.getArgumentTypes()[iter.index()];
+        Value cast =
+            rewriter.createOrFold<memref::CastOp>(loc, type, iter.value());
+        castOperands.push_back(cast);
       }
-    }
-    if (outlineFuncName == "") {
-      std::string computeName = "";
-      if (isMatmul(computeOp)) {
-        computeName = "_matmul_" + std::to_string(uniqueOutlinedMatmul++);
-      } else if (isElementwise(computeOp)) {
-        computeName =
-            "_elementwise_" + std::to_string(uniqueOutlinedElementwise++);
-      } else {
-        return WalkResult::skip();
-      }
-      outlineFuncName =
-          computeOp->getName().stripDialect().str() + computeName + "_outlined";
-      computeOpToOutlinedFuncMap[computeOp] = outlineFuncName;
+      rewriter.create<func::CallOp>(loc, outlinedFuncOp, castOperands);
     }
 
-    FailureOr<func::FuncOp> outlinedFuncOp =
-        outlinedToAFunction(rewriter, moduleOp, computeOp, outlineFuncName);
-    if (failed(outlinedFuncOp)) return WalkResult::interrupt();
-    rewriter.setInsertionPoint(computeOp);
-    rewriter.create<func::CallOp>(computeOp.getLoc(), *outlinedFuncOp,
-                                  computeOp->getOperands());
     // We cannot immediately erase the compute op because it'd be used for
     // equivalence check.
     toBeErased.push_back(computeOp);
     return WalkResult::advance();
   });
+  if (walkResult.wasInterrupted()) return signalPassFailure();
   for (Operation *op : toBeErased) {
     op->dropAllUses();
     rewriter.eraseOp(op);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/linalg_function_outlining.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/linalg_function_outlining.mlir
@@ -252,13 +252,15 @@ func.func @supported_linalg_op(%A: memref<4x8xbf16, strided<[8,1], offset:?>>, %
 
 // -----
 
-// Test illustrating the error message when a linalg.generic operation has an
-// operand that is not contiguous. This is currently unsupported.
+// Test illustrating the that when a linalg.generic operation has an
+// operand that is not contiguous, it is not outlined.
+
+// CHECK-COUNT-1: func.func
+// CHECK-NOT:     func.func
 func.func @unsupported_linalg_op(%A: memref<4x8xbf16, strided<[9,1]>>, %B: memref<bf16>) {
   %c2 = arith.constant 2 : index
   %tile = amdaie.tile(%c2, %c2)
   %1 = amdaie.core(%tile, in : [], out : []) {
-    // expected-error@+1 {{'linalg.generic' op has an operand of type 'memref<4x8xbf16, strided<[9, 1]>>' that isn't compatible with outlining.}}
     linalg.generic {
       indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                        affine_map<(d0, d1) -> ()>],


### PR DESCRIPTION
Before this PR, batch matmul and convolution didn't behave as expected. 

batch matmul: an error was emitted but not propagated to signal a pass failure, so the pass quietly continued

convolution: at the point of function outlining the convolution has already been decomposed into a rank-3 matmul. So it was being outlined as a matmul. Which is fine, except the generic being outlined was

```
 linalg.generic {indexing_maps = [#map2, #map3, #map4], 
     iterator_types = ["parallel", "parallel", "reduction"]} 
     ins(%subview_20, %subview_18 : memref<4x8xbf16, strided<[8, 1], offset: ?>, 2 : i32>, 
                                    memref<8x4xbf16, strided<[4, 1], offset: ?>, 2 : i32>) ... 
```

which has layouts on the memrefs. Outlining this without adjusting the types in the pass results in the error

```
 error: 'llvm.call' op 'generic_matmul_0_outlined' does not reference a valid LLVM function
 ```
 
This comes from the outlined function with signature  
 ```
 func.func private @generic_matmul_0_outlined(
   %arg0: memref<4x8xi8, strided<[8, 1], offset: ?>>, 
   %arg1: memref<8x8xi8, strided<[8, 1], offset: ?>>, 
   %arg2: memref<4x8xi32, strided<[8, 1]>>) 
   attributes {llvm.bareptr = true} 
 ```
 
 trying to lower through the above function through  `convert-func-to-llvm` results in the above error. 
 
 
 This PR does the following: The pass now checks if the strides on the memref are contiguous, and if they are creates a signature with memrefs without layouts. At the call site, it does a memref cast. I have confirmed that this works end-to-end for convolution (correct numerics). I guess an alternative would be just not outline in the case where the operation being outlined has operands with layouts. 
 
 