### PR TITLE
[CanonicalizeDoublyStridedOp] Add support for unit dimension folding with offsets

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeDoublyStridedOp.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeDoublyStridedOp.cpp
@@ -115,7 +115,7 @@ struct FoldDmaOpSingleDims
   }
 };
 
-/// Fold unit dimensions within a strided access pattern.
+/// Fold unit dimensions (size == 1) with within a strided access pattern.
 struct FoldDmaOpUnitDims
     : public OpInterfaceRewritePattern<AMDAIE::DoublyStridedOpInterface> {
   using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
@@ -132,10 +132,10 @@ struct FoldDmaOpUnitDims
     SmallVector<OpFoldResult> newSourceOffsets, newSourceSizes,
         newSourceStrides, newTargetOffsets, newTargetSizes, newTargetStrides;
     LogicalResult sourceRes =
-        foldUnitDims(sourceOffsets, sourceSizes, sourceStrides,
+        foldUnitDims(op.getContext(), sourceOffsets, sourceSizes, sourceStrides,
                      newSourceOffsets, newSourceSizes, newSourceStrides);
     LogicalResult targetRes =
-        foldUnitDims(targetOffsets, targetSizes, targetStrides,
+        foldUnitDims(op.getContext(), targetOffsets, targetSizes, targetStrides,
                      newTargetOffsets, newTargetSizes, newTargetStrides);
     if (failed(sourceRes) && failed(targetRes)) {
       return failure();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaUtils.h
@@ -153,8 +153,33 @@ LogicalResult foldSingleDim(SmallVector<OpFoldResult> &offsets,
                             SmallVector<OpFoldResult> &strides);
 
 /// Fold unit dimensions within a strided access pattern. Returns `success` if
-/// folding took place.
-LogicalResult foldUnitDims(const SmallVector<OpFoldResult> &offsets,
+/// folding took place. There are two cases being handled here:
+/// 1. If a dimension has `size == 1` and `offset == 0`, the dimension can be
+/// folded entirely.
+/// 2. If a dimension has `size == 1` and `offset != 0`, it can be folded into
+/// another dimension with the same stride if that exists.
+///
+/// Example for case 1:
+///
+/// offsets: [0, 0, 0], sizes: [32, 1, 8], strides: [32, 1024, 1]
+///
+/// will be transformed into:
+///
+/// offsets: [0, 0], sizes: [32, 8], strides: [32, 1]
+/// 
+/// Example for case 2:
+///
+/// offsets: [1, 0, 1, 0], sizes: [1, 32, 1, 8], strides: [1024, 32, 1024, 1]
+///
+/// will be transformed into:
+///
+/// offsets: [2, 0, 0], sizes: [1, 32, 8], strides: [1024, 32, 1]
+///
+/// Note that the dimensions are merged into the outermost one. Heuristically,
+/// this works out best with other strided access pattern transformations, but
+/// could be made an option in the future.
+LogicalResult foldUnitDims(MLIRContext *ctx,
+                           const SmallVector<OpFoldResult> &offsets,
                            const SmallVector<OpFoldResult> &strides,
                            const SmallVector<OpFoldResult> &sizes,
                            SmallVector<OpFoldResult> &newOffsets,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
@@ -226,7 +226,8 @@ void AIEDeviceBuilder::foldDims(const SmallVector<OpFoldResult> &offsets,
   SmallVector<OpFoldResult> tmpOffsets;
   SmallVector<OpFoldResult> tmpSizes;
   SmallVector<OpFoldResult> tmpStrides;
-  (void)foldUnitDims(offsets, sizes, strides, tmpOffsets, tmpSizes, tmpStrides);
+  (void)foldUnitDims(rewriter.getContext(), offsets, sizes, strides, tmpOffsets,
+                     tmpSizes, tmpStrides);
   (void)foldLinearDims(rewriter.getContext(), tmpOffsets, tmpSizes, tmpStrides,
                        newOffsets, newSizes, newStrides);
   (void)foldSingleDim(newOffsets, newSizes, newStrides);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIEDmaUtilsTest.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIEDmaUtilsTest.cpp
@@ -271,9 +271,9 @@ TEST_F(AccessPatternCombinationTest, FailCombineAccessPatterns) {
                              {128, 1}, {32, 0}, {96, 64}, {128, 1}, 4, false);
 }
 
-class FoldLinearDimsTest : public ::testing::Test {
+class FoldTest : public ::testing::Test {
  protected:
-  FoldLinearDimsTest() : rewriter(&context), loc(UnknownLoc::get(&context)) {
+  FoldTest() : rewriter(&context), loc(UnknownLoc::get(&context)) {
     context.loadDialect<arith::ArithDialect>();
   }
 
@@ -317,12 +317,45 @@ class FoldLinearDimsTest : public ::testing::Test {
     EXPECT_EQ(newStrides, expectedStridesValues);
   }
 
+  void checkFoldUnitDims(const SmallVector<int64_t> offsets,
+                         const SmallVector<int64_t> sizes,
+                         const SmallVector<int64_t> strides,
+                         const SmallVector<int64_t> expectedOffsets,
+                         const SmallVector<int64_t> expectedSizes,
+                         const SmallVector<int64_t> expectedStrides,
+                         bool shouldSucceed = true) {
+    SmallVector<OpFoldResult> offsetsValues = toOpFoldResult(offsets);
+    SmallVector<OpFoldResult> sizesValues = toOpFoldResult(sizes);
+    SmallVector<OpFoldResult> stridesValues = toOpFoldResult(strides);
+    SmallVector<OpFoldResult> expectedOffsetsValues =
+        toOpFoldResult(expectedOffsets);
+    SmallVector<OpFoldResult> expectedSizesValues =
+        toOpFoldResult(expectedSizes);
+    SmallVector<OpFoldResult> expectedStridesValues =
+        toOpFoldResult(expectedStrides);
+    SmallVector<OpFoldResult> newOffsets;
+    SmallVector<OpFoldResult> newSizes;
+    SmallVector<OpFoldResult> newStrides;
+    if (shouldSucceed) {
+      EXPECT_TRUE(succeeded(foldUnitDims(&context, offsetsValues, sizesValues,
+                                         stridesValues, newOffsets, newSizes,
+                                         newStrides)));
+      EXPECT_EQ(newOffsets, expectedOffsetsValues);
+      EXPECT_EQ(newSizes, expectedSizesValues);
+      EXPECT_EQ(newStrides, expectedStridesValues);
+    } else {
+      EXPECT_TRUE(failed(foldUnitDims(&context, offsetsValues, sizesValues,
+                                      stridesValues, newOffsets, newSizes,
+                                      newStrides)));
+    }
+  }
+
   MLIRContext context;
   IRRewriter rewriter;
   Location loc;
 };
 
-TEST_F(FoldLinearDimsTest, NoFold) {
+TEST_F(FoldTest, NoLinearDimsFold) {
   checkFoldLinearDims({}, {}, {}, {}, {}, {}, {}, false);
   checkFoldLinearDims({0}, {8}, {1}, {}, {0}, {8}, {1}, false);
   checkFoldLinearDims({0, 0}, {16, 8}, {16, 1}, {}, {0, 0}, {16, 8}, {16, 1},
@@ -331,7 +364,7 @@ TEST_F(FoldLinearDimsTest, NoFold) {
                       false);
 }
 
-TEST_F(FoldLinearDimsTest, Fold) {
+TEST_F(FoldTest, FoldLinearDims) {
   checkFoldLinearDims({0, 0}, {16, 8}, {8, 1}, {}, {0}, {128}, {1}, true);
   checkFoldLinearDims({0, 8}, {16, 8}, {8, 1}, {}, {8}, {128}, {1}, true);
   checkFoldLinearDims({0, 0, 0}, {8, 16, 8}, {128, 8, 1}, {}, {0}, {1024}, {1},
@@ -342,7 +375,7 @@ TEST_F(FoldLinearDimsTest, Fold) {
                       {8, 0}, {512, 8}, {8, 1}, true);
 }
 
-TEST_F(FoldLinearDimsTest, FoldWithMax) {
+TEST_F(FoldTest, FoldLinearDimsWithMax) {
   checkFoldLinearDims({0, 0}, {16, 8}, {8, 1}, {127}, {0, 0}, {16, 8}, {8, 1},
                       false);
   checkFoldLinearDims({0, 0}, {16, 8}, {8, 1}, {127, 127}, {0, 0}, {16, 8},
@@ -356,6 +389,42 @@ TEST_F(FoldLinearDimsTest, FoldWithMax) {
   checkFoldLinearDims({0, 0, 8, 0}, {4, 8, 16, 8}, {1024, 128, 8, 1},
                       {511, 511, 511, 511}, {0, 8, 0}, {4, 128, 8},
                       {1024, 8, 1}, true);
+}
+
+TEST_F(FoldTest, NoUnitDimsFold) {
+  checkFoldUnitDims({}, {}, {}, {}, {}, {}, false);
+  checkFoldUnitDims({0}, {8}, {1}, {}, {}, {}, false);
+  checkFoldUnitDims({0, 0}, {16, 8}, {16, 1}, {}, {}, {}, false);
+  checkFoldUnitDims({2}, {1}, {1}, {}, {}, {}, false);
+}
+
+TEST_F(FoldTest, UnitDimsFullFold) {
+  checkFoldUnitDims({0}, {1}, {32}, {}, {}, {}, true);
+  checkFoldUnitDims({0, 0, 0}, {32, 1, 8}, {32, 1024, 1}, {0, 0}, {32, 8},
+                    {32, 1}, true);
+  checkFoldUnitDims({0, 0, 0, 0}, {1, 32, 1, 8}, {1024, 32, 1024, 1}, {0, 0},
+                    {32, 8}, {32, 1}, true);
+}
+
+TEST_F(FoldTest, UnitDimsMerge) {
+  checkFoldUnitDims({1, 1}, {1, 1}, {32, 32}, {2}, {1}, {32}, true);
+  checkFoldUnitDims({1, 2}, {1, 1}, {32, 32}, {3}, {1}, {32}, true);
+  checkFoldUnitDims({2, 1}, {1, 1}, {32, 32}, {3}, {1}, {32}, true);
+  checkFoldUnitDims({1, 0, 1, 0}, {1, 32, 1, 8}, {1024, 32, 1024, 1}, {2, 0, 0},
+                    {1, 32, 8}, {1024, 32, 1}, true);
+  checkFoldUnitDims({1, 0, 2, 0}, {1, 32, 1, 8}, {1024, 32, 1024, 1}, {3, 0, 0},
+                    {1, 32, 8}, {1024, 32, 1}, true);
+  checkFoldUnitDims({2, 0, 1, 0}, {1, 32, 1, 8}, {1024, 32, 1024, 1}, {3, 0, 0},
+                    {1, 32, 8}, {1024, 32, 1}, true);
+}
+
+TEST_F(FoldTest, UnitDimsFoldAndMerge) {
+  checkFoldUnitDims({1, 0, 1}, {1, 1, 1}, {32, 1024, 32}, {2}, {1}, {32}, true);
+  checkFoldUnitDims({1, 0, 1}, {1, 1, 1}, {32, 32, 32}, {2}, {1}, {32}, true);
+  checkFoldUnitDims({1, 0, 2, 0}, {1, 1, 1, 1}, {32, 32, 32, 32}, {3}, {1},
+                    {32}, true);
+  checkFoldUnitDims({1, 0, 1, 0}, {1, 1, 1, 8}, {1024, 32, 1024, 1}, {2, 0},
+                    {1, 8}, {1024, 1}, true);
 }
 
 }  // namespace

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_doubly_strided_op.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_doubly_strided_op.mlir
@@ -77,10 +77,10 @@ func.func @circular_dma_cpy_nd_unit_between_linear(%arg0: !amdaie.logicalobjectf
 // -----
 
 // CHECK-LABEL:       func.func @circular_dma_cpy_nd_non_zero_offset
-// CHECK:             amdaie.circular_dma_cpy_nd(%{{.+}}[1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], %{{.+}}[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
-// FOLD-SINGLE-DIMS:  amdaie.circular_dma_cpy_nd(%{{.+}}[1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], %{{.+}}[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
+// CHECK:             amdaie.circular_dma_cpy_nd(%{{.+}}[3, 1, 1] [1, 8, 16] [128, 16, 1], %{{.+}}[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
+// FOLD-SINGLE-DIMS:  amdaie.circular_dma_cpy_nd(%{{.+}}[3, 1, 1] [1, 8, 16] [128, 16, 1], %{{.+}}[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
 func.func @circular_dma_cpy_nd_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
-  %0 = amdaie.circular_dma_cpy_nd(%arg0[1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  %0 = amdaie.circular_dma_cpy_nd(%arg0[2, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   "iree.keep"(%0) : (index) -> ()
   return
 }
@@ -174,10 +174,10 @@ func.func @dma_cpy_nd_unit_between_linear(%arg0: !amdaie.logicalobjectfifo<memre
 // -----
 
 // CHECK-LABEL:       func.func @dma_cpy_nd_non_zero_offset
-// CHECK:             amdaie.dma_cpy_nd(%{{.+}}[1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], %{{.+}}[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
-// FOLD-SINGLE-DIMS:  amdaie.dma_cpy_nd(%{{.+}}[1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], %{{.+}}[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
+// CHECK:             amdaie.dma_cpy_nd(%{{.+}}[3, 1, 1] [1, 8, 16] [128, 16, 1], %{{.+}}[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
+// FOLD-SINGLE-DIMS:  amdaie.dma_cpy_nd(%{{.+}}[3, 1, 1] [1, 8, 16] [128, 16, 1], %{{.+}}[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
 func.func @dma_cpy_nd_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
-  %0 = amdaie.dma_cpy_nd(%arg0[1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+  %0 = amdaie.dma_cpy_nd(%arg0[1, 2, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   "iree.keep"(%0) : (index) -> ()
   return
 }
@@ -273,11 +273,11 @@ func.func @npu_dma_cpy_nd_unit_between_linear(%arg0: !amdaie.logicalobjectfifo<m
 // -----
 
 // CHECK-LABEL:       func.func @npu_dma_cpy_nd_non_zero_offset
-// CHECK:             amdaie.npu.dma_cpy_nd %{{.+}}([1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
-// FOLD-SINGLE-DIMS:  amdaie.npu.dma_cpy_nd %{{.+}}([1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
+// CHECK:             amdaie.npu.dma_cpy_nd %{{.+}}([3, 1, 1] [1, 8, 16] [128, 16, 1], [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
+// FOLD-SINGLE-DIMS:  amdaie.npu.dma_cpy_nd %{{.+}}([3, 1, 1] [1, 8, 16] [128, 16, 1], [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
 func.func @npu_dma_cpy_nd_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
-  amdaie.npu.dma_cpy_nd %0([1, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
+  amdaie.npu.dma_cpy_nd %0([1, 2, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
   return
 }
 


### PR DESCRIPTION
This case comes up when supporting larger L2 buffers, prefetching it here.

With this change, there are two cases being handled in `foldUnitDimension`:
1. If a dimension has `size == 1` and `offset == 0`, the dimension can be
folded entirely.
2. If a dimension has `size == 1` and `offset != 0`, it can be folded into
another dimension with the same stride if that exists.

Example for case 1:
```
offsets: [0, 0, 0], sizes: [32, 1, 8], strides: [32, 1024, 1]
```
will be transformed into:
```
offsets: [0, 0], sizes: [32, 8], strides: [32, 1]
```

Example for case 2:
```
offsets: [1, 0, 1, 0], sizes: [1, 32, 1, 8], strides: [1024, 32, 1024, 1]
```
will be transformed into:
```
offsets: [2, 0, 0], sizes: [1, 32, 8], strides: [1024, 32, 1]
```
Note that the dimensions are merged into the outermost one. Heuristically,
this works out best with other strided access pattern transformations, but
could be made an option in the future.