### PR TITLE
[DmaLoopSubsumption] Limit blocking of subsumption of circular dma op to same scope

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/dma_loop_subsumption_circular.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/dma_loop_subsumption_circular.mlir
@@ -144,3 +144,67 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     return
   }
 }
+
+// -----
+
+// Ensure no subsumption happens in case of other circular connection users in nested blocks. 
+// The innermost block contains two `amdaie.npu.circular_dma_cpy_nd` to avoid them being subsumed as well.
+// CHECK-LABEL: @nested_blockers
+// CHECK:       %[[CONNECTION:.+]] = amdaie.connection
+// CHECK:       amdaie.controlcode
+// CHECK:         scf.for
+// CHECK:           amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([] [] [], [] [] [])
+// CHECK:           scf.forall
+// CHECK:             amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([0] [16] [1], [] [] [])
+// CHECK:             amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([0] [16] [1], [] [] [])
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @nested_blockers(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c6 = arith.constant 6 : index
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+      amdaie.controlcode {
+        scf.for %arg2 = %c1 to %c6 step %c2 {
+          %2 = amdaie.npu.circular_dma_cpy_nd %0([] [] [], [] [] [])
+          scf.forall (%arg3, %arg4) in (2, 6) {
+            %3 = amdaie.npu.circular_dma_cpy_nd %0([0] [16] [1], [] [] [])
+            %4 = amdaie.npu.circular_dma_cpy_nd %0([0] [16] [1], [] [] [])
+          }
+        }
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Ensure subsumption happens in case of other circular connection users outside the current one's scope.
+// CHECK-LABEL: @other_users_outside_scope
+// CHECK:       %[[CONNECTION:.+]] = amdaie.connection
+// CHECK:       amdaie.controlcode
+// CHECK-NOT:     scf.for
+// CHECK:         amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([0] [16] [1], [] [] [])
+// CHECK:         amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([0] [32] [1], [] [] [])
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @other_users_outside_scope(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c6 = arith.constant 6 : index
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+      amdaie.controlcode {
+        scf.for %arg2 = %c1 to %c6 step %c2 {
+          %2 = amdaie.npu.circular_dma_cpy_nd %0([0] [16] [1], [] [] [])
+        }
+        %3 = amdaie.npu.circular_dma_cpy_nd %0([0] [32] [1], [] [] [])
+        amdaie.end
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
Fixes the logic to block loop subsumption to only check for users within the current scope and refactors the code a bit.

Example of a case which is now supported:
```
%0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
amdaie.controlcode {
  scf.for %arg2 = %c1 to %c6 step %c2 {
    %2 = amdaie.npu.circular_dma_cpy_nd %0([0] [16] [1], [] [] [])
  }
  %3 = amdaie.npu.circular_dma_cpy_nd %0([0] [32] [1], [] [] [])
  amdaie.end
}
```
With expected output:
```
%0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
amdaie.controlcode {
  %2 = amdaie.npu.circular_dma_cpy_nd %0([0] [16] [1], [] [] [])
  %3 = amdaie.npu.circular_dma_cpy_nd %0([0] [32] [1], [] [] [])
  amdaie.end
}
```
