### PR TITLE
[LowerToAIE] Make size folding hardware-aware

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aie/AIEDialect.cpp
+++ b/compiler/plugins/target/AMD-AIE/aie/AIEDialect.cpp
@@ -494,10 +494,10 @@ LogicalResult DMABDOp::verify() {
                << "exceeds memref size "
                << std::to_string(bufferType.getNumElements());
       }
-      if (dim.getSize() >= (1UL << 9) + 1) {
-        return emitOpError() << "Size may not exceed 1023.";
+      if (dim.getSize() >= ((1UL << 10) - 1)) {
+        return emitOpError() << "Size may not exceed " << ((1UL << 10) - 1);
       }
-      if (dim.getStride() >= (1UL << 19)) {
+      if (dim.getStride() >= (1UL << 20)) {
         return emitOpError() << "Stride may not exceed " << (1 << 20);
       }
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
@@ -44,7 +44,7 @@ namespace mlir::iree_compiler::AMDAIE {
 AIE::BDDimLayoutArrayAttr
 AIEDeviceBuilder::convertSizeStrideToBDDimLayoutArrayAttr(
     const SmallVector<OpFoldResult> &sizes,
-    const SmallVector<OpFoldResult> &strides) {
+    const SmallVector<OpFoldResult> &strides, uint8_t memSpace) {
   assert(sizes.size() == strides.size() &&
          "expected stride and size vectors of same size");
   // Fold remaining dimensions, assuming zero offsets as offsets should be taken
@@ -54,7 +54,7 @@ AIEDeviceBuilder::convertSizeStrideToBDDimLayoutArrayAttr(
   SmallVector<OpFoldResult> newOffsets;
   SmallVector<OpFoldResult> newSizes;
   SmallVector<OpFoldResult> newStrides;
-  foldDims(offsets, sizes, strides, newOffsets, newSizes, newStrides);
+  foldDims(offsets, sizes, strides, newOffsets, newSizes, newStrides, memSpace);
 
   SmallVector<AIE::BDDimLayoutAttr, 4> bdDimLayoutAttr;
   // If the access pattern (strides/sizes) have a single dimension, make it
@@ -222,14 +222,18 @@ void AIEDeviceBuilder::foldDims(const SmallVector<OpFoldResult> &offsets,
                                 const SmallVector<OpFoldResult> &strides,
                                 SmallVector<OpFoldResult> &newOffsets,
                                 SmallVector<OpFoldResult> &newSizes,
-                                SmallVector<OpFoldResult> &newStrides) {
+                                SmallVector<OpFoldResult> &newStrides,
+                                uint8_t memSpace) {
   SmallVector<OpFoldResult> tmpOffsets;
   SmallVector<OpFoldResult> tmpSizes;
   SmallVector<OpFoldResult> tmpStrides;
   (void)foldUnitDims(rewriter.getContext(), offsets, sizes, strides, tmpOffsets,
                      tmpSizes, tmpStrides);
+  AMDAIE::DmaDimConfig dmaDimConfig(deviceModel, memSpace, memSpace);
+  SmallVector<int64_t> maxSizes =
+      dmaDimConfig.getMaxSizes<CopyOpOperateOn::Source>();
   (void)foldLinearDims(rewriter.getContext(), tmpOffsets, tmpSizes, tmpStrides,
-                       newOffsets, newSizes, newStrides);
+                       newOffsets, newSizes, newStrides, maxSizes);
   (void)foldSingleDim(newOffsets, newSizes, newStrides);
 }
 
@@ -500,9 +504,16 @@ LogicalResult AIEDeviceBuilder::connectionToAIE(
       return maybeNpuDmaUserOp->emitOpError()
              << "could not compute a static base offset for source";
     }
+    std::optional<uint8_t> maybeSourceMemSpace =
+        maybeNpuDmaUserOp->getSourceMemorySpaceAsUInt();
+    if (!maybeSourceMemSpace) {
+      return maybeNpuDmaUserOp->emitOpError()
+             << "expected to have a source memory space";
+    }
     AIE::BDDimLayoutArrayAttr dims = convertSizeStrideToBDDimLayoutArrayAttr(
         maybeNpuDmaUserOp->getSourceMixedSizes(),
-        maybeNpuDmaUserOp->getSourceMixedStrides());
+        maybeNpuDmaUserOp->getSourceMixedStrides(),
+        maybeSourceMemSpace.value());
     SmallVector<CopyOpInterface> objFifoProducers =
         sourceObjFifo.getCopyLikeProducers();
     SmallVector<CopyOpInterface> objFifoConsumers =
@@ -589,9 +600,16 @@ LogicalResult AIEDeviceBuilder::connectionToAIE(
       return maybeNpuDmaUserOp->emitOpError()
              << "could not compute a static base offset for source";
     }
+    std::optional<uint8_t> maybeTargetMemSpace =
+        maybeNpuDmaUserOp->getTargetMemorySpaceAsUInt();
+    if (!maybeTargetMemSpace) {
+      return maybeNpuDmaUserOp->emitOpError()
+             << "expected to have a target memory space";
+    }
     AIE::BDDimLayoutArrayAttr dims = convertSizeStrideToBDDimLayoutArrayAttr(
         maybeNpuDmaUserOp->getTargetMixedSizes(),
-        maybeNpuDmaUserOp->getTargetMixedStrides());
+        maybeNpuDmaUserOp->getTargetMixedStrides(),
+        maybeTargetMemSpace.value());
     SmallVector<CopyOpInterface> objFifoProducers =
         targetObjFifo.getCopyLikeProducers();
     SmallVector<CopyOpInterface> objFifoConsumers =
@@ -886,15 +904,8 @@ LogicalResult AIEDeviceBuilder::workgroupToAIE(AMDAIE::WorkgroupOp workgroupOp,
 /// dialect operations to AIE dialect operations.
 LogicalResult AIEDeviceBuilder::lowerToAIE(ModuleOp moduleOp) {
   Block *moduleBlock = &moduleOp->getRegion(0).front();
-
-  // Retrieve the AMDAIEDevice from the executable target attribute.
-  auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(moduleOp);
-  std::optional<AMDAIEDevice> device = getConfigAMDAIEDevice(targetAttr);
-  if (!device)
-    return moduleOp.emitOpError()
-           << "No AMDAIEDevice found in the target attribute configuration";
-  xilinx::AIE::AIEDevice aieDevice = static_cast<xilinx::AIE::AIEDevice>(
-      static_cast<uint32_t>(device.value()));
+  xilinx::AIE::AIEDevice aieDevice =
+      static_cast<xilinx::AIE::AIEDevice>(static_cast<uint32_t>(device));
 
   auto funcRes = moduleOp.walk([&](func::FuncOp funcOp) {
     if (funcOp.isPrivate()) {
@@ -1007,7 +1018,15 @@ class AMDAIELowerToAIEPass
     // Main function call to convert all operations into AIE dialect
     // operations inside an AIE device.
     ModuleOp moduleOp = getOperation();
-    AIEDeviceBuilder builder(moduleOp.getContext());
+    auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(moduleOp);
+    std::optional<AMDAIEDevice> maybeDevice = getConfigAMDAIEDevice(targetAttr);
+    if (!maybeDevice.has_value()) {
+      moduleOp->emitOpError(
+          "No AMDAIEDevice found in the target attribute configuration. This "
+          "is needed to lower to the AIE dialect.");
+      return signalPassFailure();
+    }
+    AIEDeviceBuilder builder(moduleOp.getContext(), maybeDevice.value());
     if (failed(builder.lowerToAIE(moduleOp))) return signalPassFailure();
   }
 };

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
@@ -904,8 +904,8 @@ LogicalResult AIEDeviceBuilder::workgroupToAIE(AMDAIE::WorkgroupOp workgroupOp,
 /// dialect operations to AIE dialect operations.
 LogicalResult AIEDeviceBuilder::lowerToAIE(ModuleOp moduleOp) {
   Block *moduleBlock = &moduleOp->getRegion(0).front();
-  xilinx::AIE::AIEDevice aieDevice =
-      static_cast<xilinx::AIE::AIEDevice>(static_cast<uint32_t>(device));
+  xilinx::AIE::AIEDevice aieDevice = static_cast<xilinx::AIE::AIEDevice>(
+      static_cast<uint32_t>(deviceModel.device));
 
   auto funcRes = moduleOp.walk([&](func::FuncOp funcOp) {
     if (funcOp.isPrivate()) {
@@ -1026,7 +1026,8 @@ class AMDAIELowerToAIEPass
           "is needed to lower to the AIE dialect.");
       return signalPassFailure();
     }
-    AIEDeviceBuilder builder(moduleOp.getContext(), maybeDevice.value());
+    AMDAIEDeviceModel deviceModel = getDeviceModel(maybeDevice.value());
+    AIEDeviceBuilder builder(moduleOp.getContext(), std::move(deviceModel));
     if (failed(builder.lowerToAIE(moduleOp))) return signalPassFailure();
   }
 };

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.h
@@ -30,7 +30,8 @@ namespace mlir::iree_compiler::AMDAIE {
 /// `amdaie.workgroup`.
 class AIEDeviceBuilder {
  public:
-  AIEDeviceBuilder(MLIRContext *ctx) : rewriter(ctx) {}
+  AIEDeviceBuilder(MLIRContext *ctx, AMDAIEDevice device)
+      : rewriter(ctx), device(device), deviceModel(getDeviceModel(device)) {}
 
   LogicalResult lowerToAIE(ModuleOp moduleOp);
 
@@ -67,7 +68,7 @@ class AIEDeviceBuilder {
   /// `AIE::BDDimLayoutArrayAttr`.
   AIE::BDDimLayoutArrayAttr convertSizeStrideToBDDimLayoutArrayAttr(
       const SmallVector<OpFoldResult> &sizes,
-      const SmallVector<OpFoldResult> &strides);
+      const SmallVector<OpFoldResult> &strides, uint8_t memSpace);
 
   /// Utility to create DMA blocks and add them to `memOp`.
   void createDMA(Operation *memOp, AIE::DMAChannelDir channelDir,
@@ -102,7 +103,7 @@ class AIEDeviceBuilder {
                 const SmallVector<OpFoldResult> &strides,
                 SmallVector<OpFoldResult> &newOffsets,
                 SmallVector<OpFoldResult> &newSizes,
-                SmallVector<OpFoldResult> &newStrides);
+                SmallVector<OpFoldResult> &newStrides, uint8_t memSpace);
 
   /// Utility to remap the provided operation's operands.
   void remapOperands(Operation *op);
@@ -111,6 +112,10 @@ class AIEDeviceBuilder {
 
   IRRewriter rewriter;
   IRMapping mapper;
+  /// The device and device model. The device is needed separately to convert to
+  /// the `AIEDevice`.
+  AMDAIEDevice device;
+  AMDAIEDeviceModel deviceModel;
   /// Map from tile values to AIE memory op (`aie.mem` or `aie.memtile_dma`).
   /// This is used to look up and add new DMA patterns to those memory ops.
   DenseMap<Value, Operation *> tileToMemOpMap;

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.h
@@ -30,8 +30,8 @@ namespace mlir::iree_compiler::AMDAIE {
 /// `amdaie.workgroup`.
 class AIEDeviceBuilder {
  public:
-  AIEDeviceBuilder(MLIRContext *ctx, AMDAIEDevice device)
-      : rewriter(ctx), device(device), deviceModel(getDeviceModel(device)) {}
+  AIEDeviceBuilder(MLIRContext *ctx, AMDAIEDeviceModel deviceModel)
+      : rewriter(ctx), deviceModel(std::move(deviceModel)) {}
 
   LogicalResult lowerToAIE(ModuleOp moduleOp);
 
@@ -112,9 +112,7 @@ class AIEDeviceBuilder {
 
   IRRewriter rewriter;
   IRMapping mapper;
-  /// The device and device model. The device is needed separately to convert to
-  /// the `AIEDevice`.
-  AMDAIEDevice device;
+  /// The device model for looking up hardware parameters.
   AMDAIEDeviceModel deviceModel;
   /// Map from tile values to AIE memory op (`aie.mem` or `aie.memtile_dma`).
   /// This is used to look up and add new DMA patterns to those memory ops.


### PR DESCRIPTION
Make the dimension folding inside `LowerToAIE` partially hardware-aware by retrieving max sizes from the device model. This avoids overflowing the number of available bits.

A few notes:
- This folding inside `LowerToAIE` is needed at this place and can't be done separately earlier right now because offsets can be assumed all zero here because they are already handled earlier in this pass. We should try to streamline this further in the future so that this one-off folding is not needed. This can be done for example by canonicalizing on the lowered ops instead.
- Similar checks should be done for strides as well. I can do this in a follow-up.