### PR TITLE
[AMDAIELinalgFunctionOutlining] Don't outline if operand has non-identity layout 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELinalgFunctionOutlining.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELinalgFunctionOutlining.cpp
@@ -20,7 +20,7 @@ namespace mlir::iree_compiler::AMDAIE {
 
 namespace {
 
-/// Return if `type` is a memref with an identity layout.
+/// Return true if `type` is a memref with an identity layout.
 bool isMemRefWithIdentityLayout(Type type) {
   auto memRefType = dyn_cast<MemRefType>(type);
   if (!memRefType) return false;

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/linalg_function_outlining.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/linalg_function_outlining.mlir
@@ -165,24 +165,12 @@ func.func @reduction(%A: memref<4xbf16>, %B: memref<bf16>) {
 
 // -----
 
-// Test demonstrating the outlining of a linalg.generic where one
-// operand has an unkown offset. The memref is still contiguous, however.
-// CHECK:       func.func private @generic_0_outlined
-// CHECK-SAME:    memref<4x8xbf16>,
-// CHECK-SAME:    memref<bf16>
-// CHECK:       linalg.generic
-// CHECK-SAME:    iterator_types = ["reduction", "reduction"]
-// CHECK:       return
-// CHECK:       func.func @outlineable_linalg_op
-// CHECK-SAME:    memref<4x8xbf16, strided<[8, 1], offset: ?>>
-// CHECK-SAME:    memref<bf16>
-// CHECK:       %[[CAST:.*]] = memref.cast
-// CHECK-SAME:    memref<4x8xbf16, strided<[8, 1], offset: ?>>
-// CHECK-SAME:    to memref<4x8xbf16>
-// CHECK:       func.call @generic_0_outlined(%[[CAST]], %arg1) :
-// CHECK-SAME:    (memref<4x8xbf16>, memref<bf16>) -> ()
-// CHECK:       return
-func.func @outlineable_linalg_op(%A: memref<4x8xbf16, strided<[8,1], offset:?>>, %B: memref<bf16>) {
+// Test illustrating that when a linalg.generic operation has an operand that 
+// is has an offset on the layout, it is not outlined.
+
+// CHECK-COUNT-1: func.func
+// CHECK-NOT:     func.func
+func.func @unoutlineable_layout_with_offset(%A: memref<4x8xbf16, strided<[8,1], offset:?>>, %B: memref<bf16>) {
   %c2 = arith.constant 2 : index
   %tile = amdaie.tile(%c2, %c2)
   %1 = amdaie.core(%tile, in : [], out : []) {
@@ -202,12 +190,12 @@ func.func @outlineable_linalg_op(%A: memref<4x8xbf16, strided<[8,1], offset:?>>,
 
 // -----
 
-// Test illustrating the that when a linalg.generic operation has an
-// operand that is not contiguous, it is not outlined.
+// Test illustrating that when a linalg.generic operation has an operand that 
+// is not contiguous, it is not outlined.
 
 // CHECK-COUNT-1: func.func
 // CHECK-NOT:     func.func
-func.func @unoutlineable_linalg_op(%A: memref<4x8xbf16, strided<[9,1]>>, %B: memref<bf16>) {
+func.func @unoutlineable_strided_layout(%A: memref<4x8xbf16, strided<[9,1]>>, %B: memref<bf16>) {
   %c2 = arith.constant 2 : index
   %tile = amdaie.tile(%c2, %c2)
   %1 = amdaie.core(%tile, in : [], out : []) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/linalg_function_outlining.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/linalg_function_outlining.mlir
@@ -165,8 +165,8 @@ func.func @reduction(%A: memref<4xbf16>, %B: memref<bf16>) {
 
 // -----
 
-// Test illustrating that when a linalg.generic operation has an operand that 
-// is has an offset on the layout, it is not outlined.
+// Test illustrating that when a linalg.generic operation has an operand that
+// has an offset on the layout, it is not outlined.
 
 // CHECK-COUNT-1: func.func
 // CHECK-NOT:     func.func
@@ -190,7 +190,7 @@ func.func @unoutlineable_layout_with_offset(%A: memref<4x8xbf16, strided<[8,1], 
 
 // -----
 
-// Test illustrating that when a linalg.generic operation has an operand that 
+// Test illustrating that when a linalg.generic operation has an operand that
 // is not contiguous, it is not outlined.
 
 // CHECK-COUNT-1: func.func


### PR DESCRIPTION
This is a fix for a bug I introduced in https://github.com/nod-ai/iree-amd-aie/pull/951 . I thought that the approach of removing the offset from the memref function signature worked, but it doesn't seem to. I must have been running a test other than the convolution end-to-end test when I was confirming it worked - now with function outlining enabled in gives a numerical error. 

This PR simplifies logic: any non-identity layout results in no outlining. 