### PR TITLE
[CombineStridedOps] Add support for same values

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIEDmaUtilsTest.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIEDmaUtilsTest.cpp
@@ -113,6 +113,11 @@ TEST_F(AccessPatternCombinationTest, CombinableAccessPatterns) {
                                                {16, 16, 32}, {32, 64, 1}, 4));
   EXPECT_TRUE(checkAreAccessPatternsCombinable({32, 0}, {64, 64}, {128, 1},
                                                {96, 0}, {32, 64}, {128, 1}, 4));
+  // Same access patterns
+  EXPECT_TRUE(
+      checkAreAccessPatternsCombinable({0}, {32}, {1}, {0}, {32}, {1}, 2));
+  EXPECT_TRUE(checkAreAccessPatternsCombinable({0, 0}, {16, 32}, {64, 1},
+                                               {0, 0}, {16, 32}, {64, 1}, 4));
   // size(A) > size(B)
   EXPECT_TRUE(checkAreAccessPatternsCombinable(
       {0, 0, 0}, {2, 16, 32}, {32, 64, 1}, {0, 64}, {16, 32}, {64, 1}, 4));
@@ -143,14 +148,11 @@ TEST_F(AccessPatternCombinationTest, NonCombinableAccessPatterns) {
                                                 {}, {}, 3));
   EXPECT_FALSE(checkAreAccessPatternsCombinable(
       {0, 0, 32}, {2, 16, 32}, {128, 64, 1}, {0}, {32}, {1}, 3));
-  // Same access patterns
-  EXPECT_FALSE(
-      checkAreAccessPatternsCombinable({0}, {32}, {1}, {0}, {32}, {1}, 2));
-  EXPECT_FALSE(checkAreAccessPatternsCombinable({0, 0}, {16, 32}, {64, 1},
-                                                {0, 0}, {16, 32}, {64, 1}, 4));
   // Too few dimensions
   EXPECT_FALSE(
       checkAreAccessPatternsCombinable({0}, {16}, {1}, {32}, {16}, {1}, 1));
+  EXPECT_FALSE(
+      checkAreAccessPatternsCombinable({0}, {32}, {1}, {0}, {32}, {1}, 1));
   EXPECT_FALSE(checkAreAccessPatternsCombinable({0, 0}, {16, 32}, {64, 1},
                                                 {0, 32}, {16, 32}, {64, 1}, 2));
   EXPECT_FALSE(checkAreAccessPatternsCombinable({0, 0, 0}, {16, 16, 32},
@@ -163,6 +165,15 @@ TEST_F(AccessPatternCombinationTest, NonCombinableAccessPatterns) {
       {0, 0, 0}, {2, 16, 32}, {32, 64, 1}, {0, 128}, {16, 32}, {64, 1}, 4));
   EXPECT_FALSE(checkAreAccessPatternsCombinable(
       {0, 0, 0}, {2, 16, 32}, {32, 64, 1}, {64, 0}, {16, 32}, {64, 1}, 4));
+  // size(A) > size(B) Same access pattern
+  EXPECT_FALSE(checkAreAccessPatternsCombinable({0, 0}, {32, 64}, {128, 1}, {0},
+                                                {64}, {1}, 4));
+  EXPECT_FALSE(checkAreAccessPatternsCombinable({1, 0}, {32, 64}, {128, 1}, {0},
+                                                {64}, {1}, 4));
+  EXPECT_FALSE(checkAreAccessPatternsCombinable(
+      {0, 0, 0}, {32, 64, 128}, {32, 128, 1}, {0, 0}, {64, 128}, {128, 1}, 4));
+  EXPECT_FALSE(checkAreAccessPatternsCombinable(
+      {2, 0, 0}, {32, 64, 128}, {32, 128, 1}, {0, 0}, {64, 128}, {128, 1}, 4));
   // size(B) > size(A) Incompatible offset
   EXPECT_FALSE(checkAreAccessPatternsCombinable(
       {0, 0}, {16, 32}, {64, 1}, {0, 0, 16}, {2, 16, 32}, {32, 64, 1}, 4));
@@ -170,8 +181,12 @@ TEST_F(AccessPatternCombinationTest, NonCombinableAccessPatterns) {
       {0, 0}, {16, 32}, {64, 1}, {0, 0, 96}, {2, 16, 32}, {32, 64, 1}, 4));
   EXPECT_FALSE(checkAreAccessPatternsCombinable(
       {0, 0}, {16, 32}, {64, 1}, {0, 1, 0}, {2, 16, 32}, {32, 64, 1}, 4));
-
-  // size(A) == size(B) Incompatible offset
+  // size(B) > size(A) Same access pattern
+  EXPECT_FALSE(checkAreAccessPatternsCombinable({0}, {32}, {1}, {0, 0}, {2, 32},
+                                                {8, 1}, 4));
+  EXPECT_FALSE(checkAreAccessPatternsCombinable({0}, {32}, {1}, {2, 0}, {2, 32},
+                                                {8, 1}, 4));
+  // size(A) == size(B)
   EXPECT_FALSE(checkAreAccessPatternsCombinable(
       {32, 0}, {64, 64}, {128, 1}, {32, 0}, {32, 64}, {128, 1}, 4));
   EXPECT_FALSE(checkAreAccessPatternsCombinable(
@@ -207,6 +222,11 @@ TEST_F(AccessPatternCombinationTest, CombineAccessPatterns) {
                              {2, 16, 8, 16}, {512, 16, 8, 1}, 4);
   checkCombineAccessPatterns({32, 0}, {64, 64}, {128, 1}, {96, 0}, {32, 64},
                              {128, 1}, {32, 0}, {96, 64}, {128, 1}, 4);
+  // size(A) == size(B) Same access pattern
+  checkCombineAccessPatterns({0}, {32}, {1}, {0}, {32}, {1}, {0, 0}, {2, 32},
+                             {0, 1}, 2);
+  checkCombineAccessPatterns({0, 0}, {16, 32}, {16, 1}, {0, 0}, {16, 32},
+                             {16, 1}, {0, 0, 0}, {2, 16, 32}, {0, 16, 1}, 3);
   // size(A) > size(B)
   checkCombineAccessPatterns({0, 0}, {2, 32}, {64, 1}, {128}, {32}, {1}, {0, 0},
                              {3, 32}, {64, 1}, 3);
@@ -241,6 +261,14 @@ TEST_F(AccessPatternCombinationTest, CombineAccessPatterns) {
   checkCombineAccessPatterns({2, 32}, {16, 32}, {16, 1}, {0, 6, 32},
                              {2, 16, 32}, {64, 16, 1}, {0, 2, 32}, {3, 16, 32},
                              {64, 16, 1}, 4);
+  checkCombineAccessPatterns({0}, {32}, {1}, {1, 0}, {2, 32}, {64, 1}, {0, 0},
+                             {3, 32}, {64, 1}, 3);
+  // size(B) > size(A) Same access pattern
+  checkCombineAccessPatterns({0}, {32}, {1}, {1, 0}, {3, 32}, {16, 1}, {0, 0},
+                             {4, 32}, {16, 1}, 3);
+  checkCombineAccessPatterns({0, 0}, {16, 32}, {16, 1}, {1, 0, 0}, {3, 16, 32},
+                             {64, 16, 1}, {0, 0, 0}, {4, 16, 32}, {64, 16, 1},
+                             3);
 }
 
 TEST_F(AccessPatternCombinationTest, FailCombineAccessPatterns) {
@@ -249,9 +277,6 @@ TEST_F(AccessPatternCombinationTest, FailCombineAccessPatterns) {
                              3, false);
   checkCombineAccessPatterns({0, 0}, {16, 32}, {16, 1}, {}, {}, {}, {}, {}, {},
                              3, false);
-  // Same access pattern
-  checkCombineAccessPatterns({0, 0}, {16, 32}, {16, 1}, {0, 0}, {16, 32},
-                             {16, 1}, {}, {}, {}, 3, false);
   // Too few dimensions
   checkCombineAccessPatterns({0, 0}, {16, 32}, {16, 1}, {0, 32}, {16, 32},
                              {16, 1}, {}, {}, {}, 2, false);
@@ -260,6 +285,13 @@ TEST_F(AccessPatternCombinationTest, FailCombineAccessPatterns) {
                              {3, 32}, {64, 1}, 3, false);
   checkCombineAccessPatterns({0, 0}, {2, 32}, {64, 1}, {256}, {32}, {1}, {0, 0},
                              {3, 32}, {64, 1}, 3, false);
+  // size(B) > size(A) Same access pattern
+  checkCombineAccessPatterns({0, 0}, {16, 32}, {16, 1}, {0, 0, 0}, {3, 16, 32},
+                             {64, 16, 1}, {0, 0, 0}, {4, 16, 32}, {64, 16, 1},
+                             3, false);
+  checkCombineAccessPatterns({0, 0}, {16, 32}, {16, 1}, {2, 0, 0}, {3, 16, 32},
+                             {64, 16, 1}, {0, 0, 0}, {4, 16, 32}, {64, 16, 1},
+                             3, false);
   // size(B) > size(A) Incompatible offset
   checkCombineAccessPatterns({0}, {32}, {1}, {0, 32}, {2, 32}, {64, 1}, {0, 0},
                              {3, 32}, {64, 1}, 3, false);


### PR DESCRIPTION
Add support in the `CombineStridedOpsPass` for the case when all dimensions, except possibly the first one, are the same.

Example:
```
amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0] [8, 16] [8, 1])
amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0] [8, 16] [8, 1])
```
is transformed into:
```
amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0] [2, 8, 16] [0, 8, 1])
```

Another example:
```
amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0] [16, 8, 16] [32, 8, 1])
amdaie.npu.dma_cpy_nd %0([] [] [], [1, 0, 0, 0] [2, 16, 8, 16] [64, 32, 8, 1])
```
is transformed into:
```
amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0, 0] [3, 16, 8, 16] [64, 32, 8, 1])
```