### PR TITLE
[Tests] Simplify test flags

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/conv2d_nhwc_objectfifo_e2e.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/conv2d_nhwc_objectfifo_e2e.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-tile-pipeline=conv-decompose --iree-amdaie-lower-to-aie-pipeline=objectFifo --split-input-file | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-targets --iree-amdaie-tile-pipeline=conv-decompose --iree-amdaie-lower-to-aie-pipeline=objectFifo --split-input-file %s | FileCheck %s
 
 func.func @conv_2d_nhwc_hwcf(%arg0: tensor<2x14x14x32xi32>, %arg1: tensor<3x3x32x64xi32>) -> tensor<2x12x12x64xi32> {
   %cst = arith.constant 0 : i32

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_elementwise_pack_peel_objectfifo_e2e.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_elementwise_pack_peel_objectfifo_e2e.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources --iree-amdaie-target-device=npu1_4col %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-lower-to-aie-pipeline=objectFifo --iree-amdaie-tile-pipeline=pack-peel --split-input-file | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-targets --iree-amdaie-target-device=npu1_4col --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: hal.executable.export public @matmul_truncf_bf16_dispatch_0_matmul_128x128x256_bf16
 // CHECK:       aie.device(npu1_4col) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pack_peel_air_e2e.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pack_peel_air_e2e.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-lower-to-aie-pipeline=air --iree-amdaie-tile-pipeline=pack-peel --split-input-file | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-targets --iree-amdaie-lower-to-aie-pipeline=air --iree-amdaie-tile-pipeline=pack-peel --split-input-file %s | FileCheck %s
 
 func.func @matmul_i8_i32(%lhs: tensor<32x16xi8>, %rhs: tensor<16x32xi8>) -> tensor<32x32xi32>
 {
@@ -10,11 +10,9 @@ func.func @matmul_i8_i32(%lhs: tensor<32x16xi8>, %rhs: tensor<16x32xi8>) -> tens
   return %res : tensor<32x32xi32>
 }
 
-// CHECK-LABEL: hal.executable.export public @matmul_i8_i32_dispatch_0_matmul_32x32x16_i8xi8xi32
-//       CHECK:    aie.device(npu1_4col)
-//       CHECK:    aie.shim_dma_allocation
-//       CHECK:    aie.shim_dma_allocation
-//       CHECK:    aie.shim_dma_allocation
+//   CHECK-LABEL: hal.executable.export public @matmul_i8_i32_dispatch_0_matmul_32x32x16_i8xi8xi32
+//         CHECK:    aie.device(npu1_4col)
+// CHECK-COUNT-3:    aie.shim_dma_allocation
 
 // -----
 
@@ -28,8 +26,6 @@ func.func @matmul_bf16(%lhs: tensor<16x32xbf16>, %rhs: tensor<32x16xbf16>) -> te
   return %res : tensor<16x16xf32>
 }
 
-// CHECK-LABEL: hal.executable.export public @matmul_bf16_dispatch_0_matmul_16x16x32_bf16
-//       CHECK:    aie.device(npu1_4col)
-//       CHECK:    aie.shim_dma_allocation
-//       CHECK:    aie.shim_dma_allocation
-//       CHECK:    aie.shim_dma_allocation
+//   CHECK-LABEL: hal.executable.export public @matmul_bf16_dispatch_0_matmul_16x16x32_bf16
+//         CHECK:    aie.device(npu1_4col)
+// CHECK-COUNT-3:    aie.shim_dma_allocation

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pack_peel_objectfifo_e2e.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pack_peel_objectfifo_e2e.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources --iree-amdaie-target-device=npu1_4col %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-lower-to-aie-pipeline=objectFifo --iree-amdaie-tile-pipeline=pack-peel --split-input-file | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-targets --iree-amdaie-target-device=npu1_4col --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: hal.executable.export public @matmul_i32_dispatch_0_matmul_128x128x256_i32
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pack_peel_objectfifo_ukernel_e2e.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pack_peel_objectfifo_ukernel_e2e.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources --iree-amdaie-enable-ukernels=all %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-lower-to-aie-pipeline=objectFifo --iree-amdaie-tile-pipeline=pack-peel --split-input-file | FileCheck %s --check-prefix=PHOENIX
-// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources --iree-amdaie-target-device=npu4 --iree-amdaie-enable-ukernels=all %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-target-device=npu4 --iree-amdaie-lower-to-aie-pipeline=objectFifo --iree-amdaie-tile-pipeline=pack-peel --split-input-file | FileCheck %s --check-prefix=STRIX
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-targets --iree-amdaie-enable-ukernels=all --split-input-file %s | FileCheck %s --check-prefix=PHOENIX
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-targets --iree-amdaie-target-device=npu4 --iree-amdaie-enable-ukernels=all --split-input-file %s | FileCheck %s --check-prefix=STRIX
 
 // PHOENIX-LABEL: hal.executable.export public @matmul_dispatch_0_matmul_128x128x256_bf16xbf16xf32
 // PHOENIX:       aie.device(npu1_4col) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pad_pack_air_e2e.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pad_pack_air_e2e.mlir
@@ -1,12 +1,10 @@
-// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-sources %s | iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-hal-translate-target-executable-variants{target=amd-aie})))" --iree-amdaie-tile-pipeline=pad-pack --iree-amdaie-lower-to-aie-pipeline=air --split-input-file | FileCheck %s --check-prefix=CPP
+// RUN: iree-compile --iree-hal-target-backends=amd-aie --compile-to=executable-targets --iree-amdaie-tile-pipeline=pad-pack --iree-amdaie-lower-to-aie-pipeline=air --split-input-file %s | FileCheck %s
 
 // This test demonstrates Pad-Pack pipeline based e2e lowering.
 
-// CPP-LABEL: hal.executable.export public @matmul_small_dispatch_0_matmul_8x32x16_i32
-//       CPP:    aie.device(npu1_4col)
-//       CPP:    aie.shim_dma_allocation
-//       CPP:    aie.shim_dma_allocation
-//       CPP:    aie.shim_dma_allocation
+//   CHECK-LABEL: hal.executable.export public @matmul_small_dispatch_0_matmul_8x32x16_i32
+//         CHECK:    aie.device(npu1_4col)
+// CHECK-COUNT-3:    aie.shim_dma_allocation
 func.func @matmul_small(%lhs : tensor<8x16xi32>,
     %rhs : tensor<16x32xi32>) -> tensor<8x32xi32> {
   %empty = tensor.empty() : tensor<8x32xi32>
@@ -19,11 +17,9 @@ func.func @matmul_small(%lhs : tensor<8x16xi32>,
 
 // -----
 
-// CPP-LABEL: hal.executable.export public @matmul_large_dispatch_0_matmul_2048x2048x2048_i32
-//       CPP:    aie.device(npu1_4col)
-//       CPP:    aie.shim_dma_allocation
-//       CPP:    aie.shim_dma_allocation
-//       CPP:    aie.shim_dma_allocation
+//   CHECK-LABEL: hal.executable.export public @matmul_large_dispatch_0_matmul_2048x2048x2048_i32
+//         CHECK:    aie.device(npu1_4col)
+// CHECK-COUNT-3:    aie.shim_dma_allocation
 func.func @matmul_large(%lhs: tensor<2048x2048xi32>, %rhs: tensor<2048x2048xi32>) -> tensor<2048x2048xi32> {
   %empty = tensor.empty() : tensor<2048x2048xi32>
   %cst = arith.constant 0 : i32
@@ -38,11 +34,9 @@ func.func @matmul_large(%lhs: tensor<2048x2048xi32>, %rhs: tensor<2048x2048xi32>
 // This test demonstrates Pad-Pack pipeline based e2e lowering for a linalg.generic implementing
 // a linalg.matmul_transpose_b.
 
-// CPP-LABEL: hal.executable.export public @generic_matmul_transpose_static_dispatch_0_matmul_like_8x32x16_i32
-//       CPP:    aie.device(npu1_4col)
-//       CPP:    aie.shim_dma_allocation
-//       CPP:    aie.shim_dma_allocation
-//       CPP:    aie.shim_dma_allocation
+//   CHECK-LABEL: hal.executable.export public @generic_matmul_transpose_static_dispatch_0_matmul_like_8x32x16_i32
+//         CHECK:    aie.device(npu1_4col)
+// CHECK-COUNT-3:    aie.shim_dma_allocation
 func.func @generic_matmul_transpose_static(%lhs : tensor<8x16xi32>,
     %rhs : tensor<32x16xi32>) -> tensor<8x32xi32> {
   %cst = arith.constant 0 : i32
@@ -61,11 +55,9 @@ func.func @generic_matmul_transpose_static(%lhs : tensor<8x16xi32>,
 
 // This test demonstrates Pad-Pack pipeline based e2e lowering for a linalg.matmul_transpose_b.
 
-// CPP-LABEL: hal.executable.export public @matmul_transpose_b_static_dispatch_0_matmul_transpose_b_8x32x16_i32
-//       CPP:    aie.device(npu1_4col)
-//       CPP:    aie.shim_dma_allocation
-//       CPP:    aie.shim_dma_allocation
-//       CPP:    aie.shim_dma_allocation
+//   CHECK-LABEL: hal.executable.export public @matmul_transpose_b_static_dispatch_0_matmul_transpose_b_8x32x16_i32
+//         CHECK:    aie.device(npu1_4col)
+// CHECK-COUNT-3:    aie.shim_dma_allocation
 func.func @matmul_transpose_b_static(%lhs : tensor<8x16xi32>,
     %rhs : tensor<32x16xi32>) -> tensor<8x32xi32> {
   %cst = arith.constant 0 : i32

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo_npu4.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo_npu4.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-amdaie-lowering-strategy{use-tile-pipeline=pack-peel use-lower-to-aie-pipeline=objectFifo target-device=npu4})' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-amdaie-lowering-strategy{target-device=npu4})' %s | FileCheck %s
 
 // CHECK:       #config = #iree_codegen.lowering_config<tile_sizes = [
 // CHECK-SAME:                [128, 128], [0, 0, 1], [1, 1, 0, 0, 0, 0]


### PR DESCRIPTION
This PR did some cleanup of tests including

- Changed the test flags in `Test/samples` to use `--compile-to=executable-targets` instead of `--compile-to=executable-sources` and get rid of a mixture use of `iree-compile` and `iree-opt`.
- Removed redundant (with default value) flags.
- Modified some `//CHECK` tags to keep consistent format.