### PR TITLE
[CombineStridedOps] Add case for size(A) > size(B)

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.h
@@ -101,6 +101,16 @@ struct RetrieveScaleAndBias
 // DMAs have a single inter-iteration dimension (at least in AIE2 and AIE2p).
 static const size_t kAMDAIEDmaNbInterDims = 1;
 
+/// Check whether two access patterns are equal in value, starting from
+/// specified indices.
+bool areAccessPatternsEqualFromIndices(ArrayRef<OpFoldResult> offsetsA,
+                                       ArrayRef<OpFoldResult> sizesA,
+                                       ArrayRef<OpFoldResult> stridesA,
+                                       ArrayRef<OpFoldResult> offsetsB,
+                                       ArrayRef<OpFoldResult> sizesB,
+                                       ArrayRef<OpFoldResult> stridesB,
+                                       size_t indexA = 0, size_t indexB = 0);
+
 /// Check whether the two access patterns of strided operations can be combined
 /// into one. Takes a `maxNbDims` argument to check whether a combined access
 /// pattern would not exceed the maximum number of dimensions.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIEDmaUtilsTest.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIEDmaUtilsTest.cpp
@@ -127,6 +127,13 @@ TEST_F(AccessPatternCombinationTest, CombinableAccessPatterns) {
       {0, 0, 32}, {2, 16, 32}, {32, 64, 1}, {0, 96}, {16, 32}, {64, 1}, 4));
   EXPECT_TRUE(checkAreAccessPatternsCombinable(
       {0, 2, 0}, {2, 16, 32}, {32, 16, 1}, {6, 0}, {16, 32}, {16, 1}, 4));
+  // size(A) > size(B) Same access pattern
+  EXPECT_TRUE(checkAreAccessPatternsCombinable({0, 0}, {0, 32}, {0, 1}, {0},
+                                               {32}, {1}, 2));
+  EXPECT_TRUE(checkAreAccessPatternsCombinable({0, 0}, {7, 32}, {0, 1}, {0},
+                                               {32}, {1}, 2));
+  EXPECT_TRUE(checkAreAccessPatternsCombinable(
+      {1, 0, 0}, {8, 16, 32}, {0, 64, 1}, {0, 0}, {16, 32}, {64, 1}, 4));
   // size(B) > size(A)
   EXPECT_TRUE(checkAreAccessPatternsCombinable(
       {0, 0}, {16, 32}, {64, 1}, {0, 0, 32}, {2, 16, 32}, {32, 64, 1}, 4));
@@ -244,6 +251,13 @@ TEST_F(AccessPatternCombinationTest, CombineAccessPatterns) {
   checkCombineAccessPatterns({0, 1, 32}, {2, 16, 32}, {32, 64, 1}, {2, 32},
                              {16, 32}, {64, 1}, {0, 1, 32}, {3, 16, 32},
                              {32, 64, 1}, 4);
+  // size(A) > size(B) Same access pattern
+  checkCombineAccessPatterns({0, 0}, {7, 32}, {0, 1}, {0}, {32}, {1}, {0, 0},
+                             {8, 32}, {0, 1}, 3);
+  checkCombineAccessPatterns({1, 0}, {7, 32}, {0, 1}, {0}, {32}, {1}, {1, 0},
+                             {8, 32}, {0, 1}, 3);
+  checkCombineAccessPatterns({1, 0}, {0, 32}, {0, 1}, {0}, {32}, {1}, {1, 0},
+                             {1, 32}, {0, 1}, 3);
   // size(B) > size(A)
   checkCombineAccessPatterns({0}, {32}, {1}, {0, 64}, {2, 32}, {64, 1}, {0, 0},
                              {3, 32}, {64, 1}, 3);


### PR DESCRIPTION
I missed a case for `size(A) > size(B)` in https://github.com/nod-ai/iree-amd-aie/pull/963.

If `size(A) > size(B)` and `stridesA[0] == 0` and all other dimensions are equal, then access pattern A contains N repetitions of access pattern B and they can be combined into a single access pattern with N+1 repetitions.

Example:
```
A: offsets: [0, 0], sizes: [7, 16], strides: [0, 1]
B: offsets: [0], sizes: [16], strides: [1]
```
is transformed into:
```
offsets: [0, 0], sizes: [8, 16], strides: [0, 1]
```

Note that outer offset of A can have any value as it's anyway multiplied with `strideA[0] == 0`.
