### PR TITLE
[TargetCDO] Add support for implicit locks in BD chaining

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AMDAIETargetCDODirect.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AMDAIETargetCDODirect.cpp
@@ -71,10 +71,8 @@ LogicalResult configureLocksAndBd(Block &block, const TileLoc &tileLoc,
                                   const AMDAIEDeviceModel &deviceModel) {
   FailureOr<XAie_DmaDesc> dmaTileBd = initDMADesc(deviceModel, tileLoc);
   if (failed(dmaTileBd)) return failure();
-  assert(!block.getOps<UseLockOp>().empty() && "BD block has no lock-usage");
   std::optional<int> acqValue, relValue, acqLockId, relLockId;
   bool acqEn;
-  // switch (lock->getAc)
   for (auto op : block.getOps<UseLockOp>()) {
     // Only dyn_cast if you are going to check if it was of the type
     // expected; if you aren't checking use cast instead as it will at
@@ -95,6 +93,16 @@ LogicalResult configureLocksAndBd(Block &block, const TileLoc &tileLoc,
         relValue = op.getValue().value_or(1);
         break;
     }
+  }
+  // Disable acquire and release locks if not set.
+  if (!acqLockId) {
+    acqLockId = 0;
+    acqValue = 0;
+    acqEn = false;
+  }
+  if (!relLockId) {
+    relLockId = 0;
+    relValue = 0;
   }
   assert(acqValue && relValue && acqLockId && relLockId &&
          "expected both use_lock(acquire) and use_lock(release) with bd");

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/CMakeLists.txt
@@ -52,4 +52,3 @@ iree_lit_test_suite(
   LABELS
     "hostonly"
 )
-

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/bd_chaining.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/bd_chaining.mlir
@@ -1,0 +1,530 @@
+// RUN: (aie_cdo_gen_test %s %T) 2>&1 | FileCheck %s
+
+// Checks two BD chains, one of size 2 and one of size 4 with blocks without any `aie.use_lock`.
+module {
+aie.device(npu1_4col) {
+  %tile_0_0 = aie.tile(0, 0)
+  %tile_0_1 = aie.tile(0, 1)
+  %tile_1_1 = aie.tile(1, 1)
+  %tile_2_1 = aie.tile(2, 1)
+  %tile_0_2 = aie.tile(0, 2)
+  %lock_1_1 = aie.lock(%tile_1_1, 1) {init = 1 : i8}
+  %lock_1_1_0 = aie.lock(%tile_1_1, 0) {init = 0 : i8}
+  %lock_0_1 = aie.lock(%tile_0_1, 1) {init = 1 : i8}
+  %lock_0_1_1 = aie.lock(%tile_0_1, 0) {init = 0 : i8}
+  %lock_2_1 = aie.lock(%tile_2_1, 1) {init = 1 : i8}
+  %lock_2_1_2 = aie.lock(%tile_2_1, 0) {init = 0 : i8}
+  %lock_0_2 = aie.lock(%tile_0_2, 5) {init = 1 : i8}
+  %lock_0_2_3 = aie.lock(%tile_0_2, 4) {init = 0 : i8}
+  %lock_0_2_4 = aie.lock(%tile_0_2, 3) {init = 1 : i8}
+  %lock_0_2_5 = aie.lock(%tile_0_2, 2) {init = 0 : i8}
+  %lock_0_2_6 = aie.lock(%tile_0_2, 1) {init = 1 : i8}
+  %lock_0_2_7 = aie.lock(%tile_0_2, 0) {init = 0 : i8}
+  %buf5 = aie.buffer(%tile_0_1) {address = 0 : i32, mem_bank = 0 : i32, sym_name = "buf5"} : memref<8x16xi32> 
+  %buf4 = aie.buffer(%tile_1_1) {address = 0 : i32, mem_bank = 0 : i32, sym_name = "buf4"} : memref<16x32xi32> 
+  %buf3 = aie.buffer(%tile_2_1) {address = 0 : i32, mem_bank = 0 : i32, sym_name = "buf3"} : memref<8x32xi32> 
+  %buf2 = aie.buffer(%tile_0_2) {address = 1024 : i32, mem_bank = 0 : i32, sym_name = "buf2"} : memref<2x2x4x8xi32> 
+  %buf1 = aie.buffer(%tile_0_2) {address = 1536 : i32, mem_bank = 0 : i32, sym_name = "buf1"} : memref<8x2x8x4xi32> 
+  %buf0 = aie.buffer(%tile_0_2) {address = 3584 : i32, mem_bank = 0 : i32, sym_name = "buf0"} : memref<8x2x4x4xi32> 
+  %mem_0_2 = aie.mem(%tile_0_2) {
+    %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb5, repeat_count = 1)
+  ^bb1:  // 2 preds: ^bb0, ^bb1
+    aie.use_lock(%lock_0_2_4, AcquireGreaterEqual, 1)
+    aie.dma_bd(%buf2 : memref<2x2x4x8xi32>) {bd_id = 0 : i32, len = 128 : i32, next_bd_id = 0 : i32}
+    aie.use_lock(%lock_0_2_5, Release, 1)
+    aie.next_bd ^bb1
+  ^bb2:  // pred: ^bb3
+    aie.end
+  ^bb3:  // pred: ^bb5
+    %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
+  ^bb4:  // 2 preds: ^bb3, ^bb5
+    aie.use_lock(%lock_0_2, AcquireGreaterEqual, 1)
+    aie.dma_bd(%buf1 : memref<8x2x8x4xi32>) {bd_id = 1 : i32, len = 256 : i32, next_bd_id = 2 : i32}
+    aie.next_bd ^bb5
+  ^bb5:  // 2 preds: ^bb4
+    aie.dma_bd(%buf1 : memref<8x2x8x4xi32>) {bd_id = 2 : i32, len = 256 : i32, next_bd_id = 1 : i32, offset = 256 : i32}
+    aie.use_lock(%lock_0_2_3, Release, 1)
+    aie.next_bd ^bb4
+  ^bb6:  // pred: ^bb0
+    %2 = aie.dma_start(MM2S, 0, ^bb7, ^bb3, repeat_count = 1)
+  ^bb7:  // 2 preds: ^bb6, ^bb10
+    aie.use_lock(%lock_0_2_7, AcquireGreaterEqual, 1)
+    aie.dma_bd(%buf0 : memref<8x2x4x4xi32>) {bd_id = 3 : i32, dimensions = #aie<bd_dim_layout_array[<size = 2, stride = 4>, <size = 8, stride = 32>, <size = 4, stride = 1>]>, len = 64 : i32, next_bd_id = 4 : i32}
+    aie.next_bd ^bb8
+  ^bb8:  // 2 preds: ^bb7
+    aie.dma_bd(%buf0 : memref<8x2x4x4xi32>) {bd_id = 4 : i32, dimensions = #aie<bd_dim_layout_array[<size = 2, stride = 4>, <size = 8, stride = 32>, <size = 4, stride = 1>]>, len = 64 : i32, next_bd_id = 5 : i32, offset = 8 : i32}
+    aie.next_bd ^bb9
+  ^bb9:  // 2 preds: ^bb8
+    aie.dma_bd(%buf0 : memref<8x2x4x4xi32>) {bd_id = 5 : i32, dimensions = #aie<bd_dim_layout_array[<size = 2, stride = 4>, <size = 8, stride = 32>, <size = 4, stride = 1>]>, len = 64 : i32, next_bd_id = 6 : i32, offset = 16 : i32}
+    aie.next_bd ^bb10
+  ^bb10:  // 2 preds: ^bb9
+    aie.dma_bd(%buf0 : memref<8x2x4x4xi32>) {bd_id = 6 : i32, dimensions = #aie<bd_dim_layout_array[<size = 2, stride = 4>, <size = 8, stride = 32>, <size = 4, stride = 1>]>, len = 64 : i32, next_bd_id = 3 : i32, offset = 24 : i32}
+    aie.use_lock(%lock_0_2_6, Release, 1)
+    aie.next_bd ^bb7
+  }
+  %switchbox_0_0 = aie.switchbox(%tile_0_0) {
+    aie.connect<SOUTH : 3, NORTH : 0>
+    aie.connect<SOUTH : 7, EAST : 0>
+    aie.connect<EAST : 0, SOUTH : 2>
+  }
+  %shim_mux_0_0 = aie.shim_mux(%tile_0_0) {
+    aie.connect<DMA : 0, NORTH : 3>
+    aie.connect<DMA : 1, NORTH : 7>
+    aie.connect<NORTH : 2, DMA : 0>
+  }
+  %switchbox_0_1 = aie.switchbox(%tile_0_1) {
+    aie.connect<SOUTH : 0, DMA : 0>
+    aie.connect<DMA : 0, NORTH : 0>
+  }
+  %tile_1_0 = aie.tile(1, 0)
+  %switchbox_1_0 = aie.switchbox(%tile_1_0) {
+    aie.connect<WEST : 0, NORTH : 0>
+    aie.connect<EAST : 0, WEST : 0>
+  }
+  %switchbox_1_1 = aie.switchbox(%tile_1_1) {
+    aie.connect<SOUTH : 0, DMA : 0>
+    aie.connect<DMA : 0, NORTH : 0>
+  }
+  %tile_2_0 = aie.tile(2, 0)
+  %switchbox_2_0 = aie.switchbox(%tile_2_0) {
+    aie.connect<NORTH : 0, WEST : 0>
+  }
+  %switchbox_2_1 = aie.switchbox(%tile_2_1) {
+    aie.connect<DMA : 0, SOUTH : 0>
+    aie.connect<NORTH : 0, DMA : 0>
+  }
+  %switchbox_0_2 = aie.switchbox(%tile_0_2) {
+    aie.connect<SOUTH : 0, DMA : 0>
+    aie.connect<EAST : 0, DMA : 1>
+    aie.connect<DMA : 0, EAST : 0>
+  }
+  %tile_1_2 = aie.tile(1, 2)
+  %switchbox_1_2 = aie.switchbox(%tile_1_2) {
+    aie.connect<SOUTH : 0, WEST : 0>
+    aie.connect<WEST : 0, EAST : 0>
+  }
+  %tile_2_2 = aie.tile(2, 2)
+  %switchbox_2_2 = aie.switchbox(%tile_2_2) {
+    aie.connect<WEST : 0, SOUTH : 0>
+  }
+  %memtile_dma_2_1 = aie.memtile_dma(%tile_2_1) {
+    %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+  ^bb1:  // 2 preds: ^bb0, ^bb1
+    aie.use_lock(%lock_2_1, AcquireGreaterEqual, 1)
+    aie.dma_bd(%buf3 : memref<8x32xi32>) {bd_id = 0 : i32, len = 256 : i32, next_bd_id = 0 : i32}
+    aie.use_lock(%lock_2_1_2, Release, 1)
+    aie.next_bd ^bb1
+  ^bb2:  // pred: ^bb3
+    aie.end
+  ^bb3:  // pred: ^bb0
+    %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
+  ^bb4:  // 2 preds: ^bb3, ^bb4
+    aie.use_lock(%lock_2_1_2, AcquireGreaterEqual, 1)
+    aie.dma_bd(%buf3 : memref<8x32xi32>) {bd_id = 1 : i32, len = 256 : i32, next_bd_id = 1 : i32}
+    aie.use_lock(%lock_2_1, Release, 1)
+    aie.next_bd ^bb4
+  }
+  %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+    %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+  ^bb1:  // 2 preds: ^bb0, ^bb1
+    aie.use_lock(%lock_0_1, AcquireGreaterEqual, 1)
+    aie.dma_bd(%buf5 : memref<8x16xi32>) {bd_id = 0 : i32, len = 128 : i32, next_bd_id = 0 : i32}
+    aie.use_lock(%lock_0_1_1, Release, 1)
+    aie.next_bd ^bb1
+  ^bb2:  // pred: ^bb3
+    aie.end
+  ^bb3:  // pred: ^bb0
+    %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
+  ^bb4:  // 2 preds: ^bb3, ^bb4
+    aie.use_lock(%lock_0_1_1, AcquireGreaterEqual, 1)
+    aie.dma_bd(%buf5 : memref<8x16xi32>) {bd_id = 1 : i32, dimensions = #aie<bd_dim_layout_array[<size = 2, stride = 8>, <size = 8, stride = 16>, <size = 8, stride = 1>]>, len = 128 : i32, next_bd_id = 1 : i32}
+    aie.use_lock(%lock_0_1, Release, 1)
+    aie.next_bd ^bb4
+  }
+  %memtile_dma_1_1 = aie.memtile_dma(%tile_1_1) {
+    %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
+  ^bb1:  // 2 preds: ^bb0, ^bb1
+    aie.use_lock(%lock_1_1, AcquireGreaterEqual, 1)
+    aie.dma_bd(%buf4 : memref<16x32xi32>) {bd_id = 0 : i32, len = 512 : i32, next_bd_id = 0 : i32}
+    aie.use_lock(%lock_1_1_0, Release, 1)
+    aie.next_bd ^bb1
+  ^bb2:  // pred: ^bb3
+    aie.end
+  ^bb3:  // pred: ^bb0
+    %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
+  ^bb4:  // 2 preds: ^bb3, ^bb4
+    aie.use_lock(%lock_1_1_0, AcquireGreaterEqual, 1)
+    aie.dma_bd(%buf4 : memref<16x32xi32>) {bd_id = 1 : i32, dimensions = #aie<bd_dim_layout_array[<size = 8, stride = 4>, <size = 16, stride = 32>, <size = 4, stride = 1>]>, len = 512 : i32, next_bd_id = 1 : i32}
+    aie.use_lock(%lock_1_1, Release, 1)
+    aie.next_bd ^bb4
+  }
+  aie.shim_dma_allocation @airMemcpyId12(S2MM, 0, 0)
+  memref.global "public" @airMemcpyId12 : memref<8x32xi32>
+  aie.shim_dma_allocation @airMemcpyId4(MM2S, 0, 0)
+  memref.global "public" @airMemcpyId4 : memref<8x16xi32>
+  aie.shim_dma_allocation @airMemcpyId5(MM2S, 1, 0)
+  memref.global "public" @airMemcpyId5 : memref<16x32xi32>
+  func.func @matmul_8x32_16xi32__dispatch_0_matmul_8x32x16_i32(%arg0: memref<8x16xi32>, %arg1: memref<16x32xi32>, %arg2: memref<8x32xi32>) {
+    memref.assume_alignment %arg0, 64 : memref<8x16xi32>
+    memref.assume_alignment %arg1, 64 : memref<16x32xi32>
+    memref.assume_alignment %arg2, 64 : memref<8x32xi32>
+    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 8, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<8x16xi32>
+    aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][1, 1, 16, 32][0, 0, 32, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x32xi32>
+    aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 8, 32][0, 0, 32, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<8x32xi32>
+    aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+    return
+  }
+} {sym_name = "matmul_8x32_16xi32__dispatch_0_matmul_8x32x16_i32_0"}
+}
+
+// CHECK: XAIE API: XAie_SetupPartitionConfig with args: &devInst=ptr, partBaseAddr=0, partitionStartCol=1, partitionNumCols=4
+// CHECK: XAIE API: XAie_CfgInitialize with args: &devInst=ptr, &configPtr=ptr
+// CHECK: XAIE API: XAie_SetIOBackend with args: &devInst=ptr, XAIE_IO_BACKEND_CDO=1
+// CHECK: XAIE API: XAie_UpdateNpiAddr with args: &devInst=ptr, npiAddr=0
+// CHECK: XAIE API: XAie_TurnEccOff with args: &devInst=ptr
+// CHECK: XAIE API: XAie_LockSetValue with args: devInst=ptr, lock.tileLoc=TileLoc(col: 1, row: 1), locInit=XAie_Lock(LockId: 1, LockVal: 1)
+// CHECK: XAIE API: XAie_LockSetValue with args: devInst=ptr, lock.tileLoc=TileLoc(col: 1, row: 1), locInit=XAie_Lock(LockId: 0, LockVal: 0)
+// CHECK: XAIE API: XAie_LockSetValue with args: devInst=ptr, lock.tileLoc=TileLoc(col: 0, row: 1), locInit=XAie_Lock(LockId: 1, LockVal: 1)
+// CHECK: XAIE API: XAie_LockSetValue with args: devInst=ptr, lock.tileLoc=TileLoc(col: 0, row: 1), locInit=XAie_Lock(LockId: 0, LockVal: 0)
+// CHECK: XAIE API: XAie_LockSetValue with args: devInst=ptr, lock.tileLoc=TileLoc(col: 2, row: 1), locInit=XAie_Lock(LockId: 1, LockVal: 1)
+// CHECK: XAIE API: XAie_LockSetValue with args: devInst=ptr, lock.tileLoc=TileLoc(col: 2, row: 1), locInit=XAie_Lock(LockId: 0, LockVal: 0)
+// CHECK: XAIE API: XAie_LockSetValue with args: devInst=ptr, lock.tileLoc=TileLoc(col: 0, row: 2), locInit=XAie_Lock(LockId: 5, LockVal: 1)
+// CHECK: XAIE API: XAie_LockSetValue with args: devInst=ptr, lock.tileLoc=TileLoc(col: 0, row: 2), locInit=XAie_Lock(LockId: 4, LockVal: 0)
+// CHECK: XAIE API: XAie_LockSetValue with args: devInst=ptr, lock.tileLoc=TileLoc(col: 0, row: 2), locInit=XAie_Lock(LockId: 3, LockVal: 1)
+// CHECK: XAIE API: XAie_LockSetValue with args: devInst=ptr, lock.tileLoc=TileLoc(col: 0, row: 2), locInit=XAie_Lock(LockId: 2, LockVal: 0)
+// CHECK: XAIE API: XAie_LockSetValue with args: devInst=ptr, lock.tileLoc=TileLoc(col: 0, row: 2), locInit=XAie_Lock(LockId: 1, LockVal: 1)
+// CHECK: XAIE API: XAie_LockSetValue with args: devInst=ptr, lock.tileLoc=TileLoc(col: 0, row: 2), locInit=XAie_Lock(LockId: 0, LockVal: 0)
+// CHECK: XAIE API: XAie_DmaDescInit with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 2)
+// CHECK: XAIE API: dmaDesc.DmaMod->SetLock with args: &dmaDesc=ptr, acqLock=XAie_Lock(LockId: 3, LockVal: -1), relLock=XAie_Lock(LockId: 2, LockVal: 1), acqEn=1, relEn=0
+// CHECK: XAIE API: XAie_DmaSetAddrLen with args: &dmaDesc=ptr, basePlusOffsetInBytes=1024, lenInBytes=512
+// CHECK: XAIE API: XAie_DmaSetNextBd with args: &dmaDesc=ptr, nextBdId.value()=0, enableNextBd=1
+// CHECK: XAIE API: XAie_DmaEnableBd with args: &dmaDesc=ptr
+// CHECK: XAIE API: XAie_DmaWriteBd with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 2), bdId=0
+// CHECK: XAIE API: XAie_DmaDescInit with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 2)
+// CHECK: XAIE API: dmaDesc.DmaMod->SetLock with args: &dmaDesc=ptr, acqLock=XAie_Lock(LockId: 5, LockVal: -1), relLock=XAie_Lock(LockId: 0, LockVal: 0), acqEn=1, relEn=0
+// CHECK: XAIE API: XAie_DmaSetAddrLen with args: &dmaDesc=ptr, basePlusOffsetInBytes=1536, lenInBytes=1024
+// CHECK: XAIE API: XAie_DmaSetNextBd with args: &dmaDesc=ptr, nextBdId.value()=2, enableNextBd=1
+// CHECK: XAIE API: XAie_DmaEnableBd with args: &dmaDesc=ptr
+// CHECK: XAIE API: XAie_DmaWriteBd with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 2), bdId=1
+// CHECK: XAIE API: XAie_DmaDescInit with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 2)
+// CHECK: XAIE API: dmaDesc.DmaMod->SetLock with args: &dmaDesc=ptr, acqLock=XAie_Lock(LockId: 0, LockVal: 0), relLock=XAie_Lock(LockId: 4, LockVal: 1), acqEn=0, relEn=0
+// CHECK: XAIE API: XAie_DmaSetAddrLen with args: &dmaDesc=ptr, basePlusOffsetInBytes=2560, lenInBytes=1024
+// CHECK: XAIE API: XAie_DmaSetNextBd with args: &dmaDesc=ptr, nextBdId.value()=1, enableNextBd=1
+// CHECK: XAIE API: XAie_DmaEnableBd with args: &dmaDesc=ptr
+// CHECK: XAIE API: XAie_DmaWriteBd with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 2), bdId=2
+// CHECK: XAIE API: XAie_DmaDescInit with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 2)
+// CHECK: XAIE API: dmaDesc.DmaMod->SetLock with args: &dmaDesc=ptr, acqLock=XAie_Lock(LockId: 0, LockVal: -1), relLock=XAie_Lock(LockId: 0, LockVal: 0), acqEn=1, relEn=0
+// CHECK: XAie_DmaTensor(XAie_AieMlDmaDimDesc(StepSize: 1, Wrap: 4), XAie_AieMlDmaDimDesc(StepSize: 32, Wrap: 8), XAie_AieMlDmaDimDesc(StepSize: 4, Wrap: 2))
+// CHECK: XAIE API: XAie_DmaSetMultiDimAddr with args: &dmaDesc=ptr, &dmaTileBdTensor=ptr, basePlusOffsetInBytes=3584, lenInBytes=256
+// CHECK: XAIE API: XAie_DmaSetNextBd with args: &dmaDesc=ptr, nextBdId.value()=4, enableNextBd=1
+// CHECK: XAIE API: XAie_DmaEnableBd with args: &dmaDesc=ptr
+// CHECK: XAIE API: XAie_DmaWriteBd with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 2), bdId=3
+// CHECK: XAIE API: XAie_DmaDescInit with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 2)
+// CHECK: XAIE API: dmaDesc.DmaMod->SetLock with args: &dmaDesc=ptr, acqLock=XAie_Lock(LockId: 0, LockVal: 0), relLock=XAie_Lock(LockId: 0, LockVal: 0), acqEn=0, relEn=0
+// CHECK: XAie_DmaTensor(XAie_AieMlDmaDimDesc(StepSize: 1, Wrap: 4), XAie_AieMlDmaDimDesc(StepSize: 32, Wrap: 8), XAie_AieMlDmaDimDesc(StepSize: 4, Wrap: 2))
+// CHECK: XAIE API: XAie_DmaSetMultiDimAddr with args: &dmaDesc=ptr, &dmaTileBdTensor=ptr, basePlusOffsetInBytes=3616, lenInBytes=256
+// CHECK: XAIE API: XAie_DmaSetNextBd with args: &dmaDesc=ptr, nextBdId.value()=5, enableNextBd=1
+// CHECK: XAIE API: XAie_DmaEnableBd with args: &dmaDesc=ptr
+// CHECK: XAIE API: XAie_DmaWriteBd with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 2), bdId=4
+// CHECK: XAIE API: XAie_DmaDescInit with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 2)
+// CHECK: XAIE API: dmaDesc.DmaMod->SetLock with args: &dmaDesc=ptr, acqLock=XAie_Lock(LockId: 0, LockVal: 0), relLock=XAie_Lock(LockId: 0, LockVal: 0), acqEn=0, relEn=0
+// CHECK: XAie_DmaTensor(XAie_AieMlDmaDimDesc(StepSize: 1, Wrap: 4), XAie_AieMlDmaDimDesc(StepSize: 32, Wrap: 8), XAie_AieMlDmaDimDesc(StepSize: 4, Wrap: 2))
+// CHECK: XAIE API: XAie_DmaSetMultiDimAddr with args: &dmaDesc=ptr, &dmaTileBdTensor=ptr, basePlusOffsetInBytes=3648, lenInBytes=256
+// CHECK: XAIE API: XAie_DmaSetNextBd with args: &dmaDesc=ptr, nextBdId.value()=6, enableNextBd=1
+// CHECK: XAIE API: XAie_DmaEnableBd with args: &dmaDesc=ptr
+// CHECK: XAIE API: XAie_DmaWriteBd with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 2), bdId=5
+// CHECK: XAIE API: XAie_DmaDescInit with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 2)
+// CHECK: XAIE API: dmaDesc.DmaMod->SetLock with args: &dmaDesc=ptr, acqLock=XAie_Lock(LockId: 0, LockVal: 0), relLock=XAie_Lock(LockId: 1, LockVal: 1), acqEn=0, relEn=0
+// CHECK: XAie_DmaTensor(XAie_AieMlDmaDimDesc(StepSize: 1, Wrap: 4), XAie_AieMlDmaDimDesc(StepSize: 32, Wrap: 8), XAie_AieMlDmaDimDesc(StepSize: 4, Wrap: 2))
+// CHECK: XAIE API: XAie_DmaSetMultiDimAddr with args: &dmaDesc=ptr, &dmaTileBdTensor=ptr, basePlusOffsetInBytes=3680, lenInBytes=256
+// CHECK: XAIE API: XAie_DmaSetNextBd with args: &dmaDesc=ptr, nextBdId.value()=3, enableNextBd=1
+// CHECK: XAIE API: XAie_DmaEnableBd with args: &dmaDesc=ptr
+// CHECK: XAIE API: XAie_DmaWriteBd with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 2), bdId=6
+// CHECK: XAIE API: XAie_DmaChannelSetStartQueue with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 2), chNum=0, direction=0, bdId=0, repeatCount=2, enTokenIssue=0
+// CHECK: XAIE API: XAie_DmaChannelEnable with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 2), chNum=0, direction=0
+// CHECK: XAIE API: XAie_DmaChannelSetStartQueue with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 2), chNum=1, direction=0, bdId=1, repeatCount=2, enTokenIssue=0
+// CHECK: XAIE API: XAie_DmaChannelEnable with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 2), chNum=1, direction=0
+// CHECK: XAIE API: XAie_DmaChannelSetStartQueue with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 2), chNum=0, direction=1, bdId=3, repeatCount=2, enTokenIssue=0
+// CHECK: XAIE API: XAie_DmaChannelEnable with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 2), chNum=0, direction=1
+// CHECK: XAIE API: XAie_DmaDescInit with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 2, row: 1)
+// CHECK: XAIE API: dmaDesc.DmaMod->SetLock with args: &dmaDesc=ptr, acqLock=XAie_Lock(LockId: 65, LockVal: -1), relLock=XAie_Lock(LockId: 64, LockVal: 1), acqEn=1, relEn=0
+// CHECK: XAIE API: XAie_DmaSetAddrLen with args: &dmaDesc=ptr, basePlusOffsetInBytes=524288, lenInBytes=1024
+// CHECK: XAIE API: XAie_DmaSetNextBd with args: &dmaDesc=ptr, nextBdId.value()=0, enableNextBd=1
+// CHECK: XAIE API: XAie_DmaEnableBd with args: &dmaDesc=ptr
+// CHECK: XAIE API: XAie_DmaWriteBd with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 2, row: 1), bdId=0
+// CHECK: XAIE API: XAie_DmaDescInit with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 2, row: 1)
+// CHECK: XAIE API: dmaDesc.DmaMod->SetLock with args: &dmaDesc=ptr, acqLock=XAie_Lock(LockId: 64, LockVal: -1), relLock=XAie_Lock(LockId: 65, LockVal: 1), acqEn=1, relEn=0
+// CHECK: XAIE API: XAie_DmaSetAddrLen with args: &dmaDesc=ptr, basePlusOffsetInBytes=524288, lenInBytes=1024
+// CHECK: XAIE API: XAie_DmaSetNextBd with args: &dmaDesc=ptr, nextBdId.value()=1, enableNextBd=1
+// CHECK: XAIE API: XAie_DmaEnableBd with args: &dmaDesc=ptr
+// CHECK: XAIE API: XAie_DmaWriteBd with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 2, row: 1), bdId=1
+// CHECK: XAIE API: XAie_DmaChannelSetStartQueue with args: devInst=ptr, tileLoc=TileLoc(col: 2, row: 1), chNum=0, direction=0, bdId=0, repeatCount=2, enTokenIssue=0
+// CHECK: XAIE API: XAie_DmaChannelEnable with args: devInst=ptr, tileLoc=TileLoc(col: 2, row: 1), chNum=0, direction=0
+// CHECK: XAIE API: XAie_DmaChannelSetStartQueue with args: devInst=ptr, tileLoc=TileLoc(col: 2, row: 1), chNum=0, direction=1, bdId=1, repeatCount=2, enTokenIssue=0
+// CHECK: XAIE API: XAie_DmaChannelEnable with args: devInst=ptr, tileLoc=TileLoc(col: 2, row: 1), chNum=0, direction=1
+// CHECK: XAIE API: XAie_DmaDescInit with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 1)
+// CHECK: XAIE API: dmaDesc.DmaMod->SetLock with args: &dmaDesc=ptr, acqLock=XAie_Lock(LockId: 65, LockVal: -1), relLock=XAie_Lock(LockId: 64, LockVal: 1), acqEn=1, relEn=0
+// CHECK: XAIE API: XAie_DmaSetAddrLen with args: &dmaDesc=ptr, basePlusOffsetInBytes=524288, lenInBytes=512
+// CHECK: XAIE API: XAie_DmaSetNextBd with args: &dmaDesc=ptr, nextBdId.value()=0, enableNextBd=1
+// CHECK: XAIE API: XAie_DmaEnableBd with args: &dmaDesc=ptr
+// CHECK: XAIE API: XAie_DmaWriteBd with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 1), bdId=0
+// CHECK: XAIE API: XAie_DmaDescInit with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 1)
+// CHECK: XAIE API: dmaDesc.DmaMod->SetLock with args: &dmaDesc=ptr, acqLock=XAie_Lock(LockId: 64, LockVal: -1), relLock=XAie_Lock(LockId: 65, LockVal: 1), acqEn=1, relEn=0
+// CHECK: XAie_DmaTensor(XAie_AieMlDmaDimDesc(StepSize: 1, Wrap: 8), XAie_AieMlDmaDimDesc(StepSize: 16, Wrap: 8), XAie_AieMlDmaDimDesc(StepSize: 8, Wrap: 2))
+// CHECK: XAIE API: XAie_DmaSetMultiDimAddr with args: &dmaDesc=ptr, &dmaTileBdTensor=ptr, basePlusOffsetInBytes=524288, lenInBytes=512
+// CHECK: XAIE API: XAie_DmaSetNextBd with args: &dmaDesc=ptr, nextBdId.value()=1, enableNextBd=1
+// CHECK: XAIE API: XAie_DmaEnableBd with args: &dmaDesc=ptr
+// CHECK: XAIE API: XAie_DmaWriteBd with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 0, row: 1), bdId=1
+// CHECK: XAIE API: XAie_DmaChannelSetStartQueue with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 1), chNum=0, direction=0, bdId=0, repeatCount=2, enTokenIssue=0
+// CHECK: XAIE API: XAie_DmaChannelEnable with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 1), chNum=0, direction=0
+// CHECK: XAIE API: XAie_DmaChannelSetStartQueue with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 1), chNum=0, direction=1, bdId=1, repeatCount=2, enTokenIssue=0
+// CHECK: XAIE API: XAie_DmaChannelEnable with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 1), chNum=0, direction=1
+// CHECK: XAIE API: XAie_DmaDescInit with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 1, row: 1)
+// CHECK: XAIE API: dmaDesc.DmaMod->SetLock with args: &dmaDesc=ptr, acqLock=XAie_Lock(LockId: 65, LockVal: -1), relLock=XAie_Lock(LockId: 64, LockVal: 1), acqEn=1, relEn=0
+// CHECK: XAIE API: XAie_DmaSetAddrLen with args: &dmaDesc=ptr, basePlusOffsetInBytes=524288, lenInBytes=2048
+// CHECK: XAIE API: XAie_DmaSetNextBd with args: &dmaDesc=ptr, nextBdId.value()=0, enableNextBd=1
+// CHECK: XAIE API: XAie_DmaEnableBd with args: &dmaDesc=ptr
+// CHECK: XAIE API: XAie_DmaWriteBd with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 1, row: 1), bdId=0
+// CHECK: XAIE API: XAie_DmaDescInit with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 1, row: 1)
+// CHECK: XAIE API: dmaDesc.DmaMod->SetLock with args: &dmaDesc=ptr, acqLock=XAie_Lock(LockId: 64, LockVal: -1), relLock=XAie_Lock(LockId: 65, LockVal: 1), acqEn=1, relEn=0
+// CHECK: XAie_DmaTensor(XAie_AieMlDmaDimDesc(StepSize: 1, Wrap: 4), XAie_AieMlDmaDimDesc(StepSize: 32, Wrap: 16), XAie_AieMlDmaDimDesc(StepSize: 4, Wrap: 8))
+// CHECK: XAIE API: XAie_DmaSetMultiDimAddr with args: &dmaDesc=ptr, &dmaTileBdTensor=ptr, basePlusOffsetInBytes=524288, lenInBytes=2048
+// CHECK: XAIE API: XAie_DmaSetNextBd with args: &dmaDesc=ptr, nextBdId.value()=1, enableNextBd=1
+// CHECK: XAIE API: XAie_DmaEnableBd with args: &dmaDesc=ptr
+// CHECK: XAIE API: XAie_DmaWriteBd with args: devInst=ptr, &dmaDesc=ptr, tileLoc=TileLoc(col: 1, row: 1), bdId=1
+// CHECK: XAIE API: XAie_DmaChannelSetStartQueue with args: devInst=ptr, tileLoc=TileLoc(col: 1, row: 1), chNum=0, direction=0, bdId=0, repeatCount=2, enTokenIssue=0
+// CHECK: XAIE API: XAie_DmaChannelEnable with args: devInst=ptr, tileLoc=TileLoc(col: 1, row: 1), chNum=0, direction=0
+// CHECK: XAIE API: XAie_DmaChannelSetStartQueue with args: devInst=ptr, tileLoc=TileLoc(col: 1, row: 1), chNum=0, direction=1, bdId=1, repeatCount=2, enTokenIssue=0
+// CHECK: XAIE API: XAie_DmaChannelEnable with args: devInst=ptr, tileLoc=TileLoc(col: 1, row: 1), chNum=0, direction=1
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 0), CTRL=StrmSwPortType::CTRL, slvPortNum=0, SOUTH=StrmSwPortType::SOUTH, mstrPortNum=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 0), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::SOUTH, connect.src.channel=3, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::NORTH, connect.dst.channel=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 0), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::SOUTH, connect.src.channel=7, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::EAST, connect.dst.channel=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 0), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::EAST, connect.src.channel=0, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::SOUTH, connect.dst.channel=2
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 1), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::SOUTH, connect.src.channel=0, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::DMA, connect.dst.channel=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 1), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::DMA, connect.src.channel=0, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::NORTH, connect.dst.channel=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 1, row: 0), CTRL=StrmSwPortType::CTRL, slvPortNum=0, SOUTH=StrmSwPortType::SOUTH, mstrPortNum=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 1, row: 0), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::WEST, connect.src.channel=0, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::NORTH, connect.dst.channel=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 1, row: 0), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::EAST, connect.src.channel=0, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::WEST, connect.dst.channel=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 1, row: 1), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::SOUTH, connect.src.channel=0, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::DMA, connect.dst.channel=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 1, row: 1), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::DMA, connect.src.channel=0, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::NORTH, connect.dst.channel=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 2, row: 0), CTRL=StrmSwPortType::CTRL, slvPortNum=0, SOUTH=StrmSwPortType::SOUTH, mstrPortNum=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 2, row: 0), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::NORTH, connect.src.channel=0, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::WEST, connect.dst.channel=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 2, row: 1), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::DMA, connect.src.channel=0, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::SOUTH, connect.dst.channel=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 2, row: 1), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::NORTH, connect.src.channel=0, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::DMA, connect.dst.channel=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 2), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::SOUTH, connect.src.channel=0, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::DMA, connect.dst.channel=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 2), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::EAST, connect.src.channel=0, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::DMA, connect.dst.channel=1
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 2), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::DMA, connect.src.channel=0, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::EAST, connect.dst.channel=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 1, row: 2), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::SOUTH, connect.src.channel=0, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::WEST, connect.dst.channel=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 1, row: 2), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::WEST, connect.src.channel=0, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::EAST, connect.dst.channel=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 2, row: 2), strmTtoStrmT(connect.src.bundle)=StrmSwPortType::WEST, connect.src.channel=0, strmTtoStrmT(connect.dst.bundle)=StrmSwPortType::SOUTH, connect.dst.channel=0
+// CHECK: XAIE API: XAie_StrmConnCctEnable with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 0), CTRL=StrmSwPortType::CTRL, slvPortNum=0, SOUTH=StrmSwPortType::SOUTH, mstrPortNum=0
+// CHECK: XAIE API: XAie_EnableShimDmaToAieStrmPort with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 0), connect.dst.channel=3
+// CHECK: XAIE API: XAie_EnableShimDmaToAieStrmPort with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 0), connect.dst.channel=7
+// CHECK: XAIE API: XAie_EnableAieToShimDmaStrmPort with args: devInst=ptr, tileLoc=TileLoc(col: 0, row: 0), connect.src.channel=2
+// CHECK: cdo-driver: (NOP Command): Payload Length: 0 
+// CHECK: cdo-driver: (NOP Command): Payload Length: 0 
+// CHECK: cdo-driver: (Write64): Address:  0x00000000021C0010 Data:  0x00000001  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000021C0000 Data:  0x00000000  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000001C0010 Data:  0x00000001  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000001C0000 Data:  0x00000000  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000041C0010 Data:  0x00000001  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000041C0000 Data:  0x00000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000021F050 Data:  0x00000001  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000021F040 Data:  0x00000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000021F030 Data:  0x00000001  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000021F020 Data:  0x00000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000021F010 Data:  0x00000001  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000021F000 Data:  0x00000000  
+// CHECK: cdo-driver: (NOP Command): Payload Length: 2 
+// CHECK: cdo-driver: (BlockWrite-DMAWriteCmd): Start Address: 0x000000000021D000  Size: 6
+// CHECK: cdo-driver:     Address: 0x000000000021D000  Data is: 0x00400080 
+// CHECK: cdo-driver:     Address: 0x000000000021D004  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D008  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D00C  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D010  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D014  Data is: 0x06045FE3 
+
+// CHECK: cdo-driver: (NOP Command): Payload Length: 2 
+// CHECK: cdo-driver: (BlockWrite-DMAWriteCmd): Start Address: 0x000000000021D020  Size: 6
+// CHECK: cdo-driver:     Address: 0x000000000021D020  Data is: 0x00600100 
+// CHECK: cdo-driver:     Address: 0x000000000021D024  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D028  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D02C  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D030  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D034  Data is: 0x16001FE5 
+
+// CHECK: cdo-driver: (NOP Command): Payload Length: 2 
+// CHECK: cdo-driver: (BlockWrite-DMAWriteCmd): Start Address: 0x000000000021D040  Size: 6
+// CHECK: cdo-driver:     Address: 0x000000000021D040  Data is: 0x00A00100 
+// CHECK: cdo-driver:     Address: 0x000000000021D044  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D048  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D04C  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D050  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D054  Data is: 0x0E048000 
+
+// CHECK: cdo-driver: (NOP Command): Payload Length: 2 
+// CHECK: cdo-driver: (BlockWrite-DMAWriteCmd): Start Address: 0x000000000021D060  Size: 6
+// CHECK: cdo-driver:     Address: 0x000000000021D060  Data is: 0x00E00040 
+// CHECK: cdo-driver:     Address: 0x000000000021D064  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D068  Data is: 0x0003E000 
+// CHECK: cdo-driver:     Address: 0x000000000021D06C  Data is: 0x01008003 
+// CHECK: cdo-driver:     Address: 0x000000000021D070  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D074  Data is: 0x26001FE0 
+
+// CHECK: cdo-driver: (NOP Command): Payload Length: 2 
+// CHECK: cdo-driver: (BlockWrite-DMAWriteCmd): Start Address: 0x000000000021D080  Size: 6
+// CHECK: cdo-driver:     Address: 0x000000000021D080  Data is: 0x00E20040 
+// CHECK: cdo-driver:     Address: 0x000000000021D084  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D088  Data is: 0x0003E000 
+// CHECK: cdo-driver:     Address: 0x000000000021D08C  Data is: 0x01008003 
+// CHECK: cdo-driver:     Address: 0x000000000021D090  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D094  Data is: 0x2E000000 
+
+// CHECK: cdo-driver: (NOP Command): Payload Length: 2 
+// CHECK: cdo-driver: (BlockWrite-DMAWriteCmd): Start Address: 0x000000000021D0A0  Size: 6
+// CHECK: cdo-driver:     Address: 0x000000000021D0A0  Data is: 0x00E40040 
+// CHECK: cdo-driver:     Address: 0x000000000021D0A4  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D0A8  Data is: 0x0003E000 
+// CHECK: cdo-driver:     Address: 0x000000000021D0AC  Data is: 0x01008003 
+// CHECK: cdo-driver:     Address: 0x000000000021D0B0  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D0B4  Data is: 0x36000000 
+
+// CHECK: cdo-driver: (NOP Command): Payload Length: 2 
+// CHECK: cdo-driver: (BlockWrite-DMAWriteCmd): Start Address: 0x000000000021D0C0  Size: 6
+// CHECK: cdo-driver:     Address: 0x000000000021D0C0  Data is: 0x00E60040 
+// CHECK: cdo-driver:     Address: 0x000000000021D0C4  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D0C8  Data is: 0x0003E000 
+// CHECK: cdo-driver:     Address: 0x000000000021D0CC  Data is: 0x01008003 
+// CHECK: cdo-driver:     Address: 0x000000000021D0D0  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x000000000021D0D4  Data is: 0x1E042000 
+
+// CHECK: cdo-driver: (Write64): Address:  0x000000000021DE04 Data:  0x00010000  
+// CHECK: cdo-driver: (MaskWrite64): Address: 0x000000000021DE00  Mask: 0x00000000  Data: 0x00000001 
+// CHECK: cdo-driver: (Write64): Address:  0x000000000021DE0C Data:  0x00010001  
+// CHECK: cdo-driver: (MaskWrite64): Address: 0x000000000021DE08  Mask: 0x00000000  Data: 0x00000001 
+// CHECK: cdo-driver: (Write64): Address:  0x000000000021DE14 Data:  0x00010003  
+// CHECK: cdo-driver: (MaskWrite64): Address: 0x000000000021DE10  Mask: 0x00000000  Data: 0x00000001 
+// CHECK: cdo-driver: (BlockWrite-DMAWriteCmd): Start Address: 0x00000000041A0000  Size: 8
+// CHECK: cdo-driver:     Address: 0x00000000041A0000  Data is: 0x00000100 
+// CHECK: cdo-driver:     Address: 0x00000000041A0004  Data is: 0x000A0000 
+// CHECK: cdo-driver:     Address: 0x00000000041A0008  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000041A000C  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000041A0010  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000041A0014  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000041A0018  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000041A001C  Data is: 0x8140FF41 
+
+// CHECK: cdo-driver: (NOP Command): Payload Length: 0 
+// CHECK: cdo-driver: (BlockWrite-DMAWriteCmd): Start Address: 0x00000000041A0020  Size: 8
+// CHECK: cdo-driver:     Address: 0x00000000041A0020  Data is: 0x00000100 
+// CHECK: cdo-driver:     Address: 0x00000000041A0024  Data is: 0x001A0000 
+// CHECK: cdo-driver:     Address: 0x00000000041A0028  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000041A002C  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000041A0030  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000041A0034  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000041A0038  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000041A003C  Data is: 0x8141FF40 
+
+// CHECK: cdo-driver: (Write64): Address:  0x00000000041A0604 Data:  0x00010000  
+// CHECK: cdo-driver: (MaskWrite64): Address: 0x00000000041A0600  Mask: 0x00000000  Data: 0x00000001 
+// CHECK: cdo-driver: (Write64): Address:  0x00000000041A0634 Data:  0x00010001  
+// CHECK: cdo-driver: (MaskWrite64): Address: 0x00000000041A0630  Mask: 0x00000000  Data: 0x00000001 
+// CHECK: cdo-driver: (NOP Command): Payload Length: 2 
+// CHECK: cdo-driver: (BlockWrite-DMAWriteCmd): Start Address: 0x00000000001A0000  Size: 8
+// CHECK: cdo-driver:     Address: 0x00000000001A0000  Data is: 0x00000080 
+// CHECK: cdo-driver:     Address: 0x00000000001A0004  Data is: 0x000A0000 
+// CHECK: cdo-driver:     Address: 0x00000000001A0008  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000001A000C  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000001A0010  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000001A0014  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000001A0018  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000001A001C  Data is: 0x8140FF41 
+
+// CHECK: cdo-driver: (NOP Command): Payload Length: 0 
+// CHECK: cdo-driver: (BlockWrite-DMAWriteCmd): Start Address: 0x00000000001A0020  Size: 8
+// CHECK: cdo-driver:     Address: 0x00000000001A0020  Data is: 0x00000080 
+// CHECK: cdo-driver:     Address: 0x00000000001A0024  Data is: 0x001A0000 
+// CHECK: cdo-driver:     Address: 0x00000000001A0028  Data is: 0x00100000 
+// CHECK: cdo-driver:     Address: 0x00000000001A002C  Data is: 0x0010000F 
+// CHECK: cdo-driver:     Address: 0x00000000001A0030  Data is: 0x00040007 
+// CHECK: cdo-driver:     Address: 0x00000000001A0034  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000001A0038  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000001A003C  Data is: 0x8141FF40 
+
+// CHECK: cdo-driver: (Write64): Address:  0x00000000001A0604 Data:  0x00010000  
+// CHECK: cdo-driver: (MaskWrite64): Address: 0x00000000001A0600  Mask: 0x00000000  Data: 0x00000001 
+// CHECK: cdo-driver: (Write64): Address:  0x00000000001A0634 Data:  0x00010001  
+// CHECK: cdo-driver: (MaskWrite64): Address: 0x00000000001A0630  Mask: 0x00000000  Data: 0x00000001 
+// CHECK: cdo-driver: (NOP Command): Payload Length: 2 
+// CHECK: cdo-driver: (BlockWrite-DMAWriteCmd): Start Address: 0x00000000021A0000  Size: 8
+// CHECK: cdo-driver:     Address: 0x00000000021A0000  Data is: 0x00000200 
+// CHECK: cdo-driver:     Address: 0x00000000021A0004  Data is: 0x000A0000 
+// CHECK: cdo-driver:     Address: 0x00000000021A0008  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000021A000C  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000021A0010  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000021A0014  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000021A0018  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000021A001C  Data is: 0x8140FF41 
+
+// CHECK: cdo-driver: (NOP Command): Payload Length: 0 
+// CHECK: cdo-driver: (BlockWrite-DMAWriteCmd): Start Address: 0x00000000021A0020  Size: 8
+// CHECK: cdo-driver:     Address: 0x00000000021A0020  Data is: 0x00000200 
+// CHECK: cdo-driver:     Address: 0x00000000021A0024  Data is: 0x001A0000 
+// CHECK: cdo-driver:     Address: 0x00000000021A0028  Data is: 0x00080000 
+// CHECK: cdo-driver:     Address: 0x00000000021A002C  Data is: 0x0020001F 
+// CHECK: cdo-driver:     Address: 0x00000000021A0030  Data is: 0x00100003 
+// CHECK: cdo-driver:     Address: 0x00000000021A0034  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000021A0038  Data is: 0x00000000 
+// CHECK: cdo-driver:     Address: 0x00000000021A003C  Data is: 0x8141FF40 
+
+// CHECK: cdo-driver: (Write64): Address:  0x00000000021A0604 Data:  0x00010000  
+// CHECK: cdo-driver: (MaskWrite64): Address: 0x00000000021A0600  Mask: 0x00000000  Data: 0x00000001 
+// CHECK: cdo-driver: (Write64): Address:  0x00000000021A0634 Data:  0x00010001  
+// CHECK: cdo-driver: (MaskWrite64): Address: 0x00000000021A0630  Mask: 0x00000000  Data: 0x00000001 
+// CHECK: cdo-driver: (Write64): Address:  0x000000000003F008 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000003F100 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000003F030 Data:  0x80000005  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000003F114 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000003F048 Data:  0x80000009  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000003F124 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000003F010 Data:  0x80000012  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000003F148 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000001B0000 Data:  0x80000007  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000001B011C Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000001B002C Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000001B0100 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000203F008 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000203F100 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000203F030 Data:  0x8000000A  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000203F128 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000203F020 Data:  0x80000012  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000203F148 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000021B0000 Data:  0x80000007  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000021B011C Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000021B002C Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000021B0100 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000403F008 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000403F100 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000403F020 Data:  0x8000000E  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000403F138 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000041B001C Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000041B0100 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000041B0000 Data:  0x8000000D  
+// CHECK: cdo-driver: (Write64): Address:  0x00000000041B0134 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000023F004 Data:  0x80000005  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000023F114 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000023F008 Data:  0x80000013  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000023F14C Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000023F04C Data:  0x80000001  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000023F104 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000223F024 Data:  0x80000005  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000223F114 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000223F04C Data:  0x8000000B  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000223F12C Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000423F014 Data:  0x8000000B  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000423F12C Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000003F008 Data:  0x80000000  
+// CHECK: cdo-driver: (Write64): Address:  0x000000000003F100 Data:  0x80000000  
+// CHECK: cdo-driver: (MaskWrite64): Address: 0x000000000001F000  Mask: 0x00000C00  Data: 0x00000400 
+// CHECK: cdo-driver: (MaskWrite64): Address: 0x000000000001F000  Mask: 0x0000C000  Data: 0x00004000 
+// CHECK: cdo-driver: (MaskWrite64): Address: 0x000000000001F004  Mask: 0x00000030  Data: 0x00000010 


### PR DESCRIPTION
Adds support for a chain of DMA BD configurations with implicitly disabled locks:

```
^bb3:  // pred: ^bb5
  %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
^bb4:  // 2 preds: ^bb3, ^bb5
  aie.use_lock(%lock_0_2, AcquireGreaterEqual, 1)
  aie.dma_bd(%buf1 : memref<8x2x8x4xi32>) {bd_id = 1 : i32, len = 256 : i32, next_bd_id = 2 : i32}
  aie.next_bd ^bb5
^bb5:  // 2 preds: ^bb4
  aie.dma_bd(%buf1 : memref<8x2x8x4xi32>) {bd_id = 2 : i32, len = 256 : i32, next_bd_id = 1 : i32, offset = 256 : i32}
  aie.use_lock(%lock_0_2_3, Release, 1)
  aie.next_bd ^bb4
```
Here, there are two circular chained BDs (bd_id 1 calls bd_id 2 as next bd, which calls bd_id 1 again etc). In this case, the first BD only needs to acquire a lock and the second one needs to release one. The first BD will have its release lock fields disabled and the second one will have its acquire lock fields disabled.