### PR TITLE
[Passes] Remove pass that promotes local output in pack-peel pipeline

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -182,15 +182,6 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createCanonicalizerPass());
   funcPassManager.addPass(createCSEPass());
 
-  // Promote the matmul output to local memory
-  {
-    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
-    bufferizeOptions.memorySpace = 2;
-    bufferizeOptions.bufferizeOperand = BufferizeOperand::Output;
-    funcPassManager.addPass(
-        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
-  }
-
   // Tile the reduction dimension using scf.for
   {
     AMDAIETileAndFuseOptions tileFuseOptions;


### PR DESCRIPTION
This PR removed the pass that promotes the matmul output to local memory. We leave it to `comprehensive-bufferize` pass to handle the bufferization similar to what we did for elementwise ops with https://github.com/nod-ai/iree-amd-aie/blob/d4ed19b219c9aa6bc728924d08f8f4e82a04fb15/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp#L85.

This solves the redundant allocation and copy issue with a more complicated loop structures, e.g. https://github.com/nod-ai/iree-amd-aie/commit/168414bfb1235a2b21cc4c710e4aea81ddfba70e.