### PR TITLE
[AMDAIEFuseFillIntoForall] Handle case where fill output is not sliced 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEFuseFillIntoForall.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEFuseFillIntoForall.cpp
@@ -30,30 +30,53 @@ class AMDAIEFuseFillIntoForallPass
 
 void AMDAIEFuseFillIntoForallPass::runOnOperation() {
   MLIRContext *context = &getContext();
-  mlir::FunctionOpInterface funcOp = getOperation();
   IRRewriter rewriter(context);
 
   // Find a unique FillOp with a single output, or return.
   SmallVector<linalg::FillOp> fillOps;
-  funcOp->walk([&](linalg::FillOp fillOp) { fillOps.push_back(fillOp); });
-  if (fillOps.size() != 1) return;
+  getOperation()->walk([&](linalg::FillOp fillOp) { fillOps.push_back(fillOp); });
+  if (fillOps.size() != 1) {
+    LLVM_DEBUG(llvm::dbgs() << "Expected exactly 1 fill op, but found "
+                            << fillOps.size() << ".\n");
+    return;
+  }
+
   linalg::FillOp fillOp = fillOps[0];
-  if (fillOp.getResults().size() != 1) return;
+  if (fillOp.getResults().size() != 1) {
+    LLVM_DEBUG(llvm::dbgs() << "Expected fill op to have exactly 1 result, but "
+                            << "found " << fillOp.getResults().size() << ".\n");
+
+    return;
+  };
 
   // Confirm that there is a unique user that is a forall, and match
   // the block argument that is used by the fill op, or return.
   ResultRange::use_range fillUses = fillOp->getUses();
-  if (std::distance(fillUses.begin(), fillUses.end()) != 1) return;
+  if (std::distance(fillUses.begin(), fillUses.end()) != 1) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Expected exactly 1 use of fill op, but found "
+               << std::distance(fillUses.begin(), fillUses.end()) << ".\n");
+    return;
+  }
   OpOperand &fillUse = *fillUses.begin();
   auto forallOp = dyn_cast<scf::ForallOp>(fillUse.getOwner());
-  if (!forallOp) return;
+  if (!forallOp) {
+    LLVM_DEBUG(llvm::dbgs() << "Expected fill op to be used by a forall op, "
+                            << "but the only user is "
+                            << fillUse.getOwner()->getName() << ".\n");
+    return;
+  }
   BlockArgument bbArg = forallOp.getTiedBlockArgument(&fillUse);
 
   // Find 0 or 1 ExtractSliceOps that use the fill result, or return.
   tensor::ExtractSliceOp extractSliceOp;
   for (Operation *user : bbArg.getUsers()) {
     if (auto nxt = dyn_cast<tensor::ExtractSliceOp>(user)) {
-      if (extractSliceOp) return;
+      if (extractSliceOp) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "Expected at most 1 extract_slice op, but found 2+.\n");
+        return;
+      }
       extractSliceOp = nxt;
     }
   }
@@ -67,33 +90,30 @@ void AMDAIEFuseFillIntoForallPass::runOnOperation() {
         scf::tileAndFuseProducerOfSlice(rewriter, extractSliceOp,
                                         MutableArrayRef(&loops, 1));
     if (!fusedProducer) {
-      funcOp->emitOpError("Failed to fuse fill op into forall loop.");
+      fillOp->emitOpError("could not be fused into forall");
       return signalPassFailure();
     }
-    return;
-  }
-
-  // In the case where there are no extract_slice ops, we manually create the
-  // fill at the beginning of the forall body.
-  assert(!extractSliceOp);
-  rewriter.setInsertionPointToStart(forallOp.getBody());
-  Value scalar = fillOp.value();
-  Location loc = fillOp.getLoc();
-  auto fusedFill = rewriter.create<linalg::FillOp>(loc, scalar, bbArg);
-  rewriter.replaceUsesWithIf(
-      bbArg, fusedFill.getResult(0), [&](OpOperand &operand) {
-        Operation *owner = operand.getOwner();
-        if (owner == fusedFill) {
-          return false;
-        } else if (isa<tensor::ParallelInsertSliceOp>(owner)) {
-          return false;
-        } else {
+  } else {
+    // In the case where there are no extract_slice ops, we manually create the
+    // fill at the beginning of the forall body. This situation might arise
+    // if the extract_slice has been folded, for example if the forall is
+    // over a grid if size 1.
+    rewriter.setInsertionPointToStart(forallOp.getBody());
+    Value scalar = fillOp.value();
+    Location loc = fillOp.getLoc();
+    auto fusedFill = rewriter.create<linalg::FillOp>(loc, scalar, bbArg);
+    rewriter.replaceUsesWithIf(
+        bbArg, fusedFill.getResult(0), [&](OpOperand &operand) {
+          Operation *owner = operand.getOwner();
+          if (owner == fusedFill || isa<tensor::ParallelInsertSliceOp>(owner)) {
+            return false;
+          }
           return true;
-        }
-      });
+        });
 
-  // Do not use the result of the old fill.
-  rewriter.replaceAllUsesWith(fillOp.getResults()[0], fillOp.getOutputs()[0]);
+    // Do not use the result of the old fill.
+    rewriter.replaceAllUsesWith(fillOp.getResults()[0], fillOp.getOutputs()[0]);
+  }
 }
 
 }  // namespace

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/fuse_fill_into_forall.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/fuse_fill_into_forall.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-fuse-fill-into-forall))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(func.func(iree-amdaie-fuse-fill-into-forall))' %s | FileCheck %s
 
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
 #map3 = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d1, d5, d4)>
@@ -29,3 +29,43 @@ func.func @fuse_fill_into_forall(%arg0: tensor<1x4x16x64xi8>, %arg1 : tensor<4x1
 // CHECK:     linalg.fill
 // CHECK:     linalg.generic
 // CHECK:  }
+
+// -----
+
+#map = affine_map<(d0) -> (d0)>
+
+// CHECK: @fuse_without_slice(%[[FUNCARG:.*]]: tensor<8xi8>) -> tensor<8xi8> {
+func.func @fuse_without_slice(%arg0: tensor<8xi8>) -> tensor<8xi8> {
+  %c7_i8 = arith.constant 7 : i8
+  %c3_i8 = arith.constant 3 : i8
+  %0 = linalg.fill ins(%c7_i8 : i8) outs(%arg0 : tensor<8xi8>) -> tensor<8xi8>
+  %1 = tensor.empty() : tensor<8xi8>
+
+  // check that the operand of scf.forall is not the filled tensor, because the
+  // fill will take place inside the scf.forall.
+  // CHECK: %[[FORALL:.*]] = scf.forall (%[[ARG1:.*]]) in (1)
+  // CHECK-SAME: shared_outs(%[[ARG2:.*]] = %[[FUNCARG]])
+
+  // check for the new fill
+  // CHECK: %[[NEWFILL:.*]] = linalg.fill
+  // CHECK-SAME: outs(%[[ARG2]] : tensor<8xi8>) -> tensor<8xi8>
+
+  %2 = scf.forall (%arg1) in (1) shared_outs(%arg2 = %0) -> (tensor<8xi8>) {
+
+    // CHECK: linalg.generic
+    %3 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%arg0 : tensor<8xi8>) outs(%1 : tensor<8xi8>) {
+    ^bb0(%in: i8, %out: i8):
+      %4 = arith.addi %in, %c3_i8 : i8
+      linalg.yield %4 : i8
+    } -> tensor<8xi8>
+    scf.forall.in_parallel {
+
+      // check the the parallel_insert_slice still happens on arg2, not the filled
+      // tensor. This is because it must match the shared_outs of the scf.forall.
+      // CHECK: tensor.parallel_insert_slice
+      // CHECK-SAME: into %[[ARG2]]
+      tensor.parallel_insert_slice %3 into %arg2[0] [8] [1] : tensor<8xi8> into tensor<8xi8>
+    }
+  } {mapping = [#gpu.thread<y>]}
+  return %2 : tensor<8xi8>
+}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/fuse_fill_into_forall.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/fuse_fill_into_forall.mlir
@@ -33,39 +33,34 @@ func.func @fuse_fill_into_forall(%arg0: tensor<1x4x16x64xi8>, %arg1 : tensor<4x1
 // -----
 
 #map = affine_map<(d0) -> (d0)>
-
-// CHECK: @fuse_without_slice(%[[FUNCARG:.*]]: tensor<8xi8>) -> tensor<8xi8> {
 func.func @fuse_without_slice(%arg0: tensor<8xi8>) -> tensor<8xi8> {
   %c7_i8 = arith.constant 7 : i8
   %c3_i8 = arith.constant 3 : i8
   %0 = linalg.fill ins(%c7_i8 : i8) outs(%arg0 : tensor<8xi8>) -> tensor<8xi8>
   %1 = tensor.empty() : tensor<8xi8>
-
-  // check that the operand of scf.forall is not the filled tensor, because the
-  // fill will take place inside the scf.forall.
-  // CHECK: %[[FORALL:.*]] = scf.forall (%[[ARG1:.*]]) in (1)
-  // CHECK-SAME: shared_outs(%[[ARG2:.*]] = %[[FUNCARG]])
-
-  // check for the new fill
-  // CHECK: %[[NEWFILL:.*]] = linalg.fill
-  // CHECK-SAME: outs(%[[ARG2]] : tensor<8xi8>) -> tensor<8xi8>
-
   %2 = scf.forall (%arg1) in (1) shared_outs(%arg2 = %0) -> (tensor<8xi8>) {
-
-    // CHECK: linalg.generic
     %3 = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%arg0 : tensor<8xi8>) outs(%1 : tensor<8xi8>) {
     ^bb0(%in: i8, %out: i8):
       %4 = arith.addi %in, %c3_i8 : i8
       linalg.yield %4 : i8
     } -> tensor<8xi8>
     scf.forall.in_parallel {
-
-      // check the the parallel_insert_slice still happens on arg2, not the filled
-      // tensor. This is because it must match the shared_outs of the scf.forall.
-      // CHECK: tensor.parallel_insert_slice
-      // CHECK-SAME: into %[[ARG2]]
       tensor.parallel_insert_slice %3 into %arg2[0] [8] [1] : tensor<8xi8> into tensor<8xi8>
     }
   } {mapping = [#gpu.thread<y>]}
   return %2 : tensor<8xi8>
 }
+
+// CHECK: @fuse_without_slice(%[[FUNCARG:.*]]: tensor<8xi8>) -> tensor<8xi8> {
+// check that the operand of scf.forall is not the filled tensor, because the
+// fill will take place inside the scf.forall:
+// CHECK: %[[FORALL:.*]] = scf.forall (%[[ARG1:.*]]) in (1)
+// CHECK-SAME: shared_outs(%[[ARG2:.*]] = %[[FUNCARG]])
+// check for the new fill:
+// CHECK: %[[NEWFILL:.*]] = linalg.fill
+// CHECK-SAME: outs(%[[ARG2]] : tensor<8xi8>) -> tensor<8xi8>
+// CHECK: linalg.generic
+// check the the parallel_insert_slice still happens on arg2, not the filled
+// tensor. This is because it must match the shared_outs of the scf.forall:
+// CHECK: tensor.parallel_insert_slice
+// CHECK-SAME: into %[[ARG2]]


### PR DESCRIPTION
For 2x2 or 4x4 tiling the chain of ops after the fill looks like

```
 %9 = linalg.fill ins(%cst : f32) ...
 ... 
 %12 = scf.forall (%arg3, %arg4) in (2, 2) shared_outs(%arg5 = %9)  ...
 ...
 %extracted_slice_19 = tensor.extract_slice %arg5 ... 
 ...
 %19 = linalg.generic  ... outs(%extracted_slice_19 ... )
 ```
 
 i.e. the filled value enters an extract_slice inside the scf.forall. But for 1x1 tiling, it looks like 
 
 
 ```
  %9 = linalg.fill ins(%cst : f32)
  ...
  %14 = scf.forall (%arg3, %arg4) in (1, 1) shared_outs(%arg5 = %9)
  ...
  %19 = linalg.generic  ... outs(%arg5... )
```


i.e. there is no intermediate extract_slice. 


Before this PR, the logic was hardcoded to look for an extrac_slice, this PR relaxes this. 

Before this PR, 1x1 tiling hits https://github.com/nod-ai/iree-amd-aie/blob/f5ab91ebc3eb9fd7ffd8e53bd53aed434e893c5f/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEFuseFillIntoForall.cpp#L71

After this PR, the compilation progresses further (fails much later in objectfifo pipeline, unrelated to this). 