### PR TITLE
Fix max sizes in DmaDimConfig and refactor

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeDoublyStridedOp.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeDoublyStridedOp.cpp
@@ -54,10 +54,12 @@ class FoldDmaOpLinearDims
             "expected a source and target memory space for hardware aware "
             "linear dimension folding");
       }
-      AMDAIE::DmaDimConfig dmaDimConfig(
-          deviceModel.value(), sourceMemSpace.value(), targetMemSpace.value());
-      maxSourceSizes = dmaDimConfig.getMaxSizes<CopyOpOperateOn::Source>();
-      maxTargetSizes = dmaDimConfig.getMaxSizes<CopyOpOperateOn::Target>();
+      DmaDimConfig sourceDmaDimConfig(deviceModel.value(),
+                                      sourceMemSpace.value());
+      maxSourceSizes = sourceDmaDimConfig.getMaxSizes();
+      DmaDimConfig targetDmaDimConfig(deviceModel.value(),
+                                      targetMemSpace.value());
+      maxTargetSizes = targetDmaDimConfig.getMaxSizes();
     }
     LogicalResult sourceRes = foldLinearDims(
         op.getContext(), sourceOffsets, sourceSizes, sourceStrides,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECombineStridedOps.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECombineStridedOps.cpp
@@ -83,10 +83,10 @@ struct CombineStridedOps
       return rewriter.notifyMatchFailure(
           nextStridedOp, "expected a source and target memory space");
     }
-    AMDAIE::DmaDimConfig dmaDimConfig(deviceModel, sourceMemspaceInt.value(),
-                                      targetMemspaceInt.value());
-    size_t sourceMaxNbDims = dmaDimConfig.sourceMaxNbDims;
-    size_t targetMaxNbDims = dmaDimConfig.targetMaxNbDims;
+    DmaDimConfig sourceDmaDimConfig(deviceModel, sourceMemspaceInt.value());
+    size_t sourceMaxNbDims = sourceDmaDimConfig.maxNbDims;
+    DmaDimConfig targetDmaDimConfig(deviceModel, targetMemspaceInt.value());
+    size_t targetMaxNbDims = targetDmaDimConfig.maxNbDims;
 
     SmallVector<OpFoldResult> sourceOffsetsA = op.getSourceMixedOffsets();
     SmallVector<OpFoldResult> sourceSizesA = op.getSourceMixedSizes();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlCodeLowering.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlCodeLowering.cpp
@@ -40,7 +40,8 @@ struct HalfDmaCpyNdToNpuConverter final
       ArrayRef<OpFoldResult> strides) const {
     uint8_t numIntraAddrDim = deviceModel.getDmaProp<uint8_t>(
         tileType, AMDAIE::AMDAIEDmaProp::NumAddrDim);
-    uint8_t numAddrDim = numIntraAddrDim + kAMDAIEDmaNbInterDims;
+    uint8_t numAddrDim =
+        numIntraAddrDim + deviceModel.deviceConfig.dmaNbInterDims;
     auto subspanOp = dyn_cast_if_present<IREE::HAL::InterfaceBindingSubspanOp>(
         logicalObjFifo.getMemref().getDefiningOp());
     if (!subspanOp) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
@@ -229,9 +229,8 @@ void AIEDeviceBuilder::foldDims(const SmallVector<OpFoldResult> &offsets,
   SmallVector<OpFoldResult> tmpStrides;
   (void)foldUnitDims(rewriter.getContext(), offsets, sizes, strides, tmpOffsets,
                      tmpSizes, tmpStrides);
-  AMDAIE::DmaDimConfig dmaDimConfig(deviceModel, memSpace, memSpace);
-  SmallVector<int64_t> maxSizes =
-      dmaDimConfig.getMaxSizes<CopyOpOperateOn::Source>();
+  DmaDimConfig dmaDimConfig(deviceModel, memSpace);
+  SmallVector<int64_t> maxSizes = dmaDimConfig.getMaxSizes();
   (void)foldLinearDims(rewriter.getContext(), tmpOffsets, tmpSizes, tmpStrides,
                        newOffsets, newSizes, newStrides, maxSizes);
   (void)foldSingleDim(newOffsets, newSizes, newStrides);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_doubly_strided_op_hardware_aware.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_doubly_strided_op_hardware_aware.mlir
@@ -38,7 +38,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK-LABEL:    func.func @dma_cpy_nd_no_fold
 // CHECK:          amdaie.dma_cpy_nd(%{{.+}}[0, 0] [2, 512] [512, 1], %{{.+}}[0, 0] [2, 512] [512, 1])
 // CHECK:          amdaie.dma_cpy_nd(%{{.+}}[0, 0, 0] [128, 8, 512] [2048, 256, 1], %{{.+}}[0, 0, 0] [128, 8, 512] [2048, 256, 1])
-// CHECK:          amdaie.dma_cpy_nd(%{{.+}}[0, 0, 0, 0, 0] [8, 8, 16, 8, 512] [1024, 128, 1024, 256, 1], %{{.+}}[0, 0, 0, 0, 0] [8, 8, 16, 8, 512] [1024, 128, 1024, 256, 1])
+// CHECK:          amdaie.dma_cpy_nd(%{{.+}}[0, 0, 0, 0] [64, 16, 8, 512] [128, 1024, 256, 1], %{{.+}}[0, 0, 0, 0] [64, 16, 8, 512] [128, 1024, 256, 1])
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @dma_cpy_nd_no_fold(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {

--- a/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.h
+++ b/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.h
@@ -234,6 +234,32 @@ struct AMDAIEDeviceModel {
     ///////////////////////////////////////
     // AIE Array configuration constants //
     ///////////////////////////////////////
+    /// Constant specifying the number of inter-iteration dimension for DMA
+    /// operations.
+    ///
+    /// NOTE(jornt): this number is implicitly assumed in the device model and can't
+    /// be retrieved from it afaik.
+    ///
+    /// Some background:
+    ///
+    /// DMAs support multi-dimensional addressing through buffer descriptors in two
+    /// ways:
+    /// 1. Intra-iteration access pattern. Specified via 'strides' ('steps' in buffer
+    /// descriptor lingo), 'sizes' ('wraps' in buffer descriptro lingo) and
+    /// 'padding'. When a DMA executes a buffer descriptor, it will access the data
+    /// (read/write) as specified by the intra-iteration access pattern.
+    /// 2. Inter-iteration access pattern. Specified via an iteration 'stride',
+    /// 'size' and 'current_iteration' ('stride' is the same as 'stepsize' and 'size'
+    /// is the same as 'wrap' in buffer descriptor lingo). Here, 'current_iteration'
+    /// keeps track of the current execution iteration of the buffer descriptor and
+    /// is incremented after buffer descriptor execution. the 'stride' is the offset
+    /// to be used for each execution of the buffer descriptor, relative to the
+    /// previous one. When 'iteration_current' is equal to 'size', the
+    /// 'iteration_current' is reset to zero.
+    ///
+    /// Although DMAs can have a different number of intra-iteration dimensions, all
+    /// DMAs have a single inter-iteration dimension (at least in AIE2 and AIE2p).
+    uint8_t dmaNbInterDims = 1;
     /// The number of shim tile rows. Not found in aie-rt data structures, but
     /// provided as `XAIE_SHIM_NUM_ROWS`.
     uint8_t shimTileNumRows{1};


### PR DESCRIPTION
Some incorrect max size calculation in `DmaDimConfig` was blocking linear dimension folding and causing the following error when trying to increase the L1 matmul problem from 32x32x32 to 32x32x64 (MxNxK) for bf16:

```
<unknown>:0: error: 'aie.dma_bd' op Cannot give more than 3 dimensions for step sizes and wraps in this  tile (got 4 dimensions).
```

With this PR, that error should be resolved, but I am leaving the addition of that change to a separate PR. cc @yzhang93 