### PR TITLE
Add vectorization support for matmul_transpose_a ops

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -1809,17 +1809,16 @@ class Tests:
                 "transpose_a": False,
                 "transpose_b": False,
             },
-            # Todo: Enable this transpose_a test once it is supported.
-            # {
-            #     "M": 4096,
-            #     "N": 512,
-            #     "K": 512,
-            #     "use_ukernel": False,
-            #     "peano_opt_level": 3,
-            #     "outline": True,
-            #     "transpose_a": True,
-            #     "transpose_b": False,
-            # },
+            {
+                "M": 4096,
+                "N": 512,
+                "K": 512,
+                "use_ukernel": False,
+                "peano_opt_level": 3,
+                "outline": True,
+                "transpose_a": True,
+                "transpose_b": False,
+            },
         ]
 
         # Some bf16 Performance tests:

--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -1638,7 +1638,10 @@ class Tests:
             self.register(MatmulTransposeB(1536, 1536, 2048, input_type, acc_type))
 
         # MatmulTransposeA test(s):
-        for input_type, acc_type in zip(["i32"], ["i32"]):
+        # Note: i8->i32 tests don't work because of the following op
+        # %10 = vector.transpose %9, [1, 0] : vector<8x4xi8> to vector<4x8xi8>
+        # failed to lowering to an `aievec.shuffle` op.
+        for input_type, acc_type in zip(["i32", "bf16"], ["i32", "f32"]):
             self.register(MatmulTransposeA(32, 32, 32, input_type, acc_type))
             self.register(MatmulTransposeA(128, 256, 128, input_type, acc_type))
             self.register(MatmulTransposeA(1536, 1536, 2048, input_type, acc_type))

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_loops_for_vectorization.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_loops_for_vectorization.mlir
@@ -140,30 +140,6 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     return %0 : !t3_f32
   }
 
-  // Check that the final 3 dimensions do have the pattern of a matmul (or matmul transpose)
-  // CHECK-LABEL: batched1
-  // CHECK-NOT:     scf.for
-  func.func @batched1(%arg0: !t3_bf16, %arg1: !t3_bf16, %arg2: !t3_f32) -> !t3_f32 {
-    %0 = linalg.generic {indexing_maps =
-                          [
-                           // This is like a matmul but the first operand is
-                           // transposed:
-                           affine_map<(b0, d0, d1, d2) -> (b0, d2, d0)>,
-                           affine_map<(b0, d0, d1, d2) -> (b0, d2, d1)>,
-                           affine_map<(b0, d0, d1, d2) -> (b0, d0, d1)>
-                          ],
-                         iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
-                         ins(%arg0, %arg1 : !t3_bf16, !t3_bf16) outs(%arg2 : !t3_f32) {
-    ^bb0(%in_0_bf16: bf16, %in_1_bf16: bf16, %out: f32):
-      %in_0 = arith.extf %in_0_bf16: bf16 to f32
-      %in_1 = arith.extf %in_1_bf16: bf16 to f32
-      %1 = arith.mulf %in_0, %in_1 : f32
-      %2 = arith.addf %out, %1 : f32
-      linalg.yield %2 : f32
-    } -> !t3_f32
-    return %0 : !t3_f32
-  }
-
   // Check for a batched matmul where operand 0 is broadcast:
   // CHECK-LABEL: batched2
   // CHECK:         scf.for

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_loops_for_vectorization.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_loops_for_vectorization.mlir
@@ -115,15 +115,43 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     return %0 : !t3_f32
   }
 
-  // Another test with a transposed matmul, but in this case A is transposed.
-  // Currently the pass does not modify this (so no scf.for should appear).
-  // We'll probably add support for this in the future, but for now we don't.
+  // A test like the above, but with a matmul_tranpose_a instead of a matmul
   // CHECK-LABEL: batched_transpose_a
-  // CHECK-NOT:      scf.for
-
+  // CHECK:         scf.for
+  // CHECK:           linalg.generic
+  // CHECK-SAME:        iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+  // CHECK-SAME:        ins
+  // CHECK-SAME:        tensor<1x64x64xbf16>, tensor<1x64x64xbf16>
+  // CHECK-SAME:        outs
+  // CHECK-SAME:        tensor<1x64x64xf32>
+  // CHECK-NOT:     scf.for
   func.func @batched_transpose_a(%arg0: !t3_bf16, %arg1: !t3_bf16, %arg2: !t3_f32) -> !t3_f32 {
     %0 = linalg.generic {indexing_maps =
                           [
+                           affine_map<(b0, d0, d1, d2) -> (b0, d2, d0)>,
+                           affine_map<(b0, d0, d1, d2) -> (b0, d2, d1)>,
+                           affine_map<(b0, d0, d1, d2) -> (b0, d0, d1)>
+                          ],
+                         iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
+                         ins(%arg0, %arg1 : !t3_bf16, !t3_bf16) outs(%arg2 : !t3_f32) {
+    ^bb0(%in_0_bf16: bf16, %in_1_bf16: bf16, %out: f32):
+      %in_0 = arith.extf %in_0_bf16: bf16 to f32
+      %in_1 = arith.extf %in_1_bf16: bf16 to f32
+      %1 = arith.mulf %in_0, %in_1 : f32
+      %2 = arith.addf %out, %1 : f32
+      linalg.yield %2 : f32
+    } -> !t3_f32
+    return %0 : !t3_f32
+  }
+
+  // Check that the final 3 dimensions do have the pattern of a matmul (or matmul transpose)
+  // CHECK-LABEL: batched1
+  // CHECK-NOT:     scf.for
+  func.func @batched1(%arg0: !t3_bf16, %arg1: !t3_bf16, %arg2: !t3_f32) -> !t3_f32 {
+    %0 = linalg.generic {indexing_maps =
+                          [
+                           // This is like a matmul but the first operand is
+                           // (b, k, n) and second is (b, k, m)
                            affine_map<(b0, d0, d1, d2) -> (b0, d2, d1)>,
                            affine_map<(b0, d0, d1, d2) -> (b0, d2, d0)>,
                            affine_map<(b0, d0, d1, d2) -> (b0, d0, d1)>


### PR DESCRIPTION
With this PR, `mamtul_transpose_a` ops work with bf16->f32 vectorization. But i8->i32 tests don't work because of the following op
```
%10 = vector.transpose %9, [1, 0] : vector<8x4xi8> to vector<4x8xi8>
```
failed to lower to an `aievec.shuffle` op. 

 https://github.com/nod-ai/iree-amd-aie/blob/befab5e1adb9a884d08f96bffb0b189f80f19aaa/compiler/plugins/target/AMD-AIE/aievec/VectorToAIEVecConversions.cpp#L244