### PR TITLE
Add explicit loop subsumption for circular DMA ops

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaLoopSubsumption.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaLoopSubsumption.cpp
@@ -176,23 +176,6 @@ struct SubsumeLoopIntoDMA
           "parent op.");
     }
 
-    // Handle ops with trait `CircularDmaOp`. If circular DMA ops don't have a
-    // loop dependency, they can be hoisted outside the loop without any
-    // changes as in principal they run indefinitely until the resource operated
-    // on is dedicated to another operation. Therefore, care should be taken to
-    // ensure that the resource being operated on is not touched within the same
-    // scope.
-    // TODO(jornt): find a way to annotate the DMA resource(s) being
-    // operated on so that this touch checking logic can be implemented in
-    // general for different ops.
-    if (op->hasTrait<CircularDmaOp>() &&
-        !hasLoopDependency(op, allInductionValues)) {
-      rewriter.setInsertionPoint(loopOp);
-      Operation *cloneOp = rewriter.clone(*op.getOperation());
-      rewriter.replaceOp(op, cloneOp);
-      return success();
-    }
-
     // Initialize new access pattern offsets/sizes/strides with current values.
     SmallVector<OpFoldResult> newSourceOffsets = op.getSourceMixedOffsets();
     SmallVector<OpFoldResult> newSourceSizes = op.getSourceMixedSizes();
@@ -210,16 +193,18 @@ struct SubsumeLoopIntoDMA
       if (nbIterations == 0) return failure();
       if (nbIterations > 1) nbNonUnitIterations++;
     }
-    if (newSourceOffsets.size() + nbNonUnitIterations >
-        sourceDmaDimConfig.maxNbDims)
+    if (sourceDmaDimConfig.exceedsNbDims(newSourceOffsets.size() +
+                                         nbNonUnitIterations)) {
       return failure();
-    if (newTargetOffsets.size() + nbNonUnitIterations >
-        targetDmaDimConfig.maxNbDims)
+    }
+    if (targetDmaDimConfig.exceedsNbDims(newTargetOffsets.size() +
+                                         nbNonUnitIterations)) {
       return failure();
+    }
 
     // Fail if zero stride is only supported on the outer dimension and adding
     // this loop to the strided access pattern would violate that.
-    if (onlyZeroStrideOnOuterDim) {
+    if (onlyZeroStrideOnOuterDim && !op->hasTrait<CircularDmaOp>()) {
       if (!newSourceStrides.empty()) {
         std::optional<int64_t> outerStride =
             getConstantIntValue(newSourceStrides[0]);
@@ -256,20 +241,6 @@ struct SubsumeLoopIntoDMA
         }
       }
     }
-
-    auto anyOutOfRange = [](const SmallVector<int64_t> &values,
-                            const SmallVector<int64_t> &maxValues,
-                            size_t begin) -> bool {
-      assert(maxValues.size() - begin >= values.size() &&
-             "begin should be set so that the values don't exceed the max "
-             "values slice");
-      for (size_t i = 0; i < values.size(); ++i) {
-        int64_t value = values[i];
-        int64_t maxValue = maxValues[begin + i];
-        if (value < 0 || value > maxValue) return true;
-      }
-      return false;
-    };
 
     auto insertInFront =
         [](SmallVector<OpFoldResult> &origOpFold,
@@ -310,14 +281,10 @@ struct SubsumeLoopIntoDMA
             insertInFront(newSourceSizes, insertSourceSizes);
         SmallVector<int64_t> newSourceStridesInt =
             insertInFront(newSourceStrides, insertSourceStrides);
-        SmallVector<int64_t> maxSizes = sourceDmaDimConfig.getMaxSizes();
-        SmallVector<int64_t> maxStrides = sourceDmaDimConfig.getMaxStrides();
-        assert(maxSizes.size() >= newSourceSizesInt.size() &&
-               "Max number of dimensions exceeded");
-        size_t begin = maxSizes.size() - newSourceSizesInt.size();
-        if (anyOutOfRange(newSourceSizesInt, maxSizes, begin)) return failure();
-        if (anyOutOfRange(newSourceStridesInt, maxStrides, begin))
+        if (!sourceDmaDimConfig.isValidAccessPattern(newSourceSizesInt,
+                                                     newSourceStridesInt)) {
           return failure();
+        }
       }
       // Add loop iteration to the access pattern on the target side.
       if (!newTargetOffsets.empty()) {
@@ -334,14 +301,10 @@ struct SubsumeLoopIntoDMA
             insertInFront(newTargetSizes, insertTargetSizes);
         SmallVector<int64_t> newTargetStridesInt =
             insertInFront(newTargetStrides, insertTargetStrides);
-        SmallVector<int64_t> maxSizes = targetDmaDimConfig.getMaxSizes();
-        SmallVector<int64_t> maxStrides = targetDmaDimConfig.getMaxStrides();
-        assert(maxSizes.size() >= newTargetSizesInt.size() &&
-               "Max number of dimensions exceeded");
-        size_t begin = maxSizes.size() - newTargetSizesInt.size();
-        if (anyOutOfRange(newTargetSizesInt, maxSizes, begin)) return failure();
-        if (anyOutOfRange(newTargetStridesInt, maxStrides, begin))
+        if (!targetDmaDimConfig.isValidAccessPattern(newTargetSizesInt,
+                                                     newTargetStridesInt)) {
           return failure();
+        }
       }
     }
 
@@ -502,11 +465,13 @@ struct SubsumeLoopIntoDMA
       return false;
     };
 
-    std::optional<uint8_t> sourceMemspaceInt;
-    std::optional<uint8_t> targetMemspaceInt;
+    std::unique_ptr<DmaDimConfig> sourceDmaDimConfig;
+    std::unique_ptr<DmaDimConfig> targetDmaDimConfig;
     if (auto npuDmaOp = dyn_cast<AMDAIE::NpuDmaCpyNdOp>(op.getOperation())) {
-      sourceMemspaceInt = npuDmaOp.getSourceMemorySpaceAsUInt();
-      targetMemspaceInt = npuDmaOp.getTargetMemorySpaceAsUInt();
+      std::optional<uint8_t> sourceMemspaceInt =
+          npuDmaOp.getSourceMemorySpaceAsUInt();
+      std::optional<uint8_t> targetMemspaceInt =
+          npuDmaOp.getTargetMemorySpaceAsUInt();
 
       // Check that the connection this `amdaie.npu.dma_cpy_nd` operation is
       // operating on, is not being touched within the same scope. Otherwise,
@@ -533,11 +498,17 @@ struct SubsumeLoopIntoDMA
             "Has users of same DMA in scope, analysis to check validity of "
             "subsumption unimplemented");
       }
+      sourceDmaDimConfig = std::make_unique<DmaDimConfig>(
+          deviceModel, sourceMemspaceInt.value());
+      targetDmaDimConfig = std::make_unique<DmaDimConfig>(
+          deviceModel, targetMemspaceInt.value());
     } else if (auto npuCircularDmaOp =
                    dyn_cast<AMDAIE::NpuCircularDmaCpyNdOp>(op.getOperation())) {
       // TODO(jornt): Consolidate with `NpuDmaCpyNdOp`.
-      sourceMemspaceInt = npuCircularDmaOp.getSourceMemorySpaceAsUInt();
-      targetMemspaceInt = npuCircularDmaOp.getTargetMemorySpaceAsUInt();
+      std::optional<uint8_t> sourceMemspaceInt =
+          npuCircularDmaOp.getSourceMemorySpaceAsUInt();
+      std::optional<uint8_t> targetMemspaceInt =
+          npuCircularDmaOp.getTargetMemorySpaceAsUInt();
       FailureOr<bool> hasBlockingUsers =
           doesCircularDmaHaveUsersBlockingSubsumption(npuCircularDmaOp);
       if (failed(hasBlockingUsers)) {
@@ -551,6 +522,10 @@ struct SubsumeLoopIntoDMA
             "loop. The analysis to check validity of subsumption in this case "
             "might have to be implemented");
       }
+      sourceDmaDimConfig = std::make_unique<CircularDmaDimConfig>(
+          deviceModel, sourceMemspaceInt.value());
+      targetDmaDimConfig = std::make_unique<CircularDmaDimConfig>(
+          deviceModel, targetMemspaceInt.value());
     } else {
       return rewriter.notifyMatchFailure(
           op,
@@ -558,19 +533,12 @@ struct SubsumeLoopIntoDMA
           "`amdaie.npu.circular_dma_cpy_nd` operation");
     }
 
-    if (!sourceMemspaceInt || !targetMemspaceInt) {
-      return rewriter.notifyMatchFailure(
-          op, "expected a source and target memory space");
-    }
-    DmaDimConfig sourceDmaDimConfig(deviceModel, sourceMemspaceInt.value());
-    DmaDimConfig targetDmaDimConfig(deviceModel, targetMemspaceInt.value());
-
     if (isa<scf::ForOp>(parentOp)) {
-      return rewriteWithForOpParent(op, rewriter, sourceDmaDimConfig,
-                                    targetDmaDimConfig);
+      return rewriteWithForOpParent(op, rewriter, *sourceDmaDimConfig,
+                                    *targetDmaDimConfig);
     } else if (isa<scf::ForallOp>(parentOp)) {
-      return rewriteWithForallOpParent(op, rewriter, sourceDmaDimConfig,
-                                       targetDmaDimConfig);
+      return rewriteWithForallOpParent(op, rewriter, *sourceDmaDimConfig,
+                                       *targetDmaDimConfig);
     } else {
       return rewriter.notifyMatchFailure(
           op, "Has parent operation of currently unsupported type");

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.h
@@ -26,6 +26,8 @@ using namespace xilinx;
 
 namespace mlir::iree_compiler::AMDAIE {
 
+using BDDimLayoutAndLength = std::pair<AIE::BDDimLayoutArrayAttr, int64_t>;
+
 /// Class to build an `aie.device` from a `module` containing
 /// `amdaie.workgroup`.
 class AIEDeviceBuilder {
@@ -66,17 +68,18 @@ class AIEDeviceBuilder {
 
   /// Utility to convert vectors of `size` and `stride` into an
   /// `AIE::BDDimLayoutArrayAttr`.
-  AIE::BDDimLayoutArrayAttr convertSizeStrideToBDDimLayoutArrayAttr(
-      const SmallVector<OpFoldResult> &sizes,
-      const SmallVector<OpFoldResult> &strides, uint8_t memSpace);
+  FailureOr<BDDimLayoutAndLength> convertSizeStrideToBDDimLayoutArrayAttr(
+      SmallVector<OpFoldResult> sizes, SmallVector<OpFoldResult> strides,
+      uint8_t memSpace, function_ref<InFlightDiagnostic()> emitError);
 
   /// Utility to create DMA blocks and add them to `memOp`.
-  void createDMA(Operation *memOp, AIE::DMAChannelDir channelDir,
-                 int channelIndex, AIE::BDDimLayoutArrayAttr dims,
-                 size_t acqNum, size_t relNum, int64_t len, int64_t offset,
-                 const SmallVector<AIE::BufferOp> &bufferOps,
-                 const std::pair<AIE::LockOp, AIE::LockOp> &locks,
-                 std::optional<uint8_t> pktId);
+  LogicalResult createDMA(Operation *memOp, AIE::DMAChannelDir channelDir,
+                          int channelIndex, SmallVector<OpFoldResult> sizes,
+                          SmallVector<OpFoldResult> strides, uint8_t memSpace,
+                          size_t acqNum, size_t relNum, int64_t offset,
+                          const SmallVector<AIE::BufferOp> &bufferOps,
+                          const std::pair<AIE::LockOp, AIE::LockOp> &locks,
+                          std::optional<uint8_t> pktId);
 
   /// Utility to create flow ops from connection ops.
   SmallVector<Operation *> createFlowOps(

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.cpp
@@ -308,23 +308,17 @@ LogicalResult combineAccessPatterns(RewriterBase &rewriter,
 /// represented by:
 ///
 /// `offsets: [0], sizes: [16], strides: [1]`
-LogicalResult foldLinearDims(MLIRContext *ctx,
-                             const SmallVector<OpFoldResult> &offsets,
-                             const SmallVector<OpFoldResult> &sizes,
-                             const SmallVector<OpFoldResult> &strides,
-                             SmallVector<OpFoldResult> &newOffsets,
-                             SmallVector<OpFoldResult> &newSizes,
-                             SmallVector<OpFoldResult> &newStrides,
-                             ArrayRef<int64_t> maxSizes) {
+LogicalResult foldLinearDims(
+    MLIRContext *ctx, const SmallVector<OpFoldResult> &offsets,
+    const SmallVector<OpFoldResult> &sizes,
+    const SmallVector<OpFoldResult> &strides,
+    SmallVector<OpFoldResult> &newOffsets, SmallVector<OpFoldResult> &newSizes,
+    SmallVector<OpFoldResult> &newStrides,
+    function_ref<bool(size_t, int64_t)> checkValidSize) {
   assert(offsets.size() == sizes.size() && offsets.size() == strides.size() &&
          "expected same number of offsets, sizes and strides");
   bool foldableLinearDimsFound = false;
   if (offsets.size() == 0) return success(foldableLinearDimsFound);
-
-  // As the new offsets/sizes/strides are created in reverse order, reverse the
-  // maxSizes as well for easy comparison.
-  SmallVector<int64_t> maxSizesReversed(maxSizes);
-  std::reverse(maxSizesReversed.begin(), maxSizesReversed.end());
 
   std::optional<SmallVector<int64_t>> staticSizes = getConstantIntValues(sizes);
   std::optional<SmallVector<int64_t>> staticStrides =
@@ -344,9 +338,8 @@ LogicalResult foldLinearDims(MLIRContext *ctx,
     // 2. newSizes[-1] x newStrides[-1] == strides[i]. With this we can have
     // newSizes[-1] = sizes[i] * newSizes[-1] , and then fold away the i
     // dimension
-    // 3. sizes[i] * newSizes[-1] <= maxSizes[newSizes.size() - 1], IF max
-    // constraints are provided. This allows hardware constraints to be
-    // provided.
+    // 3. checkValidSize(sizes[i] * newSizes[-1]). This allows hardware
+    // constraints to be checked.
     size_t vecSize = newOffsets.size();
     int64_t newStride = staticStrideVals[i];
     int64_t newSize = staticSizeVals[i];
@@ -356,11 +349,7 @@ LogicalResult foldLinearDims(MLIRContext *ctx,
     // Fail if max constraints are provided, but the newly created
     // offsets/sizes/strides start exceeding the number of provide max
     // constraints as this will result in undefined behaviour.
-    if (maxSizesReversed.size() > 0 && vecSize > maxSizesReversed.size())
-      return failure();
-    bool fitsMaxConstraint =
-        maxSizesReversed.size() == 0 ||
-        newSize * prevSize <= maxSizesReversed[vecSize - 1];
+    bool fitsMaxConstraint = checkValidSize(vecSize - 1, newSize * prevSize);
     if (fitsMaxConstraint && isConstantIntValue(offsets[i], 0) &&
         dimExtent == newStride) {
       foldableLinearDimsFound = true;
@@ -377,6 +366,40 @@ LogicalResult foldLinearDims(MLIRContext *ctx,
   std::reverse(newSizes.begin(), newSizes.end());
   std::reverse(newStrides.begin(), newStrides.end());
   return success(foldableLinearDimsFound);
+}
+
+LogicalResult foldRepetitionCount(MLIRContext *ctx,
+                                  SmallVector<OpFoldResult> &sizes,
+                                  SmallVector<OpFoldResult> &strides,
+                                  std::optional<int64_t> maybeRepetitionCount) {
+  // If no repetition count is provided, fold all leading dimensions with
+  // `stride == 0`.
+  if (!maybeRepetitionCount.has_value()) {
+    for (auto &&[idx, stride] : llvm::enumerate(strides)) {
+      if (!isConstantIntValue(stride, 0)) break;
+      sizes[idx] = getAsIndexOpFoldResult(ctx, 1);
+    }
+    return success();
+  }
+  int64_t repetitionCount = maybeRepetitionCount.value();
+  for (size_t i = 0; i < strides.size(); i++) {
+    if (repetitionCount == 1) break;
+    if (!isConstantIntValue(strides[i], 0)) return failure();
+    std::optional<int64_t> maybeSize = getConstantIntValue(sizes[i]);
+    if (!maybeSize) return failure();
+    int64_t size = maybeSize.value();
+    if (size >= repetitionCount) {
+      if (size % repetitionCount != 0) return failure();
+      sizes[i] = getAsIndexOpFoldResult(ctx, size / repetitionCount);
+      repetitionCount = 1;
+    } else {
+      if (repetitionCount % size != 0) return failure();
+      sizes[i] = getAsIndexOpFoldResult(ctx, 1);
+      repetitionCount /= size;
+    }
+  }
+  if (repetitionCount != 1) return failure();
+  return success();
 }
 
 /// Fold single dimension linear accesses and make them implicit. This requires
@@ -487,27 +510,119 @@ LogicalResult moveNpuDmaSyncUsersAfterAncestorInSameBlock(
 // DmaDimConfig
 //===----------------------------------------------------------------------===//
 
-SmallVector<int64_t> DmaDimConfig::getMaxSizes() const {
+static bool anyOutOfRange(ArrayRef<int64_t> values, ArrayRef<int64_t> maxValues,
+                          size_t begin) {
+  assert(maxValues.size() - begin >= values.size() &&
+         "begin should be set so that the values don't exceed the max "
+         "values slice");
+  for (auto [value, maxValue] :
+       llvm::zip(values, maxValues.drop_front(begin))) {
+    if (value < 0 || value > maxValue) return true;
+  }
+  return false;
+}
+
+bool DmaDimConfig::isValidAccessPattern(ArrayRef<int64_t> sizes,
+                                        ArrayRef<int64_t> strides) const {
+  assert(sizes.size() == strides.size() &&
+         "`sizes` and `strides` should have the same size");
+  SmallVector<int64_t> maxSizes = getMaxSizes(sizes.size());
+  assert(maxSizes.size() >= sizes.size() &&
+         "Max number of dimensions exceeded");
+  size_t frontToDrop = maxSizes.size() - sizes.size();
+  if (anyOutOfRange(sizes, maxSizes, frontToDrop)) return false;
+  SmallVector<int64_t> maxStrides = getMaxStrides(sizes.size());
+  if (anyOutOfRange(strides, maxStrides, frontToDrop)) return false;
+  return true;
+}
+
+SmallVector<int64_t> DmaDimConfig::getMaxSizes(
+    std::optional<size_t> maybeNbDims) const {
+  size_t nbDims = maybeNbDims.has_value() ? maybeNbDims.value() : maxNbDims;
   uint32_t maxIntraSize = deviceModel.getDmaBdProp<uint16_t>(
       tileType, 0, AMDAIE::AMDAIEDmaBdProp::WrapMax);
   uint32_t maxInterSize = deviceModel.getDmaBdProp<uint8_t>(
       tileType, 0, AMDAIE::AMDAIEDmaBdProp::IterWrapMax);
-  SmallVector<int64_t> maxSizes(maxNbDims, maxIntraSize);
-  std::fill_n(maxSizes.begin(), nbInterDims, maxInterSize);
-  // The outermost intra size doesn't have limit in HW.
-  maxSizes[nbInterDims] = std::numeric_limits<int64_t>::max();
+  SmallVector<int64_t> maxSizes(nbDims, 0);
+  int64_t nbIntraDimsToBeFilled =
+      std::min((int64_t)nbIntraDims, (int64_t)maxSizes.size());
+  int64_t intraStart = maxSizes.size() - nbIntraDimsToBeFilled;
+  std::fill_n(maxSizes.begin() + intraStart, nbIntraDimsToBeFilled,
+              maxIntraSize);
+  assert(intraStart >= 0);
+  if (intraStart < maxSizes.size())
+    maxSizes[intraStart] = std::numeric_limits<int64_t>::max();
+  int64_t nbInterDimsToBeFilled = std::min((int64_t)nbInterDims, intraStart);
+  int64_t interStart = intraStart - nbInterDimsToBeFilled;
+  assert(interStart >= 0);
+  std::fill_n(maxSizes.begin() + interStart, nbInterDimsToBeFilled,
+              maxInterSize);
   return maxSizes;
 }
 
-SmallVector<int64_t> DmaDimConfig::getMaxStrides() const {
+SmallVector<int64_t> DmaDimConfig::getMaxStrides(
+    std::optional<size_t> maybeNbDims) const {
+  size_t nbDims = maybeNbDims.has_value() ? maybeNbDims.value() : maxNbDims;
   uint32_t maxIntraStride = deviceModel.getDmaBdProp<uint32_t>(
       tileType, 0, AMDAIE::AMDAIEDmaBdProp::StepSizeMax);
   uint32_t maxInterStride = deviceModel.getDmaBdProp<uint32_t>(
       tileType, 0, AMDAIE::AMDAIEDmaBdProp::IterStepSizeMax);
+  SmallVector<int64_t> stepSizes(nbDims, 0);
+  int64_t nbIntraDimsToBeFilled =
+      std::min((int64_t)nbIntraDims, (int64_t)stepSizes.size());
+  int64_t intraStart = stepSizes.size() - nbIntraDimsToBeFilled;
+  assert(intraStart >= 0);
   // +1 because values are encoded in HW BDs as (value - 1), so the range is
   // [1:2^x].
-  SmallVector<int64_t> stepSizes(maxNbDims, maxIntraStride + 1);
-  std::fill_n(stepSizes.begin(), nbInterDims, maxInterStride + 1);
+  std::fill_n(stepSizes.begin() + intraStart, nbIntraDimsToBeFilled,
+              maxIntraStride + 1);
+  int64_t nbInterDimsToBeFilled = std::min((int64_t)nbInterDims, intraStart);
+  int64_t interStart = intraStart - nbInterDimsToBeFilled;
+  assert(interStart >= 0);
+  // +1 because values are encoded in HW BDs as (value - 1), so the range is
+  // [1:2^x].
+  std::fill_n(stepSizes.begin() + interStart, nbInterDimsToBeFilled,
+              maxInterStride + 1);
+  return stepSizes;
+}
+
+SmallVector<int64_t> CircularDmaDimConfig::getMaxSizes(
+    std::optional<size_t> maybeNbDims) const {
+  size_t nbDims = maybeNbDims.has_value() ? maybeNbDims.value() : maxNbDims;
+  uint32_t maxIntraSize = deviceModel.getDmaBdProp<uint16_t>(
+      tileType, 0, AMDAIE::AMDAIEDmaBdProp::WrapMax);
+  SmallVector<int64_t> maxSizes(nbDims, 0);
+  int64_t nbIntraDimsToBeFilled =
+      std::min((int64_t)nbIntraDims, (int64_t)maxSizes.size());
+  int64_t intraStart = maxSizes.size() - nbIntraDimsToBeFilled;
+  std::fill_n(maxSizes.begin() + intraStart, nbIntraDimsToBeFilled,
+              maxIntraSize);
+  assert(intraStart >= 0);
+  if (intraStart < maxSizes.size())
+    maxSizes[intraStart] = std::numeric_limits<int64_t>::max();
+  // All other dimension can have any size for circular DMAs.
+  std::fill_n(maxSizes.begin(), intraStart,
+              std::numeric_limits<int64_t>::max());
+  return maxSizes;
+}
+
+SmallVector<int64_t> CircularDmaDimConfig::getMaxStrides(
+    std::optional<size_t> maybeNbDims) const {
+  size_t nbDims = maybeNbDims.has_value() ? maybeNbDims.value() : maxNbDims;
+  uint32_t maxIntraStride = deviceModel.getDmaBdProp<uint32_t>(
+      tileType, 0, AMDAIE::AMDAIEDmaBdProp::StepSizeMax);
+  SmallVector<int64_t> stepSizes(nbDims, 0);
+  int64_t nbIntraDimsToBeFilled =
+      std::min((int64_t)nbIntraDims, (int64_t)stepSizes.size());
+  int64_t intraStart = stepSizes.size() - nbIntraDimsToBeFilled;
+  assert(intraStart >= 0);
+  // +1 because values are encoded in HW BDs as (value - 1), so the range is
+  // [1:2^x].
+  std::fill_n(stepSizes.begin() + intraStart, nbIntraDimsToBeFilled,
+              maxIntraStride + 1);
+  // All other dimension can have any stride for circular DMAs.
+  std::fill_n(stepSizes.begin(), intraStart,
+              std::numeric_limits<int64_t>::max());
   return stepSizes;
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/dma_loop_subsumption_circular.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/dma_loop_subsumption_circular.mlir
@@ -6,9 +6,9 @@
 // CHECK:       %[[CONNECTION_2:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:     scf.for
-// CHECK:         amdaie.npu.circular_dma_cpy_nd %[[CONNECTION_2]]([0] [16] [1], [] [] [])
 // CHECK-NOT:     scf.forall
 // CHECK:         amdaie.npu.circular_dma_cpy_nd %[[CONNECTION_1]]([] [] [], [] [] [])
+// CHECK:         amdaie.npu.circular_dma_cpy_nd %[[CONNECTION_2]]([0, 0, 0, 0] [3, 2, 6, 16] [0, 0, 0, 1], [] [] [])
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @no_loop_dependency(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
@@ -66,7 +66,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:     scf.forall
-// CHECK:         amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([0] [2048] [1], [] [] [])
+// CHECK:         amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([0, 0, 0] [2, 2, 128] [0, 0, 1], [] [] [])
 // CHECK:         amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0, 0] [2, 2, 32, 64] [0, 64, 128, 1])
 #map = affine_map<(d0) -> (d0 * 64)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
@@ -77,7 +77,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       amdaie.controlcode {
         scf.forall (%arg2, %arg3) in (2, 2) {
           %1 = affine.apply #map(%arg3)
-          amdaie.npu.circular_dma_cpy_nd %0([0] [2048] [1], [] [] [])
+          amdaie.npu.circular_dma_cpy_nd %0([0] [128] [1], [] [] [])
           amdaie.npu.dma_cpy_nd %0([] [] [], [0, %1] [32, 64] [128, 1])
         }
         amdaie.end
@@ -187,7 +187,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:     scf.for
-// CHECK:         amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([0] [16] [1], [] [] [])
+// CHECK:         amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([0, 0] [3, 16] [0, 1], [] [] [])
 // CHECK:         amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([0] [32] [1], [] [] [])
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {


### PR DESCRIPTION
This PR adds support for explicit loop subsumption for circular DMA ops, for example:
```
scf.forall (%arg0, %arg0) in (2, 6) {
   %1 = amdaie.npu.circular_dma_cpy_nd %0([0] [16] [1], [] [] [])
}
```
is transformed into:
```
%1 = amdaie.npu.circular_dma_cpy_nd %0([0, 0, 0] [2, 6, 16] [0, 0, 1], [] [] [])
```
instead of the implicit repetition dimensions of earlier:
```
%1 = amdaie.npu.circular_dma_cpy_nd %0([0] [16] [1], [] [] [])
```
This is needed for enabling caching of more data on the outer dimensions (M, N) on MemTile for improving matmul performance.

Note that this PR contains quite a few changes on checking the validity of sizes/strides as circular DMA ops now have to be handled differently from the non-circular ones.