### PR TITLE
[LowerToAIE] Add support for DMA chains

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.h
@@ -103,7 +103,8 @@ class AIEDeviceBuilder {
   LogicalResult foldDimsAndReturnAsStatic(
       SmallVector<OpFoldResult> sizes, SmallVector<OpFoldResult> strides,
       SmallVector<int64_t> &newSizes, SmallVector<int64_t> &newStrides,
-      uint8_t memSpace, function_ref<InFlightDiagnostic()> emitError);
+      size_t repetitionCount, uint8_t memSpace,
+      function_ref<InFlightDiagnostic()> emitError);
 
   /// Utility to remap the provided operation's operands.
   void remapOperands(Operation *op);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
@@ -630,7 +630,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // connection), is lowered to a chain of `dma_bd` operations with a lock
 // acquire at the beginning of the chain and a lock release at the end. Note
 // that this lowering to multiple `dma_bd` operations is needed because 
-// `stride == 0` is not supported in hardware and/or becauser there are more
+// `stride == 0` is not supported in hardware and/or because there are more
 // dimensions needed than supported in `dma_bd`.
 // CHECK:     aie.device(npu1_4col)
 // CHECK-DAG:   %[[TILE_0_2:.*]] = aie.tile(0, 2)


### PR DESCRIPTION
Adds support for lowering `amdaie.npu.circular_dma_cpy_nd` to a chain of `aie.dma_bd` operations. This is needed becaused low-level DMA BD configurations currently don't support a  zero stride.

For example:

```
amdaie.npu.circular_dma_cpy_nd %some_connection([] [] [], [0, 0, 0] [2, 32, 32] [0, 64, 1])
```
contains an outer dimension with zero stride, which describes a repetition, and if this is not the common repetition count of all connections operating on a logical objectFifo, this is lowered to a chain of `dma_bd` operations to implement the zero stride:

```
^bb3:  // 2 preds: ^bb2, ^bb4
  aie.use_lock(%lock_0_1_0, AcquireGreaterEqual, 1)
  aie.dma_bd(%buffer_0_1 : memref<4096xi32, 1 : i32>) {dimensions = #aie<bd_dim_layout_array[<size = 32, stride = 64>, <size = 32, stride = 1>]>, len = 1024 : i32}
  aie.next_bd ^bb4
^bb4:  // pred: ^bb3
  aie.dma_bd(%buffer_0_1 : memref<4096xi32, 1 : i32>) {dimensions = #aie<bd_dim_layout_array[<size = 32, stride = 64>, <size = 32, stride = 1>]>, len = 1024 : i32}
  aie.use_lock(%lock_0_1, Release, 1)
  aie.next_bd ^bb3
```

Note how the first block contains a lock acquire operation, but no lock release operation as it needs to hand off to the second block before releasing a lock to create the DMA chain.
