### PR TITLE
[SplitLogicalObjectFifos] Modify the split factor to depend on num_cols

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -1708,6 +1708,22 @@ class Tests:
             )
         )
 
+        # Matmul test on 4(rows)x2(cols) cores
+        self.register(
+            Matmul(
+                32,
+                32,
+                32,
+                "bf16",
+                "f32",
+                aie_compilation_flags=[
+                    "--iree-amdaie-num-rows=4",
+                    "--iree-amdaie-num-cols=2",
+                ],
+                name_suffix="4rows_2cols",
+            )
+        )
+
         performance_tests = [
             {
                 "M": 512,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -19,7 +19,8 @@ void addAMDAIEObjectFifoLoweringPasses(
     OpPassManager &passManager, bool enablePacketFlow,
     TilePassPipeline useTilePipeline, bool enableVectorizationPasses,
     bool enableCoalescingLoops, bool enableCollapsingUnitDims,
-    bool enableFunctionOutlining, bool insertLoopAroundCoreBlock);
+    bool enableFunctionOutlining, bool insertLoopAroundCoreBlock,
+    uint32_t numCols);
 
 /// Add passes to lower from MLIR-AIR through AIE. This is
 /// currently the default passes used for lowering after IREEs tiling.
@@ -290,7 +291,8 @@ std::unique_ptr<Pass> createAMDAIERemoveMemorySpacePass();
 std::unique_ptr<Pass> createAMDAIESinkIntoCorePass();
 
 /// Create a pass to split logicalobjectfifos for shimTile/memTile distribution.
-std::unique_ptr<Pass> createAMDAIESplitLogicalObjFifosPass();
+std::unique_ptr<Pass> createAMDAIESplitLogicalObjFifosPass(
+    AMDAIESplitLogicalObjFifosOptions options = {});
 
 /// Create a pass to split logicalobjectfifos for connection reuse.
 std::unique_ptr<Pass> createAMDAIESplitLogicalObjFifosForConnectionReusePass();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -705,17 +705,20 @@ def AMDAIESplitLogicalObjFifos :
   let description = [{
     Splitting L2 input and output logical objectFifos and their user dma operations,
     so that the logical objectFifos can be distributed on multiple shimTiles/memTiles.
-    Ideally, the split factor should only depend on the number of AIE columns being used,
-    however the current implementation only considers situations in which `nrows == ncols`.
+    The split factor depends on the number of AIE columns being used.
 
     For example, for the case of a matmul C = A x B, the two outermost dimensions
     of the L2 buffers are the implications of `nrows x ncols` AIE cores being used.
-    So if, A matrix is distributed on a 2x2 AIE array, with L2 buffer size
-    `[2, 1, 32, 32]`, will be split to two `[1, 1, 32, 32]` buffers.
-    Similarly, B matrix is distributed on a 2x2 AIE array with L2 buffer size
+    So if, A matrix is distributed on a 4x2 AIE array, with L2 buffer size
+    `[4, 1, 32, 32]`, will be split to two `[2, 1, 32, 32]` buffers.
+    Similarly, B matrix is distributed on a 4x2 AIE array with L2 buffer size
     `[1, 2, 32, 32]`, will be split to two `[1, 1, 32, 32]` buffers.
   }];
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIESplitLogicalObjFifosPass()";
+  let options = [
+    Option<"numCols", "num-cols", "uint32_t", /*default=*/"4",
+      "Number of columns used in an AIE core array">
+  ];
 }
 
 def AMDAIESplitLogicalObjFifosForConnectionReuse :


### PR DESCRIPTION
The old logic always split the outermost dimension of logical objectFifo to 1 without considering the number of Shim/MemTile used and could result in more channel usage than the limit. This PR modifies the splitting logic to depend on number of columns, so for example on a 4x2 AIE array, `amdaie.logicalobjectfifo<memref<4x1x32x32xi32, 1 : i32>>` will be split to two `amdaie.logicalobjectfifo<memref<2x1x32x32xi32, 1 : i32>>` .

This makes the e2e tests working for `numCols != numRows` cases.