### PR TITLE
[SplitLogicalObjFifos] Support loop dependency and stride

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -599,13 +599,8 @@ void addAMDAIEObjectFifoLoweringPasses(
 
   passManager.addPass(createAMDAIESplitLogicalObjFifosForConnectionReusePass());
   // Currently, SplitLogicalObjFifos pass only works for matmul-like ops.
-  {
-    if (useTilePipeline == TilePassPipeline::PackPeelPipeline) {
-      AMDAIESplitLogicalObjFifosOptions splitOptions;
-      splitOptions.numCols = numCols;
-      passManager.addPass(createAMDAIESplitLogicalObjFifosPass(splitOptions));
-    }
-  }
+  if (useTilePipeline == TilePassPipeline::PackPeelPipeline)
+    passManager.addPass(createAMDAIESplitLogicalObjFifosPass());
 
   passManager.addPass(createCSEPass());
   passManager.addPass(createCanonicalizerPass());

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -291,8 +291,7 @@ std::unique_ptr<Pass> createAMDAIERemoveMemorySpacePass();
 std::unique_ptr<Pass> createAMDAIESinkIntoCorePass();
 
 /// Create a pass to split logicalobjectfifos for shimTile/memTile distribution.
-std::unique_ptr<Pass> createAMDAIESplitLogicalObjFifosPass(
-    AMDAIESplitLogicalObjFifosOptions options = {});
+std::unique_ptr<Pass> createAMDAIESplitLogicalObjFifosPass();
 
 /// Create a pass to split logicalobjectfifos for connection reuse.
 std::unique_ptr<Pass> createAMDAIESplitLogicalObjFifosForConnectionReusePass();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -715,10 +715,6 @@ def AMDAIESplitLogicalObjFifos :
     `[1, 2, 32, 32]`, will be split to two `[1, 1, 32, 32]` buffers.
   }];
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIESplitLogicalObjFifosPass()";
-  let options = [
-    Option<"numCols", "num-cols", "uint32_t", /*default=*/"4",
-      "Number of columns used in an AIE core array">
-  ];
 }
 
 def AMDAIESplitLogicalObjFifosForConnectionReuse :

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIELogicalObjFifoSplittingUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIELogicalObjFifoSplittingUtils.h
@@ -11,6 +11,19 @@
 
 namespace mlir::iree_compiler::AMDAIE {
 
+/// Utility to get the `DmaCpyNdOp` producers and consumers of a given
+/// objectFifo op.
+LogicalResult getDmaCpyNdOpProducersAndConsumers(
+    AMDAIE::LogicalObjectFifoFromMemrefOp op,
+    SmallVector<AMDAIE::DmaCpyNdOp> &producers,
+    SmallVector<AMDAIE::DmaCpyNdOp> &consumers);
+
+/// Utility to return the indices of the dimensions with stride equal to the
+/// expected stride and with dynamic or non-zero offsets.
+SmallVector<size_t> getStrideIndicesWithDynamicOrNonZeroOffset(
+    ArrayRef<OpFoldResult> offsets, ArrayRef<OpFoldResult> strides,
+    size_t expectedStride);
+
 /// Utility to split logicalobjectfifos given a vector of L2->L1 dma ops.
 LogicalResult splitLogicalObjectFifoForElementwiseOp(
     IRRewriter &rewriter, SmallVector<AMDAIE::DmaCpyNdOp> &l2ToL1DmaOps,
@@ -21,7 +34,8 @@ LogicalResult splitLogicalObjectFifoForElementwiseOp(
 /// objectFifo will be split on the size of the dimension being split.
 LogicalResult splitLogicalObjectFifo(
     IRRewriter &rewriter, AMDAIE::LogicalObjectFifoFromMemrefOp op,
-    size_t splitDim = 0, std::optional<size_t> splitFactor = std::nullopt);
+    size_t splitDim = 0, std::optional<size_t> splitFactor = std::nullopt,
+    int64_t splitStride = 1);
 
 /// Split doubly strided operations on a source and target split dimension with
 /// the provided split factor. If no split factor is provided, the doubly
@@ -29,7 +43,8 @@ LogicalResult splitLogicalObjectFifo(
 LogicalResult splitDoublyStridedOp(
     IRRewriter &rewriter, AMDAIE::DoublyStridedOpInterface op,
     size_t sourceSplitDim = 0, size_t targetSplitDim = 0,
-    std::optional<size_t> splitFactor = std::nullopt);
+    std::optional<size_t> splitFactor = std::nullopt,
+    int64_t sourceSplitStride = 1, int64_t targetSplitStride = 1);
 
 }  // namespace mlir::iree_compiler::AMDAIE
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEUtils.h
@@ -22,6 +22,14 @@ std::optional<AMDAIEDevice> getConfigAMDAIEDevice(
 /// attr in the AST.
 std::optional<AMDAIEDevice> getConfigAMDAIEDevice(Operation *op);
 
+/// Returns the number of columns being targeted.
+std::optional<int64_t> getConfigNumColumns(
+    IREE::HAL::ExecutableTargetAttr targetAttr);
+
+/// Returns the number of rows being targeted.
+std::optional<int64_t> getConfigNumRows(
+    IREE::HAL::ExecutableTargetAttr targetAttr);
+
 /// Utility to retrieve a constant index from an OpFoldResult.
 int64_t getConstantIndexOrAssert(OpFoldResult ofr);
 


### PR DESCRIPTION
This PR add support for splitting logical objectFifos and DMAs with loop dependencies and a strided access specified through an affine expression. 

For example, if the data in a 4x4 objectFifo at some point is:

```
[0, 0, 0, 0]
[1, 1, 1, 1]
[2, 2, 2, 2]
[3, 3, 3, 3]
```

and for an `index` from 0 -> 2, two consumer DMAs access the following rows:
````
consumer 1: 2 * `index`  (thus rows 0 and 2) 
consumer 2: 2 * `index` + 1  (thus rows 1 and 3)
````

Then, the objectFifo is split into two objectFifos in the following way:

new objectFifo 1:
```
[0, 0, 0, 0]
[2, 2, 2, 2]
```

new objectFifo 2:
```
[1, 1, 1, 1]
[3, 3, 3, 3]
```
