### PR TITLE
[IR] Pretty-printer for LogicalObjectFifoFromMemrefOp

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -1279,8 +1279,9 @@ def AMDAIE_LogicalObjectFifoFromBuffersOp
 }
 
 def AMDAIE_LogicalObjectFifoFromMemrefOp
-    : AMDAIE_Op<"logicalobjectfifo.from_memref",
-    [DeclareOpInterfaceMethods<LogicalObjFifoOpInterface, ["replaceWithNewTiles"]>,
+    : AMDAIE_Op<"logicalobjectfifo.from_memref", [
+     DeclareOpInterfaceMethods<LogicalObjFifoOpInterface, ["replaceWithNewTiles"]>,
+     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
      Pure]> {
   let summary = "Create a logical objectFifo from a memref";
   let description = [{


### PR DESCRIPTION
Makes IR easier to mentally parse -- it should be easier to figure out which columns/rows a ` LogicalObjectFifoFromMemrefOp` is on. 


```
%lof_3_2 = ... // column 3, row 2
%lof_3_r = ... // column 3, multiple rows or unkown row 
```

The lit tests have more examples