### PR TITLE
Add new pack-peel pipeline with 4 tiling levels

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -363,6 +363,7 @@ class MatmulBenchmark(BaseMatmul):
         name_suffix="",
         use_ukernel=False,
         run_on_target=["npu1_4col"],
+        tile_pipeline="pack-peel",
         additional_labels=None,
         aie_compilation_flags=None,
         n_repeats=1,
@@ -380,7 +381,7 @@ class MatmulBenchmark(BaseMatmul):
             K=K,
             input_type=input_type,
             acc_type=acc_type,
-            tile_pipeline="pack-peel",
+            tile_pipeline=tile_pipeline,
             use_ukernel=use_ukernel,
             n_repeats=n_repeats,
             n_kernel_runs=n_kernel_runs,
@@ -417,6 +418,7 @@ class MatmulTransposeB(BaseMatmul):
         name_suffix="",
         use_ukernel=False,
         run_on_target=["npu1_4col"],
+        tile_pipeline="pack-peel",
         additional_labels=None,
         aie_compilation_flags=None,
         n_repeats=1,
@@ -429,6 +431,7 @@ class MatmulTransposeB(BaseMatmul):
             K=K,
             input_type=input_type,
             acc_type=acc_type,
+            tile_pipeline=tile_pipeline,
             use_ukernel=use_ukernel,
             function_name="matmul_transpose_b",
             n_repeats=n_repeats,
@@ -471,6 +474,7 @@ class MatmulTransposeBBenchmark(BaseMatmul):
         name_suffix="",
         use_ukernel=False,
         run_on_target=["npu1_4col"],
+        tile_pipeline="pack-peel",
         additional_labels=None,
         aie_compilation_flags=None,
         n_repeats=1,
@@ -488,7 +492,7 @@ class MatmulTransposeBBenchmark(BaseMatmul):
             K=K,
             input_type=input_type,
             acc_type=acc_type,
-            tile_pipeline="pack-peel",
+            tile_pipeline=tile_pipeline,
             use_ukernel=use_ukernel,
             n_repeats=n_repeats,
             n_kernel_runs=n_kernel_runs,
@@ -526,6 +530,7 @@ class MatmulTransposeA(BaseMatmul):
         name_suffix="",
         use_ukernel=False,
         run_on_target=["npu1_4col"],
+        tile_pipeline="pack-peel",
         additional_labels=None,
         aie_compilation_flags=None,
         n_repeats=1,
@@ -538,6 +543,7 @@ class MatmulTransposeA(BaseMatmul):
             K=K,
             input_type=input_type,
             acc_type=acc_type,
+            tile_pipeline=tile_pipeline,
             use_ukernel=use_ukernel,
             function_name="matmul_transpose_a",
             n_repeats=n_repeats,
@@ -580,6 +586,7 @@ class MatmulTransposeABenchmark(BaseMatmul):
         name_suffix="",
         use_ukernel=False,
         run_on_target=["npu1_4col"],
+        tile_pipeline="pack-peel",
         additional_labels=None,
         aie_compilation_flags=None,
         n_repeats=1,
@@ -597,7 +604,7 @@ class MatmulTransposeABenchmark(BaseMatmul):
             K=K,
             input_type=input_type,
             acc_type=acc_type,
-            tile_pipeline="pack-peel",
+            tile_pipeline=tile_pipeline,
             use_ukernel=use_ukernel,
             n_repeats=n_repeats,
             n_kernel_runs=n_kernel_runs,
@@ -1734,6 +1741,7 @@ class Tests:
                 "outline": False,
                 "transpose_a": False,
                 "transpose_b": False,
+                "tile_pipeline": "pack-peel",
             },
             {
                 "M": 512,
@@ -1744,6 +1752,7 @@ class Tests:
                 "outline": True,
                 "transpose_a": False,
                 "transpose_b": False,
+                "tile_pipeline": "pack-peel",
             },
             {
                 "M": 512,
@@ -1754,6 +1763,7 @@ class Tests:
                 "outline": False,
                 "transpose_a": False,
                 "transpose_b": False,
+                "tile_pipeline": "pack-peel",
             },
             {
                 "M": 512,
@@ -1764,6 +1774,7 @@ class Tests:
                 "outline": True,
                 "transpose_a": False,
                 "transpose_b": False,
+                "tile_pipeline": "pack-peel",
             },
             {
                 "M": 512,
@@ -1774,6 +1785,7 @@ class Tests:
                 "outline": True,
                 "transpose_a": False,
                 "transpose_b": False,
+                "tile_pipeline": "pack-peel",
             },
             {
                 "M": 512,
@@ -1784,6 +1796,7 @@ class Tests:
                 "outline": True,
                 "transpose_a": False,
                 "transpose_b": False,
+                "tile_pipeline": "pack-peel",
             },
             {
                 "M": 512,
@@ -1794,6 +1807,7 @@ class Tests:
                 "outline": True,
                 "transpose_a": False,
                 "transpose_b": False,
+                "tile_pipeline": "pack-peel",
             },
             {
                 "M": 512,
@@ -1804,6 +1818,7 @@ class Tests:
                 "outline": True,
                 "transpose_a": False,
                 "transpose_b": True,
+                "tile_pipeline": "pack-peel",
             },
             {
                 "M": 4096,
@@ -1814,6 +1829,7 @@ class Tests:
                 "outline": True,
                 "transpose_a": False,
                 "transpose_b": False,
+                "tile_pipeline": "pack-peel",
             },
             {
                 "M": 4096,
@@ -1824,6 +1840,7 @@ class Tests:
                 "outline": True,
                 "transpose_a": False,
                 "transpose_b": False,
+                "tile_pipeline": "pack-peel",
             },
             {
                 "M": 4096,
@@ -1834,6 +1851,7 @@ class Tests:
                 "outline": True,
                 "transpose_a": True,
                 "transpose_b": False,
+                "tile_pipeline": "pack-peel",
             },
             # Test where the compute is omitted, this should help triangulate
             # how much performance gain can be obtained with better matmul
@@ -1849,6 +1867,45 @@ class Tests:
                 "transpose_a": False,
                 "transpose_b": False,
                 "skip_numerics": True,
+                "tile_pipeline": "pack-peel",
+            },
+            {
+                "M": 512,
+                "N": 4096,
+                "K": 512,
+                "use_ukernel": False,
+                "peano_opt_level": 3,
+                "outline": True,
+                "transpose_a": False,
+                "transpose_b": False,
+                "tile_pipeline": "pack-peel-4-level-tiling",
+            },
+            {
+                "M": 512,
+                "N": 4096,
+                "K": 512,
+                "use_ukernel": True,
+                "peano_opt_level": 3,
+                "outline": True,
+                "transpose_a": False,
+                "transpose_b": False,
+                "tile_pipeline": "pack-peel-4-level-tiling",
+            },
+            # Test where the compute is omitted, this should help triangulate
+            # how much performance gain can be obtained with better matmul
+            # on core vs data movement.
+            {
+                "M": 512,
+                "N": 4096,
+                "K": 512,
+                "use_ukernel": False,
+                "peano_opt_level": 3,
+                "outline": True,
+                "outline_to_empty_function": True,
+                "transpose_a": False,
+                "transpose_b": False,
+                "skip_numerics": True,
+                "tile_pipeline": "pack-peel-4-level-tiling",
             },
         ]
 
@@ -1862,6 +1919,7 @@ class Tests:
             outline = test["outline"]
             transpose_a = test["transpose_a"]
             transpose_b = test["transpose_b"]
+            tile_pipeline = test["tile_pipeline"]
 
             outlining_string = "--iree-amdaie-enable-function-outlining=" + str(
                 int(outline)
@@ -1902,6 +1960,9 @@ class Tests:
             else:
                 raise ValueError("Transposing both LHS and RHS is not supported.")
 
+            if tile_pipeline == "pack-peel-4-level-tiling":
+                name_suffix += "_4_level_tiling"
+
             # This should only be the case for benchmark tests which we expect
             # to not pass numerically.
             if "skip_numerics" in test and test["skip_numerics"]:
@@ -1914,6 +1975,7 @@ class Tests:
                         K,
                         "bf16",
                         "f32",
+                        tile_pipeline=tile_pipeline,
                         use_ukernel=use_ukernel,
                         n_repeats=2,
                         aie_compilation_flags=aie_compilation_flags,
@@ -1929,6 +1991,7 @@ class Tests:
                     K,
                     "bf16",
                     "f32",
+                    tile_pipeline=tile_pipeline,
                     additional_labels=["Performance"],
                     use_ukernel=use_ukernel,
                     n_repeats=5,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
@@ -153,6 +153,11 @@ struct AMDAIEOptions {
             clEnumValN(TilePassPipeline::PackPeelPipeline, "pack-peel",
                        "Use the pack-peel based lowering strategy for "
                        "matmul-like ops"),
+            clEnumValN(TilePassPipeline::PackPeel4LevelTilingPipeline,
+                       "pack-peel-4-level-tiling",
+                       "Use the pack-peel based lowering strategy with 4 "
+                       "levels of tiling for "
+                       "matmul-like ops"),
             clEnumValN(
                 TilePassPipeline::PadPackPipeline, "pad-pack",
                 "Use the pad-pack based lowering strategy for matmul-like ops"),

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerExecutableTarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerExecutableTarget.cpp
@@ -53,8 +53,8 @@ class AMDAIELowerExecutableTargetPass
   }
 
   AMDAIELowerExecutableTargetPass() = default;
-  AMDAIELowerExecutableTargetPass(const AMDAIELowerExecutableTargetPass &pass) {
-  };
+  AMDAIELowerExecutableTargetPass(
+      const AMDAIELowerExecutableTargetPass &pass){};
   AMDAIELowerExecutableTargetPass(
       const AMDAIELowerExecutableTargetOptions &options)
       : AMDAIELowerExecutableTargetBase(options) {}
@@ -111,6 +111,12 @@ void AMDAIELowerExecutableTargetPass::runOnOperation() {
         addPackPeelBasedPassPipeline(executableLoweringPipeline, tilingConfig,
                                      pathToUkernels, enableVectorizationPasses,
                                      TilePassPipeline::PackPeelPipeline);
+      } else if (useTilePipeline ==
+                 TilePassPipeline::PackPeel4LevelTilingPipeline) {
+        addPackPeel4LevelTilingBasedPassPipeline(
+            executableLoweringPipeline, tilingConfig, pathToUkernels,
+            enableVectorizationPasses,
+            TilePassPipeline::PackPeel4LevelTilingPipeline);
       } else if (useTilePipeline == TilePassPipeline::PadPackPipeline) {
         addPadPackBasedPassPipeline(executableLoweringPipeline, tilingConfig,
                                     pathToUkernels, enableVectorizationPasses,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIETileAndFuse.cpp
@@ -400,10 +400,14 @@ void AMDAIETileAndFusePass::runOnOperation() {
           "expected to be an scf.forall operation.");
       signalPassFailure();
     }
-    auto groupType =
-        tilingLevel == 0 ? GPUGroupType::Block : GPUGroupType::Thread;
-    if (failed(setGpuAttributeOnForall(groupType, loopForAll, consumerOp))) {
-      return signalPassFailure();
+    if (hardwareMapping == HardwareMapping::Core ||
+        hardwareMapping == HardwareMapping::Block) {
+      auto groupType = hardwareMapping == HardwareMapping::Core
+                           ? GPUGroupType::Thread
+                           : GPUGroupType::Block;
+      if (failed(setGpuAttributeOnForall(groupType, loopForAll, consumerOp))) {
+        return signalPassFailure();
+      }
     }
   }
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
@@ -25,6 +25,7 @@ enum class LowerToAIEPassPipeline {
 /// This is an enum to pick different pass pipelines in IREE.
 enum class TilePassPipeline {
   PackPeelPipeline,
+  PackPeel4LevelTilingPipeline,
   PadPackPipeline,
   ConvDecomposePipeline,
   None
@@ -35,6 +36,13 @@ enum class PeelingType { First, Last, FirstLast };
 
 /// Enum for operands to be bufferized to allocation.
 enum class BufferizeOperand { LinalgInputOutput, LinalgInput, LinalgOutput, PackInput };
+
+/// Enum for hardware mapping attributes.
+enum class HardwareMapping {
+  Core,
+  Block,
+  None
+};
 
 LogicalResult initAIELaunchConfig(FunctionOpInterface funcOp,
                                   TilePassPipeline useTilePipeline,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -83,7 +83,9 @@ static void addAMDAIEBufferizePasses(OpPassManager &pm,
                         ValueRange dynamicSizes, unsigned _alignment) {
         int64_t numDims = memRefType.getShape().size();
         AMDAIEMemSpace memSpace = AMDAIEMemSpace::Local;
-        if (useTilePipeline == TilePassPipeline::PackPeelPipeline &&
+        if ((useTilePipeline == TilePassPipeline::PackPeelPipeline ||
+             useTilePipeline ==
+                 TilePassPipeline::PackPeel4LevelTilingPipeline) &&
             numDims == 4) {
           memSpace = AMDAIEMemSpace::Shared;
         }
@@ -131,6 +133,7 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
   // First level tiling using scf.forall
   {
     AMDAIETileAndFuseOptions tileFuseOptions;
+    tileFuseOptions.hardwareMapping = HardwareMapping::Block;
     tileFuseOptions.tilingLevel = 0;
     tileFuseOptions.useSCFFor = false;
     funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions));
@@ -218,6 +221,7 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
   // Second level tiling using scf.forall
   {
     AMDAIETileAndFuseOptions tileFuseOptions;
+    tileFuseOptions.hardwareMapping = HardwareMapping::Core;
     tileFuseOptions.tilingLevel = 2;
     tileFuseOptions.useSCFFor = false;
     tileFuseOptions.tileElementwise = false;
@@ -298,6 +302,205 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
   funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
 }
 
+void addPackPeel4LevelTilingBasedPassPipeline(
+    OpPassManager &funcPassManager, TilingConfig &tilingConfig,
+    const std::string &pathToUkernels, bool enableVectorizationPasses,
+    TilePassPipeline useTilePipeline) {
+  // First level tiling using scf.forall
+  {
+    AMDAIETileAndFuseOptions tileFuseOptions;
+    tileFuseOptions.tilingLevel = 0;
+    tileFuseOptions.useSCFFor = false;
+    funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions));
+  }
+  funcPassManager.addPass(createAMDAIECleanupPass());
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+
+  // First level packing
+  {
+    AMDAIEPackAndTransposeOptions packOptions;
+    packOptions.packLevel = 0;
+    funcPassManager.addPass(createAMDAIEPackAndTransposePass(packOptions));
+  }
+
+  // Propagate pack ops for the elementwise op
+  funcPassManager.addPass(createAMDAIEPropagateDataLayoutPass());
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+
+  // Promote the matmul output to shared memory
+  {
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
+    bufferizeOptions.memorySpace = 1;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::LinalgOutput;
+    funcPassManager.addPass(
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
+  }
+
+  // Promote the elementwise input to shared memory
+  {
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
+    bufferizeOptions.memorySpace = 1;
+    bufferizeOptions.bufferizeElementwise = true;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::LinalgInput;
+    funcPassManager.addPass(
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
+  }
+
+  // Second level packing
+  {
+    AMDAIEPackAndTransposeOptions packOptions;
+    packOptions.packLevel = 1;
+    funcPassManager.addPass(createAMDAIEPackAndTransposePass(packOptions));
+  }
+
+  // Propagate pack ops for the elementwise op
+  funcPassManager.addPass(createAMDAIEPropagateDataLayoutPass());
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+
+  // Second level tiling using scf.forall.
+  {
+    AMDAIETileAndFuseOptions tileFuseOptions;
+    tileFuseOptions.tilingLevel = 1;
+    tileFuseOptions.useSCFFor = false;
+    funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions));
+  }
+  funcPassManager.addPass(createAMDAIECleanupPass());
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+
+  // Fuse the second level of pack ops into forall loop
+  {
+    AMDAIEFusePackIntoLoopOptions fusePackOptions;
+    fusePackOptions.fusePackDepth = 1;
+    fusePackOptions.useSCFFor = false;
+    funcPassManager.addPass(createAMDAIEFusePackIntoLoopPass(fusePackOptions));
+  }
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+
+  // Tile the reduction dimension using scf.for
+  {
+    AMDAIETileAndFuseOptions tileFuseOptions;
+    tileFuseOptions.tilingLevel = 2;
+    tileFuseOptions.useSCFFor = true;
+    tileFuseOptions.tileElementwise = false;
+    funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions));
+  }
+  funcPassManager.addPass(createAMDAIECleanupPass());
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+
+  // Fuse the second level of pack ops into for loop
+  {
+    AMDAIEFusePackIntoLoopOptions fusePackOptions;
+    fusePackOptions.fusePackDepth = 1;
+    fusePackOptions.useSCFFor = true;
+    funcPassManager.addPass(createAMDAIEFusePackIntoLoopPass(fusePackOptions));
+  }
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+
+  // Promote the operands of pack at depth 2 from the linalg ops to shared
+  // memory.
+  {
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
+    bufferizeOptions.memorySpace = 1;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::PackInput;
+    bufferizeOptions.packDepth = 2;
+    funcPassManager.addPass(
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
+  }
+
+  // Third level tiling using scf.forall
+  {
+    AMDAIETileAndFuseOptions tileFuseOptions;
+    tileFuseOptions.hardwareMapping = HardwareMapping::Core;
+    tileFuseOptions.tilingLevel = 3;
+    tileFuseOptions.useSCFFor = false;
+    tileFuseOptions.tileElementwise = false;
+    funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions));
+  }
+  funcPassManager.addPass(createAMDAIECleanupPass());
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+
+  // Fuse second level pack ops into forall loop
+  {
+    AMDAIEFusePackIntoLoopOptions fusePackOptions;
+    fusePackOptions.fusePackDepth = 1;
+    fusePackOptions.useSCFFor = false;
+    funcPassManager.addPass(createAMDAIEFusePackIntoLoopPass(fusePackOptions));
+  }
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+
+  // Promote the matmul inputs to local memory
+  {
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
+    bufferizeOptions.memorySpace = 2;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::LinalgInput;
+    funcPassManager.addPass(
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
+  }
+
+  // Hoist static allocations
+  funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+
+  // Peel the first and last iteration. Note: Do not run CSE pass afterwards,
+  // because it may bring problem for bufferization.
+  funcPassManager.addPass(createAMDAIEPeelForLoopPass());
+  funcPassManager.addPass(createCanonicalizerPass());
+
+  // Fuse fill op into the first inner forall loop
+  funcPassManager.addPass(createAMDAIEFuseFillIntoForallPass());
+
+  // Fuse unpack/elementwise consumer ops into the last inner forall loop
+  funcPassManager.addPass(createAMDAIEFuseConsumerIntoLoopPass());
+
+  // Note: canonicalizer pass should not run starting from here until
+  // bufferization to avoid creating redundant allocation and data copy.
+  // TODO (vivian): solve the bufferization problem upstream
+
+  // Fuse pack ops into the last inner forall loop
+  {
+    AMDAIEFusePackIntoLoopOptions fusePackOptions;
+    fusePackOptions.fusePackDepth = 1;
+    fusePackOptions.useSCFFor = false;
+    fusePackOptions.targetElementwise = true;
+    funcPassManager.addPass(createAMDAIEFusePackIntoLoopPass(fusePackOptions));
+  }
+
+  // Promote the elementwise input to local memory
+  {
+    AMDAIEBufferizeToAllocationOptions bufferizeOptions;
+    bufferizeOptions.memorySpace = 2;
+    bufferizeOptions.bufferizeElementwise = true;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::LinalgInput;
+    funcPassManager.addPass(
+        createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
+  }
+
+  // Lower to UKernels.
+  {
+    AMDAIELowerToUKernelsOptions options;
+    // windows
+    options.pathToUkernels = escapeCommandLineComponent(pathToUkernels);
+    funcPassManager.addPass(createAMDAIELowerToUKernelsPass(options));
+  }
+
+  // Comprehensive bufferization
+  addAMDAIEBufferizePasses(funcPassManager, useTilePipeline);
+  funcPassManager.addPass(createHoistStaticallyBoundAllocationsPass());
+  funcPassManager.addPass(createCanonicalizerPass());
+  funcPassManager.addPass(createCSEPass());
+  funcPassManager.addPass(createCanonicalizerPass());
+}
+
 void addPadPackBasedPassPipeline(OpPassManager &funcPassManager,
                                  TilingConfig &tilingConfig,
                                  const std::string &pathToUkernels,
@@ -306,6 +509,7 @@ void addPadPackBasedPassPipeline(OpPassManager &funcPassManager,
   // First level tiling using scf.forall
   {
     AMDAIETileAndFuseOptions tileFuseOptions;
+    tileFuseOptions.hardwareMapping = HardwareMapping::Block;
     tileFuseOptions.tilingLevel = 0;
     tileFuseOptions.useSCFFor = false;
     funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions));
@@ -343,6 +547,7 @@ void addPadPackBasedPassPipeline(OpPassManager &funcPassManager,
   // Second level tiling using scf.forall
   {
     AMDAIETileAndFuseOptions tileFuseOptions;
+    tileFuseOptions.hardwareMapping = HardwareMapping::Core;
     tileFuseOptions.tilingLevel = 2;
     tileFuseOptions.useSCFFor = false;
     funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions));
@@ -421,6 +626,7 @@ void addConvDecomposePassPipeline(OpPassManager &funcPassManager,
   // First level tiling using scf.forall
   {
     AMDAIETileAndFuseOptions tileFuseOptions;
+    tileFuseOptions.hardwareMapping = HardwareMapping::Block;
     tileFuseOptions.tilingLevel = 0;
     tileFuseOptions.useSCFFor = false;
     funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions));
@@ -446,6 +652,7 @@ void addConvDecomposePassPipeline(OpPassManager &funcPassManager,
   // Second level tiling using scf.forall
   {
     AMDAIETileAndFuseOptions tileFuseOptions;
+    tileFuseOptions.hardwareMapping = HardwareMapping::Core;
     tileFuseOptions.tilingLevel = 1;
     tileFuseOptions.useSCFFor = false;
     funcPassManager.addPass(createAMDAIETileAndFusePass(tileFuseOptions));
@@ -610,7 +817,8 @@ void addAMDAIEObjectFifoLoweringPasses(
 
   passManager.addPass(createAMDAIESplitLogicalObjFifosForConnectionReusePass());
   // Currently, SplitLogicalObjFifos pass only works for matmul-like ops.
-  if (useTilePipeline == TilePassPipeline::PackPeelPipeline)
+  if (useTilePipeline == TilePassPipeline::PackPeelPipeline ||
+      useTilePipeline == TilePassPipeline::PackPeel4LevelTilingPipeline)
     passManager.addPass(createAMDAIESplitLogicalObjFifosPass());
 
   passManager.addPass(createCSEPass());
@@ -782,7 +990,8 @@ void addMLIRAIRLoweringPasses(OpPassManager &passManager, AMDAIEDevice device,
   passManager.addPass(createCSEPass());
 
   passManager.addPass(xilinx::air::createAIRDependencyPass());
-  if (!(useTilePipeline == TilePassPipeline::PackPeelPipeline &&
+  if (!((useTilePipeline == TilePassPipeline::PackPeelPipeline ||
+         useTilePipeline == TilePassPipeline::PackPeel4LevelTilingPipeline) &&
         matmulElementwiseFusion)) {
     passManager.addPass(xilinx::air::createAIRDependencyScheduleOptPass());
     passManager.addPass(xilinx::air::createAIRSpecializeDmaBroadcast());
@@ -798,7 +1007,8 @@ void addMLIRAIRLoweringPasses(OpPassManager &passManager, AMDAIEDevice device,
   passManager.addPass(createCSEPass());
   {
     xilinx::air::AIRFuseChannelsOptions options;
-    if (useTilePipeline == TilePassPipeline::PackPeelPipeline &&
+    if ((useTilePipeline == TilePassPipeline::PackPeelPipeline ||
+         useTilePipeline == TilePassPipeline::PackPeel4LevelTilingPipeline) &&
         matmulElementwiseFusion) {
       const static llvm::SmallVector<std::string> mode = {"L1"};
       options.clAggressiveMode = mode;
@@ -875,7 +1085,8 @@ void addMLIRAIRLoweringPasses(OpPassManager &passManager, AMDAIEDevice device,
     // with given factors, and subsequently unrolled in
     // AIRUnrollOuterPerfectlyNestedLoopsPass, to enforce SHIM DMA BD count
     // within the hardware limit.
-    if (useTilePipeline == TilePassPipeline::PackPeelPipeline) {
+    if (useTilePipeline == TilePassPipeline::PackPeelPipeline ||
+        useTilePipeline == TilePassPipeline::PackPeel4LevelTilingPipeline) {
       const static llvm::SmallVector<unsigned> tile_sizes = {2, 2};
       options.clTileSizes = tile_sizes;
     } else if (useTilePipeline == TilePassPipeline::PadPackPipeline) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -52,6 +52,14 @@ void addPackPeelBasedPassPipeline(OpPassManager &oassManager,
                                   bool enableVectorizationPasses,
                                   TilePassPipeline useTilePipeline);
 
+/// Populates passes needed to lower the IR via a Pack-Peel based approach with
+/// 4 levels of tiling.
+void addPackPeel4LevelTilingBasedPassPipeline(OpPassManager &oassManager,
+                                              TilingConfig &tilingConfig,
+                                              const std::string &pathToUkernels,
+                                              bool enableVectorizationPasses,
+                                              TilePassPipeline useTilePipeline);
+
 /// Populates passes needed to lower the IR via a Pad-Pack based approach.
 void addPadPackBasedPassPipeline(OpPassManager &passManager,
                                  TilingConfig &tilingConfig,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -461,6 +461,8 @@ def AMDAIELowerExecutableTarget :
       [{::llvm::cl::values(
         clEnumValN(mlir::iree_compiler::AMDAIE::TilePassPipeline::PackPeelPipeline, "pack-peel",
                    "Use the pack-peel based lowering strategy for matmul-like ops."),
+        clEnumValN(mlir::iree_compiler::AMDAIE::TilePassPipeline::PackPeel4LevelTilingPipeline, "pack-peel-4-level-tiling",
+                   "Use the pack-peel based lowering strategy with 4 tiling levels for matmul-like ops."),
         clEnumValN(mlir::iree_compiler::AMDAIE::TilePassPipeline::PadPackPipeline, "pad-pack",
                    "Use the pad-pack based lowering strategy for matmul-like ops."),
         clEnumValN(mlir::iree_compiler::AMDAIE::TilePassPipeline::ConvDecomposePipeline, "conv-decompose",
@@ -484,6 +486,8 @@ def AMDAIELoweringStrategy :
       [{::llvm::cl::values(
         clEnumValN(mlir::iree_compiler::AMDAIE::TilePassPipeline::PackPeelPipeline, "pack-peel",
                    "Use the pack-peel based lowering strategy for matmul-like ops."),
+        clEnumValN(mlir::iree_compiler::AMDAIE::TilePassPipeline::PackPeel4LevelTilingPipeline, "pack-peel-4-level-tiling",
+                   "Use the pack-peel based lowering strategy with 4 tiling levels for matmul-like ops."),
         clEnumValN(mlir::iree_compiler::AMDAIE::TilePassPipeline::PadPackPipeline, "pad-pack",
                    "Use the pad-pack based lowering strategy for matmul-like ops."),
         clEnumValN(mlir::iree_compiler::AMDAIE::TilePassPipeline::ConvDecomposePipeline, "conv-decompose",
@@ -786,7 +790,19 @@ def AMDAIETileAndFuse :
     Option<"tilingLevel", "tiling-level", "int64_t", /*default=*/"-1",
       "Use default tiling level used to retrieve the configuration from lowering_config">,
     Option<"tileElementwise", "tile-elementwise", "bool", /*default=*/"true",
-      "Option to whether tile and fuse the elementwise op">
+      "Option to whether tile and fuse the elementwise op">,
+    Option<"hardwareMapping", "hardware-mapping",
+      "mlir::iree_compiler::AMDAIE::HardwareMapping",
+      /*default=*/"mlir::iree_compiler::AMDAIE::HardwareMapping::None",
+      "The hardware mapping to use for this tiling level.",
+      [{::llvm::cl::values(
+        clEnumValN(mlir::iree_compiler::AMDAIE::HardwareMapping::None, "none",
+                   "No hardware mapping for this tiling level."),
+        clEnumValN(mlir::iree_compiler::AMDAIE::HardwareMapping::Core, "core",
+                   "Map this tiling level to cores."),
+        clEnumValN(mlir::iree_compiler::AMDAIE::HardwareMapping::Block, "block",
+                   "Map this tiling level to blocks.")
+      )}]>,
   ];
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo_npu1.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo_npu1.mlir
@@ -1,6 +1,7 @@
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-amdaie-lowering-strategy{target-device=npu1_4col num-rows=2 num-cols=2})' %s | FileCheck %s --check-prefix=CHECK-2x2
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-amdaie-lowering-strategy{target-device=npu1_4col num-rows=4 num-cols=2})' %s | FileCheck %s --check-prefix=CHECK-4x2
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-amdaie-lowering-strategy{target-device=npu1_4col})' %s | FileCheck %s --check-prefix=CHECK-4x4
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-amdaie-lowering-strategy{target-device=npu1_4col use-tile-pipeline=pack-peel-4-level-tiling})' %s | FileCheck %s --check-prefix=PACK-PEEL-4-LEVEL
 
 // CHECK-2x2{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
 // CHECK-2x2{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
@@ -10,6 +11,9 @@
 
 // CHECK-4x4{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
 // CHECK-4x4{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+
+// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[256, 256], [4, 4, 0], [0, 0, 1], [1, 1, 0, 0, 0, 0]]
+// PACK-PEEL-4-LEVEL{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
   <storage_buffer>,
@@ -43,6 +47,9 @@ module {
 
 // CHECK-4x4{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
 // CHECK-4x4{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+
+// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[256, 256], [4, 4, 0], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
+// PACK-PEEL-4-LEVEL{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
   <storage_buffer>,
@@ -76,6 +83,9 @@ module {
 
 // CHECK-4x4{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
 // CHECK-4x4{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 8, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+
+// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[256, 256], [4, 4, 0], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
+// PACK-PEEL-4-LEVEL{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 8, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
   <storage_buffer>,
@@ -109,6 +119,9 @@ module {
 
 // CHECK-4x4{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[1, 128, 128], [0, 0, 0, 1], [0, 1, 1, 0, 0, 0, 0]]>
 // CHECK-4x4{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [0, 32, 32, 32], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 2], [0, 2, 1], [0, 2, 1]]}, {packedSizes = [0, 0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 2, 4, 3], [0, 1, 2, 4, 3], [0, 1, 2, 4, 3]]}]>
+
+// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[1, 128, 128], [0, 4, 4, 0], [0, 0, 0, 1], [0, 1, 1, 0, 0, 0, 0]]>
+// PACK-PEEL-4-LEVEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [0, 32, 32, 32], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 2], [0, 2, 1], [0, 2, 1]]}, {packedSizes = [0, 0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 2, 4, 3], [0, 1, 2, 4, 3], [0, 1, 2, 4, 3]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
   <storage_buffer>,
@@ -142,6 +155,9 @@ module {
 
 // CHECK-4x4{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
 // CHECK-4x4{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [0, 1], [0, 1]], outerPerm = [[0, 1], [0, 1], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [0, 1], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+
+// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[256, 256], [4, 4, 0], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
+// PACK-PEEL-4-LEVEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [0, 1], [0, 1]], outerPerm = [[0, 1], [0, 1], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [0, 1], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
   <storage_buffer>,
@@ -175,6 +191,9 @@ module {
 
 // CHECK-4x4{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
 // CHECK-4x4{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[1, 0], [1, 0], [0, 1]], outerPerm = [[1, 0], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[1, 0], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+
+// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[256, 256], [4, 4, 0], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
+// PACK-PEEL-4-LEVEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[1, 0], [1, 0], [0, 1]], outerPerm = [[1, 0], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[1, 0], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
   <storage_buffer>,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo_npu4.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo_npu4.mlir
@@ -1,4 +1,5 @@
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-amdaie-lowering-strategy{target-device=npu4})' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-amdaie-lowering-strategy{target-device=npu4 use-tile-pipeline=pack-peel-4-level-tiling})' %s | FileCheck %s --check-prefix=PACK-PEEL-4-LEVEL
 
 // CHECK:       #config = #iree_codegen.lowering_config<tile_sizes = [
 // CHECK-SAME:                [128, 128], [0, 0, 1], [1, 1, 0, 0, 0, 0]
@@ -14,6 +15,9 @@
 // CHECK-SAME:                   ], outerPerm = [
 // CHECK-SAME:                              [0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]
 // CHECK-SAME:                   ]}]>
+
+// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[256, 256], [4, 4, 0], [0, 0, 1], [1, 1, 0, 0, 0, 0]]>
+// PACK-PEEL-4-LEVEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 32], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 8, 8, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
   <storage_buffer>,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_convolution_using_scf_forall.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_convolution_using_scf_forall.mlir
@@ -1,8 +1,8 @@
 // In these tests, we tile at just level 0.
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=0}))' --split-input-file %s | FileCheck %s --check-prefix=TILE-LEVEL-0
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=0 hardware-mapping=block}))' --split-input-file %s | FileCheck %s --check-prefix=TILE-LEVEL-0
 
 // In these tests, we tile at level 0, and then at level 1.
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=0}, iree-amdaie-tile-and-fuse{tiling-level=1}))' --split-input-file --verify-diagnostics %s | FileCheck %s --check-prefix=TILE-LEVEL-1
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=0 hardware-mapping=block}, iree-amdaie-tile-and-fuse{tiling-level=1 hardware-mapping=core}))' --split-input-file --verify-diagnostics %s | FileCheck %s --check-prefix=TILE-LEVEL-1
 
 // -----
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_matmul_using_scf_forall.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/tile_and_fuse_matmul_using_scf_forall.mlir
@@ -1,6 +1,6 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=0}))' --split-input-file %s                        | FileCheck %s --check-prefix=TILE-LEVEL-0
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=1}))' --split-input-file --verify-diagnostics %s   | FileCheck %s --check-prefix=TILE-LEVEL-1
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=0 tile-elementwise=false}))' --split-input-file %s | FileCheck %s --check-prefix=TILE-MATMUL-ONLY
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=0 hardware-mapping=block}))' --split-input-file %s                        | FileCheck %s --check-prefix=TILE-LEVEL-0
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=1 hardware-mapping=core}))' --split-input-file --verify-diagnostics %s   | FileCheck %s --check-prefix=TILE-LEVEL-1
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-tile-and-fuse{tiling-level=0 hardware-mapping=block tile-elementwise=false}))' --split-input-file %s | FileCheck %s --check-prefix=TILE-MATMUL-ONLY
 
 func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> tensor<8x8xi32> {
   %c0 = arith.constant 0 : index

--- a/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.cc
+++ b/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.cc
@@ -320,6 +320,11 @@ uint32_t AMDAIEDeviceModel::getMemInternalBaseAddress() const {
   return getMemEastBaseAddress();
 }
 
+uint32_t AMDAIEDeviceModel::getMemTileSizeInBytes() const {
+  return devInst.DevProp.DevMod[static_cast<uint8_t>(AMDAIETileType::MEMTILE)]
+      .MemMod->Size;
+}
+
 uint32_t AMDAIEDeviceModel::getMemTileSize(uint8_t col, uint8_t row) const {
   AMDAIETileType tileType = getTileType(col, row);
   assert(tileType == AMDAIETileType::MEMTILE && "expected memtile");

--- a/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.h
+++ b/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.h
@@ -368,6 +368,7 @@ struct AMDAIEDeviceModel {
   uint32_t getMemNorthBaseAddress() const;
   uint32_t getMemEastBaseAddress() const;
   uint32_t getLocalMemorySize(uint8_t col, uint8_t row) const;
+  uint32_t getMemTileSizeInBytes() const;
   uint32_t getMemTileSize(uint8_t col, uint8_t row) const;
   uint32_t getCoreTileLocalMemorySize() const;
 


### PR DESCRIPTION
Adds a new pipeline with an additional level of tiling for matmul-like operations on the outer dimension. This should reduce the DDR BW requirements by caching more data slices on L2/MemTile.