### PR TITLE
[AssignTiles] Fix ValueRange -> SmallVector<Value> for storing tiles

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignTiles.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignTiles.cpp
@@ -29,7 +29,7 @@ LogicalResult getUserTiles(AMDAIE::LogicalObjFifoOpInterface logicalObjectFifo,
       auto target = dyn_cast_if_present<AMDAIE::LogicalObjFifoOpInterface>(
           copyOp.getTarget().getDefiningOp());
       if (!source || !target) continue;
-      ValueRange tileIndices;
+      SmallVector<Value> tileIndices;
       if constexpr (OperateOn == CopyOpOperateOn::Source) {
         if (target != logicalObjectFifo) continue;
         tileIndices = source.getTiles();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_tiles.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_tiles.mlir
@@ -429,3 +429,83 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     return
   }
 }
+
+// -----
+
+// CHECK-LABEL: @same_row_multi_col_l2_tile_assignment
+// CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG:   %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG:   %[[C2:.*]] = arith.constant 2 : index
+// CHECK-DAG:   %[[C3:.*]] = arith.constant 3 : index
+// CHECK-DAG:   %[[C4:.*]] = arith.constant 4 : index
+// CHECK-DAG:   %[[C5:.*]] = arith.constant 5 : index
+// CHECK-DAG:   %[[C6:.*]] = arith.constant 6 : index
+// CHECK-DAG:   %[[ALLOC_0:.*]] = memref.alloc() : memref<1024xi32, 2 : i32>
+// CHECK-DAG:   %[[ALLOC_1:.*]] = memref.alloc() : memref<4x1024xi32, 1 : i32>
+// CHECK-DAG:   %[[TILE_0_1:.*]] = amdaie.tile(%[[C0]], %[[C1]])
+// CHECK-DAG:   %[[L1_LOF:.*]] = amdaie.logicalobjectfifo.from_memref %[[ALLOC_1]], {%tile_0_1}
+// CHECK-DAG:   %[[TILE_0_2:.*]] = amdaie.tile(%[[C0]], %[[C2]])
+// CHECK-DAG:   %[[TILE_1_2:.*]] = amdaie.tile(%[[C1]], %[[C2]])
+// CHECK-DAG:   %[[TILE_2_2:.*]] = amdaie.tile(%[[C2]], %[[C2]])
+// CHECK-DAG:   %[[TILE_3_2:.*]] = amdaie.tile(%[[C3]], %[[C2]])
+// CHECK-DAG:   %[[TILE_4_2:.*]] = amdaie.tile(%[[C4]], %[[C2]])
+// CHECK-DAG:   %[[TILE_5_2:.*]] = amdaie.tile(%[[C5]], %[[C2]])
+// CHECK-DAG:   %[[TILE_6_2:.*]] = amdaie.tile(%[[C6]], %[[C2]])
+// CHECK-DAG:   amdaie.logicalobjectfifo.from_memref %[[ALLOC_0]], {%[[TILE_0_2]], %[[TILE_1_2]], %[[TILE_2_2]], %[[TILE_3_2]], %[[TILE_4_2]], %[[TILE_5_2]], %[[TILE_6_2]]}
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu4", ukernels = "none"}>
+#translation = #iree_codegen.translation_info<pipeline = Custom>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @same_row_multi_col_l2_tile_assignment() attributes {translation_info = #translation} {
+    %c7 = arith.constant 7 : index
+    %c6 = arith.constant 6 : index
+    %c5 = arith.constant 5 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() : memref<1024xi32, 2 : i32>
+    %alloc_0 = memref.alloc() : memref<4x1024xi32, 1 : i32>
+    %0 = amdaie.logicalobjectfifo.from_memref %alloc_0, {} : memref<4x1024xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<4x1024xi32, 1 : i32>>
+    %tile_6_2 = amdaie.tile(%c6, %c2)
+    %tile_5_2 = amdaie.tile(%c5, %c2)
+    %tile_4_2 = amdaie.tile(%c4, %c2)
+    %tile_3_2 = amdaie.tile(%c3, %c2)
+    %tile_2_2 = amdaie.tile(%c2, %c2)
+    %tile_1_2 = amdaie.tile(%c1, %c2)
+    %tile_0_2 = amdaie.tile(%c0, %c2)
+    %1 = amdaie.logicalobjectfifo.from_memref %alloc, {%tile_0_2, %tile_1_2, %tile_2_2, %tile_3_2, %tile_4_2, %tile_5_2, %tile_6_2} : memref<1024xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>>
+    %2 = amdaie.dma_cpy_nd(%1[0] [1024] [1], %0[0, 0] [1, 1024] [1024, 1]) : (!amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>>, !amdaie.logicalobjectfifo<memref<4x1024xi32, 1 : i32>>)
+    %3 = amdaie.core(%tile_0_2, in : [%2], out : []) {
+      %11 = amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>> -> memref<1024xi32, 2 : i32>
+      amdaie.end
+    }
+    %4 = amdaie.core(%tile_1_2, in : [%2], out : []) {
+      %11 = amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>> -> memref<1024xi32, 2 : i32>
+      amdaie.end
+    }
+    %5 = amdaie.core(%tile_2_2, in : [%2], out : []) {
+      %11 = amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>> -> memref<1024xi32, 2 : i32>
+      amdaie.end
+    }
+    %6 = amdaie.core(%tile_3_2, in : [%2], out : []) {
+      %11 = amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>> -> memref<1024xi32, 2 : i32>
+      amdaie.end
+    }
+    %7 = amdaie.core(%tile_4_2, in : [%2], out : []) {
+      %11 = amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>> -> memref<1024xi32, 2 : i32>
+      amdaie.end
+    }
+    %8 = amdaie.core(%tile_5_2, in : [%2], out : []) {
+      %11 = amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>> -> memref<1024xi32, 2 : i32>
+      amdaie.end
+    }
+    %9 = amdaie.core(%tile_6_2, in : [%2], out : []) {
+      %11 = amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>> -> memref<1024xi32, 2 : i32>
+      amdaie.end
+    }
+    memref.dealloc %alloc_0 : memref<4x1024xi32, 1 : i32>
+    memref.dealloc %alloc : memref<1024xi32, 2 : i32>
+    return
+  }
+}


### PR DESCRIPTION
-- This commit changes ValueRange -> SmallVector<Value> for single row
   multi column non-local buffer's tile assignment.

Signed-off-by: Ian Wood <ianwood2024@u.northwestern.edu>