### PR TITLE
Added Parentheses Around Some Comparison Operations

### DIFF
--- a/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/bo.cpp
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/bo.cpp
@@ -98,13 +98,13 @@ uint32_t import_drm_bo(const shim_xdna::pdev &dev,
   return imp_bo.handle;
 }
 
-bool is_power_of_two(size_t x) { return x > 0 && (x & x - 1) == 0; }
+bool is_power_of_two(size_t x) { return x > 0 && (x & (x - 1)) == 0; }
 
 void *addr_align(void *p, size_t align) {
   if (!is_power_of_two(align))
     shim_xdna::shim_err(EINVAL, "Alignment 0x%lx is not power of two", align);
 
-  return reinterpret_cast<void *>((uintptr_t)p + align & ~(align - 1));
+  return reinterpret_cast<void *>(((uintptr_t)p + align) & ~(align - 1));
 }
 
 amdxdna_bo_type flag_to_type(shim_xcl_bo_flags flags) {


### PR DESCRIPTION
Hi mates, 

During the build process with the below-mentioned CMake instructions, I encountered an error in the XRT-LITE HAL codes. The errors are many due to missing parentheses in some of its comparison operations and I also included the error for the reference. 

Regards 
Vimal

Error:
```
error: suggest parentheses around ‘-’ in operand of ‘&’ [-Werror=parentheses]
```

CMake:
```
cmake \
  -B <WHERE_YOU_WOULD_LIKE_TO_BUILD> \
  -S third_party/iree \
  -DIREE_CMAKE_PLUGIN_PATHS=$PWD \
  -DIREE_BUILD_PYTHON_BINDINGS=ON \
  -DIREE_INPUT_STABLEHLO=OFF \
  -DIREE_INPUT_TORCH=OFF \
  -DIREE_INPUT_TOSA=OFF \
  -DIREE_HAL_DRIVER_DEFAULTS=OFF \
  -DIREE_TARGET_BACKEND_DEFAULTS=OFF \
  -DIREE_TARGET_BACKEND_LLVM_CPU=ON \
  -DIREE_BUILD_TESTS=ON \
  -DIREE_EXTERNAL_HAL_DRIVERS=xrt-lite \
  -DCMAKE_INSTALL_PREFIX=<WHERE_YOU_WOULD_LIKE_TO_INSTALL>
cmake --build <WHERE_YOU_WOULD_LIKE_TO_BUILD>
```