### PR TITLE
Compilation error fix for matmul transpose B with pack-peel-4-level-tiling pipeline

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEConvertCoreForallToFor.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEConvertCoreForallToFor.cpp
@@ -38,9 +38,12 @@ LogicalResult coreForallToFor(RewriterBase &rewriter, AMDAIE::CoreOp coreOp) {
     SmallVector<scf::ForOp> forOps = llvm::map_to_vector(
         forOpResults,
         [](Operation *loop) { return dyn_cast<scf::ForOp>(loop); });
-    if (failed(coalesceLoops(rewriter, forOps))) {
-      coreOp.emitOpError() << "failed to coalesce for loops";
-      return WalkResult::interrupt();
+
+    if (forOps.size() > 1) {
+      if (failed(coalesceLoops(rewriter, forOps))) {
+        coreOp.emitOpError() << "failed to coalesce for loops";
+        return WalkResult::interrupt();
+      }
     }
 
     return WalkResult::advance();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEConvertCoreForallToFor.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEConvertCoreForallToFor.cpp
@@ -39,6 +39,10 @@ LogicalResult coreForallToFor(RewriterBase &rewriter, AMDAIE::CoreOp coreOp) {
         forOpResults,
         [](Operation *loop) { return dyn_cast<scf::ForOp>(loop); });
 
+    // The upstream function colaesceLoops, rather than silently doing nothing
+    // if there is only one loop, will emit an error. So we need to confirm that
+    // there is more than one loop before calling it. If there is still an error
+    // with 2+ for loops, this might be something serious and so the pass fails.
     if (forOps.size() > 1) {
       if (failed(coalesceLoops(rewriter, forOps))) {
         coreOp.emitOpError() << "failed to coalesce for loops";


### PR DESCRIPTION
This fixes the error 

```
error: 'amdaie.core' op failed to coalesce for loops
```

in the test 

```
MatmulTransposeB(
    128,
    256,
    128,
    "i8",
    "i32",
    tile_pipeline="pack-peel-4-level-tiling"
)
```

The source of error is some very defensive code in MLIR: https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/SCF/Utils/Utils.cpp#L903 (Why shouldn't I do a no-op coalesce of 1 for op?). 

Note: compilation gets further with this fix, but doesn't compile to completion 