### PR TITLE
[BufferizeToAllocation] Add support to bufferize linalg.copy ops given input depth

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp
@@ -69,8 +69,8 @@ static SmallVector<Value> getInputOperands(linalg::LinalgOp &linalgOp) {
 
 /// Utility to fetch pack operands at a specified depth from the LinalgOp's
 /// input operands.
-static FailureOr<SmallVector<Value>> getPackOperands(linalg::LinalgOp linalgOp,
-                                                     uint32_t depthLevel) {
+static FailureOr<SmallVector<Value>> getPackOrCopyOperands(
+    linalg::LinalgOp linalgOp, uint32_t depthLevel) {
   SmallVector<Value> operands;
   for (auto input : llvm::enumerate(linalgOp.getDpsInputs())) {
     uint32_t currentLevel{0};
@@ -79,15 +79,19 @@ static FailureOr<SmallVector<Value>> getPackOperands(linalg::LinalgOp linalgOp,
       if (dyn_cast<tensor::PackOp>(currentOp)) {
         currentLevel++;
         if (currentLevel == depthLevel) break;
+      } else if (dyn_cast<linalg::CopyOp>(currentOp)) {
+        currentLevel++;
+        if (currentLevel == depthLevel) break;
       }
       currentOp = currentOp->getOperand(0).getDefiningOp();
     }
-    // The defining op has to be a pack op, fail otherwise.
+    // The defining op has to be a pack or a copy op, fail otherwise.
     if (!currentOp) {
       return linalgOp.emitOpError()
-             << "operand #" << input.index() << " only has pack ops to depth "
-             << currentLevel << ", but request is for a depth " << depthLevel
-             << " pack op.";
+             << "operand #" << input.index()
+             << " only has pack/copy ops to depth " << currentLevel
+             << ", but request is for a depth " << depthLevel
+             << " pack/copy op.";
     }
     // We only want to fetch the input operand of the pack op.
     operands.push_back(currentOp->getResult(0));
@@ -100,7 +104,7 @@ static FailureOr<SmallVector<Value>> getPackOperands(linalg::LinalgOp linalgOp,
 // `bufferizeOperand` parameter.
 static FailureOr<SmallVector<Value>> getOperandsToBufferize(
     BufferizeOperand bufferizeOperand, linalg::LinalgOp &linalgOp,
-    uint32_t packDepth) {
+    uint32_t inputDepth) {
   switch (bufferizeOperand) {
     /// Create new allocations for Lhs, Rhs and Out.
     case BufferizeOperand::LinalgInputOutput:
@@ -112,8 +116,8 @@ static FailureOr<SmallVector<Value>> getOperandsToBufferize(
     case BufferizeOperand::LinalgOutput:
       return SmallVector<Value>(linalgOp.getDpsInits());
     /// Create new allocations for operands from the pack ops.
-    case BufferizeOperand::PackInput:
-      return getPackOperands(linalgOp, packDepth);
+    case BufferizeOperand::PackOrCopyInput:
+      return getPackOrCopyOperands(linalgOp, inputDepth);
     default:
       return failure();
   }
@@ -125,6 +129,9 @@ static AMDAIEMemSpaceAttr getMemorySpaceAttr(RewriterBase &rewriter,
                                              int64_t memorySpace) {
   AMDAIEMemSpace memSpace;
   switch (memorySpace) {
+    case 0:
+      memSpace = AMDAIEMemSpace::Global;
+      break;
     case 1:
       memSpace = AMDAIEMemSpace::Shared;
       break;
@@ -189,7 +196,7 @@ void AMDAIEBufferizeToAllocationPass::runOnOperation() {
   // Find the producer ops for linalg (matmul) op, and bufferizes them in new
   // allocations.
   FailureOr<SmallVector<Value>> operandsToBufferize =
-      getOperandsToBufferize(bufferizeOperand, linalgOp, packDepth);
+      getOperandsToBufferize(bufferizeOperand, linalgOp, inputDepth);
   if (failed(operandsToBufferize)) {
     linalgOp->emitOpError("could not fetch operands to bufferize");
     return signalPassFailure();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
@@ -35,7 +35,7 @@ enum class BufferizeOperand {
   LinalgInputOutput,
   LinalgInput,
   LinalgOutput,
-  PackInput
+  PackOrCopyInput
 };
 
 /// Enum for hardware mapping attributes.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -212,8 +212,8 @@ void addPackPeelBasedPassPipeline(OpPassManager &funcPassManager,
   {
     AMDAIEBufferizeToAllocationOptions bufferizeOptions;
     bufferizeOptions.memorySpace = 1;
-    bufferizeOptions.bufferizeOperand = BufferizeOperand::PackInput;
-    bufferizeOptions.packDepth = 2;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::PackOrCopyInput;
+    bufferizeOptions.inputDepth = 2;
     funcPassManager.addPass(
         createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
   }
@@ -408,8 +408,8 @@ void addPackPeel4LevelTilingBasedPassPipeline(
   {
     AMDAIEBufferizeToAllocationOptions bufferizeOptions;
     bufferizeOptions.memorySpace = 1;
-    bufferizeOptions.bufferizeOperand = BufferizeOperand::PackInput;
-    bufferizeOptions.packDepth = 2;
+    bufferizeOptions.bufferizeOperand = BufferizeOperand::PackOrCopyInput;
+    bufferizeOptions.inputDepth = 2;
     funcPassManager.addPass(
         createAMDAIEBufferizeToAllocationPass(bufferizeOptions));
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -99,12 +99,12 @@ def AMDAIEBufferizeToAllocation :
                    "Create new allocations for lhs, rhs of a linalg op."),
         clEnumValN(mlir::iree_compiler::AMDAIE::BufferizeOperand::LinalgOutput, "linalg-output",
                    "Create new allocations for output of a linalg op."),
-        clEnumValN(mlir::iree_compiler::AMDAIE::BufferizeOperand::PackInput, "pack-input",
-                   "Create new allocations for operands from the pack op inputs of a linalg op.")
+        clEnumValN(mlir::iree_compiler::AMDAIE::BufferizeOperand::PackOrCopyInput, "pack-or-copy-input",
+                   "Create new allocations for operands from the pack or copy op inputs of a linalg op.")
     )}]>,
-    Option<"packDepth", "pack-depth", "int64_t", /*default=*/"1",
-      "Set the depth of the pack operands to look for. Default is `1` to operate"
-      " on the first level of pack operations.">,
+    Option<"inputDepth", "input-depth", "int64_t", /*default=*/"1",
+      "Set the depth of the pack/copy operands to look for. Default is `1` to operate"
+      " on the first level of pack/copy operations.">,
   ];
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
@@ -19,7 +19,7 @@ iree_lit_test_suite(
     "assign_tiles.mlir"
     "bridge_to_air.mlir"
     "bufferize_to_allocation.mlir"
-    "bufferize_to_allocation_pack.mlir"
+    "bufferize_to_allocation_pack_or_copy.mlir"
     "canonicalize_doubly_strided_op.mlir"
     "canonicalize_doubly_strided_op_hardware_aware.mlir"
     "canonicalize_npu_dma_cpy_nd.mlir"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/bufferize_to_allocation.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/bufferize_to_allocation.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=2 bufferize-operand=linalg-input-output}))' --split-input-file %s | FileCheck %s --check-prefix=LINALG-INPUT-OUTPUT
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=2 bufferize-operand=linalg-input}))' --split-input-file %s | FileCheck %s --check-prefix=LINALG-INPUT
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=2 bufferize-operand=linalg-output}))' --split-input-file %s | FileCheck %s --check-prefix=LINALG-OUTPUT
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=1 bufferize-operand=pack-input pack-depth=2}))' --split-input-file %s | FileCheck %s --check-prefix=PACK-INPUT
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=1 bufferize-operand=pack-or-copy-input input-depth=2}))' --split-input-file %s | FileCheck %s --check-prefix=PACK-INPUT
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=2 bufferize-elementwise=true bufferize-operand=linalg-input}))' --split-input-file %s | FileCheck %s --check-prefix=ELEMENTWISE-INPUT
 // RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-bufferize-to-allocation{memory-space=2 bufferize-elementwise=true bufferize-operand=linalg-input-output}))' --split-input-file %s | FileCheck %s --check-prefix=ELEMENTWISE-INPUT-OUTPUT
 


### PR DESCRIPTION
The defining ops of the inputs of computation op can be copy or pack ops. This PR extends the support to cover the copy ops given depth to the computational op.