### PR TITLE
[CI] Track performance numbers on a webpage

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -236,9 +236,9 @@ jobs:
             $DEVICE_TEST_DIR/$t --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS
           done
 
-      # Only publish the performance results on main branch pushes.
+      # Only publish the performance results for `main` branch.
       - name: Publish performance results
-        if: github.event_name == 'push' && github.ref == 'zhewen_track_perf'
+        if: github.ref == 'zhewen_track_perf'
         run: |
           cp build_tools/ci/cpu_comparison/performance_publish.py .
           git fetch origin zhewen-gh-pages

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -242,8 +242,8 @@ jobs:
         if: github.ref_name == '1035/merge'
         run: |
           cp build_tools/ci/cpu_comparison/performance_publish.py .
-          git fetch origin zhewen-gh-pages
-          git checkout zhewen-gh-pages
+          git fetch origin gh-pages
+          git checkout gh-pages
           python performance_publish.py results.json results_history.json results_history.html
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -236,9 +236,10 @@ jobs:
             $DEVICE_TEST_DIR/$t --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS
           done
 
-      # Only publish the performance results for `main` branch.
+      # Only publish the performance results on main branch pushes.
+      # github.event_name == 'push' && github.ref_name == 'main'
       - name: Publish performance results
-        if: github.ref == 'zhewen_track_perf'
+        if: github.ref_name == '1035/merge'
         run: |
           cp build_tools/ci/cpu_comparison/performance_publish.py .
           git fetch origin zhewen-gh-pages

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -237,9 +237,8 @@ jobs:
           done
 
       # Only publish the performance results on main branch pushes.
-      # github.event_name == 'push' && github.ref_name == 'main'
       - name: Publish performance results
-        if: github.ref_name == '1035/merge'
+        if: github.event_name == 'push' && github.ref_name == 'main'
         run: |
           cp build_tools/ci/cpu_comparison/performance_publish.py .
           git fetch origin gh-pages

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -238,7 +238,6 @@ jobs:
 
       # Only publish the performance results on main branch pushes.
       # github.event_name == 'push' && github.ref_name == 'main'
-      # testing
       - name: Publish performance results
         if: github.ref_name == '1035/merge'
         run: |

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ci-build-test-cpp-linux-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   build_and_ctest:
     name: Build and Test (linux, ASSERTIONS)
@@ -206,7 +209,7 @@ jobs:
 
           # Print a summary of the findings.
           python build_tools/ci/cpu_comparison/performance_summarizer.py \
-            performance.log
+            performance.log results.json
 
       - name: XRT-LITE tests
         run: |
@@ -214,6 +217,20 @@ jobs:
           for t in $(ls $DEVICE_TEST_DIR); do
             $DEVICE_TEST_DIR/$t --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS
           done
+
+      # Only publish the performance results on main branch pushes.
+      - name: Publish performance results
+        if: github.event_name == 'push' && github.ref == 'zhewen_track_perf'
+        run: |
+          cp build_tools/ci/cpu_comparison/performance_publish.py .
+          git fetch origin zhewen-gh-pages
+          git checkout zhewen-gh-pages
+          python performance_publish.py results.json results_history.json results_history.html
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add results_history.json results_history.html
+          git commit -m "Update performance results and deploy"
+          git push
 
   test_linux_strix:
     name: E2E Test Linux Strix

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -238,6 +238,7 @@ jobs:
 
       # Only publish the performance results on main branch pushes.
       # github.event_name == 'push' && github.ref_name == 'main'
+      # testing
       - name: Publish performance results
         if: github.ref_name == '1035/merge'
         run: |

--- a/build_tools/ci/cpu_comparison/performance_publish.py
+++ b/build_tools/ci/cpu_comparison/performance_publish.py
@@ -5,18 +5,8 @@
 import json
 import sys
 
-if __name__ == "__main__":
-    if len(sys.argv) != 4:
-        print(
-            "Usage: python3 performance_publish.py <path_to_results_json> <path_to_results_history> <path_to_results_html>\n"
-            "This script reads the performance results from the specified JSON file, appends them to the history file, and generates an HTML visualizarion.\n"
-        )
-        sys.exit(1)
 
-    results_json_path = sys.argv[1]
-    results_history_path = sys.argv[2]
-    results_html_path = sys.argv[3]
-
+def append_history(results_json_path: str, results_history_path: str):
     # Get the results for the current run.
     with open(results_json_path, "r") as f:
         results = json.load(f)
@@ -24,7 +14,6 @@ if __name__ == "__main__":
     # Append the results to the history.
     results_history = []
     max_history = 100
-    time_unit = "us"
     with open(results_history_path, "r+") as f:
         results_history = json.load(f)
         results_history.append(results)
@@ -32,11 +21,18 @@ if __name__ == "__main__":
         if len(results_history) > max_history:
             results_history = results_history[-max_history:]
         f.seek(0)
+        # Write the updated history back to the file.
         json.dump(results_history, f, indent=2)
-    assert len(results_history) > 0 and len(results_history) <= max_history
+
+
+def generate_html(results_history_path: str, results_html_path: str):
+    results_history = []
+    with open(results_history_path, "r") as f:
+        results_history = json.load(f)
 
     # Reformat the data for the graph.
     graph_data = {}
+    time_unit = "us"
     for entry in results_history:
         commit_hash = entry["commit_hash"]
         # Truncate commit hash to first 7 characters
@@ -117,5 +113,21 @@ if __name__ == "__main__":
     """
 
     # Save the HTML file
-    with open("results_history.html", "w") as f:
+    with open(results_html_path, "w") as f:
         f.write(html_content)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        print(
+            "Usage: python3 performance_publish.py <path_to_results_json> <path_to_results_history> <path_to_results_html>\n"
+            "This script reads the performance results from the specified JSON file, appends them to the history file, and generates an HTML visualization.\n"
+        )
+        sys.exit(1)
+
+    results_json_path = sys.argv[1]
+    results_history_path = sys.argv[2]
+    results_html_path = sys.argv[3]
+
+    append_history(results_json_path, results_history_path)
+    generate_html(results_history_path, results_html_path)

--- a/build_tools/ci/cpu_comparison/performance_publish.py
+++ b/build_tools/ci/cpu_comparison/performance_publish.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 The IREE Authors
+
+import json
+import sys
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        print(
+            "Usage: python3 performance_publish.py <path_to_results_json> <path_to_results_history> <path_to_results_html>\n"
+            "This script reads the performance results from the specified JSON file, appends them to the history file, and generates an HTML visualizarion.\n"
+        )
+        sys.exit(1)
+
+    results_json_path = sys.argv[1]
+    results_history_path = sys.argv[2]
+    results_html_path = sys.argv[3]
+
+    # Get the results for the current run.
+    with open(results_json_path, "r") as f:
+        results = json.load(f)
+
+    # Append the results to the history.
+    results_history = []
+    max_history = 100
+    time_unit = "us"
+    with open(results_history_path, "r+") as f:
+        results_history = json.load(f)
+        results_history.append(results)
+        # Keep only the most recent results.
+        if len(results_history) > max_history:
+            results_history = results_history[-max_history:]
+        f.seek(0)
+        json.dump(results_history, f, indent=2)
+    assert len(results_history) > 0 and len(results_history) <= max_history
+
+    # Reformat the data for the graph.
+    graph_data = {}
+    for entry in results_history:
+        commit_hash = entry["commit_hash"]
+        # Truncate commit hash to first 7 characters
+        truncated_commit_hash = str(commit_hash)[:7]
+        for test in entry["tests"]:
+            test_name = test["name"]
+            duration = test["time_mean"]
+            assert test["time_mean_unit"] == time_unit
+            if test_name not in graph_data:
+                graph_data[test_name] = {"commit_hashes": [], "durations": []}
+            graph_data[test_name]["commit_hashes"].append(truncated_commit_hash)
+            graph_data[test_name]["durations"].append(duration)
+
+    # Start building the HTML content
+    html_content = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>Performance History</title>
+        <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+        <style>
+            body { font-family: Arial, sans-serif; line-height: 1.6; padding: 20px; }
+            .chart-container { width: 80%; margin: 30px auto; }
+            canvas { width: 100%; height: auto; }
+        </style>
+    </head>
+    <body>
+        <h1>Performance History</h1>
+        <p>Overview of test results for the most recent commits:</p>
+    """
+
+    # Add a graph for each test
+    for test_name, data in graph_data.items():
+        html_content += f"""
+        <div class="chart-container">
+            <h2>Performance for {test_name}</h2>
+            <canvas id="chart-{test_name.replace(' ', '-')}"></canvas>
+        </div>
+        <script>
+            const ctx_{test_name.replace(' ', '_')} = document.getElementById('chart-{test_name.replace(' ', '-')}')
+            const chart_{test_name.replace(' ', '_')} = new Chart(ctx_{test_name.replace(' ', '_')}, {{
+                type: 'line',
+                data: {{
+                    labels: {data["commit_hashes"]},  // Truncated commit hashes as X-axis labels
+                    datasets: [{{
+                        label: 'Duration ({time_unit})',
+                        data: {data["durations"]},   // Test durations as Y-axis
+                        borderColor: 'rgba(75, 192, 192, 1)',
+                        backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                        borderWidth: 2
+                    }}]
+                }},
+                options: {{
+                    responsive: true,
+                    scales: {{
+                        x: {{
+                            title: {{
+                                display: true,
+                                text: 'Commit Hash'
+                            }}
+                        }},
+                        y: {{
+                            title: {{
+                                display: true,
+                                text: 'Duration ({time_unit})'
+                            }}
+                        }}
+                    }}
+                }}
+            }});
+        </script>
+        """
+
+    # Close the HTML content
+    html_content += """
+    </body>
+    </html>
+    """
+
+    # Save the HTML file
+    with open("results_history.html", "w") as f:
+        f.write(html_content)

--- a/build_tools/ci/cpu_comparison/performance_summarizer.py
+++ b/build_tools/ci/cpu_comparison/performance_summarizer.py
@@ -2,28 +2,62 @@
 
 # Copyright 2024 The IREE Authors
 
-if __name__ == "__main__":
-    import sys
+import os
+import sys
+import json
+import re
+from pathlib import Path
 
-    if len(sys.argv) != 2:
+
+def get_cpu_name():
+    cpu_name = None
+    with open("/proc/cpuinfo", "r") as f:
+        for line in f:
+            if "model name" in line:
+                cpu_name = line.split(":")[1].strip()
+                break
+    return cpu_name
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
         print(
-            "Usage: python3 performance_summarizer.py <path_to_log_file>. This will strip out the performance numbers from the log file and print a summary."
+            "Usage: python3 performance_summarizer.py <path_to_log_file> <path_to_output_file>\n"
+            "This script extracts performance numbers from the specified log file and generates a summary.\n"
+            "The summary will be printed to the console and saved to the specified output file in JSON format.\n"
         )
         sys.exit(1)
-    path = sys.argv[1]
+
+    # Read the log file.
+    log_path = sys.argv[1]
     single_dash_line = ""
-    with open(path, "r") as f:
+    test_results = {
+        "commit_hash": os.getenv("GITHUB_SHA"),
+        "cpu": get_cpu_name(),
+        "tests": [],
+    }
+    with open(log_path, "r") as f:
         lines = f.readlines()
+
+    # Parse the log file.
     for line in lines:
         if "Performance benchmark:" in line:
             print("\n")
-            print(line.split()[-1].split("/")[-1])
+            # Extract the test name.
+            path_str = line.split()[-1]
+            test_name = Path(path_str).stem
+            test_results["tests"].append({"name": test_name})
+            print(test_name)
         if "----------------------" in line:
             single_dash_line = line.strip()
             print(single_dash_line)
         if "Benchmark" in line:
             print(line.strip())
         if "real_time_mean" in line:
+            # Extract the first number and unit.
+            match = re.search(r"(\d+)\s+([a-zA-Z]+)", line)
+            test_results["tests"][-1]["time_mean"] = match.group(1)
+            test_results["tests"][-1]["time_mean_unit"] = match.group(2)
             print(line.strip())
         if "real_time_median" in line:
             print(line.strip())
@@ -32,3 +66,8 @@ if __name__ == "__main__":
         if "The largest program memory size" in line:
             print(single_dash_line)
             print(line)
+
+    # Write to the json file.
+    output_path = sys.argv[2]
+    with open(output_path, "w") as f:
+        json.dump(test_results, f, indent=2)


### PR DESCRIPTION
The workflow: 

- run performance benchmarks the same way as before, generating `performance.log`
- convert `performance.log` into `results.json`
- switch to the `gh-pages` branch
- append the new  `results.json` data to `results_history.json`
- create `results_history.html` based on the updated `results_history.json`

(only when CI is triggered from the `main` branch)
- commit the updated `results_history.json` and `results_history.html` using the action bot

To preview what it looks like: [https://rawcdn.githack.com/nod-ai/iree-amd-aie/a70ddbeea9d0b0d14f8ab24208efc599bc3c2f39/results_history.html](https://rawcdn.githack.com/nod-ai/iree-amd-aie/a70ddbeea9d0b0d14f8ab24208efc599bc3c2f39/results_history.html)

I don’t have access to set up the webpage for this repository, but once the `gh-pages` branch is properly configured, the webpage shall be live on [https://nod-ai.github.io/iree-amd-aie/results_history.html](https://nod-ai.github.io/iree-amd-aie/results_history.html)
