### PR TITLE
[SplitLogicalObjFifo] Allow using gcd for computing splitFactor

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIELogicalObjFifoSplittingUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIELogicalObjFifoSplittingUtils.cpp
@@ -804,9 +804,10 @@ LogicalResult splitDoublyStridedOp(IRRewriter &rewriter,
                             ? maybeSplitFactor.value()
                             : std::gcd(sourceSize, targetSize);
   if (sourceSize % splitFactor != 0 || targetSize % splitFactor != 0) {
-    return op.emitOpError() << "the target or source size is not divisible by "
-                               "the provided splitting factor: "
-                            << splitFactor;
+    int64_t newSplitFactor = std::gcd(sourceSize, targetSize);
+    LLVM_DEBUG(llvm::dbgs() << "split factor has been changed from "
+                            << splitFactor << " to " << newSplitFactor);
+    splitFactor = newSplitFactor;
   }
 
   int64_t newSourceSize = sourceSize / splitFactor;


### PR DESCRIPTION
-- We anyway use gcd for computing splitFactor when split factor has
   not been explicitly provided/computed. But we error out if the
   provided split factor doesn't divide source/target size.
-- This commit therefore allows replacing the explicitly provided
   split factor with gcd when the former doesn't divide source/target
   size.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>