### PR TITLE
[DmaComposition] Rework logic to enable new composition opportunity

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeDoublyStridedOp.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeDoublyStridedOp.cpp
@@ -154,22 +154,16 @@ struct FoldDmaOpUnitDims
     SmallVector<OpFoldResult> targetOffsets = op.getTargetMixedOffsets();
     SmallVector<OpFoldResult> targetSizes = op.getTargetMixedSizes();
     SmallVector<OpFoldResult> targetStrides = op.getTargetMixedStrides();
-    SmallVector<OpFoldResult> newSourceOffsets, newSourceSizes,
-        newSourceStrides, newTargetOffsets, newTargetSizes, newTargetStrides;
-    LogicalResult sourceRes =
-        foldUnitDims(op.getContext(), sourceOffsets, sourceSizes, sourceStrides,
-                     newSourceOffsets, newSourceSizes, newSourceStrides);
-    LogicalResult targetRes =
-        foldUnitDims(op.getContext(), targetOffsets, targetSizes, targetStrides,
-                     newTargetOffsets, newTargetSizes, newTargetStrides);
-    if (failed(sourceRes) && failed(targetRes)) {
-      return failure();
-    }
+    LogicalResult sourceRes = foldUnitDims(op.getContext(), sourceOffsets,
+                                           sourceSizes, sourceStrides);
+    LogicalResult targetRes = foldUnitDims(op.getContext(), targetOffsets,
+                                           targetSizes, targetStrides);
+    if (failed(sourceRes) && failed(targetRes)) return failure();
 
     rewriter.setInsertionPointAfter(op);
     auto newDoublyStridedOp = op.createDoublyStridedOp(
-        rewriter, newTargetOffsets, newTargetSizes, newTargetStrides,
-        newSourceOffsets, newSourceSizes, newSourceStrides);
+        rewriter, targetOffsets, targetSizes, targetStrides, sourceOffsets,
+        sourceSizes, sourceStrides);
     rewriter.replaceOp(op, newDoublyStridedOp.getOperation());
     return success();
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.cpp
@@ -7,201 +7,251 @@
 #include "AMDAIEDmaUtils.h"
 
 #include "AMDAIEUtils.h"
+#include "iree-amd-aie/IR/AMDAIEOps.h"
 #include "iree-amd-aie/Transforms/Utils/AMDAIEUtils.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 
 #define DEBUG_TYPE "iree-amdaie-dma-utils"
 
 namespace mlir::iree_compiler::AMDAIE {
 
-static bool isEqualConstantIntOrValueArrayFromIndices(
-    ArrayRef<OpFoldResult> ofrsA, ArrayRef<OpFoldResult> ofrsB,
-    size_t indexA = 0, size_t indexB = 0) {
-  if ((ofrsA.size() - indexA) != (ofrsB.size() - indexB)) return false;
-  return isEqualConstantIntOrValueArray(ofrsA.drop_front(indexA),
-                                        ofrsB.drop_front(indexB));
+// Functions in namespace `detail` are not intended to be used outside of this
+// file, but are exposed in the .h file for testing purposes.
+namespace detail {
+
+void matchStridesOfUnitDims(MLIRContext *ctx, ArrayRef<OpFoldResult> sizesX,
+                            SmallVector<OpFoldResult> &stridesX,
+                            SmallVector<OpFoldResult> &offsetsX,
+                            ArrayRef<OpFoldResult> stridesY) {
+  for (int i = 0; i < sizesX.size(); ++i) {
+    if (stridesX[i] != stridesY[i]) {
+      std::optional<int64_t> maybeIntSize = getConstantIntValue(sizesX[i]);
+      if (maybeIntSize.has_value() && maybeIntSize.value() == 1) {
+        std::optional<int64_t> maybeOffset = getConstantIntValue(offsetsX[i]);
+        std::optional<int64_t> maybeStrideX = getConstantIntValue(stridesX[i]);
+        std::optional<int64_t> maybeStrideY = getConstantIntValue(stridesY[i]);
+        if (maybeOffset.has_value() && maybeStrideX.has_value() &&
+            maybeStrideY.has_value()) {
+          int64_t offset = maybeOffset.value();
+          int64_t strideX = maybeStrideX.value();
+          int64_t strideY = maybeStrideY.value();
+          int64_t numerator = offset * strideX;
+          int64_t denominator = strideY;
+          if (numerator % denominator == 0) {
+            offsetsX[i] = getAsIndexOpFoldResult(ctx, numerator / denominator);
+            stridesX[i] = stridesY[i];
+          }
+        }
+      }
+    }
+  }
 }
 
-bool areAccessPatternsEqualFromIndices(ArrayRef<OpFoldResult> offsetsA,
-                                       ArrayRef<OpFoldResult> sizesA,
-                                       ArrayRef<OpFoldResult> stridesA,
-                                       ArrayRef<OpFoldResult> offsetsB,
-                                       ArrayRef<OpFoldResult> sizesB,
-                                       ArrayRef<OpFoldResult> stridesB,
-                                       size_t indexA, size_t indexB) {
-  return isEqualConstantIntOrValueArrayFromIndices(offsetsA, offsetsB, indexA,
-                                                   indexB) &&
-         isEqualConstantIntOrValueArrayFromIndices(sizesA, sizesB, indexA,
-                                                   indexB) &&
-         isEqualConstantIntOrValueArrayFromIndices(stridesA, stridesB, indexA,
-                                                   indexB);
+std::optional<int64_t> getGlobalOffsetDifference(
+    ArrayRef<OpFoldResult> offsetsX, ArrayRef<OpFoldResult> stridesX,
+    ArrayRef<OpFoldResult> offsetsY, ArrayRef<OpFoldResult> stridesY) {
+  assert(offsetsX.size() == stridesX.size() &&
+         "expected same number of offsets and strides for X");
+  assert(offsetsY.size() == stridesY.size() &&
+         "expected same number of offsets and strides for Y");
+  assert(offsetsX.size() == offsetsY.size() &&
+         "expected same number of offsets for X and Y");
+
+  // In this function we're computing the constant globalOffsetDifference:
+  //
+  //    sum_{d} offsetsA[d] * stridesA[d]  -
+  //    sum_{d} offsetsB[d] * stridesB[d] .
+  //
+  // If all values in offsetsA, offsetsB, stridesA, stridesB are constant,
+  // this is straightforward. If not, we need all the non-constant terms to
+  // cancel. In the maps below, we store the terms with non-constants, and then
+  // check at the end of this function that they've all cancelled. In
+  // `valToConst` we store terms where one of offset and stride is constant, and
+  // the other is not. In `valPairs`, we keep track of all the terms where
+  // neither the stride nor the offset is constant.
+  DenseMap<Value, int64_t> valToConst;
+  auto incrementValToConst = [&](Value v, int64_t signedStride) {
+    auto iter = valToConst.find(v);
+    if (iter == valToConst.end()) {
+      valToConst[v] = signedStride;
+    } else {
+      iter->second += signedStride;
+    }
+  };
+
+  DenseMap<std::pair<Value, Value>, int64_t> valPairs;
+  auto incrementValPairs = [&](Value v0, Value v1, int64_t sign) {
+    std::pair<Value, Value> p0(v0, v1);
+    auto iter0 = valPairs.find(p0);
+    if (iter0 != valPairs.end()) {
+      iter0->second += sign;
+      return;
+    }
+    std::pair<Value, Value> p1(v1, v0);
+    auto iter1 = valPairs.find(p1);
+    if (iter1 != valPairs.end()) {
+      iter1->second += sign;
+      return;
+    }
+    valPairs.insert({p0, sign});
+  };
+
+  int64_t globalOffsetDifference{0};
+
+  // Add the term `offset * stride * sign` to the global offset different,
+  // triaging the different combinations of constant/non-constant.
+  auto updateGlobalOffsetDifference = [&](OpFoldResult offset,
+                                          OpFoldResult stride, int64_t sign) {
+    std::optional<int64_t> cOffset = getConstantIntValue(offset);
+    std::optional<int64_t> cStride = getConstantIntValue(stride);
+    Value vOffset = dyn_cast<Value>(offset);
+    Value vStride = dyn_cast<Value>(stride);
+
+    if (!cOffset.has_value() && !cStride.has_value()) {
+      incrementValPairs(vOffset, vStride, sign);
+    } else if (cOffset.has_value() && cStride.has_value()) {
+      globalOffsetDifference += sign * cOffset.value() * cStride.value();
+    } else if (cOffset.has_value()) {
+      incrementValToConst(cast<Value>(stride), sign * cOffset.value());
+    } else if (cStride.has_value()) {
+      incrementValToConst(cast<Value>(offset), sign * cStride.value());
+    }
+  };
+
+  for (uint32_t i = 0; i < offsetsX.size(); ++i) {
+    updateGlobalOffsetDifference(offsetsX[i], stridesX[i], 1);
+    updateGlobalOffsetDifference(offsetsY[i], stridesY[i], -1);
+  }
+
+  // The cases where the non-constant terms did not all cancel, and so the
+  // global offset difference could not be determined to be constant.
+  if (llvm::any_of(valToConst, [](auto x) { return x.second != 0; })) {
+    return std::nullopt;
+  }
+  if (llvm::any_of(valPairs, [](auto x) { return x.second != 0; })) {
+    return std::nullopt;
+  }
+
+  return globalOffsetDifference;
+}
+}  // namespace detail
+
+namespace {
+
+/// Consider 2 access patterns X and Y, where the access pattern for Y has one
+/// more dimension than the access pattern for X. This function inserts a
+/// singleton dimension into the access pattern for X, at the first dimension
+/// from the back where the access patterns differ.
+///
+/// For example if X and Y have access patterns
+///
+/// X:  (offset: [0, 0]    sizes: [2, 8]    strides: [8, 1])
+/// Y:  (offset: [0, 0, 0] sizes: [2, 4, 8] strides: [8, 16, 1])
+///
+/// then X is transformed into
+///
+/// X:  (offset: [0, 0, 0] sizes: [2, 1, 8] strides: [8, 16, 1])
+void insertUnitDimension(MLIRContext *ctx, SmallVector<OpFoldResult> &offsetsX,
+                         SmallVector<OpFoldResult> &sizesX,
+                         SmallVector<OpFoldResult> &stridesX,
+                         ArrayRef<OpFoldResult> stridesY) {
+  assert(stridesY.size() == stridesX.size() + 1 &&
+         "expected Y's rank to be 1 greater than X's");
+  uint32_t index = stridesX.size();
+  while (index > 0) {
+    if (stridesY[index] != stridesX[index - 1]) break;
+    index--;
+  }
+  OpFoldResult zeroFoldResult = getAsIndexOpFoldResult(ctx, 0);
+  OpFoldResult oneFoldResult = getAsIndexOpFoldResult(ctx, 1);
+  sizesX.insert(sizesX.begin() + index, oneFoldResult);
+  stridesX.insert(stridesX.begin() + index, stridesY[index]);
+  offsetsX.insert(offsetsX.begin() + index, zeroFoldResult);
 }
 
-bool areAccessPatternsCombinable(const SmallVector<OpFoldResult> &offsetsA,
-                                 const SmallVector<OpFoldResult> &sizesA,
-                                 const SmallVector<OpFoldResult> &stridesA,
-                                 const SmallVector<OpFoldResult> &offsetsB,
-                                 const SmallVector<OpFoldResult> &sizesB,
-                                 const SmallVector<OpFoldResult> &stridesB,
-                                 function_ref<bool(size_t)> exceedsNbDims) {
-  assert(offsetsA.size() == sizesA.size() &&
-         "expected same number of source offsets and sizes");
-  assert(offsetsA.size() == stridesA.size() &&
-         "expected same number of source offsets and strides");
-  assert(offsetsB.size() == sizesB.size() &&
-         "expected same number of source offsets and sizes");
-  assert(offsetsB.size() == stridesB.size() &&
-         "expected same number of source offsets and strides");
-  if (std::abs((ssize_t)offsetsA.size() - (ssize_t)offsetsB.size()) > 1)
+/// If access pattern `A` followed by `B` can be merged into a single access
+/// pattern, merge `B` into `A` and return true. Otherwise return false.
+bool mergeInFirst(MLIRContext *ctx, SmallVector<OpFoldResult> &offsetsA,
+                  SmallVector<OpFoldResult> &sizesA,
+                  SmallVector<OpFoldResult> &stridesA,
+                  SmallVector<OpFoldResult> offsetsB,
+                  SmallVector<OpFoldResult> sizesB,
+                  SmallVector<OpFoldResult> stridesB) {
+  // Two rank-0 patterns merge into a single rank-0 pattern.
+  if (offsetsA.size() == 0 && offsetsB.size() == 0) return true;
+
+  // Local canonicalization to improve opportunities for merging:
+  if (sizesA.size() + 1 == sizesB.size()) {
+    insertUnitDimension(ctx, offsetsA, sizesA, stridesA, stridesB);
+  } else if (sizesB.size() + 1 == sizesA.size()) {
+    insertUnitDimension(ctx, offsetsB, sizesB, stridesB, stridesA);
+  } else if (sizesA.size() != sizesB.size()) {
+    // If the ranks of the accesses differ by more than 1, it is impossible
+    // to merge them (unless the higher ranked access pattern has 2+ leading
+    // dimensions of size 1, which is being ignored for now).
     return false;
-  // Empty access patterns are always combinable as they effectively mean:
-  // 'don't perform any or change the addressing'.
-  if (offsetsA.empty() && offsetsB.empty()) return true;
-  // In case both access patterns have the same number of dimension, a new
-  // dimension will need to be added, so fail if there aren't enough
-  // dimensions.
-  if (offsetsA.size() == offsetsB.size() &&
-      exceedsNbDims(offsetsA.size() + 1)) {
-    LLVM_DEBUG(llvm::dbgs() << "Exceeded maximum number of dimensions\n");
+  }
+  detail::matchStridesOfUnitDims(ctx, sizesA, stridesA, offsetsA, stridesB);
+  detail::matchStridesOfUnitDims(ctx, sizesB, stridesB, offsetsB, stridesA);
+
+  // Check that strides and sizes are compatible for merging.
+  if (stridesA != stridesB) return false;
+  if (ArrayRef<OpFoldResult>(sizesA).drop_front() !=
+      ArrayRef<OpFoldResult>(sizesB).drop_front()) {
     return false;
   }
 
-  // Equality of the last N elements of the access patterns of A and B with N =
-  // min(sizeA, sizeB) results in some simple cases in which the access
-  // patterns are combinable. Note that abs(sizeB - sizeA) should <= 1 and this
-  // is checked for earlier, so just asserted here.
-  assert(std::abs((ssize_t)offsetsB.size() - (ssize_t)offsetsA.size()) <= 1 &&
-         "The distance between the indices should be smaller or equal to one.");
-  size_t indexA = offsetsA.size() > offsetsB.size() ? 1 : 0;
-  size_t indexB = offsetsB.size() > offsetsA.size() ? 1 : 0;
-  if (areAccessPatternsEqualFromIndices(offsetsA, sizesA, stridesA, offsetsB,
-                                        sizesB, stridesB, indexA, indexB)) {
-    if (offsetsA.size() == offsetsB.size()) {
+  std::optional<int64_t> maybeOffsetDifference =
+      detail::getGlobalOffsetDifference(offsetsB, stridesB, offsetsA, stridesA);
+
+  // The case where the global offset difference is not constant is difficult to
+  // handle, unless we can prove that it is non-negative. Leaving this edge case
+  // for future work.
+  if (!maybeOffsetDifference.has_value()) return false;
+  int64_t offsetDifference = maybeOffsetDifference.value();
+
+  // The special case where the global offset difference exactly matches the
+  // pattern of A, in this case no new dimension is needed when merging the
+  // patterns.
+  std::optional<int64_t> cStrideA0 = getConstantIntValue(stridesA[0]);
+  std::optional<int64_t> cSizeA0 = getConstantIntValue(sizesA[0]);
+  std::optional<int64_t> cSizeB0 = getConstantIntValue(sizesB[0]);
+  if (cStrideA0 && cSizeA0 && cSizeB0) {
+    int64_t extended = cSizeA0.value() * cStrideA0.value();
+    int64_t sum = cSizeA0.value() + cSizeB0.value();
+    if (offsetDifference == extended) {
+      sizesA[0] = getAsIndexOpFoldResult(ctx, sum);
       return true;
-    } else if (offsetsA.size() > offsetsB.size()) {
-      // The access pattern A has N repetitions of access pattern B, so they can
-      // be combined together into N+1 repetitions.
-      return isConstantIntValue(stridesA[0], 0);
-    } else {
-      // offsetsB.size() > offsetsA.size()
-      // The access pattern B has N repetitions of access pattern A, so they can
-      // be combined together into N+1 repetitions.
-      if (isConstantIntValue(stridesB[0], 0)) return true;
-      // The access pattern of B is the same as the access pattern of A, but at
-      // a different offset. They can be combined by reducing the offset of B to
-      // zero.
-      if (isConstantIntValue(offsetsB[0], 1)) return true;
-      return false;
     }
   }
 
-  for (auto &&[strideA, strideB] :
-       llvm::zip(llvm::reverse(stridesA), llvm::reverse(stridesB))) {
-    std::optional<int64_t> maybeStrideA = getConstantIntValue(strideA);
-    std::optional<int64_t> maybeStrideB = getConstantIntValue(strideB);
-    // Handle static and constant value with same int value.
-    if (maybeStrideA && maybeStrideB &&
-        maybeStrideA.value() == maybeStrideB.value()) {
-      continue;
-    }
-    if (strideA != strideB) return false;
+  // This is the case where the 2 patterns don't connect seamlessly, and we need
+  // to introduce a new dimension to contain a new offset.
+  if (sizesA[0] == sizesB[0] && (offsetDifference >= 0)) {
+    int32_t index = 0;
+    std::optional<int64_t> cSizeA0 = getConstantIntValue(sizesA[0]);
+    if (cSizeA0.has_value() && cSizeA0.value() == 1) ++index;
+    OpFoldResult of = getAsIndexOpFoldResult(ctx, offsetDifference);
+    sizesA.insert(sizesA.begin() + index, getAsIndexOpFoldResult(ctx, 2));
+    stridesA.insert(stridesA.begin() + index, of);
+    offsetsA.insert(offsetsA.begin() + index, getAsIndexOpFoldResult(ctx, 0));
+    return true;
   }
 
-  // Don't check the outermost dimension of size at this point.
-  SmallVector<OpFoldResult> innerSizesA;
-  SmallVector<OpFoldResult> innerSizesB;
-  std::copy(sizesA.begin() + 1, sizesA.end(), std::back_inserter(innerSizesA));
-  std::copy(sizesB.begin() + 1, sizesB.end(), std::back_inserter(innerSizesB));
-  for (auto &&[sizeA, sizeB] :
-       llvm::zip(llvm::reverse(innerSizesA), llvm::reverse(innerSizesB))) {
-    std::optional<int64_t> maybeSizeA = getConstantIntValue(sizeA);
-    std::optional<int64_t> maybeSizeB = getConstantIntValue(sizeB);
-    // Handle static and constant value with same int value.
-    if (maybeSizeA && maybeSizeB && maybeSizeA.value() == maybeSizeB.value()) {
-      continue;
-    }
-    if (sizeA != sizeB) return false;
-  }
-
-  // Edge case for sizesA[0] != sizesB[0].
-  if (offsetsB.size() == offsetsA.size() && sizesA[0] != sizesB[0]) {
-    std::optional<int64_t> constOffsetA = getConstantIntValue(offsetsA[0]);
-    std::optional<int64_t> constSizeA = getConstantIntValue(sizesA[0]);
-    std::optional<int64_t> constOffsetB = getConstantIntValue(offsetsB[0]);
-    std::optional<int64_t> constSizeB = getConstantIntValue(sizesB[0]);
-    if (constOffsetA && constOffsetB && constSizeA && constSizeB) {
-      int64_t offsetDiff = constOffsetB.value() - constOffsetA.value();
-      if (constSizeA.value() != offsetDiff) return false;
-    } else {
-      return false;
-    }
-  }
-
-  bool foundDiff{false};
-  for (auto iter : llvm::enumerate(
-           llvm::zip(llvm::reverse(offsetsA), llvm::reverse(offsetsB)))) {
-    const OpFoldResult &offsetA = std::get<0>(iter.value());
-    const OpFoldResult &offsetB = std::get<1>(iter.value());
-    if (offsetA == offsetB) continue;
-    std::optional<int64_t> maybeOffsetA = getConstantIntValue(offsetA);
-    std::optional<int64_t> maybeOffsetB = getConstantIntValue(offsetB);
-    if (maybeOffsetA && maybeOffsetB &&
-        maybeOffsetA.value() == maybeOffsetB.value()) {
-      continue;
-    }
-    // Retrieve the corresponding stride for this dimension.
-    std::optional<int64_t> maybeStride =
-        getConstantIntValue(stridesA[stridesA.size() - 1 - iter.index()]);
-    if (maybeOffsetA && maybeOffsetB && maybeStride) {
-      int64_t diff =
-          (maybeOffsetB.value() - maybeOffsetA.value()) * maybeStride.value();
-      // Handle the three different size cases. Return early in case of an
-      // incompatibility.
-      if (offsetsA.size() > offsetsB.size()) {
-        std::optional<int64_t> constOffset = getConstantIntValue(offsetsA[0]);
-        std::optional<int64_t> constStride = getConstantIntValue(stridesA[0]);
-        std::optional<int64_t> constSize = getConstantIntValue(sizesA[0]);
-        if (constOffset && constStride && constSize &&
-            constOffset.value() == 0 &&
-            (constStride.value() * constSize.value()) == diff) {
-          if (foundDiff) return false;
-          foundDiff = true;
-        } else {
-          return false;
-        }
-      } else if (offsetsB.size() > offsetsA.size()) {
-        std::optional<int64_t> constOffset = getConstantIntValue(offsetsB[0]);
-        std::optional<int64_t> constStride = getConstantIntValue(stridesB[0]);
-        if (constOffset && constStride && constOffset.value() == 0 &&
-            constStride.value() == diff) {
-          if (foundDiff) return false;
-          foundDiff = true;
-        } else {
-          return false;
-        }
-      } else {
-        if (foundDiff) return false;
-        foundDiff = true;
-      }
-    } else {
-      return false;
-    }
-  }
-  return foundDiff;
+  return false;
 }
 
-LogicalResult combineAccessPatterns(RewriterBase &rewriter,
-                                    const SmallVector<OpFoldResult> &offsetsA,
-                                    const SmallVector<OpFoldResult> &sizesA,
-                                    const SmallVector<OpFoldResult> &stridesA,
-                                    const SmallVector<OpFoldResult> &offsetsB,
-                                    const SmallVector<OpFoldResult> &sizesB,
-                                    const SmallVector<OpFoldResult> &stridesB,
-                                    SmallVector<OpFoldResult> &newOffsets,
-                                    SmallVector<OpFoldResult> &newSizes,
-                                    SmallVector<OpFoldResult> &newStrides,
-                                    function_ref<bool(size_t)> exceedsNbDims) {
+}  // namespace
+
+LogicalResult combineAccessPatterns(
+    MLIRContext *ctx, ArrayRef<OpFoldResult> offsetsA,
+    ArrayRef<OpFoldResult> sizesA, ArrayRef<OpFoldResult> stridesA,
+    ArrayRef<OpFoldResult> offsetsB, ArrayRef<OpFoldResult> sizesB,
+    ArrayRef<OpFoldResult> stridesB, SmallVector<OpFoldResult> &newOffsets,
+    SmallVector<OpFoldResult> &newSizes, SmallVector<OpFoldResult> &newStrides,
+    function_ref<bool(size_t)> exceedsNbDims) {
   assert(offsetsA.size() == sizesA.size() &&
          "expected same number of source offsets and sizes");
   assert(offsetsA.size() == stridesA.size() &&
@@ -210,89 +260,35 @@ LogicalResult combineAccessPatterns(RewriterBase &rewriter,
          "expected same number of source offsets and sizes");
   assert(offsetsB.size() == stridesB.size() &&
          "expected same number of source offsets and strides");
-  if (!areAccessPatternsCombinable(offsetsA, sizesA, stridesA, offsetsB, sizesB,
-                                   stridesB, exceedsNbDims)) {
-    return failure();
-  }
-  if (offsetsA.empty() && offsetsB.empty()) return success();
-  if (offsetsB.size() > offsetsA.size()) {
-    newOffsets = offsetsB;
-    newSizes = sizesB;
-    newStrides = stridesB;
-    // If the offset on the first dimension of B is larger than zero, we can
-    // just decrease that one by one to accomplish the access pattern merge.
-    // Otherwise, we check for and update the other differing offsets.
-    std::optional<int64_t> offset = getConstantIntValue(newOffsets[0]);
-    if (offset && offset.value() > 0) {
-      newOffsets[0] = rewriter.getI64IntegerAttr(offset.value() - 1);
-    } else {
-      for (int i = 1; i <= offsetsA.size(); i++) {
-        if (offsetsA[offsetsA.size() - i] != offsetsB[offsetsB.size() - i]) {
-          newOffsets[newOffsets.size() - i] = offsetsA[offsetsA.size() - i];
-          break;
-        }
-      }
+
+  // Ensure that OpFoldResults are Attributes when they can be. Specifally
+  // this will replace arith.constant values with attributes.
+  auto simplified =
+      [&](ArrayRef<OpFoldResult> input) -> SmallVector<OpFoldResult> {
+    SmallVector<OpFoldResult> x(input.begin(), input.end());
+    for (OpFoldResult &y : x) {
+      std::optional<int64_t> c = getConstantIntValue(y);
+      if (c.has_value()) y = getAsIndexOpFoldResult(ctx, c.value());
     }
-    std::optional<int64_t> size = getConstantIntValue(newSizes[0]);
-    if (!size) return failure();
-    newSizes[0] = rewriter.getI64IntegerAttr(size.value() + 1);
-  } else if (offsetsA.size() > offsetsB.size()) {
-    newOffsets = offsetsA;
-    newSizes = sizesA;
-    newStrides = stridesA;
-    std::optional<int64_t> size = getConstantIntValue(newSizes[0]);
-    if (!size) return failure();
-    newSizes[0] = rewriter.getI64IntegerAttr(size.value() + 1);
-  } else {
-    // Edge case for sizesA[0] != sizesB[0].
-    if (sizesA[0] != sizesB[0]) {
-      newOffsets = offsetsA;
-      newSizes = sizesA;
-      newStrides = stridesA;
-      std::optional<int64_t> sizeA = getConstantIntValue(sizesA[0]);
-      std::optional<int64_t> sizeB = getConstantIntValue(sizesB[0]);
-      if (!sizeA || !sizeB) return failure();
-      newSizes[0] = rewriter.getI64IntegerAttr(sizeA.value() + sizeB.value());
-    } else {
-      // All dims of sizes are the same, so add a new dimension with
-      // 'offset == 0', 'size == 2' and 'stride == offsetDiff'.
-      newOffsets.push_back(rewriter.getI64IntegerAttr(0));
-      int64_t offsetDiff{0};
-      int64_t strideMultiplier{0};
-      for (auto iter : llvm::enumerate(llvm::zip(offsetsA, offsetsB))) {
-        const OpFoldResult &offsetA = std::get<0>(iter.value());
-        const OpFoldResult &offsetB = std::get<1>(iter.value());
-        newOffsets.push_back(offsetA);
-        if (offsetA != offsetB) {
-          std::optional<int64_t> constOffsetA = getConstantIntValue(offsetA);
-          std::optional<int64_t> constOffsetB = getConstantIntValue(offsetB);
-          if (!constOffsetA || !constOffsetB) {
-            return emitError(rewriter.getUnknownLoc())
-                   << "differing offsets should be constants";
-          }
-          offsetDiff = constOffsetB.value() - constOffsetA.value();
-          std::optional<int64_t> maybeStride =
-              getConstantIntValue(stridesA[iter.index()]);
-          if (!maybeStride) {
-            return emitError(rewriter.getUnknownLoc())
-                   << "no constant stride found at the same index where the "
-                      "offset "
-                      "difference occurs";
-          }
-          strideMultiplier = maybeStride.value();
-        }
-      }
-      newSizes.push_back(rewriter.getI64IntegerAttr(2));
-      newSizes.append(sizesA.begin(), sizesA.end());
-      newStrides.push_back(
-          rewriter.getI64IntegerAttr(offsetDiff * strideMultiplier));
-      newStrides.append(stridesA.begin(), stridesA.end());
-    }
-  }
-  assert(newOffsets.size() == newSizes.size() &&
-         "expected same number of new offsets and sizes");
-  assert(newOffsets.size() == newStrides.size() &&
-         "expected same number of new offsets and strides");
+    return x;
+  };
+
+  newOffsets = simplified(offsetsA);
+  newSizes = simplified(sizesA);
+  newStrides = simplified(stridesA);
+  SmallVector<OpFoldResult> mutableOffsetsB = simplified(offsetsB);
+  SmallVector<OpFoldResult> mutableSizesB = simplified(sizesB);
+  SmallVector<OpFoldResult> mutableStridesB = simplified(stridesB);
+
+  bool combined = mergeInFirst(ctx, newOffsets, newSizes, newStrides,
+                               mutableOffsetsB, mutableSizesB, mutableStridesB);
+
+  // This is the case where the patterns could not be combined, even before the
+  // check for exceeding the number of dimensions.
+  if (!combined) return failure();
+  (void)foldUnitDims(ctx, newOffsets, newSizes, newStrides);
+  if (exceedsNbDims(newOffsets.size())) return failure();
+
   return success();
 }
 
@@ -430,55 +426,6 @@ LogicalResult foldSingleDim(SmallVector<OpFoldResult> &offsets,
   return success();
 }
 
-/// Fold unit dimensions within a strided access pattern. There are two cases
-/// being handled here:
-/// 1. If a dimension has `size == 1` and `offset == 0`, the dimension can be
-/// folded entirely.
-/// 2. If a dimension has `size == 1` and `offset != 0`, it can be folded into
-/// another dimension with the same stride if that exists.
-LogicalResult foldUnitDims(MLIRContext *ctx,
-                           const SmallVector<OpFoldResult> &offsets,
-                           const SmallVector<OpFoldResult> &sizes,
-                           const SmallVector<OpFoldResult> &strides,
-                           SmallVector<OpFoldResult> &newOffsets,
-                           SmallVector<OpFoldResult> &newSizes,
-                           SmallVector<OpFoldResult> &newStrides) {
-  bool foldableUnitDimsFound = false;
-  DenseMap<int64_t, std::pair<size_t, int64_t>> strideToIndexAndOffset;
-  for (int i = 0; i < offsets.size(); i++) {
-    // If a dimension has `size == 1` and `offset == 0`, the dimension can be
-    /// folded entirely.
-    if (isConstantIntValue(offsets[i], 0) && isConstantIntValue(sizes[i], 1)) {
-      foldableUnitDimsFound = true;
-      continue;
-    }
-    std::optional<int64_t> maybeOffset = getConstantIntValue(offsets[i]);
-    std::optional<int64_t> maybeStride = getConstantIntValue(strides[i]);
-    if (maybeOffset && maybeStride) {
-      int64_t offset = maybeOffset.value();
-      int64_t stride = maybeStride.value();
-      if (isConstantIntValue(sizes[i], 1) &&
-          strideToIndexAndOffset.contains(stride)) {
-        foldableUnitDimsFound = true;
-        strideToIndexAndOffset[stride].second += offset;
-        // Continue to not add to newOffsets, newSizes, newStrides
-        continue;
-      } else {
-        strideToIndexAndOffset[stride] = {newOffsets.size(), offset};
-      }
-    }
-    newOffsets.push_back(offsets[i]);
-    newStrides.push_back(strides[i]);
-    newSizes.push_back(sizes[i]);
-  }
-  // Update offsets
-  for (auto &&[stride, indexAndOffset] : strideToIndexAndOffset) {
-    newOffsets[indexAndOffset.first] =
-        getAsIndexOpFoldResult(ctx, indexAndOffset.second);
-  }
-  return success(foldableUnitDimsFound);
-}
-
 LogicalResult moveNpuDmaSyncUsersAfterAncestorInSameBlock(
     RewriterBase &rewriter, Operation *parentOp) {
   WalkResult res = parentOp->walk([&](AMDAIE::NpuDmaWaitOp npuDmaWaitOp) {
@@ -508,6 +455,89 @@ LogicalResult moveNpuDmaSyncUsersAfterAncestorInSameBlock(
     return WalkResult::advance();
   });
   if (res.wasInterrupted()) return failure();
+  return success();
+}
+
+/// Try to add `offsetToMerge` to one of the offsets in `offsets`.  This
+/// function assumes an effective stride for `offsetToMerge` of 1 so to add
+/// `offsetToMerge` to the offset in dimension `d`, `offsetToMerge` must be
+/// divisable by the stride in dimension `d`.
+///
+/// \return false if `offsetToMerge` could not be added to any of the offsets.
+bool mergeOffset(MLIRContext *ctx, int64_t offsetToMerge,
+                 SmallVector<OpFoldResult> &offsets,
+                 ArrayRef<OpFoldResult> strides) {
+  if (offsetToMerge == 0) return true;
+  for (uint32_t i = 0; i < offsets.size(); ++i) {
+    std::optional<int64_t> cOffset = getConstantIntValue(offsets[i]);
+    std::optional<int64_t> cStride = getConstantIntValue(strides[i]);
+    if (cOffset.has_value() && cStride.has_value()) {
+      int64_t offset = cOffset.value();
+      int64_t stride = cStride.value();
+      if (offsetToMerge % stride == 0) {
+        offset += offsetToMerge / stride;
+        offsets[i] = getAsIndexOpFoldResult(ctx, offset);
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/// This function tries to reduce the rank of the access pattern by merging
+/// unit dimensions into other dimensions.
+LogicalResult foldUnitDims(MLIRContext *ctx, SmallVector<OpFoldResult> &offsets,
+                           SmallVector<OpFoldResult> &sizes,
+                           SmallVector<OpFoldResult> &strides) {
+  uint64_t initialRank = offsets.size();
+
+  int64_t cumulativeOffset{0};
+  int64_t insertionIndex{0};
+
+  SmallVector<OpFoldResult> newOffsets;
+  SmallVector<OpFoldResult> newSizes;
+  SmallVector<OpFoldResult> newStrides;
+
+  for (int i = 0; i < offsets.size(); ++i) {
+    // If in dimension `i` there is constant offset, constant stride, and size
+    // of 1, then update the cumulative offset.
+    std::optional<int64_t> cOffset = getConstantIntValue(offsets[i]);
+    std::optional<int64_t> cSize = getConstantIntValue(sizes[i]);
+    std::optional<int64_t> cStride = getConstantIntValue(strides[i]);
+    bool isSizeOne = cSize.has_value() && cSize.value() == 1;
+    if (cOffset.has_value() && cStride.has_value() && isSizeOne) {
+      cumulativeOffset += cOffset.value() * cStride.value();
+    } else {
+      insertionIndex += isSizeOne;
+      newOffsets.push_back(offsets[i]);
+      newSizes.push_back(sizes[i]);
+      newStrides.push_back(strides[i]);
+    }
+  }
+
+  // This is the case where there are no unit dimensions to fold.
+  if (newStrides.size() == initialRank) return failure();
+
+  bool merged = mergeOffset(ctx, cumulativeOffset, newOffsets, newStrides);
+
+  // This is the case where there is one unit dimension, but it cannot be
+  // merged into another dimension.
+  if (!merged && (newStrides.size() + 1 == initialRank)) return failure();
+
+  // At this point we know that we will be able to reduce the rank, and so will
+  // start updating offsets, sizes, and strides.
+  offsets = newOffsets;
+  sizes = newSizes;
+  strides = newStrides;
+  if (!merged) {
+    OpFoldResult one = getAsIndexOpFoldResult(ctx, 1);
+    OpFoldResult offset = getAsIndexOpFoldResult(ctx, cumulativeOffset);
+    offsets.insert(offsets.begin() + insertionIndex, one);
+    sizes.insert(sizes.begin() + insertionIndex, one);
+    strides.insert(strides.begin() + insertionIndex, offset);
+  }
+
+  assert(offsets.size() < initialRank && "Rank should have been reduced");
   return success();
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.h
@@ -7,12 +7,7 @@
 #ifndef IREE_AMD_AIE_TRANSFORMS_AMDAIEDMAUTILS_H_
 #define IREE_AMD_AIE_TRANSFORMS_AMDAIEDMAUTILS_H_
 
-#include "iree-amd-aie/IR/AMDAIEAttrs.h"
-#include "iree-amd-aie/IR/AMDAIEDmaOpInterface.h"
-#include "iree-amd-aie/IR/AMDAIEOps.h"
 #include "iree-amd-aie/aie_runtime/iree_aie_runtime.h"
-#include "llvm/ADT/SmallVector.h"
-#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/IR/AffineExprVisitor.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OpDefinition.h"
@@ -74,43 +69,88 @@ struct RetrieveScaleAndBias
   }
 };
 
-/// Check whether two access patterns are equal in value, starting from
-/// specified indices.
-bool areAccessPatternsEqualFromIndices(ArrayRef<OpFoldResult> offsetsA,
-                                       ArrayRef<OpFoldResult> sizesA,
-                                       ArrayRef<OpFoldResult> stridesA,
-                                       ArrayRef<OpFoldResult> offsetsB,
-                                       ArrayRef<OpFoldResult> sizesB,
-                                       ArrayRef<OpFoldResult> stridesB,
-                                       size_t indexA = 0, size_t indexB = 0);
+namespace detail {
 
-/// Check whether the two access patterns of strided operations can be combined
-/// into one. Takes a `maxNbDims` argument to check whether a combined access
-/// pattern would not exceed the maximum number of dimensions.
-bool areAccessPatternsCombinable(const SmallVector<OpFoldResult> &offsetsA,
-                                 const SmallVector<OpFoldResult> &sizesA,
-                                 const SmallVector<OpFoldResult> &stridesA,
-                                 const SmallVector<OpFoldResult> &offsetsB,
-                                 const SmallVector<OpFoldResult> &sizesB,
-                                 const SmallVector<OpFoldResult> &stridesB,
-                                 function_ref<bool(size_t)> exceedsNbDims);
+/// Update the strides and offsets of `X` to match the strides of `Y` if it is
+/// possible to do so without changing the underlying access pattern of `X`. For
+/// example if
+///
+/// X has access pattern (offset: [5] sizes: [1] strides: [6]) and
+/// Y has access pattern (offset: [a] sizes: [b] strides: [3])
+///
+/// Then the access pattern for X can be changed to have access pattern
+/// (offset: [10] sizes: [1] strides: [3]) so that its stride matches Y's.
+///
+/// For this transformation to be possible in dimension `d` is it necessary that
+///
+/// 1) the size in dimension `d` of `X` is 1, and
+/// 2) the updated offset in `d` of `X` (i.e. offset * strideX / strideY)
+///    is an integer.
+///
+/// As another example, if we have:
+///
+/// X with access pattern (offset: [4, 8]  sizes: [1, 1] strides: [3, 8])
+/// Y with access pattern (offset: [a, b]  sizes: [d, e] strides: [6, 2])
+///
+/// then X can be transformed to have access pattern
+///                       (offset: [2, 32] sizes: [1, 1] strides: [6, 2])
+void matchStridesOfUnitDims(MLIRContext *ctx, ArrayRef<OpFoldResult> sizesX,
+                            SmallVector<OpFoldResult> &stridesX,
+                            SmallVector<OpFoldResult> &offsetsX,
+                            ArrayRef<OpFoldResult> stridesY);
+
+/// This function computes the difference between the global offsets of two
+/// access patterns. If it is not constant, i.e. if the difference contains
+/// an MLIR value which is not a constant, then nullopt is returned.
+///
+/// This function is useful when determining if the access pattern A, followed
+/// by the access pattern B, can be merged into a single access pattern.
+///
+/// The reason for this API design, as opposed to a more intuitive design of
+/// having a function to compute the global offset difference for a single
+/// access pattern, say `getGlobalOffset`, and then computing the difference
+/// as `getGlobalOffset(A) - getGlobalOffset(B)`, is that the global offset
+/// difference might be constant while each individual offsets are not, and
+/// determining that the non-constants cancel is easier with this API.
+///
+/// \return global_offset(X) - global_offset(Y).
+///
+/// Background info: offsets, sizes, and strides define an access pattern into
+/// an array, where the i'th element accessed, for 0 <= i < prod_{d<D} sizes[d],
+/// is at index
+///
+///     sum_{d<D} (l(d,i) + offset[d]) * stride[d]                (1)
+///
+/// where l(d,i) is the component of global index `i` in dimension `d`:
+///
+///     i  = sum_{d<D} l(d,i) * size[d]                           (2)
+///
+/// Equation (1) can be rewritten with a global offset as
+///
+///     global_offset + sum_{d<D} l(d,i) * stride[d]              (3)
+///
+/// where the global offset is
+///
+///     global_offset = sum_{d<D} offset[d] * stride[d].
+///
+std::optional<int64_t> getGlobalOffsetDifference(
+    ArrayRef<OpFoldResult> offsetsX, ArrayRef<OpFoldResult> stridesX,
+    ArrayRef<OpFoldResult> offsetsY, ArrayRef<OpFoldResult> stridesY);
+
+}  // namespace detail
 
 /// Combine two access patterns into a single one. Assumes that access pattern A
 /// belongs to a strided op which is ordered before the strided op B. Takes a
 /// `maxNbDims` argument to ensure that a combined access pattern would not
 /// exceed the maximum number of dimensions. Returns `success` if the access
 /// patterns were combined successfully.
-LogicalResult combineAccessPatterns(RewriterBase &rewriter,
-                                    const SmallVector<OpFoldResult> &offsetsA,
-                                    const SmallVector<OpFoldResult> &sizesA,
-                                    const SmallVector<OpFoldResult> &stridesA,
-                                    const SmallVector<OpFoldResult> &offsetsB,
-                                    const SmallVector<OpFoldResult> &sizesB,
-                                    const SmallVector<OpFoldResult> &stridesB,
-                                    SmallVector<OpFoldResult> &newOffsets,
-                                    SmallVector<OpFoldResult> &newSizes,
-                                    SmallVector<OpFoldResult> &newStrides,
-                                    function_ref<bool(size_t)> exceedsNbDims);
+LogicalResult combineAccessPatterns(
+    MLIRContext *, ArrayRef<OpFoldResult> offsetsA,
+    ArrayRef<OpFoldResult> sizesA, ArrayRef<OpFoldResult> stridesA,
+    ArrayRef<OpFoldResult> offsetsB, ArrayRef<OpFoldResult> sizesB,
+    ArrayRef<OpFoldResult> stridesB, SmallVector<OpFoldResult> &newOffsets,
+    SmallVector<OpFoldResult> &newSizes, SmallVector<OpFoldResult> &newStrides,
+    function_ref<bool(size_t)> exceedsNbDims);
 
 /// Fold subsequent dimensions within a strided access pattern that describe a
 /// single linear access. Returns `success` if folding took place.
@@ -121,7 +161,7 @@ LogicalResult combineAccessPatterns(RewriterBase &rewriter,
 /// around, BUT after canonicalization, the number of sizes should be smaller or
 /// equal to the number of max sizes (if specified).
 LogicalResult foldLinearDims(
-    MLIRContext *ctx, const SmallVector<OpFoldResult> &offsets,
+    MLIRContext *, const SmallVector<OpFoldResult> &offsets,
     const SmallVector<OpFoldResult> &sizes,
     const SmallVector<OpFoldResult> &strides,
     SmallVector<OpFoldResult> &newOffsets, SmallVector<OpFoldResult> &newSizes,
@@ -150,7 +190,7 @@ LogicalResult foldLinearDims(
 ///
 /// sizes: [2, 8], strides: [0, 1]
 LogicalResult foldRepetitionCount(
-    MLIRContext *ctx, SmallVector<OpFoldResult> &sizes,
+    MLIRContext *, SmallVector<OpFoldResult> &sizes,
     SmallVector<OpFoldResult> &strides,
     std::optional<int64_t> maybeRepetitionCount = std::nullopt);
 
@@ -161,38 +201,76 @@ LogicalResult foldSingleDim(SmallVector<OpFoldResult> &offsets,
                             SmallVector<OpFoldResult> &strides);
 
 /// Fold unit dimensions within a strided access pattern. Returns `success` if
-/// folding took place. There are two cases being handled here:
-/// 1. If a dimension has `size == 1` and `offset == 0`, the dimension can be
-/// folded entirely.
-/// 2. If a dimension has `size == 1` and `offset != 0`, it can be folded into
-/// another dimension with the same stride if that exists.
+/// folding took place. If `success` is returned, then the rank of the access
+/// pattern has been reduced. If `failure` is returned, `offsets`, `sizes`, and
+/// `strides` are left unchanged.
 ///
-/// Example for case 1:
+/// Unit dimensions without any offset can be directly removed. Other unit
+/// dimensions with offsets contribute to a global offset, which can be
+/// considered an 'initial pointer address'.
 ///
-/// offsets: [0, 0, 0], sizes: [32, 1, 8], strides: [32, 1024, 1]
+/// The algorithm works roughly as follows:
+/// (1) find all the unit dimensions with constant stride and offset and combine
+///     them into a single dimension.
+/// (2) try to merge the offset from step (1) into a non-unit dimension. This
+///     requires finding a non-unit dimension with a stride that divides the
+///     offset in (1). This is guaranteed to succeed if there is dimension with
+///     stride 1, which is usually the case for the inner-most dimension.
 ///
-/// will be transformed into:
 ///
-/// offsets: [0, 0], sizes: [32, 8], strides: [32, 1]
+/// After this function has been called, `sizes` will contain either one or
+/// zero unit dimensions `d` where offset[d] and stride[d] are constant. It will
+/// contain zero such dimensions if step (2) above was successful, and one if
+/// it was not.
 ///
-/// Example for case 2:
+/// Example 1:
+/// ---------
 ///
-/// offsets: [1, 0, 1, 0], sizes: [1, 32, 1, 8], strides: [1024, 32, 1024, 1]
+///   offsets: [0, 0, 0], sizes: [32, 1, 8], strides: [32, 1024, 1]
 ///
-/// will be transformed into:
+/// this has a global offset of 0, and will be transformed into:
 ///
-/// offsets: [2, 0, 0], sizes: [1, 32, 8], strides: [1024, 32, 1]
+///   offsets: [0, 0], sizes: [32, 8], strides: [32, 1]
 ///
-/// Note that the dimensions are merged into the outermost one. Heuristically,
-/// this works out best with other strided access pattern transformations, but
-/// could be made an option in the future.
-LogicalResult foldUnitDims(MLIRContext *ctx,
-                           const SmallVector<OpFoldResult> &offsets,
-                           const SmallVector<OpFoldResult> &strides,
-                           const SmallVector<OpFoldResult> &sizes,
-                           SmallVector<OpFoldResult> &newOffsets,
-                           SmallVector<OpFoldResult> &newStrides,
-                           SmallVector<OpFoldResult> &newSizes);
+/// Example 2:
+/// ---------
+///
+///   offsets: [1, 0, 1, 0], sizes: [1, 32, 1, 8], strides: [1024, 32, 1024, 1]
+///
+/// this has a global offset of 2048, and will be transformed into:
+///
+///   offsets: [64, 0], sizes: [32, 8], strides: [32, 1]
+///
+/// it could equally well have been transformed into
+///
+///   offsets: [0, 2048], sizes: [32, 8], strides: [32, 1]
+///
+/// but the current implementation arbitrarily attempts to be merge the offset
+/// starting from the left-most dimension.
+///
+/// Example 3:
+/// ---------
+///
+///   offsets: [2, 2, 15],  sizes: [1, 1, 10],  strides: [4, 6, 10]
+///
+/// becomes
+///
+///   offset: [17],  sizes: [10], strides: [10]
+///
+/// Example 4:
+/// ---------
+///
+///   offset: [3, 1, 15],  sizes: [1, 1, 10],  strides: [4, 6, 10]
+///
+/// becomes
+///
+///   offset: [1, 15],  sizes: [1, 10],  strides: [18, 10]
+///
+/// In this example, step (2) of the algorithm failed, but `success` is still
+/// returned because the rank of the access pattern was reduced.
+LogicalResult foldUnitDims(MLIRContext *, SmallVector<OpFoldResult> &offsets,
+                           SmallVector<OpFoldResult> &strides,
+                           SmallVector<OpFoldResult> &sizes);
 
 /// Utility DMA configuration which is calculated based on AMDAIEDeviceModel
 /// information.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIEDmaUtilsTest.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIEDmaUtilsTest.cpp
@@ -6,14 +6,26 @@
 
 #include "gtest/gtest.h"
 #include "iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 
 namespace {
 
 using namespace mlir;
 using namespace mlir::iree_compiler::AMDAIE;
+
+SmallVector<int64_t> fromOpFoldResults(SmallVector<OpFoldResult> ofrs) {
+  SmallVector<int64_t> vals;
+  for (auto ofr : ofrs) {
+    auto asInt = getConstantIntValue(ofr);
+    if (asInt.has_value())
+      vals.push_back(asInt.value());
+    else
+      assert(false && "expected integer");
+  }
+  return vals;
+}
 
 //===----------------------------------------------------------------------===//
 // Test Fixture
@@ -26,94 +38,77 @@ class AccessPatternCombinationTest : public ::testing::Test {
     context.loadDialect<arith::ArithDialect>();
   }
 
-  SmallVector<OpFoldResult> toOpFoldResult(const SmallVector<int64_t> &values) {
+  SmallVector<OpFoldResult> toOpFoldResults(SmallVector<int64_t> values) {
     return llvm::map_to_vector(values, [&](int64_t v) -> OpFoldResult {
-      return rewriter.getI64IntegerAttr(v);
+      return getAsIndexOpFoldResult(&context, v);
     });
   }
 
-  bool checkAreAccessPatternsCombinable(
-      const SmallVector<int64_t> &offsetsA, const SmallVector<int64_t> &sizesA,
-      const SmallVector<int64_t> &stridesA,
-      const SmallVector<int64_t> &offsetsB, const SmallVector<int64_t> &sizesB,
-      const SmallVector<int64_t> &stridesB,
-      function_ref<bool(size_t)> exceedsNbDims) {
-    SmallVector<OpFoldResult> offsetsValuesA = toOpFoldResult(offsetsA);
-    SmallVector<OpFoldResult> sizesValuesA = toOpFoldResult(sizesA);
-    SmallVector<OpFoldResult> stridesValuesA = toOpFoldResult(stridesA);
-    SmallVector<OpFoldResult> offsetsValuesB = toOpFoldResult(offsetsB);
-    SmallVector<OpFoldResult> sizesValuesB = toOpFoldResult(sizesB);
-    SmallVector<OpFoldResult> stridesValuesB = toOpFoldResult(stridesB);
-    return areAccessPatternsCombinable(
-        offsetsValuesA, sizesValuesA, stridesValuesA, offsetsValuesB,
-        sizesValuesB, stridesValuesB, exceedsNbDims);
+  bool checkAccessPaternsCombinable(SmallVector<int64_t> offsetsA,
+                                    SmallVector<int64_t> sizesA,
+                                    SmallVector<int64_t> stridesA,
+                                    SmallVector<int64_t> offsetsB,
+                                    SmallVector<int64_t> sizesB,
+                                    SmallVector<int64_t> stridesB,
+                                    function_ref<bool(size_t)> exceedsNbDims) {
+    SmallVector<OpFoldResult> newOffsets, newSizes, newStrides;
+    return succeeded(combineAccessPatterns(
+        &context, toOpFoldResults(offsetsA), toOpFoldResults(sizesA),
+        toOpFoldResults(stridesA), toOpFoldResults(offsetsB),
+        toOpFoldResults(sizesB), toOpFoldResults(stridesB), newOffsets,
+        newSizes, newStrides, exceedsNbDims));
   }
 
-  bool checkAreAccessPatternsCombinable(const SmallVector<int64_t> &offsetsA,
-                                        const SmallVector<int64_t> &sizesA,
-                                        const SmallVector<int64_t> &stridesA,
-                                        const SmallVector<int64_t> &offsetsB,
-                                        const SmallVector<int64_t> &sizesB,
-                                        const SmallVector<int64_t> &stridesB,
-                                        size_t maxNbDims) {
-    return checkAreAccessPatternsCombinable(
-        offsetsA, sizesA, stridesA, offsetsB, sizesB, stridesB,
-        [&](size_t dim) { return dim > maxNbDims; });
+  bool checkAccessPaternsCombinable(SmallVector<int64_t> offsetsA,
+                                    SmallVector<int64_t> sizesA,
+                                    SmallVector<int64_t> stridesA,
+                                    SmallVector<int64_t> offsetsB,
+                                    SmallVector<int64_t> sizesB,
+                                    SmallVector<int64_t> stridesB,
+                                    size_t maxNbDims) {
+    auto rankTooLarge = [&](size_t r) { return r > maxNbDims; };
+    return checkAccessPaternsCombinable(offsetsA, sizesA, stridesA, offsetsB,
+                                        sizesB, stridesB, rankTooLarge);
   }
 
-  void checkCombineAccessPatterns(
-      const SmallVector<int64_t> offsetsA, const SmallVector<int64_t> sizesA,
-      const SmallVector<int64_t> stridesA, const SmallVector<int64_t> offsetsB,
-      const SmallVector<int64_t> sizesB, const SmallVector<int64_t> stridesB,
-      const SmallVector<int64_t> expectedOffsets,
-      const SmallVector<int64_t> expectedSizes,
-      const SmallVector<int64_t> expectedStrides,
-      function_ref<bool(size_t)> exceedsNbDims, bool shouldSucceed = true) {
-    SmallVector<OpFoldResult> offsetsValuesA = toOpFoldResult(offsetsA);
-    SmallVector<OpFoldResult> sizesValuesA = toOpFoldResult(sizesA);
-    SmallVector<OpFoldResult> stridesValuesA = toOpFoldResult(stridesA);
-    SmallVector<OpFoldResult> offsetsValuesB = toOpFoldResult(offsetsB);
-    SmallVector<OpFoldResult> sizesValuesB = toOpFoldResult(sizesB);
-    SmallVector<OpFoldResult> stridesValuesB = toOpFoldResult(stridesB);
-    SmallVector<OpFoldResult> expectedOffsetsValues =
-        toOpFoldResult(expectedOffsets);
-    SmallVector<OpFoldResult> expectedSizesValues =
-        toOpFoldResult(expectedSizes);
-    SmallVector<OpFoldResult> expectedStridesValues =
-        toOpFoldResult(expectedStrides);
+  bool checkCombine(SmallVector<int64_t> offsetsA, SmallVector<int64_t> sizesA,
+                    SmallVector<int64_t> stridesA,
+                    SmallVector<int64_t> offsetsB, SmallVector<int64_t> sizesB,
+                    SmallVector<int64_t> stridesB,
+                    SmallVector<int64_t> expectedOffsets,
+                    SmallVector<int64_t> expectedSizes,
+                    SmallVector<int64_t> expectedStrides, size_t maxNbDims,
+                    bool checkValues = true) {
     SmallVector<OpFoldResult> newOffsets;
     SmallVector<OpFoldResult> newSizes;
     SmallVector<OpFoldResult> newStrides;
-    if (shouldSucceed) {
-      EXPECT_TRUE(succeeded(combineAccessPatterns(
-          rewriter, offsetsValuesA, sizesValuesA, stridesValuesA,
-          offsetsValuesB, sizesValuesB, stridesValuesB, newOffsets, newSizes,
-          newStrides, exceedsNbDims)));
-      EXPECT_EQ(newOffsets, expectedOffsetsValues);
-      EXPECT_EQ(newSizes, expectedSizesValues);
-      EXPECT_EQ(newStrides, expectedStridesValues);
-    } else {
-      EXPECT_TRUE(failed(combineAccessPatterns(
-          rewriter, offsetsValuesA, sizesValuesA, stridesValuesA,
-          offsetsValuesB, sizesValuesB, stridesValuesB, newOffsets, newSizes,
-          newStrides, exceedsNbDims)));
+
+    auto success = combineAccessPatterns(
+        &context, toOpFoldResults(offsetsA), toOpFoldResults(sizesA),
+        toOpFoldResults(stridesA), toOpFoldResults(offsetsB),
+        toOpFoldResults(sizesB), toOpFoldResults(stridesB), newOffsets,
+        newSizes, newStrides, [&](size_t dim) { return dim > maxNbDims; });
+    if (checkValues) {
+      EXPECT_EQ(fromOpFoldResults(newOffsets), expectedOffsets);
+      EXPECT_EQ(fromOpFoldResults(newSizes), expectedSizes);
+      EXPECT_EQ(fromOpFoldResults(newStrides), expectedStrides);
     }
+    return succeeded(success);
   }
 
-  void checkCombineAccessPatterns(const SmallVector<int64_t> offsetsA,
-                                  const SmallVector<int64_t> sizesA,
-                                  const SmallVector<int64_t> stridesA,
-                                  const SmallVector<int64_t> offsetsB,
-                                  const SmallVector<int64_t> sizesB,
-                                  const SmallVector<int64_t> stridesB,
-                                  const SmallVector<int64_t> expectedOffsets,
-                                  const SmallVector<int64_t> expectedSizes,
-                                  const SmallVector<int64_t> expectedStrides,
-                                  size_t maxNbDims, bool shouldSucceed = true) {
-    checkCombineAccessPatterns(
-        offsetsA, sizesA, stridesA, offsetsB, sizesB, stridesB, expectedOffsets,
-        expectedSizes, expectedStrides,
-        [&](size_t dim) { return dim > maxNbDims; }, shouldSucceed);
+  int64_t getGlobalOffsetDifference(SmallVector<int64_t> offsetsX,
+                                    SmallVector<int64_t> stridesX,
+                                    SmallVector<int64_t> offsetsY,
+                                    SmallVector<int64_t> stridesY) {
+    std::optional<int64_t> goDiff =
+        mlir::iree_compiler::AMDAIE::detail::getGlobalOffsetDifference(
+            toOpFoldResults(offsetsX), toOpFoldResults(stridesX),
+            toOpFoldResults(offsetsY), toOpFoldResults(stridesY));
+
+    EXPECT_TRUE(goDiff.has_value());
+    if (goDiff.has_value()) return goDiff.value();
+
+    return -1;
   }
 
   MLIRContext context;
@@ -121,260 +116,321 @@ class AccessPatternCombinationTest : public ::testing::Test {
   Location loc;
 };
 
+// This test checks correctness in the case where all inputs (offsets and
+// strides) are constant. The cases where they are mlir Values are tested in the
+// lit testing.
+TEST_F(AccessPatternCombinationTest, GlobalOffsetTest) {
+  EXPECT_EQ(getGlobalOffsetDifference({}, {}, {}, {}), 0);
+  EXPECT_EQ(getGlobalOffsetDifference({1}, {1}, {2}, {3}), 1 * 1 - 2 * 3);
+  EXPECT_EQ(
+      getGlobalOffsetDifference({2, 3, 5}, {7, 11, 13}, {1, 2, 3}, {4, 5, 6}),
+      (2 * 7 + 3 * 11 + 5 * 13) - (1 * 4 + 2 * 5 + 3 * 6));
+}
+
 TEST_F(AccessPatternCombinationTest, CombinableAccessPatterns) {
-  EXPECT_TRUE(checkAreAccessPatternsCombinable({}, {}, {}, {}, {}, {}, 1));
   // size(A) == size(B)
-  EXPECT_TRUE(
-      checkAreAccessPatternsCombinable({0}, {16}, {1}, {32}, {16}, {1}, 2));
-  EXPECT_TRUE(checkAreAccessPatternsCombinable({0, 0}, {16, 32}, {64, 1},
-                                               {0, 32}, {16, 32}, {64, 1}, 4));
-  EXPECT_TRUE(checkAreAccessPatternsCombinable({1, 0}, {16, 32}, {64, 1},
-                                               {1, 32}, {16, 32}, {64, 1}, 4));
-  EXPECT_TRUE(checkAreAccessPatternsCombinable({0, 0, 0}, {16, 16, 32},
-                                               {32, 64, 1}, {0, 0, 32},
-                                               {16, 16, 32}, {32, 64, 1}, 4));
-  EXPECT_TRUE(checkAreAccessPatternsCombinable({0, 2, 0}, {16, 16, 32},
-                                               {32, 64, 1}, {0, 2, 32},
-                                               {16, 16, 32}, {32, 64, 1}, 4));
-  EXPECT_TRUE(checkAreAccessPatternsCombinable({32, 0}, {64, 64}, {128, 1},
-                                               {96, 0}, {32, 64}, {128, 1}, 4));
+  EXPECT_TRUE(checkAccessPaternsCombinable({}, {}, {}, {}, {}, {}, 1));
+  EXPECT_TRUE(checkAccessPaternsCombinable({0}, {16}, {1}, {32}, {16}, {1}, 2));
+  EXPECT_TRUE(checkAccessPaternsCombinable({0, 0}, {16, 32}, {64, 1}, {0, 32},
+                                           {16, 32}, {64, 1}, 4));
+  EXPECT_TRUE(checkAccessPaternsCombinable({1, 0}, {16, 32}, {64, 1}, {1, 32},
+                                           {16, 32}, {64, 1}, 4));
+  EXPECT_TRUE(checkAccessPaternsCombinable({0, 0, 0}, {16, 16, 32}, {32, 64, 1},
+                                           {0, 0, 32}, {16, 16, 32},
+                                           {32, 64, 1}, 4));
+  EXPECT_TRUE(checkAccessPaternsCombinable({0, 2, 0}, {16, 16, 32}, {32, 64, 1},
+                                           {0, 2, 32}, {16, 16, 32},
+                                           {32, 64, 1}, 4));
+  EXPECT_TRUE(checkAccessPaternsCombinable({32, 0}, {64, 64}, {128, 1}, {96, 0},
+                                           {32, 64}, {128, 1}, 4));
+
   // Same access patterns
-  EXPECT_TRUE(
-      checkAreAccessPatternsCombinable({0}, {32}, {1}, {0}, {32}, {1}, 2));
-  EXPECT_TRUE(checkAreAccessPatternsCombinable({0, 0}, {16, 32}, {64, 1},
-                                               {0, 0}, {16, 32}, {64, 1}, 4));
+  EXPECT_TRUE(checkAccessPaternsCombinable({0}, {32}, {1}, {0}, {32}, {1}, 2));
+  EXPECT_TRUE(checkAccessPaternsCombinable({0, 0}, {16, 32}, {64, 1}, {0, 0},
+                                           {16, 32}, {64, 1}, 4));
+
   // size(A) > size(B)
-  EXPECT_TRUE(checkAreAccessPatternsCombinable(
-      {0, 0, 0}, {2, 16, 32}, {32, 64, 1}, {0, 64}, {16, 32}, {64, 1}, 4));
-  EXPECT_TRUE(checkAreAccessPatternsCombinable(
-      {0, 0, 0}, {2, 16, 32}, {32, 64, 1}, {1, 0}, {16, 32}, {64, 1}, 4));
-  EXPECT_TRUE(checkAreAccessPatternsCombinable(
-      {0, 0, 32}, {2, 16, 32}, {32, 64, 1}, {0, 96}, {16, 32}, {64, 1}, 4));
-  EXPECT_TRUE(checkAreAccessPatternsCombinable(
-      {0, 2, 0}, {2, 16, 32}, {32, 16, 1}, {6, 0}, {16, 32}, {16, 1}, 4));
+  EXPECT_TRUE(checkAccessPaternsCombinable({0, 0, 0}, {2, 16, 32}, {32, 64, 1},
+                                           {0, 64}, {16, 32}, {64, 1}, 4));
+  EXPECT_TRUE(checkAccessPaternsCombinable({0, 0, 0}, {2, 16, 32}, {32, 64, 1},
+                                           {1, 0}, {16, 32}, {64, 1}, 4));
+  EXPECT_TRUE(checkAccessPaternsCombinable({0, 0, 32}, {2, 16, 32}, {32, 64, 1},
+                                           {0, 96}, {16, 32}, {64, 1}, 4));
+  EXPECT_TRUE(checkAccessPaternsCombinable({0, 2, 0}, {2, 16, 32}, {32, 16, 1},
+                                           {6, 0}, {16, 32}, {16, 1}, 4));
+
   // size(A) > size(B) Same access pattern
-  EXPECT_TRUE(checkAreAccessPatternsCombinable({0, 0}, {0, 32}, {0, 1}, {0},
-                                               {32}, {1}, 2));
-  EXPECT_TRUE(checkAreAccessPatternsCombinable({0, 0}, {7, 32}, {0, 1}, {0},
-                                               {32}, {1}, 2));
-  EXPECT_TRUE(checkAreAccessPatternsCombinable(
-      {1, 0, 0}, {8, 16, 32}, {0, 64, 1}, {0, 0}, {16, 32}, {64, 1}, 4));
+  EXPECT_TRUE(
+      checkAccessPaternsCombinable({0, 0}, {0, 32}, {0, 1}, {0}, {32}, {1}, 2));
+  EXPECT_TRUE(
+      checkAccessPaternsCombinable({0, 0}, {7, 32}, {0, 1}, {0}, {32}, {1}, 2));
+  EXPECT_TRUE(checkAccessPaternsCombinable({1, 0, 0}, {8, 16, 32}, {0, 64, 1},
+                                           {0, 0}, {16, 32}, {64, 1}, 4));
+
   // size(B) > size(A)
-  EXPECT_TRUE(checkAreAccessPatternsCombinable(
+  EXPECT_TRUE(checkAccessPaternsCombinable(
       {0, 0}, {16, 32}, {64, 1}, {0, 0, 32}, {2, 16, 32}, {32, 64, 1}, 4));
-  EXPECT_TRUE(checkAreAccessPatternsCombinable(
-      {0, 0}, {16, 32}, {16, 1}, {0, 2, 0}, {2, 16, 32}, {32, 16, 1}, 4));
-  EXPECT_TRUE(checkAreAccessPatternsCombinable(
+  EXPECT_TRUE(checkAccessPaternsCombinable({0, 0}, {16, 32}, {16, 1}, {0, 2, 0},
+                                           {2, 16, 32}, {32, 16, 1}, 4));
+  EXPECT_TRUE(checkAccessPaternsCombinable(
       {0, 32}, {16, 32}, {64, 1}, {0, 0, 64}, {2, 16, 32}, {32, 64, 1}, 4));
-  EXPECT_TRUE(checkAreAccessPatternsCombinable(
-      {2, 0}, {16, 32}, {16, 1}, {0, 4, 0}, {2, 16, 32}, {32, 16, 1}, 4));
+  EXPECT_TRUE(checkAccessPaternsCombinable({2, 0}, {16, 32}, {16, 1}, {0, 4, 0},
+                                           {2, 16, 32}, {32, 16, 1}, 4));
 }
 
 TEST_F(AccessPatternCombinationTest, NonCombinableAccessPatterns) {
   // |size(A) - size(B)| > 1
-  EXPECT_FALSE(checkAreAccessPatternsCombinable({}, {}, {}, {0, 0}, {16, 32},
-                                                {64, 1}, 3));
-  EXPECT_FALSE(checkAreAccessPatternsCombinable({0}, {32}, {1}, {0, 0, 32},
-                                                {2, 16, 32}, {128, 64, 1}, 3));
-  EXPECT_FALSE(checkAreAccessPatternsCombinable({0, 0}, {16, 32}, {64, 1}, {},
-                                                {}, {}, 3));
-  EXPECT_FALSE(checkAreAccessPatternsCombinable(
-      {0, 0, 32}, {2, 16, 32}, {128, 64, 1}, {0}, {32}, {1}, 3));
+  EXPECT_FALSE(
+      checkAccessPaternsCombinable({}, {}, {}, {0, 0}, {16, 32}, {64, 1}, 3));
+  EXPECT_FALSE(checkAccessPaternsCombinable({0}, {32}, {1}, {0, 0, 32},
+                                            {2, 16, 32}, {128, 64, 1}, 3));
+  EXPECT_FALSE(
+      checkAccessPaternsCombinable({0, 0}, {16, 32}, {64, 1}, {}, {}, {}, 3));
+  EXPECT_FALSE(checkAccessPaternsCombinable({0, 0, 32}, {2, 16, 32},
+                                            {128, 64, 1}, {0}, {32}, {1}, 3));
+
   // Too few dimensions
   EXPECT_FALSE(
-      checkAreAccessPatternsCombinable({0}, {16}, {1}, {32}, {16}, {1}, 1));
-  EXPECT_FALSE(
-      checkAreAccessPatternsCombinable({0}, {32}, {1}, {0}, {32}, {1}, 1));
-  EXPECT_FALSE(checkAreAccessPatternsCombinable({0, 0}, {16, 32}, {64, 1},
-                                                {0, 32}, {16, 32}, {64, 1}, 2));
-  EXPECT_FALSE(checkAreAccessPatternsCombinable({0, 0, 0}, {16, 16, 32},
-                                                {32, 64, 1}, {0, 0, 32},
-                                                {16, 16, 32}, {32, 64, 1}, 3));
+      checkAccessPaternsCombinable({0}, {16}, {1}, {32}, {16}, {1}, 1));
+  EXPECT_FALSE(checkAccessPaternsCombinable({0}, {32}, {1}, {0}, {32}, {1}, 1));
+  EXPECT_FALSE(checkAccessPaternsCombinable({0, 0}, {16, 32}, {64, 1}, {0, 32},
+                                            {16, 32}, {64, 1}, 2));
+  EXPECT_FALSE(checkAccessPaternsCombinable({0, 0, 0}, {16, 16, 32},
+                                            {32, 64, 1}, {0, 0, 32},
+                                            {16, 16, 32}, {32, 64, 1}, 3));
+
   // size(A) > size(B) Incompatible offset
-  EXPECT_FALSE(checkAreAccessPatternsCombinable(
-      {0, 0, 0}, {2, 16, 32}, {32, 64, 1}, {0, 32}, {16, 32}, {64, 1}, 4));
-  EXPECT_FALSE(checkAreAccessPatternsCombinable(
-      {0, 0, 0}, {2, 16, 32}, {32, 64, 1}, {0, 128}, {16, 32}, {64, 1}, 4));
-  EXPECT_FALSE(checkAreAccessPatternsCombinable(
-      {0, 0, 0}, {2, 16, 32}, {32, 64, 1}, {64, 0}, {16, 32}, {64, 1}, 4));
+  EXPECT_FALSE(checkAccessPaternsCombinable({0, 0, 0}, {2, 16, 32}, {32, 64, 1},
+                                            {0, 32}, {16, 32}, {64, 1}, 4));
+  EXPECT_FALSE(checkAccessPaternsCombinable({0, 0, 0}, {2, 16, 32}, {32, 64, 1},
+                                            {0, 128}, {16, 32}, {64, 1}, 4));
+  EXPECT_FALSE(checkAccessPaternsCombinable({0, 0, 0}, {2, 16, 32}, {32, 64, 1},
+                                            {64, 0}, {16, 32}, {64, 1}, 4));
+
   // size(A) > size(B) Same access pattern
-  EXPECT_FALSE(checkAreAccessPatternsCombinable({0, 0}, {32, 64}, {128, 1}, {0},
-                                                {64}, {1}, 4));
-  EXPECT_FALSE(checkAreAccessPatternsCombinable({1, 0}, {32, 64}, {128, 1}, {0},
-                                                {64}, {1}, 4));
-  EXPECT_FALSE(checkAreAccessPatternsCombinable(
+  EXPECT_FALSE(checkAccessPaternsCombinable({0, 0}, {32, 64}, {128, 1}, {0},
+                                            {64}, {1}, 4));
+  EXPECT_FALSE(checkAccessPaternsCombinable({1, 0}, {32, 64}, {128, 1}, {0},
+                                            {64}, {1}, 4));
+  EXPECT_FALSE(checkAccessPaternsCombinable(
       {0, 0, 0}, {32, 64, 128}, {32, 128, 1}, {0, 0}, {64, 128}, {128, 1}, 4));
-  EXPECT_FALSE(checkAreAccessPatternsCombinable(
+  EXPECT_FALSE(checkAccessPaternsCombinable(
       {2, 0, 0}, {32, 64, 128}, {32, 128, 1}, {0, 0}, {64, 128}, {128, 1}, 4));
+
   // size(B) > size(A) Incompatible offset
-  EXPECT_FALSE(checkAreAccessPatternsCombinable(
+  EXPECT_FALSE(checkAccessPaternsCombinable(
       {0, 0}, {16, 32}, {64, 1}, {0, 0, 16}, {2, 16, 32}, {32, 64, 1}, 4));
-  EXPECT_FALSE(checkAreAccessPatternsCombinable(
+  EXPECT_FALSE(checkAccessPaternsCombinable(
       {0, 0}, {16, 32}, {64, 1}, {0, 0, 96}, {2, 16, 32}, {32, 64, 1}, 4));
-  EXPECT_FALSE(checkAreAccessPatternsCombinable(
+  EXPECT_FALSE(checkAccessPaternsCombinable(
       {0, 0}, {16, 32}, {64, 1}, {0, 1, 0}, {2, 16, 32}, {32, 64, 1}, 4));
+
   // size(B) > size(A) Same access pattern
-  EXPECT_FALSE(checkAreAccessPatternsCombinable({0}, {32}, {1}, {0, 0}, {2, 32},
-                                                {8, 1}, 4));
-  EXPECT_FALSE(checkAreAccessPatternsCombinable({0}, {32}, {1}, {2, 0}, {2, 32},
-                                                {8, 1}, 4));
+  EXPECT_FALSE(
+      checkAccessPaternsCombinable({0}, {32}, {1}, {0, 0}, {2, 32}, {8, 1}, 4));
+  EXPECT_FALSE(
+      checkAccessPaternsCombinable({0}, {32}, {1}, {2, 0}, {2, 32}, {8, 1}, 4));
+
   // size(A) == size(B)
-  EXPECT_FALSE(checkAreAccessPatternsCombinable(
-      {32, 0}, {64, 64}, {128, 1}, {32, 0}, {32, 64}, {128, 1}, 4));
-  EXPECT_FALSE(checkAreAccessPatternsCombinable(
-      {32, 0}, {32, 64}, {128, 1}, {96, 0}, {64, 64}, {128, 1}, 4));
+  EXPECT_FALSE(checkAccessPaternsCombinable({32, 0}, {64, 64}, {128, 1},
+                                            {32, 0}, {32, 64}, {128, 1}, 4));
+  EXPECT_FALSE(checkAccessPaternsCombinable({32, 0}, {32, 64}, {128, 1},
+                                            {96, 0}, {64, 64}, {128, 1}, 4));
 }
 
 TEST_F(AccessPatternCombinationTest, AnyNbDims) {
   auto exceedsNbDims = [](size_t dims) { return false; };
-  EXPECT_TRUE(checkAreAccessPatternsCombinable({0}, {16}, {1}, {32}, {16}, {1},
-                                               exceedsNbDims));
-  EXPECT_TRUE(checkAreAccessPatternsCombinable(
-      {0, 0, 0}, {16, 16, 32}, {32, 64, 1}, {0, 0, 32}, {16, 16, 32},
-      {32, 64, 1}, exceedsNbDims));
+  EXPECT_TRUE(checkAccessPaternsCombinable({0}, {16}, {1}, {32}, {16}, {1},
+                                           exceedsNbDims));
+  EXPECT_TRUE(checkAccessPaternsCombinable({0, 0, 0}, {16, 16, 32}, {32, 64, 1},
+                                           {0, 0, 32}, {16, 16, 32},
+                                           {32, 64, 1}, exceedsNbDims));
 }
 
 TEST_F(AccessPatternCombinationTest, NoDims) {
   auto exceedsNbDims = [](size_t dims) { return true; };
-  EXPECT_FALSE(checkAreAccessPatternsCombinable({0}, {16}, {1}, {32}, {16}, {1},
-                                                exceedsNbDims));
-  EXPECT_FALSE(checkAreAccessPatternsCombinable(
+  EXPECT_FALSE(checkAccessPaternsCombinable({0}, {16}, {1}, {32}, {16}, {1},
+                                            exceedsNbDims));
+  EXPECT_FALSE(checkAccessPaternsCombinable(
       {0, 0, 0}, {16, 16, 32}, {32, 64, 1}, {0, 0, 32}, {16, 16, 32},
       {32, 64, 1}, exceedsNbDims));
 }
 
 TEST_F(AccessPatternCombinationTest, CombineAccessPatterns) {
-  checkCombineAccessPatterns({}, {}, {}, {}, {}, {}, {}, {}, {}, 1);
   // size(A) == size(B)
-  checkCombineAccessPatterns({0}, {16}, {1}, {32}, {16}, {1}, {0, 0}, {2, 16},
-                             {32, 1}, 2);
-  checkCombineAccessPatterns({0, 0}, {8, 16}, {8, 1}, {0, 32}, {8, 16}, {8, 1},
-                             {0, 0, 0}, {2, 8, 16}, {32, 8, 1}, 3);
-  checkCombineAccessPatterns({0, 32}, {8, 16}, {8, 1}, {0, 64}, {8, 16}, {8, 1},
-                             {0, 0, 32}, {2, 8, 16}, {32, 8, 1}, 3);
-  checkCombineAccessPatterns({1, 32}, {8, 16}, {8, 1}, {1, 64}, {8, 16}, {8, 1},
-                             {0, 1, 32}, {2, 8, 16}, {32, 8, 1}, 3);
-  checkCombineAccessPatterns({0, 0}, {8, 16}, {8, 1}, {32, 0}, {8, 16}, {8, 1},
-                             {0, 0, 0}, {2, 8, 16}, {256, 8, 1}, 3);
-  checkCombineAccessPatterns({8, 0}, {8, 16}, {8, 1}, {40, 0}, {8, 16}, {8, 1},
-                             {0, 8, 0}, {2, 8, 16}, {256, 8, 1}, 3);
-  checkCombineAccessPatterns({0, 0, 0}, {16, 8, 16}, {16, 8, 1}, {0, 0, 32},
-                             {16, 8, 16}, {16, 8, 1}, {0, 0, 0, 0},
-                             {2, 16, 8, 16}, {32, 16, 8, 1}, 4);
-  checkCombineAccessPatterns({0, 0, 32}, {16, 8, 16}, {16, 8, 1}, {0, 0, 64},
-                             {16, 8, 16}, {16, 8, 1}, {0, 0, 0, 32},
-                             {2, 16, 8, 16}, {32, 16, 8, 1}, 4);
-  checkCombineAccessPatterns({0, 0, 0}, {16, 8, 16}, {16, 8, 1}, {32, 0, 0},
-                             {16, 8, 16}, {16, 8, 1}, {0, 0, 0, 0},
-                             {2, 16, 8, 16}, {512, 16, 8, 1}, 4);
-  checkCombineAccessPatterns({8, 0, 0}, {16, 8, 16}, {16, 8, 1}, {40, 0, 0},
-                             {16, 8, 16}, {16, 8, 1}, {0, 8, 0, 0},
-                             {2, 16, 8, 16}, {512, 16, 8, 1}, 4);
-  checkCombineAccessPatterns({32, 0}, {64, 64}, {128, 1}, {96, 0}, {32, 64},
-                             {128, 1}, {32, 0}, {96, 64}, {128, 1}, 4);
+  EXPECT_TRUE(checkCombine({0, 0}, {8, 16}, {8, 1}, {0, 32}, {8, 16}, {8, 1},
+                           {0, 0, 0}, {2, 8, 16}, {32, 8, 1}, 3));
+  EXPECT_TRUE(checkCombine({}, {}, {}, {}, {}, {}, {}, {}, {}, 1));
+  EXPECT_TRUE(checkCombine({0}, {16}, {1}, {32}, {16}, {1}, {0, 0}, {2, 16},
+                           {32, 1}, 2));
+  EXPECT_TRUE(checkCombine({0, 32}, {8, 16}, {8, 1}, {0, 64}, {8, 16}, {8, 1},
+                           {0, 0, 32}, {2, 8, 16}, {32, 8, 1}, 3));
+  EXPECT_TRUE(checkCombine({1, 32}, {8, 16}, {8, 1}, {1, 64}, {8, 16}, {8, 1},
+                           {0, 1, 32}, {2, 8, 16}, {32, 8, 1}, 3));
+  EXPECT_TRUE(checkCombine({0, 0}, {8, 16}, {8, 1}, {32, 0}, {8, 16}, {8, 1},
+                           {0, 0, 0}, {2, 8, 16}, {256, 8, 1}, 3));
+  EXPECT_TRUE(checkCombine({8, 0}, {8, 16}, {8, 1}, {40, 0}, {8, 16}, {8, 1},
+                           {0, 8, 0}, {2, 8, 16}, {256, 8, 1}, 3));
+  EXPECT_TRUE(checkCombine({0, 0, 0}, {16, 8, 16}, {16, 8, 1}, {0, 0, 32},
+                           {16, 8, 16}, {16, 8, 1}, {0, 0, 0, 0},
+                           {2, 16, 8, 16}, {32, 16, 8, 1}, 4));
+  EXPECT_TRUE(checkCombine({0, 0, 32}, {16, 8, 16}, {16, 8, 1}, {0, 0, 64},
+                           {16, 8, 16}, {16, 8, 1}, {0, 0, 0, 32},
+                           {2, 16, 8, 16}, {32, 16, 8, 1}, 4));
+  EXPECT_TRUE(checkCombine({0, 0, 0}, {16, 8, 16}, {16, 8, 1}, {32, 0, 0},
+                           {16, 8, 16}, {16, 8, 1}, {0, 0, 0, 0},
+                           {2, 16, 8, 16}, {512, 16, 8, 1}, 4));
+  EXPECT_TRUE(checkCombine({8, 0, 0}, {16, 8, 16}, {16, 8, 1}, {40, 0, 0},
+                           {16, 8, 16}, {16, 8, 1}, {0, 8, 0, 0},
+                           {2, 16, 8, 16}, {512, 16, 8, 1}, 4));
+  EXPECT_TRUE(checkCombine({32, 0}, {64, 64}, {128, 1}, {96, 0}, {32, 64},
+                           {128, 1}, {32, 0}, {96, 64}, {128, 1}, 4));
+
   // size(A) == size(B) Same access pattern
-  checkCombineAccessPatterns({0}, {32}, {1}, {0}, {32}, {1}, {0, 0}, {2, 32},
-                             {0, 1}, 2);
-  checkCombineAccessPatterns({0, 0}, {16, 32}, {16, 1}, {0, 0}, {16, 32},
-                             {16, 1}, {0, 0, 0}, {2, 16, 32}, {0, 16, 1}, 3);
+  EXPECT_TRUE(
+      checkCombine({0}, {32}, {1}, {0}, {32}, {1}, {0, 0}, {2, 32}, {0, 1}, 2));
+  EXPECT_TRUE(checkCombine({0, 0}, {16, 32}, {16, 1}, {0, 0}, {16, 32}, {16, 1},
+                           {0, 0, 0}, {2, 16, 32}, {0, 16, 1}, 3));
+
   // size(A) > size(B)
-  checkCombineAccessPatterns({0, 0}, {2, 32}, {64, 1}, {128}, {32}, {1}, {0, 0},
-                             {3, 32}, {64, 1}, 3);
-  checkCombineAccessPatterns({0, 32}, {3, 32}, {64, 1}, {224}, {32}, {1},
-                             {0, 32}, {4, 32}, {64, 1}, 3);
-  checkCombineAccessPatterns({0, 0, 0}, {2, 16, 32}, {32, 64, 1}, {0, 64},
-                             {16, 32}, {64, 1}, {0, 0, 0}, {3, 16, 32},
-                             {32, 64, 1}, 4);
-  checkCombineAccessPatterns({0, 0, 0}, {2, 16, 32}, {32, 64, 1}, {1, 0},
-                             {16, 32}, {64, 1}, {0, 0, 0}, {3, 16, 32},
-                             {32, 64, 1}, 4);
-  checkCombineAccessPatterns({0, 1, 0}, {2, 16, 32}, {32, 64, 1}, {2, 0},
-                             {16, 32}, {64, 1}, {0, 1, 0}, {3, 16, 32},
-                             {32, 64, 1}, 4);
-  checkCombineAccessPatterns({0, 1, 32}, {2, 16, 32}, {32, 64, 1}, {2, 32},
-                             {16, 32}, {64, 1}, {0, 1, 32}, {3, 16, 32},
-                             {32, 64, 1}, 4);
+  EXPECT_TRUE(checkCombine({0, 0}, {2, 32}, {64, 1}, {128}, {32}, {1}, {0, 0},
+                           {3, 32}, {64, 1}, 3, true));
+  EXPECT_TRUE(checkCombine({0, 32}, {3, 32}, {64, 1}, {224}, {32}, {1}, {0, 32},
+                           {4, 32}, {64, 1}, 3, true));
+  EXPECT_TRUE(checkCombine({0, 0, 0}, {2, 16, 32}, {32, 64, 1}, {0, 64},
+                           {16, 32}, {64, 1}, {0, 0, 0}, {3, 16, 32},
+                           {32, 64, 1}, 4));
+  EXPECT_TRUE(checkCombine({0, 0, 0}, {2, 16, 32}, {32, 64, 1}, {1, 0},
+                           {16, 32}, {64, 1}, {0, 0, 0}, {3, 16, 32},
+                           {32, 64, 1}, 4));
+  EXPECT_TRUE(checkCombine({0, 1, 0}, {2, 16, 32}, {32, 64, 1}, {2, 0},
+                           {16, 32}, {64, 1}, {0, 1, 0}, {3, 16, 32},
+                           {32, 64, 1}, 4));
+  EXPECT_TRUE(checkCombine({0, 1, 32}, {2, 16, 32}, {32, 64, 1}, {2, 32},
+                           {16, 32}, {64, 1}, {0, 1, 32}, {3, 16, 32},
+                           {32, 64, 1}, 4));
+
   // size(A) > size(B) Same access pattern
-  checkCombineAccessPatterns({0, 0}, {7, 32}, {0, 1}, {0}, {32}, {1}, {0, 0},
-                             {8, 32}, {0, 1}, 3);
-  checkCombineAccessPatterns({1, 0}, {7, 32}, {0, 1}, {0}, {32}, {1}, {1, 0},
-                             {8, 32}, {0, 1}, 3);
-  checkCombineAccessPatterns({1, 0}, {0, 32}, {0, 1}, {0}, {32}, {1}, {1, 0},
-                             {1, 32}, {0, 1}, 3);
+  EXPECT_TRUE(checkCombine({0, 0}, {7, 32}, {0, 1}, {0}, {32}, {1}, {0, 0},
+                           {8, 32}, {0, 1}, 3, true));
+  EXPECT_TRUE(checkCombine({1, 0}, {7, 32}, {0, 1}, {0}, {32}, {1}, {1, 0},
+                           {8, 32}, {0, 1}, 3, true));
+  EXPECT_TRUE(
+      checkCombine({1, 0}, {0, 32}, {0, 1}, {0}, {32}, {1}, {0}, {32}, {1}, 3));
+
   // size(B) > size(A)
-  checkCombineAccessPatterns({0}, {32}, {1}, {0, 64}, {2, 32}, {64, 1}, {0, 0},
-                             {3, 32}, {64, 1}, 3);
-  checkCombineAccessPatterns({32}, {32}, {1}, {0, 96}, {2, 32}, {64, 1},
-                             {0, 32}, {3, 32}, {64, 1}, 3);
-  checkCombineAccessPatterns({0, 0}, {16, 32}, {16, 1}, {0, 0, 64}, {2, 16, 32},
-                             {64, 16, 1}, {0, 0, 0}, {3, 16, 32}, {64, 16, 1},
-                             4);
-  checkCombineAccessPatterns({0, 32}, {16, 32}, {16, 1}, {0, 0, 96},
-                             {2, 16, 32}, {64, 16, 1}, {0, 0, 32}, {3, 16, 32},
-                             {64, 16, 1}, 4);
-  checkCombineAccessPatterns({2, 0}, {16, 32}, {16, 1}, {0, 6, 0}, {2, 16, 32},
-                             {64, 16, 1}, {0, 2, 0}, {3, 16, 32}, {64, 16, 1},
-                             4);
-  checkCombineAccessPatterns({2, 32}, {16, 32}, {16, 1}, {0, 6, 32},
-                             {2, 16, 32}, {64, 16, 1}, {0, 2, 32}, {3, 16, 32},
-                             {64, 16, 1}, 4);
-  checkCombineAccessPatterns({0}, {32}, {1}, {1, 0}, {2, 32}, {64, 1}, {0, 0},
-                             {3, 32}, {64, 1}, 3);
+  EXPECT_TRUE(checkCombine({0}, {32}, {1}, {0, 64}, {2, 32}, {64, 1}, {0, 0},
+                           {3, 32}, {64, 1}, 3, true));
+  EXPECT_TRUE(checkCombine({32}, {32}, {1}, {0, 96}, {2, 32}, {64, 1}, {0, 32},
+                           {3, 32}, {64, 1}, 3, true));
+  EXPECT_TRUE(checkCombine({0, 0}, {16, 32}, {16, 1}, {0, 0, 64}, {2, 16, 32},
+                           {64, 16, 1}, {0, 0, 0}, {3, 16, 32}, {64, 16, 1},
+                           4));
+  EXPECT_TRUE(checkCombine({0, 32}, {16, 32}, {16, 1}, {0, 0, 96}, {2, 16, 32},
+                           {64, 16, 1}, {0, 0, 32}, {3, 16, 32}, {64, 16, 1},
+                           4));
+  EXPECT_TRUE(checkCombine({2, 0}, {16, 32}, {16, 1}, {0, 6, 0}, {2, 16, 32},
+                           {64, 16, 1}, {0, 2, 0}, {3, 16, 32}, {64, 16, 1},
+                           4));
+  EXPECT_TRUE(checkCombine({2, 32}, {16, 32}, {16, 1}, {0, 6, 32}, {2, 16, 32},
+                           {64, 16, 1}, {0, 2, 32}, {3, 16, 32}, {64, 16, 1},
+                           4));
+  EXPECT_TRUE(checkCombine({0}, {32}, {1}, {1, 0}, {2, 32}, {64, 1}, {0, 0},
+                           {3, 32}, {64, 1}, 3, true));
+
   // size(B) > size(A) Same access pattern
-  checkCombineAccessPatterns({0}, {32}, {1}, {1, 0}, {3, 32}, {16, 1}, {0, 0},
-                             {4, 32}, {16, 1}, 3);
-  checkCombineAccessPatterns({0, 0}, {16, 32}, {16, 1}, {1, 0, 0}, {3, 16, 32},
-                             {64, 16, 1}, {0, 0, 0}, {4, 16, 32}, {64, 16, 1},
-                             3);
+  EXPECT_TRUE(checkCombine({0}, {32}, {1}, {1, 0}, {3, 32}, {16, 1}, {0, 0},
+                           {4, 32}, {16, 1}, 3, true));
+  EXPECT_TRUE(checkCombine({0, 0}, {16, 32}, {16, 1}, {1, 0, 0}, {3, 16, 32},
+                           {64, 16, 1}, {0, 0, 0}, {4, 16, 32}, {64, 16, 1},
+                           3));
+  EXPECT_TRUE(checkCombine({}, {}, {}, {}, {}, {}, {}, {}, {}, 100));
+  EXPECT_TRUE(checkCombine({0, 0}, {16, 32}, {16, 1}, {0, 32}, {16, 32},
+                           {16, 1}, {0, 0, 0}, {2, 16, 32}, {32, 16, 1}, 100));
+}
+
+TEST_F(AccessPatternCombinationTest, StrideMatching) {
+  EXPECT_TRUE(checkCombine({0, 0}, {8, 16}, {64, 1},      //
+                           {8 * 64, 0}, {1, 16}, {1, 1},  //
+                           {0, 0}, {9, 16}, {64, 1}, 3));
+
+  // offset A : 4*64
+  // offset B : 12*64
+  // offset difference: 8*64
+  // for A, size[0]*stride[0] is 8*64 (= offset difference)
+  // ==> no new dimension required.
+  EXPECT_TRUE(checkCombine({4, 0}, {8, 16}, {64, 1},       //
+                           {12 * 64, 0}, {1, 16}, {1, 1},  //
+                           {4, 0}, {9, 16}, {64, 1}, 3));
+
+  // First access pattern is [10,...19]
+  // Second access pattern is [13,...,22].
+  //
+  // This is
+  // for d0 = 0:2
+  //   for d1 = 0:10
+  //    access (d0+0)*3 + (d1+10)*1
+  //
+  // from which we one set of possible new params:
+  // size: [2, 10] offset: [0, 10] stride:[3, 1]
+  EXPECT_TRUE(checkCombine({10}, {10}, {1},          //
+                           {2, 5}, {1, 10}, {4, 1},  //
+                           {0, 10}, {2, 10}, {3, 1}, 4, true));
+
+  // First access pattern is [10,...,19]
+  // Second access pattern is [8,...,17].
+  // so they cannot be merged, as the difference between the pointers to the
+  // first elements is negative.
+  EXPECT_FALSE(checkCombine({10}, {10}, {1},          //
+                            {2, 0}, {1, 10}, {4, 1},  //
+                            {}, {}, {}, 4, false));
+
+  // First access pattern is [10,...,19]
+  // Second access pattern is [20,...,29].
+  // so these could in theory be combined into a rank-1 access, but merging
+  // dimensions that are not size 1 is not the responsibility of this function.
+  EXPECT_TRUE(checkCombine({10}, {10}, {1},          //
+                           {4, 4}, {1, 10}, {4, 1},  //
+                           {0, 10}, {2, 10}, {10, 1}, 4, true));
 }
 
 TEST_F(AccessPatternCombinationTest, FailCombineAccessPatterns) {
   // |size(A) - size(B)| > 1
-  checkCombineAccessPatterns({}, {}, {}, {0, 0}, {16, 32}, {16, 1}, {}, {}, {},
-                             3, false);
-  checkCombineAccessPatterns({0, 0}, {16, 32}, {16, 1}, {}, {}, {}, {}, {}, {},
-                             3, false);
+  EXPECT_FALSE(checkCombine({}, {}, {}, {0, 0}, {16, 32}, {16, 1}, {}, {}, {},
+                            3, false));
+  EXPECT_FALSE(checkCombine({0, 0}, {16, 32}, {16, 1}, {}, {}, {}, {}, {}, {},
+                            3, false));
   // Too few dimensions
-  checkCombineAccessPatterns({0, 0}, {16, 32}, {16, 1}, {0, 32}, {16, 32},
-                             {16, 1}, {}, {}, {}, 2, false);
+  EXPECT_FALSE(checkCombine({0, 0}, {16, 32}, {16, 1}, {0, 32}, {16, 32},
+                            {16, 1}, {}, {}, {}, 2, false));
+
   // size(A) > size(B) Incompatible offset
-  checkCombineAccessPatterns({0, 0}, {2, 32}, {64, 1}, {96}, {32}, {1}, {0, 0},
-                             {3, 32}, {64, 1}, 3, false);
-  checkCombineAccessPatterns({0, 0}, {2, 32}, {64, 1}, {256}, {32}, {1}, {0, 0},
-                             {3, 32}, {64, 1}, 3, false);
+  EXPECT_FALSE(checkCombine({0, 0}, {2, 32}, {64, 1}, {96}, {32}, {1}, {0, 0},
+                            {3, 32}, {64, 1}, 3, false));
+  EXPECT_FALSE(checkCombine({0, 0}, {2, 32}, {64, 1}, {256}, {32}, {1}, {0, 0},
+                            {3, 32}, {64, 1}, 3, false));
   // size(B) > size(A) Same access pattern
-  checkCombineAccessPatterns({0, 0}, {16, 32}, {16, 1}, {0, 0, 0}, {3, 16, 32},
-                             {64, 16, 1}, {0, 0, 0}, {4, 16, 32}, {64, 16, 1},
-                             3, false);
-  checkCombineAccessPatterns({0, 0}, {16, 32}, {16, 1}, {2, 0, 0}, {3, 16, 32},
-                             {64, 16, 1}, {0, 0, 0}, {4, 16, 32}, {64, 16, 1},
-                             3, false);
+  EXPECT_FALSE(checkCombine({0, 0}, {16, 32}, {16, 1}, {0, 0, 0}, {3, 16, 32},
+                            {64, 16, 1}, {0, 0, 0}, {4, 16, 32}, {64, 16, 1}, 3,
+                            false));
+  EXPECT_FALSE(checkCombine({0, 0}, {16, 32}, {16, 1}, {2, 0, 0}, {3, 16, 32},
+                            {64, 16, 1}, {0, 0, 0}, {4, 16, 32}, {64, 16, 1}, 3,
+                            false));
+
   // size(B) > size(A) Incompatible offset
-  checkCombineAccessPatterns({0}, {32}, {1}, {0, 32}, {2, 32}, {64, 1}, {0, 0},
-                             {3, 32}, {64, 1}, 3, false);
-  checkCombineAccessPatterns({0}, {32}, {1}, {0, 96}, {2, 32}, {64, 1}, {0, 0},
-                             {3, 32}, {64, 1}, 3, false);
+  EXPECT_FALSE(checkCombine({0}, {32}, {1}, {0, 32}, {2, 32}, {64, 1}, {0, 0},
+                            {3, 32}, {64, 1}, 3, false));
+  EXPECT_FALSE(checkCombine({0}, {32}, {1}, {0, 96}, {2, 32}, {64, 1}, {0, 0},
+                            {3, 32}, {64, 1}, 3, false));
 
   // size(A) == size(B) Incompatible offset
-  checkCombineAccessPatterns({32, 0}, {32, 64}, {128, 1}, {96, 0}, {64, 64},
-                             {128, 1}, {32, 0}, {96, 64}, {128, 1}, 4, false);
-}
-
-TEST_F(AccessPatternCombinationTest, CombineAccessPatternsAnyNbDims) {
-  auto exceedsNbDims = [](size_t dims) { return false; };
-  checkCombineAccessPatterns({}, {}, {}, {}, {}, {}, {}, {}, {}, exceedsNbDims);
-  checkCombineAccessPatterns({0, 0}, {16, 32}, {16, 1}, {0, 32}, {16, 32},
-                             {16, 1}, {0, 0, 0}, {2, 16, 32}, {32, 16, 1},
-                             exceedsNbDims);
-}
-
-TEST_F(AccessPatternCombinationTest, CombineAccessPatternsNoDims) {
-  auto exceedsNbDims = [](size_t dims) { return true; };
-  checkCombineAccessPatterns({0}, {16}, {1}, {32}, {16}, {1}, {}, {}, {},
-                             exceedsNbDims, false);
-  checkCombineAccessPatterns({0, 0}, {16, 32}, {16, 1}, {0, 32}, {16, 32},
-                             {16, 1}, {0, 0, 0}, {2, 16, 32}, {32, 16, 1},
-                             exceedsNbDims, false);
+  EXPECT_FALSE(checkCombine({32, 0}, {32, 64}, {128, 1}, {96, 0}, {64, 64},
+                            {128, 1}, {32, 0}, {96, 64}, {128, 1}, 4, false));
+  EXPECT_FALSE(
+      checkCombine({0}, {16}, {1}, {32}, {16}, {1}, {}, {}, {}, 0, false));
+  EXPECT_FALSE(checkCombine({0, 0}, {16, 32}, {16, 1}, {0, 32}, {16, 32},
+                            {16, 1}, {0, 0, 0}, {2, 16, 32}, {32, 16, 1}, 0,
+                            false));
 }
 
 class FoldTest : public ::testing::Test {
@@ -383,29 +439,27 @@ class FoldTest : public ::testing::Test {
     context.loadDialect<arith::ArithDialect>();
   }
 
-  SmallVector<OpFoldResult> toOpFoldResult(ArrayRef<int64_t> values) {
+  SmallVector<OpFoldResult> toOpFoldResults(SmallVector<int64_t> values) {
     return llvm::map_to_vector(values, [&](int64_t v) -> OpFoldResult {
       return getAsIndexOpFoldResult(&context, v);
     });
   }
 
-  void checkFoldLinearDims(const SmallVector<int64_t> offsets,
-                           const SmallVector<int64_t> sizes,
-                           const SmallVector<int64_t> strides,
-                           ArrayRef<int64_t> maxSizes,
-                           const SmallVector<int64_t> expectedOffsets,
-                           const SmallVector<int64_t> expectedSizes,
-                           const SmallVector<int64_t> expectedStrides,
-                           bool shouldSucceed = true) {
-    SmallVector<OpFoldResult> offsetsValues = toOpFoldResult(offsets);
-    SmallVector<OpFoldResult> sizesValues = toOpFoldResult(sizes);
-    SmallVector<OpFoldResult> stridesValues = toOpFoldResult(strides);
+  void checkFoldLinearDims(
+      SmallVector<int64_t> offsets, SmallVector<int64_t> sizes,
+      SmallVector<int64_t> strides, SmallVector<int64_t> maxSizes,
+      SmallVector<int64_t> expectedOffsets, SmallVector<int64_t> expectedSizes,
+      SmallVector<int64_t> expectedStrides, bool shouldSucceed = true) {
+    SmallVector<OpFoldResult> offsetsValues = toOpFoldResults(offsets);
+    SmallVector<OpFoldResult> sizesValues = toOpFoldResults(sizes);
+    SmallVector<OpFoldResult> stridesValues = toOpFoldResults(strides);
+
     SmallVector<OpFoldResult> expectedOffsetsValues =
-        toOpFoldResult(expectedOffsets);
+        toOpFoldResults(expectedOffsets);
     SmallVector<OpFoldResult> expectedSizesValues =
-        toOpFoldResult(expectedSizes);
+        toOpFoldResults(expectedSizes);
     SmallVector<OpFoldResult> expectedStridesValues =
-        toOpFoldResult(expectedStrides);
+        toOpFoldResults(expectedStrides);
     SmallVector<OpFoldResult> newOffsets;
     SmallVector<OpFoldResult> newSizes;
     SmallVector<OpFoldResult> newStrides;
@@ -428,37 +482,30 @@ class FoldTest : public ::testing::Test {
     EXPECT_EQ(newStrides, expectedStridesValues);
   }
 
-  void checkFoldUnitDims(const SmallVector<int64_t> offsets,
-                         const SmallVector<int64_t> sizes,
-                         const SmallVector<int64_t> strides,
-                         const SmallVector<int64_t> expectedOffsets,
-                         const SmallVector<int64_t> expectedSizes,
-                         const SmallVector<int64_t> expectedStrides,
-                         bool shouldSucceed = true) {
-    SmallVector<OpFoldResult> offsetsValues = toOpFoldResult(offsets);
-    SmallVector<OpFoldResult> sizesValues = toOpFoldResult(sizes);
-    SmallVector<OpFoldResult> stridesValues = toOpFoldResult(strides);
-    SmallVector<OpFoldResult> expectedOffsetsValues =
-        toOpFoldResult(expectedOffsets);
-    SmallVector<OpFoldResult> expectedSizesValues =
-        toOpFoldResult(expectedSizes);
-    SmallVector<OpFoldResult> expectedStridesValues =
-        toOpFoldResult(expectedStrides);
-    SmallVector<OpFoldResult> newOffsets;
-    SmallVector<OpFoldResult> newSizes;
-    SmallVector<OpFoldResult> newStrides;
-    if (shouldSucceed) {
-      EXPECT_TRUE(succeeded(foldUnitDims(&context, offsetsValues, sizesValues,
-                                         stridesValues, newOffsets, newSizes,
-                                         newStrides)));
-      EXPECT_EQ(newOffsets, expectedOffsetsValues);
-      EXPECT_EQ(newSizes, expectedSizesValues);
-      EXPECT_EQ(newStrides, expectedStridesValues);
-    } else {
-      EXPECT_TRUE(failed(foldUnitDims(&context, offsetsValues, sizesValues,
-                                      stridesValues, newOffsets, newSizes,
-                                      newStrides)));
-    }
+  bool checkFoldUnitDims(SmallVector<int64_t> offsets,
+                         SmallVector<int64_t> sizes,
+                         SmallVector<int64_t> strides,
+                         SmallVector<int64_t> expectedOffsets,
+                         SmallVector<int64_t> expectedSizes,
+                         SmallVector<int64_t> expectedStrides) {
+    SmallVector<OpFoldResult> offsetsValues = toOpFoldResults(offsets);
+    SmallVector<OpFoldResult> sizesValues = toOpFoldResults(sizes);
+    SmallVector<OpFoldResult> stridesValues = toOpFoldResults(strides);
+
+    auto folded =
+        foldUnitDims(&context, offsetsValues, sizesValues, stridesValues);
+
+    EXPECT_EQ(fromOpFoldResults(offsetsValues), expectedOffsets);
+    EXPECT_EQ(fromOpFoldResults(sizesValues), expectedSizes);
+    EXPECT_EQ(fromOpFoldResults(stridesValues), expectedStrides);
+
+    return succeeded(folded);
+  }
+
+  bool checkNotFoldUnitDims(SmallVector<int64_t> offsets,
+                            SmallVector<int64_t> sizes,
+                            SmallVector<int64_t> strides) {
+    return checkFoldUnitDims(offsets, sizes, strides, offsets, sizes, strides);
   }
 
   void checkFoldRepetitionCount(
@@ -467,12 +514,12 @@ class FoldTest : public ::testing::Test {
       const SmallVector<int64_t> expectedStrides,
       std::optional<int64_t> maybeRepetitionCount = std::nullopt,
       bool shouldSucceed = true) {
-    SmallVector<OpFoldResult> sizesValues = toOpFoldResult(sizes);
-    SmallVector<OpFoldResult> stridesValues = toOpFoldResult(strides);
+    SmallVector<OpFoldResult> sizesValues = toOpFoldResults(sizes);
+    SmallVector<OpFoldResult> stridesValues = toOpFoldResults(strides);
     SmallVector<OpFoldResult> expectedSizesValues =
-        toOpFoldResult(expectedSizes);
+        toOpFoldResults(expectedSizes);
     SmallVector<OpFoldResult> expectedStridesValues =
-        toOpFoldResult(expectedStrides);
+        toOpFoldResults(expectedStrides);
     if (shouldSucceed) {
       EXPECT_TRUE(succeeded(foldRepetitionCount(
           &context, sizesValues, stridesValues, maybeRepetitionCount)));
@@ -526,39 +573,48 @@ TEST_F(FoldTest, FoldLinearDimsWithMax) {
 }
 
 TEST_F(FoldTest, NoUnitDimsFold) {
-  checkFoldUnitDims({}, {}, {}, {}, {}, {}, false);
-  checkFoldUnitDims({0}, {8}, {1}, {}, {}, {}, false);
-  checkFoldUnitDims({0, 0}, {16, 8}, {16, 1}, {}, {}, {}, false);
-  checkFoldUnitDims({2}, {1}, {1}, {}, {}, {}, false);
+  EXPECT_FALSE(checkNotFoldUnitDims({}, {}, {}));
+  EXPECT_FALSE(checkNotFoldUnitDims({0}, {8}, {1}));
+  EXPECT_FALSE(checkNotFoldUnitDims({0, 0}, {16, 8}, {16, 1}));
+  EXPECT_FALSE(checkNotFoldUnitDims({2}, {1}, {1}));
 }
 
 TEST_F(FoldTest, UnitDimsFullFold) {
-  checkFoldUnitDims({0}, {1}, {32}, {}, {}, {}, true);
-  checkFoldUnitDims({0, 0, 0}, {32, 1, 8}, {32, 1024, 1}, {0, 0}, {32, 8},
-                    {32, 1}, true);
-  checkFoldUnitDims({0, 0, 0, 0}, {1, 32, 1, 8}, {1024, 32, 1024, 1}, {0, 0},
-                    {32, 8}, {32, 1}, true);
+  EXPECT_TRUE(checkFoldUnitDims({0}, {1}, {32}, {}, {}, {}));
+  EXPECT_TRUE(checkFoldUnitDims({0, 0, 0}, {32, 1, 8}, {32, 1024, 1}, {0, 0},
+                                {32, 8}, {32, 1}));
+  EXPECT_TRUE(checkFoldUnitDims({0, 0, 0, 0}, {1, 32, 1, 8},
+                                {1024, 32, 1024, 1}, {0, 0}, {32, 8}, {32, 1}));
 }
 
 TEST_F(FoldTest, UnitDimsMerge) {
-  checkFoldUnitDims({1, 1}, {1, 1}, {32, 32}, {2}, {1}, {32}, true);
-  checkFoldUnitDims({1, 2}, {1, 1}, {32, 32}, {3}, {1}, {32}, true);
-  checkFoldUnitDims({2, 1}, {1, 1}, {32, 32}, {3}, {1}, {32}, true);
-  checkFoldUnitDims({1, 0, 1, 0}, {1, 32, 1, 8}, {1024, 32, 1024, 1}, {2, 0, 0},
-                    {1, 32, 8}, {1024, 32, 1}, true);
-  checkFoldUnitDims({1, 0, 2, 0}, {1, 32, 1, 8}, {1024, 32, 1024, 1}, {3, 0, 0},
-                    {1, 32, 8}, {1024, 32, 1}, true);
-  checkFoldUnitDims({2, 0, 1, 0}, {1, 32, 1, 8}, {1024, 32, 1024, 1}, {3, 0, 0},
-                    {1, 32, 8}, {1024, 32, 1}, true);
+  EXPECT_TRUE(checkFoldUnitDims({1, 1}, {1, 1}, {32, 32}, {1}, {1}, {64}));
+  EXPECT_TRUE(checkFoldUnitDims({1, 2}, {1, 1}, {32, 32}, {1}, {1}, {96}));
+  EXPECT_TRUE(checkFoldUnitDims({2, 1}, {1, 1}, {32, 32}, {1}, {1}, {96}));
+  EXPECT_TRUE(checkFoldUnitDims({1, 0, 1, 0}, {1, 32, 1, 8},
+                                {1024, 32, 1024, 1}, {64, 0}, {32, 8},
+                                {32, 1}));
+  EXPECT_TRUE(checkFoldUnitDims({1, 0, 2, 0}, {1, 32, 1, 8},
+                                {1024, 32, 1024, 1}, {96, 0}, {32, 8},
+                                {32, 1}));
+  EXPECT_TRUE(checkFoldUnitDims({2, 0, 1, 0}, {1, 32, 1, 8},
+                                {1024, 32, 1024, 1}, {96, 0}, {32, 8},
+                                {32, 1}));
+  EXPECT_TRUE(
+      checkFoldUnitDims({2, 2, 15}, {1, 1, 10}, {4, 6, 10}, {17}, {10}, {10}));
+  EXPECT_TRUE(checkFoldUnitDims({3, 1, 15}, {1, 1, 10}, {4, 6, 10}, {1, 15},
+                                {1, 10}, {18, 10}));
 }
 
 TEST_F(FoldTest, UnitDimsFoldAndMerge) {
-  checkFoldUnitDims({1, 0, 1}, {1, 1, 1}, {32, 1024, 32}, {2}, {1}, {32}, true);
-  checkFoldUnitDims({1, 0, 1}, {1, 1, 1}, {32, 32, 32}, {2}, {1}, {32}, true);
-  checkFoldUnitDims({1, 0, 2, 0}, {1, 1, 1, 1}, {32, 32, 32, 32}, {3}, {1},
-                    {32}, true);
-  checkFoldUnitDims({1, 0, 1, 0}, {1, 1, 1, 8}, {1024, 32, 1024, 1}, {2, 0},
-                    {1, 8}, {1024, 1}, true);
+  EXPECT_TRUE(
+      checkFoldUnitDims({1, 0, 1}, {1, 1, 1}, {32, 1024, 32}, {1}, {1}, {64}));
+  EXPECT_TRUE(
+      checkFoldUnitDims({1, 0, 1}, {1, 1, 1}, {32, 32, 32}, {1}, {1}, {64}));
+  EXPECT_TRUE(checkFoldUnitDims({1, 0, 2, 0}, {1, 1, 1, 1}, {32, 32, 32, 32},
+                                {1}, {1}, {96}));
+  EXPECT_TRUE(checkFoldUnitDims({1, 0, 1, 0}, {1, 1, 1, 8}, {1024, 32, 1024, 1},
+                                {2048}, {8}, {1}));
 }
 
 TEST_F(FoldTest, FoldRepetitionCount) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIEDmaUtilsTest.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIEDmaUtilsTest.cpp
@@ -16,15 +16,9 @@ using namespace mlir;
 using namespace mlir::iree_compiler::AMDAIE;
 
 SmallVector<int64_t> fromOpFoldResults(SmallVector<OpFoldResult> ofrs) {
-  SmallVector<int64_t> vals;
-  for (auto ofr : ofrs) {
-    auto asInt = getConstantIntValue(ofr);
-    if (asInt.has_value())
-      vals.push_back(asInt.value());
-    else
-      assert(false && "expected integer");
-  }
-  return vals;
+  std::optional<SmallVector<int64_t>> vals = getConstantIntValues(ofrs);
+  assert(vals.has_value() && "expected constant values");
+  return vals.value();
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_doubly_strided_op.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_doubly_strided_op.mlir
@@ -77,8 +77,8 @@ func.func @circular_dma_cpy_nd_unit_between_linear(%arg0: !amdaie.logicalobjectf
 // -----
 
 // CHECK-LABEL:       func.func @circular_dma_cpy_nd_non_zero_offset
-// CHECK:             amdaie.circular_dma_cpy_nd(%{{.+}}[3, 1, 1] [1, 8, 16] [128, 16, 1], %{{.+}}[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
-// FOLD-SINGLE-DIMS:  amdaie.circular_dma_cpy_nd(%{{.+}}[3, 1, 1] [1, 8, 16] [128, 16, 1], %{{.+}}[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
+// CHECK:             amdaie.circular_dma_cpy_nd(%{{.+}}[25, 1] [8, 16] [16, 1], %{{.+}}[5, 1, 1] [4, 2, 8] [16, 8, 1])
+// FOLD-SINGLE-DIMS:  amdaie.circular_dma_cpy_nd(%{{.+}}[25, 1] [8, 16] [16, 1], %{{.+}}[5, 1, 1] [4, 2, 8] [16, 8, 1])
 func.func @circular_dma_cpy_nd_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[2, 1, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   "iree.keep"(%0) : (index) -> ()
@@ -174,8 +174,8 @@ func.func @dma_cpy_nd_unit_between_linear(%arg0: !amdaie.logicalobjectfifo<memre
 // -----
 
 // CHECK-LABEL:       func.func @dma_cpy_nd_non_zero_offset
-// CHECK:             amdaie.dma_cpy_nd(%{{.+}}[3, 1, 1] [1, 8, 16] [128, 16, 1], %{{.+}}[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
-// FOLD-SINGLE-DIMS:  amdaie.dma_cpy_nd(%{{.+}}[3, 1, 1] [1, 8, 16] [128, 16, 1], %{{.+}}[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
+// CHECK:             amdaie.dma_cpy_nd(%{{.+}}[25, 1] [8, 16] [16, 1], %{{.+}}[5, 1, 1] [4, 2, 8] [16, 8, 1])
+// FOLD-SINGLE-DIMS:  amdaie.dma_cpy_nd(%{{.+}}[25, 1] [8, 16] [16, 1], %{{.+}}[5, 1, 1] [4, 2, 8] [16, 8, 1])
 func.func @dma_cpy_nd_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.dma_cpy_nd(%arg0[1, 2, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], %arg1[1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   "iree.keep"(%0) : (index) -> ()
@@ -273,8 +273,8 @@ func.func @npu_dma_cpy_nd_unit_between_linear(%arg0: !amdaie.logicalobjectfifo<m
 // -----
 
 // CHECK-LABEL:       func.func @npu_dma_cpy_nd_non_zero_offset
-// CHECK:             amdaie.npu.dma_cpy_nd %{{.+}}([3, 1, 1] [1, 8, 16] [128, 16, 1], [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
-// FOLD-SINGLE-DIMS:  amdaie.npu.dma_cpy_nd %{{.+}}([3, 1, 1] [1, 8, 16] [128, 16, 1], [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])
+// CHECK:             amdaie.npu.dma_cpy_nd %{{.+}}([25, 1] [8, 16] [16, 1], [5, 1, 1] [4, 2, 8] [16, 8, 1])
+// FOLD-SINGLE-DIMS:  amdaie.npu.dma_cpy_nd %{{.+}}([25, 1] [8, 16] [16, 1], [5, 1, 1] [4, 2, 8] [16, 8, 1])
 func.func @npu_dma_cpy_nd_non_zero_offset(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
   %0 = amdaie.circular_dma_cpy_nd(%arg0[] [] [], %arg1[] [] []) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
   amdaie.npu.dma_cpy_nd %0([1, 2, 1, 1] [1, 1, 8, 16] [128, 128, 16, 1], [1, 1, 1, 1] [1, 4, 2, 8] [64, 16, 8, 1])

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/combine_strided_ops.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/combine_strided_ops.mlir
@@ -654,3 +654,118 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     return
   }
 }
+
+// -----
+
+// CHECK:          @with_simple_variable_offset
+// CHECK-SAME:     %[[ARG0:.+]]: index
+// CHECK:          %[[CONNECTION:.+]] = amdaie.connection
+// CHECK:          amdaie.npu.circular_dma_cpy_nd
+// CHECK-SAME:     %[[CONNECTION]]([0, 0, 0, 0] [2, 32, 8, 8] [0, 8, 256, 1],
+// CHECK-SAME:     [%[[ARG0]], 0, 0, 0] [1, 2, 32, 64] [4096, 2048, 64, 1])
+
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @with_simple_variable_offset(%arg0: index, %arg1: !amdaie.logicalobjectfifo<memref<bf16>>) {
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg1, %arg1) : (!amdaie.logicalobjectfifo<memref<bf16>>, !amdaie.logicalobjectfifo<memref<bf16>>)
+      amdaie.controlcode {
+        %1 = amdaie.npu.circular_dma_cpy_nd %0([0, 0, 0] [32, 8, 8] [8, 256, 1], [%arg0, 0, 0] [1, 32, 64] [4096, 64, 1])
+        %2 = amdaie.npu.circular_dma_cpy_nd %0([0, 0, 0] [32, 8, 8] [8, 256, 1], [%arg0, 1, 0, 0] [1, 1, 32, 64] [4096, 2048, 64, 1])
+        // we check that the above 2 copies are combined to  become
+        // amdaie.npu.circular_dma_cpy_nd  %0([0, 0, 0, 0] [2, 32, 8, 8] [0, 8, 256, 1], [%arg0, 0, 0, 0] [1, 2, 32, 64] [4096, 2048 64, 1])
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+
+// -----
+
+
+// CHECK-LABEL: @with_complex_variable_offset
+// CHECK:       amdaie.npu.circular_dma_cpy_nd
+// CHECK-SAME:    [0, 0] [2, 1000] [0, 1]
+// CHECK-SAME:    [0, %arg0, %arg1, %arg2] [2, 10, 10, 10] [0, 400, 20, 1])
+// CHECK-NOT:   amdaie.npu.circular_dma_cpy_nd
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @with_complex_variable_offset(%arg0: index, %arg1 : index, %arg2 : index, %arg3: !amdaie.logicalobjectfifo<memref<bf16>>) {
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg3, %arg3) : (!amdaie.logicalobjectfifo<memref<bf16>>, !amdaie.logicalobjectfifo<memref<bf16>>)
+      amdaie.controlcode {
+        %1 = amdaie.npu.circular_dma_cpy_nd %0([0] [1000] [1], [%arg0, %arg1, %arg2] [10, 10, 10] [400, 20, 1])
+        %2 = amdaie.npu.circular_dma_cpy_nd %0([0] [1000] [1], [%arg0, %arg1, %arg2] [10, 10, 10] [400, 20, 1])
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+
+// CHECK-LABEL: @with_mixed_offsets
+// CHECK:       amdaie.npu.circular_dma_cpy_nd
+// CHECK-SAME:    [0, 0] [2, 1000] [0, 1]
+// CHECK-SAME:    [0, 0, %arg1, %arg2] [2, 10, 10, 10] [400000, 400, %arg0, 1])
+// CHECK-NOT:   amdaie.npu.circular_dma_cpy_nd
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @with_mixed_offsets(%arg0: index, %arg1 : index, %arg2 : index, %arg3: !amdaie.logicalobjectfifo<memref<bf16>>) {
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg3, %arg3) : (!amdaie.logicalobjectfifo<memref<bf16>>, !amdaie.logicalobjectfifo<memref<bf16>>)
+      amdaie.controlcode {
+        %1 = amdaie.npu.circular_dma_cpy_nd %0([0] [1000] [1], [0, %arg1, %arg2] [10, 10, 10] [400, %arg0, 1])
+        %2 = amdaie.npu.circular_dma_cpy_nd %0([0] [1000] [1], [1000, %arg1, %arg2] [10, 10, 10] [400, %arg0, 1])
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @with_nonconst_offset_difference
+// CHECK:       amdaie.npu.circular_dma_cpy_nd
+// CHECK-NEXT:  amdaie.npu.circular_dma_cpy_nd
+// CHECK-NEXT:  amdaie.end
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @with_nonconst_offset_difference(%arg0: index, %arg1 : index, %arg3: !amdaie.logicalobjectfifo<memref<bf16>>) {
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg3, %arg3) : (!amdaie.logicalobjectfifo<memref<bf16>>, !amdaie.logicalobjectfifo<memref<bf16>>)
+      amdaie.controlcode {
+        %1 = amdaie.npu.circular_dma_cpy_nd %0([0] [1000] [1], [%arg0, 0, 0] [1, 1, 10] [1, 1, 1])
+        %2 = amdaie.npu.circular_dma_cpy_nd %0([0] [1000] [1], [0, %arg1, 0] [1, 1, 10] [1, 1, 1])
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @with_nonconst_offset_product_difference
+// CHECK:       amdaie.npu.circular_dma_cpy_nd
+// CHECK-NEXT:  amdaie.npu.circular_dma_cpy_nd
+// CHECK-NEXT:  amdaie.end
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @with_nonconst_offset_product_difference(%arg0: index, %arg1 : index, %arg3: !amdaie.logicalobjectfifo<memref<bf16>>) {
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg3, %arg3) : (!amdaie.logicalobjectfifo<memref<bf16>>, !amdaie.logicalobjectfifo<memref<bf16>>)
+      amdaie.controlcode {
+        %1 = amdaie.npu.circular_dma_cpy_nd %0([0] [1000] [1], [0, %arg0, 0] [1, 1, 10] [1, %arg0, 1])
+        %2 = amdaie.npu.circular_dma_cpy_nd %0([0] [1000] [1], [0, %arg1, 0] [1, 1, 10] [1, %arg0, 1])
+        amdaie.end
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
- slight modification to logic used for compositing DMAs, makes use of global offset difference (please see comments in code)
- more aggressive folding of unit dimensions 
- new unit test in combine_strided_ops.mlir shows the case that was being missed in an end-to-end matmul transpose b with the new pipeline pack-peel-4-level-tiling 

