### PR TITLE
Disable failing batch_matmul tests

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -1636,7 +1636,9 @@ class Tests:
             )
 
         # BatchMatmul test(s):
-        for tile_pipeline in ["pack-peel", "pack-peel-4-level-tiling"]:
+        # TODO(jornt): BatchMatmul tests with the pack-peel-4-level-tiling pipeline result in intermittent
+        # numerics issues. Re-enable.
+        for tile_pipeline in ["pack-peel"]:
             for input_type, acc_type in zip(["i32", "bf16"], ["i32", "f32"]):
                 # Batch size = 1:
                 self.register(


### PR DESCRIPTION
The batch_matmul tests with the pack-peel-4-level-tiling pipeline result in intermittent numerics issues, making the CI unstable. I was able to reproduce this offline and will need to investigate this further.