### PR TITLE
[LowerToAIE] fix for `op could not fold repetition counts`

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -219,16 +219,10 @@ class BaseMatmul(BaseTest):
         self.n_kernel_runs = n_kernel_runs
 
         self.tile_pipeline = tile_pipeline
-        if tile_pipeline == "pack-peel":
-            self.labels.append("PackPeel")
-        elif tile_pipeline == "pad-pack":
-            self.labels.append("PadPack")
+        self.labels.append(self.tile_pipeline)
 
         self.lower_to_aie_pipeline = lower_to_aie_pipeline
-        if lower_to_aie_pipeline == "air":
-            self.labels.append("Air")
-        elif lower_to_aie_pipeline == "objectFifo":
-            self.labels.append("ObjectFifo")
+        self.labels.append(self.lower_to_aie_pipeline)
 
         self.use_ukernel = use_ukernel
         if use_ukernel:
@@ -1670,6 +1664,17 @@ class Tests:
         for input_type, acc_type in zip(["i8", "bf16"], ["i32", "f32"]):
             self.register(MatmulTransposeB(32, 32, 32, input_type, acc_type))
             self.register(MatmulTransposeB(128, 256, 128, input_type, acc_type))
+            self.register(
+                MatmulTransposeB(
+                    128,
+                    256,
+                    128,
+                    input_type,
+                    acc_type,
+                    tile_pipeline="pack-peel-4-level-tiling",
+                    name_suffix="4level",
+                )
+            )
             self.register(MatmulTransposeB(1536, 1536, 2048, input_type, acc_type))
 
         # MatmulTransposeA test(s):

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEUtils.cpp
@@ -13,6 +13,13 @@
 
 namespace mlir::iree_compiler::AMDAIE {
 
+std::string getConstantIntValuesString(ArrayRef<OpFoldResult> ofrs) {
+  auto maybeValues = mlir::getConstantIntValues(ofrs);
+  if (maybeValues.has_value())
+    return getArrayString<int64_t>(maybeValues.value());
+  return "[not all constant integers]";
+}
+
 template <typename T>
 std::optional<T> getConfigAttr(IREE::HAL::ExecutableTargetAttr targetAttr,
                                StringRef name) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEUtils.h
@@ -91,6 +91,20 @@ int findLargestFactor(int num, int max, int multiple);
 
 }  // namespace detail
 
+/// Convert an array into a string, for example "[1,2,3]".
+template <typename T>
+std::string getArrayString(ArrayRef<T> vs) {
+  return std::string("[")
+      .append(llvm::join(
+          llvm::map_range(vs, [](T v) { return std::to_string(v); }), ","))
+      .append("]");
+}
+
+/// If all values in `opFoldResults` are constant, return a string
+/// representation of the constant values. Otherwise, return
+/// "[not constant integers]".
+std::string getConstantIntValuesString(ArrayRef<OpFoldResult> opFoldResults);
+
 }  // namespace mlir::iree_compiler::AMDAIE
 
 #endif

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIEUtilsTest.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIEUtilsTest.cpp
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include "iree-amd-aie/Transforms/Utils/AMDAIEUtils.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 
 namespace {
 
@@ -40,6 +41,24 @@ TEST(FindLargestFactorTest, Test0) {
   int firstPrimeAbove1e5 = 10'037;
   EXPECT_EQ(
       detail::findLargestFactor(firstPrimeAbove1e5, firstPrimeAbove1e5 - 1), 1);
+}
+
+TEST(OpFoldResultPrinting, Test0) {
+  mlir::MLIRContext context;
+  llvm::SmallVector<mlir::OpFoldResult> opFoldResults = {};
+  EXPECT_EQ(getConstantIntValuesString(opFoldResults), "[]");
+
+  mlir::OpFoldResult three = getAsIndexOpFoldResult(&context, 3);
+  opFoldResults.push_back(three);
+  EXPECT_EQ(getConstantIntValuesString(opFoldResults), "[3]");
+
+  mlir::OpFoldResult four = getAsIndexOpFoldResult(&context, 4);
+  opFoldResults.push_back(four);
+  EXPECT_EQ(getConstantIntValuesString(opFoldResults), "[3,4]");
+
+  opFoldResults.push_back(mlir::Value{});
+  EXPECT_EQ(getConstantIntValuesString(opFoldResults),
+            "[not all constant integers]");
 }
 
 }  // namespace

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
@@ -1140,10 +1140,12 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // -----
 
 
-// Before this PR: error: unexpected error: 'amdaie.npu.circular_dma_cpy_nd' op could not fold repetition counts
 // This IR is derived from a matmul_transpose_b example
+// Checking that 
+// `error: unexpected error: 'amdaie.npu.circular_dma_cpy_nd' op could not fold repetition counts` 
+// is not observed. 
 
-// CHECK-LABEL: func @repetition_counts_can_fold()
+// CHECK-LABEL: @repetition_counts_can_fold
 
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 #translation = #iree_codegen.translation_info<pipeline = Custom>

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
@@ -1141,9 +1141,9 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 
 
 // This IR is derived from a matmul_transpose_b example
-// Checking that 
-// `error: unexpected error: 'amdaie.npu.circular_dma_cpy_nd' op could not fold repetition counts` 
-// is not observed. 
+// Checking that
+// `error: unexpected error: 'amdaie.npu.circular_dma_cpy_nd' op could not fold repetition counts`
+// is not observed.
 
 // CHECK-LABEL: @repetition_counts_can_fold
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
@@ -1135,3 +1135,55 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     return
   }
 }
+
+
+// -----
+
+
+// Before this PR: error: unexpected error: 'amdaie.npu.circular_dma_cpy_nd' op could not fold repetition counts
+// This IR is derived from a matmul_transpose_b example
+
+// CHECK-LABEL: func @repetition_counts_can_fold()
+
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+#translation = #iree_codegen.translation_info<pipeline = Custom>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @repetition_counts_can_fold() attributes {translation_info = #translation} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c3 = arith.constant 3 : index
+    amdaie.workgroup {
+      %tile_0_3 = amdaie.tile(%c0, %c3)
+      %tile_1_0 = amdaie.tile(%c1, %c0)
+      %tile_1_1 = amdaie.tile(%c1, %c1)
+      %tile_1_3 = amdaie.tile(%c1, %c3)
+      %buffer = amdaie.buffer(%tile_1_1) : memref<512xi8, 1 : i32>
+      %lock = amdaie.lock(%tile_1_1(0), 1)
+      %lock_0 = amdaie.lock(%tile_1_1(1), 0)
+      %0 = amdaie.logicalobjectfifo.from_buffers({%buffer}, {%lock}, {%lock_0}) : memref<512xi8, 1 : i32> -> !amdaie.logicalobjectfifo<memref<512xi8, 1 : i32>>
+      %1 = amdaie.logicalobjectfifo.placeholder{%tile_1_0} : !amdaie.logicalobjectfifo<memref<32x32xi8>>
+      %channel = amdaie.channel(%tile_1_0, 0, port_type = DMA, direction = MM2S)
+      %channel_1 = amdaie.channel(%tile_1_1, 0, port_type = DMA, direction = S2MM)
+      %2 = amdaie.flow({%channel} -> {%channel_1}) {is_packet_flow = false}
+      %3 = amdaie.connection(%0 {%channel_1}, %1 {%channel}, flow = %2) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<512xi8, 1 : i32>>, !amdaie.logicalobjectfifo<memref<32x32xi8>>)
+      %buffer_2 = amdaie.buffer(%tile_1_3) : memref<512xi8, 2 : i32>
+      %lock_3 = amdaie.lock(%tile_1_3(2), 1)
+      %lock_4 = amdaie.lock(%tile_1_3(3), 0)
+      %buffer_5 = amdaie.buffer(%tile_0_3) : memref<512xi8, 2 : i32>
+      %lock_6 = amdaie.lock(%tile_0_3(2), 1)
+      %lock_7 = amdaie.lock(%tile_0_3(3), 0)
+      %4 = amdaie.logicalobjectfifo.from_buffers({%buffer_5, %buffer_2}, {%lock_6, %lock_3}, {%lock_7, %lock_4}) : memref<512xi8, 2 : i32>, memref<512xi8, 2 : i32> -> !amdaie.logicalobjectfifo<memref<512xi8, 2 : i32>>
+      %channel_8 = amdaie.channel(%tile_1_1, 1, port_type = DMA, direction = MM2S)
+      %channel_9 = amdaie.channel(%tile_0_3, 1, port_type = DMA, direction = S2MM)
+      %channel_10 = amdaie.channel(%tile_1_3, 1, port_type = DMA, direction = S2MM)
+      %5 = amdaie.flow({%channel_8} -> {%channel_9, %channel_10}) {is_packet_flow = false}
+      %6 = amdaie.connection(%4 {%channel_9, %channel_10}, %0 {%channel_8}, flow = %5) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<512xi8, 2 : i32>>, !amdaie.logicalobjectfifo<memref<512xi8, 1 : i32>>)
+      amdaie.controlcode {
+        %7 = amdaie.npu.circular_dma_cpy_nd %3([0] [512] [1], [] [] [])
+        %8 = amdaie.npu.circular_dma_cpy_nd %6([0, 0, 0, 0] [2, 16, 4, 8] [0, 8, 128, 1], [0, 0] [2, 512] [0, 1])
+        amdaie.end
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
This is a fix for the compilation error
```
<unknown>:0: error: 'amdaie.npu.circular_dma_cpy_nd' op could not fold repetition counts
```

that is observed some transposed matmuls with the new pack-peel pipeline. What was happening was that the `lower-to-aie` pass is assumed a stride-0 leading dimension was always or never present, but that wasn't the case 