### PR TITLE
[LinalgFunctionOutlining] Add none, all and balanced outlining strategies

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -800,7 +800,9 @@ class MatmulTruncf(BaseMatmul):
         """
         Currently without function outlining, we run out of program memory.
         """
-        self.add_aie_compilation_flags(["--iree-amdaie-enable-function-outlining"])
+        self.add_aie_compilation_flags(
+            ["--iree-amdaie-enable-function-outlining=balanced"]
+        )
         aie_vs_baseline(
             config=config,
             aie_compilation_flags=self.aie_compilation_flags,
@@ -1822,7 +1824,7 @@ class Tests:
                 "K": 4096,
                 "use_ukernel": False,
                 "peano_opt_level": 2,
-                "outline": False,
+                "outline": "none",
                 "transpose_a": False,
                 "transpose_b": False,
                 "tile_pipeline": "pack-peel",
@@ -1833,7 +1835,7 @@ class Tests:
                 "K": 4096,
                 "use_ukernel": False,
                 "peano_opt_level": 2,
-                "outline": True,
+                "outline": "balanced",
                 "transpose_a": False,
                 "transpose_b": False,
                 "tile_pipeline": "pack-peel",
@@ -1844,7 +1846,7 @@ class Tests:
                 "K": 4096,
                 "use_ukernel": False,
                 "peano_opt_level": 3,
-                "outline": False,
+                "outline": "none",
                 "transpose_a": False,
                 "transpose_b": False,
                 "tile_pipeline": "pack-peel",
@@ -1855,7 +1857,7 @@ class Tests:
                 "K": 4096,
                 "use_ukernel": False,
                 "peano_opt_level": 3,
-                "outline": True,
+                "outline": "balanced",
                 "transpose_a": False,
                 "transpose_b": False,
                 "tile_pipeline": "pack-peel",
@@ -1866,7 +1868,7 @@ class Tests:
                 "K": 4096,
                 "use_ukernel": True,
                 "peano_opt_level": 3,
-                "outline": True,
+                "outline": "balanced",
                 "transpose_a": False,
                 "transpose_b": False,
                 "tile_pipeline": "pack-peel",
@@ -1877,7 +1879,7 @@ class Tests:
                 "K": 512,
                 "use_ukernel": False,
                 "peano_opt_level": 3,
-                "outline": True,
+                "outline": "balanced",
                 "transpose_a": False,
                 "transpose_b": False,
                 "tile_pipeline": "pack-peel",
@@ -1888,7 +1890,7 @@ class Tests:
                 "K": 512,
                 "use_ukernel": True,
                 "peano_opt_level": 3,
-                "outline": True,
+                "outline": "balanced",
                 "transpose_a": False,
                 "transpose_b": False,
                 "tile_pipeline": "pack-peel",
@@ -1899,7 +1901,7 @@ class Tests:
                 "K": 512,
                 "use_ukernel": False,
                 "peano_opt_level": 3,
-                "outline": True,
+                "outline": "balanced",
                 "transpose_a": False,
                 "transpose_b": True,
                 "tile_pipeline": "pack-peel",
@@ -1910,7 +1912,7 @@ class Tests:
                 "K": 512,
                 "use_ukernel": False,
                 "peano_opt_level": 3,
-                "outline": True,
+                "outline": "balanced",
                 "transpose_a": False,
                 "transpose_b": False,
                 "tile_pipeline": "pack-peel",
@@ -1921,7 +1923,7 @@ class Tests:
                 "K": 512,
                 "use_ukernel": True,
                 "peano_opt_level": 3,
-                "outline": True,
+                "outline": "balanced",
                 "transpose_a": False,
                 "transpose_b": False,
                 "tile_pipeline": "pack-peel",
@@ -1932,7 +1934,7 @@ class Tests:
                 "K": 512,
                 "use_ukernel": False,
                 "peano_opt_level": 3,
-                "outline": True,
+                "outline": "balanced",
                 "transpose_a": True,
                 "transpose_b": False,
                 "tile_pipeline": "pack-peel",
@@ -1946,7 +1948,7 @@ class Tests:
                 "K": 512,
                 "use_ukernel": False,
                 "peano_opt_level": 3,
-                "outline": True,
+                "outline": "balanced",
                 "outline_to_empty_function": True,
                 "transpose_a": False,
                 "transpose_b": False,
@@ -1959,7 +1961,7 @@ class Tests:
                 "K": 512,
                 "use_ukernel": False,
                 "peano_opt_level": 3,
-                "outline": True,
+                "outline": "balanced",
                 "transpose_a": False,
                 "transpose_b": False,
                 "tile_pipeline": "pack-peel-4-level-tiling",
@@ -1970,7 +1972,7 @@ class Tests:
                 "K": 512,
                 "use_ukernel": True,
                 "peano_opt_level": 3,
-                "outline": True,
+                "outline": "balanced",
                 "transpose_a": False,
                 "transpose_b": False,
                 "tile_pipeline": "pack-peel-4-level-tiling",
@@ -1984,7 +1986,7 @@ class Tests:
                 "K": 512,
                 "use_ukernel": False,
                 "peano_opt_level": 3,
-                "outline": True,
+                "outline": "balanced",
                 "outline_to_empty_function": True,
                 "transpose_a": False,
                 "transpose_b": False,
@@ -2005,9 +2007,7 @@ class Tests:
             transpose_b = test["transpose_b"]
             tile_pipeline = test["tile_pipeline"]
 
-            outlining_string = "--iree-amdaie-enable-function-outlining=" + str(
-                int(outline)
-            )
+            outlining_string = "--iree-amdaie-enable-function-outlining=" + outline
 
             peano_opt_level_string = f'"-O{peano_opt_level}"'
             aie_compilation_flags = [
@@ -2026,7 +2026,7 @@ class Tests:
                 )
 
             name_suffix = "O" + str(peano_opt_level)
-            if outline:
+            if outline != "none":
                 if outline_to_empty_function:
                     name_suffix += "_outline_empty"
                 else:

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
@@ -56,7 +56,7 @@ struct AMDAIEOptions {
   bool enableVectorizationPasses{true};
   bool enableCoalescingLoops{false};
   bool enableCollapsingUnitDims{false};
-  bool enableFunctionOutlining{true};
+  OutliningStrategy enableFunctionOutlining{OutliningStrategy::Balanced};
   bool replaceOutlinedFunctionsWithEmpty{false};
   bool insertLoopAroundCoreBlock{false};
   bool matmulElementwiseFusion{false};
@@ -197,11 +197,19 @@ struct AMDAIEOptions {
             "unit dims of a tensor/memref depending on this pass flag. It is "
             "intended for development purposes only."));
 
-    binder.opt<bool>(
+    binder.opt<OutliningStrategy>(
         "iree-amdaie-enable-function-outlining", enableFunctionOutlining,
         llvm::cl::cat(category),
         llvm::cl::desc("Flag to enable/disable linalg-function-outlining pass."
-                       "It is intended for development purposes only."));
+                       "It is intended for development purposes only."),
+        llvm::cl::values(clEnumValN(OutliningStrategy::None, "none",
+                                    "No linalg ops will be outlined."),
+                         clEnumValN(OutliningStrategy::All, "all",
+                                    "All linalg ops will be outlined."),
+                         clEnumValN(OutliningStrategy::Balanced, "balanced",
+                                    "Will outline some ops, to try to achieve "
+                                    "a good balance between "
+                                    "performance and program size.")));
 
     binder.opt<bool>(
         "iree-amdaie-replace-outlined-functions-with-empty",

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
@@ -41,6 +41,16 @@ enum class BufferizeOperand {
 /// Enum for hardware mapping attributes.
 enum class HardwareMapping { Core, Block, None };
 
+enum class OutliningStrategy {
+  // No outlining.
+  None,
+  // Try outlining all ops.
+  All,
+  // A balanced strategy trying to achieve good performance and low program
+  // memory size.
+  Balanced,
+};
+
 LogicalResult initAIELaunchConfig(FunctionOpInterface funcOp,
                                   TilePassPipeline useTilePipeline,
                                   LowerToAIEPassPipeline useLowerToAIEPipeline,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -19,8 +19,9 @@ void addAMDAIEObjectFifoLoweringPasses(
     OpPassManager &passManager, bool enablePacketFlow,
     TilePassPipeline useTilePipeline, bool enableVectorizationPasses,
     bool enableCoalescingLoops, bool enableCollapsingUnitDims,
-    bool enableFunctionOutlining, bool replaceOutlinedFunctionsWithEmpty,
-    bool insertLoopAroundCoreBlock, uint32_t numCols);
+    OutliningStrategy enableFunctionOutlining,
+    bool replaceOutlinedFunctionsWithEmpty, bool insertLoopAroundCoreBlock,
+    uint32_t numCols);
 
 /// Add passes to lower from MLIR-AIR through AIE. This is
 /// currently the default passes used for lowering after IREEs tiling.
@@ -42,7 +43,7 @@ void buildAMDAIETransformPassPipeline(
     LowerToAIEPassPipeline useLowerToAIEPipeline, bool matmulElementwiseFusion,
     bool enableVectorizationPasses, const std::string &pathToUkernels,
     bool enablePacketFlow, bool enableCoalescingLoops,
-    bool enableCollapsingUnitDims, bool enableFunctionOutlining,
+    bool enableCollapsingUnitDims, OutliningStrategy enableFunctionOutlining,
     bool replaceOutlinedFunctionsWithEmpty, bool insertLoopAroundCoreBlock);
 
 /// Populates passes needed to lower the IR via a Pack-Peel based approach.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -308,8 +308,21 @@ def AMDAIELinalgFunctionOutlining :
       "Replace all outlined functions with a function that does nothing, "
       "i.e. it just returns. Useful for measuring the performance of data "
       "movement to/from the device -- by doing zero compute, all time is spent "
-      "moving data to/from the AIE cores.">
-    ];
+      "moving data to/from the AIE cores.">,
+    Option<"outliningStrategy", "outlining-strategy",
+      "mlir::iree_compiler::AMDAIE::OutliningStrategy",
+      /*default=*/"mlir::iree_compiler::AMDAIE::OutliningStrategy::Balanced",
+      "The strategy to be used for outlining. The default is balanced to "
+      "achieve a good tradeoff in performance and program size.",
+      [{::llvm::cl::values(
+        clEnumValN(mlir::iree_compiler::AMDAIE::OutliningStrategy::None, "none",
+                   "No ops are outlined."),
+        clEnumValN(mlir::iree_compiler::AMDAIE::OutliningStrategy::All, "all",
+                   "All ops are outlined."),
+        clEnumValN(mlir::iree_compiler::AMDAIE::OutliningStrategy::Balanced, "balanced",
+                   "A strategy that tries to achieve a balanced tradeoff between performance and program size.")
+      )}]>,
+  ];
 }
 
 def AMDAIEFoldDmaWaits :

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/disable_linalg_function_outlining.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/disable_linalg_function_outlining.mlir
@@ -2,23 +2,23 @@
 // pipeline. We check 3 paths:
 //
 // 1) Explicitly disabling linalg function outlining with
-//              --iree-amdaie-enable-function-outlining=0
+//              --iree-amdaie-enable-function-outlining=none
 //
-// 2) Explicitly enabling linalg function outlining with
-//              --iree-amdaie-enable-function-outlining=1
+// 2) Explicitly enabling linalg function outlining for all linalg ops with
+//              --iree-amdaie-enable-function-outlining=all
 //
-// 3) Not specifying the flag at all, which should use the default value (1).
+// 3) Not specifying the flag at all, which should use the default value (balanced).
 
 
 // 1) Explicitly disabled:
 // RUN: iree-compile --iree-hal-target-backends=amd-aie \
-// RUN:   --compile-to=executable-targets --iree-amdaie-enable-function-outlining=0 %s | FileCheck %s -check-prefix=CHECK-DISABLED
+// RUN:   --compile-to=executable-targets --iree-amdaie-enable-function-outlining=none %s | FileCheck %s -check-prefix=CHECK-DISABLED
 
 // 2) Explicitly enabled:
 // RUN: iree-compile --iree-hal-target-backends=amd-aie \
-// RUN:   --compile-to=executable-targets --iree-amdaie-enable-function-outlining=1 %s | FileCheck %s -check-prefix=CHECK-ENABLED
+// RUN:   --compile-to=executable-targets --iree-amdaie-enable-function-outlining=all %s | FileCheck %s -check-prefix=CHECK-ENABLED
 
-// 3) Default value:
+// 3) Default value (balanced):
 // RUN: iree-compile --iree-hal-target-backends=amd-aie \
 // RUN:   --compile-to=executable-targets %s | FileCheck %s -check-prefix=CHECK-DEFAULT
 
@@ -33,6 +33,6 @@ func.func @matmul(%lhs: tensor<64x64xbf16>,
   return %res : tensor<64x64xf32>
 }
 
-// CHECK-DISABLED-NOT: func.call
-// CHECK-ENABLED:      func.call
-// CHECK-DEFAULT:      func.call
+// CHECK-DISABLED-NOT:    func.call
+// CHECK-ENABLED-COUNT-2: func.call
+// CHECK-DEFAULT-COUNT-1: func.call


### PR DESCRIPTION
To avoid overheads of non-outlined ops when using `outlining=true` with `--iree-amdaie-replace-outlined-functions-with-empty`, I think there should be an option to outline all ops if needed, so I created three outlining strategies:
- None: no outlining.
- All: outline all ops.
- Balanced (default): this is the same as what happens in main currently, outlining some ops and not others for a tradeoff in performance and program size.