### PR TITLE
[CI] Add larger shape e2e bfp16 Ukernel test

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -1751,7 +1751,6 @@ class Tests:
                 )
             )
 
-        # TODO: Failure is expected for the 128x128 case we don't yet understand why.
         self.register(
             Matmul(
                 64,
@@ -1808,6 +1807,42 @@ class Tests:
                 name_suffix="4rows_8cols_npu4_pack_peel_4_level_tiling_ukernel",
                 use_ukernel=True,
                 tile_pipeline="pack-peel-4-level-tiling",
+                run_on_target=["npu4"],
+                aie_compilation_flags=[
+                    "--iree-amdaie-num-rows=4",
+                    "--iree-amdaie-num-cols=8",
+                ],
+                use_chess=True,
+            )
+        )
+        self.register(
+            Matmul(
+                512,
+                512,
+                512,
+                "bf16",
+                "f32",
+                name_suffix="4rows_8cols_npu4_pack_peel_4_level_tiling_ukernel",
+                use_ukernel=True,
+                tile_pipeline="pack-peel-4-level-tiling",
+                run_on_target=["npu4"],
+                aie_compilation_flags=[
+                    "--iree-amdaie-num-rows=4",
+                    "--iree-amdaie-num-cols=8",
+                ],
+                use_chess=True,
+            )
+        )
+        self.register(
+            Matmul(
+                512,
+                512,
+                512,
+                "bf16",
+                "f32",
+                name_suffix="4rows_8cols_npu4_pack_peel",
+                use_ukernel=True,
+                tile_pipeline="pack-peel",
                 run_on_target=["npu4"],
                 aie_compilation_flags=[
                     "--iree-amdaie-num-rows=4",

--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -1833,24 +1833,6 @@ class Tests:
                 use_chess=True,
             )
         )
-        self.register(
-            Matmul(
-                512,
-                512,
-                512,
-                "bf16",
-                "f32",
-                name_suffix="4rows_8cols_npu4_pack_peel",
-                use_ukernel=True,
-                tile_pipeline="pack-peel",
-                run_on_target=["npu4"],
-                aie_compilation_flags=[
-                    "--iree-amdaie-num-rows=4",
-                    "--iree-amdaie-num-cols=8",
-                ],
-                use_chess=True,
-            )
-        )
 
         # Matmul test on 2(rows)x2(cols) cores
         self.register(


### PR DESCRIPTION
-- This commit adds larger shape e2e bfp16 Ukernel test to CI for
   both `pack-peel` as well as `pack-peel-4-level-tiling` targeting
   4x8 array on Strix.
-- It wasn't working earlier (3 months ago) but now it does - hence
    enabling.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>