### PR TITLE
[CI] Disable reset_npu in phoenix e2e test

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -206,10 +206,10 @@ jobs:
             --peano_dir=$PWD/llvm-aie \
             --vitis_dir=/opt/Xilinx/Vitis/2024.2 \
             --target_device="npu1_4col" \
-            --reset_npu_between_runs -v \
             --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS \
             --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS \
-            --skip_tests=Performance
+            --skip_tests=Performance \
+            -v
 
       # Run the 'Performance' tests. These do not check numerical correctness,
       # just measure the time to run some workloads.


### PR DESCRIPTION
Disable reset_npu in `E2E comparison of AIE to llvm-cpu` on Phoenix runner, but still keep it in the `Performance` session. We'll see if it solves the crash issue.