### PR TITLE
[AssignPacketIds] Prioritize ID assignment for control packets 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -126,6 +126,12 @@ def AMDAIE_FlowOp: AMDAIE_Op<"flow", [AttrSizedOperandSegments]>,
 
   let assemblyFormat = [{ `(` `{` $sources `}` `->` `{` $targets `}` `)` attr-dict }];
   let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    FailureOr<AMDAIE::ChannelOp> getSourceChannelOp();
+    FailureOr<SmallVector<AMDAIE::ChannelOp>> getTargetChannelOps();
+    FailureOr<bool> isControlFlow();
+  }];
 }
 
 def AMDAIE_TileOp: AMDAIE_Op<"tile", [

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_packet_ids.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_packet_ids.mlir
@@ -212,3 +212,55 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     return
   }
 }
+
+
+// -----
+
+// Test that control packets should take priority in the ID assignment.
+// CHECK-LABEL: @assign_ctrl_packet_ids_in_priority
+// CHECK:       %[[C0:.*]] = arith.constant 0 : index
+// CHECK:       %[[C1:.*]] = arith.constant 1 : index
+// CHECK:       %[[C2:.*]] = arith.constant 2 : index
+// CHECK:       amdaie.workgroup
+// CHECK:         %[[TILE_0_0:.*]] = amdaie.tile(%[[C0]], %[[C0]])
+// CHECK:         %[[TILE_0_1:.*]] = amdaie.tile(%[[C0]], %[[C1]])
+// CHECK:         %[[TILE_1_0:.*]] = amdaie.tile(%[[C1]], %[[C0]])
+// CHECK:         %[[TILE_1_2:.*]] = amdaie.tile(%[[C1]], %[[C2]])
+// CHECK:         %[[CHANNEL:.*]] = amdaie.channel(%[[TILE_0_0]], 0, port_type = DMA, direction = MM2S)
+// CHECK:         %[[CHANNEL_1:.*]] = amdaie.channel(%[[TILE_0_1]], 0, port_type = DMA, direction = S2MM)
+// CHECK:         %[[CHANNEL_2:.*]] = amdaie.channel(%[[TILE_0_1]], 0, port_type = CTRL, direction = S2MM)
+// CHECK:         %[[CHANNEL_3:.*]] = amdaie.channel(%[[TILE_1_0]], 1, port_type = DMA, direction = MM2S)
+// CHECK:         %[[CHANNEL_4:.*]] = amdaie.channel(%[[TILE_1_2]], 1, port_type = DMA, direction = S2MM)
+// CHECK:         %[[CHANNEL_5:.*]] = amdaie.channel(%[[TILE_1_2]], 0, port_type = CTRL, direction = S2MM)
+// CHECK:         amdaie.flow({%[[CHANNEL]]} -> {%[[CHANNEL_1]]}) {is_packet_flow = true, packet_id = 1 : ui8}
+// CHECK:         amdaie.flow({%[[CHANNEL]]} -> {%[[CHANNEL_2]]}) {is_packet_flow = true, packet_id = 0 : ui8}
+// CHECK:         amdaie.flow({%[[CHANNEL_3]]} -> {%[[CHANNEL_4]]}) {is_packet_flow = true, packet_id = 1 : ui8}
+// CHECK:         amdaie.flow({%[[CHANNEL_3]]} -> {%[[CHANNEL_5]]}) {is_packet_flow = true, packet_id = 0 : ui8}
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @assign_ctrl_packet_ids_in_priority() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    amdaie.workgroup {
+      %tile_0_0 = amdaie.tile(%c0, %c0)
+      %tile_0_1 = amdaie.tile(%c0, %c1)
+      %tile_1_0 = amdaie.tile(%c1, %c0)
+      %tile_1_2 = amdaie.tile(%c1, %c2)
+      %channel = amdaie.channel(%tile_0_0, 0, port_type = DMA, direction = MM2S)
+      %channel_1 = amdaie.channel(%tile_0_1, 0, port_type = DMA, direction = S2MM)
+      %channel_2 = amdaie.channel(%tile_0_1, 0, port_type = CTRL, direction = S2MM)
+      %channel_3 = amdaie.channel(%tile_1_0, 1, port_type = DMA, direction = MM2S)
+      %channel_4 = amdaie.channel(%tile_1_2, 1, port_type = DMA, direction = S2MM)
+      %channel_5 = amdaie.channel(%tile_1_2, 0, port_type = CTRL, direction = S2MM)
+      %0 = amdaie.flow({%channel} -> {%channel_1}) {is_packet_flow = true}
+      %1 = amdaie.flow({%channel} -> {%channel_2}) {is_packet_flow = true}
+      %2 = amdaie.flow({%channel_3} -> {%channel_4}) {is_packet_flow = true}
+      %3 = amdaie.flow({%channel_3} -> {%channel_5}) {is_packet_flow = true}
+      amdaie.controlcode {
+        amdaie.end
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
This change is part of the effort to make control packet routing static.