### PR TITLE
[e2e CI] Add Strix Batchmatmul - pack-peel-4-level-tiling - i32->i32 - 4x8

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -579,7 +579,6 @@ class BatchMatmul(BaseMatmul):
             K=K,
             input_type=input_type,
             acc_type=acc_type,
-            n_repeats=1,
         )
         self.labels.append("BatchMatmul")
         self.B = B

--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -1496,10 +1496,7 @@ class Tests:
                         256,
                         input_type,
                         acc_type,
-                        test_params=TestParams(
-                            tile_pipeline=tile_pipeline,
-                            run_on_target=run_on_target,
-                        ),
+                        test_params=TestParams(tile_pipeline=tile_pipeline),
                     )
                 )
                 # Batch size = 2:
@@ -1511,10 +1508,7 @@ class Tests:
                         64,
                         input_type,
                         acc_type,
-                        test_params=TestParams(
-                            tile_pipeline=tile_pipeline,
-                            run_on_target=run_on_target,
-                        ),
+                        test_params=TestParams(tile_pipeline=tile_pipeline),
                     )
                 )
         # Strix + pack-peel-4-level-tiling + 4x8 + i32->i32.


### PR DESCRIPTION
-- This commit adds e2e Batchmatmul CI test for Strix targeting 4x8
   array and pack-peel-4-level-tiling. Since the numerical inconsistency
   has been known to be on Phoenix, it adds `n_repeats=10` for each of
   the new tests added.
-- Currently only for i32->i32 the tests are added as the vectorization
    support for bf16->f32 is not enabled for Strix.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>