### PR TITLE
Vectorization of linalg.fill 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
+++ b/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
@@ -493,7 +493,7 @@ struct SerializeSplatTransferReadWithTargetLoadSize
                                          "source is smaller than write size");
     }
 
-    // Mae a transfer_write that writes to the original memref destination,
+    // Create a transfer_write that writes to the original memref destination,
     // but with an adjusted number of elements and an adjusted offset index.
     auto createTransferWrite = [&](uint32_t n, Value offset) {
       VectorType type = VectorType::get({n}, elementType);

--- a/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
+++ b/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
@@ -17,6 +17,7 @@
 #include "Passes.h"
 #include "aievec/AIEVecOps.h"
 #include "iree-amd-aie/Transforms/Utils/AMDAIEUtils.h"
+#include "iree-amd-aie/aie_runtime/AMDAIEEnums.h"
 #include "iree-amd-aie/aie_runtime/iree_aie_runtime.h"
 #include "llvm/ADT/STLExtras.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
@@ -24,7 +25,11 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
@@ -104,7 +109,7 @@ static SmallVector<Value> getCollapsedIndices(RewriterBase &rewriter,
   OpFoldResult collapsedOffset =
       rewriter.create<arith::ConstantIndexOp>(loc, 0).getResult();
 
-  auto collapsedStrides = computeSuffixProduct(
+  SmallVector<int64_t> collapsedStrides = computeSuffixProduct(
       ArrayRef<int64_t>(shape.begin() + firstDimToCollapse, shape.end()));
 
   // Compute the collapsed offset.
@@ -142,7 +147,7 @@ class FlattenContiguousRowMajorTransferReadPattern
 
   LogicalResult matchAndRewrite(vector::TransferReadOp transferReadOp,
                                 PatternRewriter &rewriter) const override {
-    auto loc = transferReadOp.getLoc();
+    Location loc = transferReadOp.getLoc();
     Value vector = transferReadOp.getVector();
     VectorType vectorType = cast<VectorType>(vector.getType());
     auto source = transferReadOp.getSource();
@@ -182,7 +187,7 @@ class FlattenContiguousRowMajorTransferReadPattern
     // 2.1. New dim exprs + affine map
     SmallVector<AffineExpr, 1> dimExprs{
         getAffineDimExpr(firstDimToCollapse, rewriter.getContext())};
-    auto collapsedMap =
+    AffineMap collapsedMap =
         AffineMap::get(collapsedRank, 0, dimExprs, rewriter.getContext());
 
     // 2.2 New indices
@@ -229,7 +234,7 @@ class FlattenContiguousRowMajorTransferWritePattern
 
   LogicalResult matchAndRewrite(vector::TransferWriteOp transferWriteOp,
                                 PatternRewriter &rewriter) const override {
-    auto loc = transferWriteOp.getLoc();
+    Location loc = transferWriteOp.getLoc();
     Value vector = transferWriteOp.getVector();
     VectorType vectorType = cast<VectorType>(vector.getType());
     Value source = transferWriteOp.getSource();
@@ -272,7 +277,7 @@ class FlattenContiguousRowMajorTransferWritePattern
     // 2.1. New dim exprs + affine map
     SmallVector<AffineExpr, 1> dimExprs{
         getAffineDimExpr(firstDimToCollapse, rewriter.getContext())};
-    auto collapsedMap =
+    AffineMap collapsedMap =
         AffineMap::get(collapsedRank, 0, dimExprs, rewriter.getContext());
 
     // 2.2 New indices
@@ -360,6 +365,221 @@ struct CanonicalizeTrivialReadAccessSubviewOpPattern
     rewriter.replaceOpWithNewOp<vector::TransferReadOp>(
         readOp, readOp.getType(), subViewOp.getSource(), newIndices,
         readOp.getPadding(), readOp.getInBoundsValues());
+    return success();
+  }
+};
+
+/// `vector.transfer_write` gets converted to `llvm.store` in the pass
+/// --convert-vector-to-llvm. The `llvm.store` persists through the
+/// translation to LLVMIR, and then through peano's `opt`. Then in peano's
+/// `llc` (VLIW code generation), what the `llvm.store` gets converted to
+/// depends on the size of the store. This pattern splits a transfer_read
+/// into smaller transfer_reads based on the best size for hitting vector
+/// assembly loads after `llc`. For example, assuming 128 bytes is the
+/// best store size for vectorization.
+///
+/// INPUT:
+///  %c0 = arith.constant 0 : index
+///  %cst = arith.constant dense<0> : vector<256xi32>
+///  %a = memref.alloc() : memref<256xi32>
+///  vector.transfer_write %cst, %a[%c0] {..} vector<256xi32>, memref<256xi32>
+///
+/// OUTPUT:
+///  %c0 = arith.constant 0 : index
+///  %c32 = arith.constant 32 : index
+///  %c256 = arith.constant 256 : index
+///  %cst = arith.constant dense<0> : vector<32xi32>
+///  %a = memref.alloc() : memref<256xi32>
+///  scf.for %arg0 = %c0 to %c256 step %c32 {
+///    vector.transfer_write %cst, %a[%arg0] {..} : vector<32xi32>,
+///                                                 memref<256xi32>
+///  }
+///
+/// Note: the closest thing to this that I can find upstream is
+/// `populateVectorUnrollPatterns` but that isn't quite what we want.
+/// Itunrolls the loop (this pass doesn't) and creates ops to extract
+/// and insert strided slices that are not needed when the vector is a splat
+/// value.
+
+struct SerializeSplatTransferReadWithTargetLoadSize
+    : public OpRewritePattern<vector::TransferWriteOp> {
+  using OpRewritePattern<vector::TransferWriteOp>::OpRewritePattern;
+  SerializeSplatTransferReadWithTargetLoadSize(MLIRContext *context,
+                                               AMDAIE::AMDAIEDevice d)
+      : OpRewritePattern<vector::TransferWriteOp>(context),
+        deviceModel(AMDAIE::getDeviceModel(d)) {}
+
+ private:
+  AMDAIE::AMDAIEDeviceModel deviceModel;
+  LogicalResult matchAndRewrite(vector::TransferWriteOp writeOp,
+                                PatternRewriter &rewriter) const override {
+    Value writeDestination = writeOp.getSource();
+    MemRefType writeDestinationType =
+        dyn_cast<MemRefType>(writeDestination.getType());
+    {
+      assert(writeDestinationType && "transfer_write must write to memref");
+      if (!writeDestinationType.hasStaticShape()) {
+        return rewriter.notifyMatchFailure(writeOp, "source has dynamic shape");
+      }
+      MemRefLayoutAttrInterface layout = writeDestinationType.getLayout();
+      if (layout && !layout.isIdentity()) {
+        return rewriter.notifyMatchFailure(writeOp,
+                                           "source has non-identity layout");
+      }
+    }
+    // This pass only succeeds when the memref that is written to a rank-1.
+    // There is already a pattern for flattening memrefs that should
+    // be included with this pattern in a pattern set.
+    if (writeDestinationType.getRank() != 1) {
+      return rewriter.notifyMatchFailure(writeOp, "memref isn't rank-1");
+    }
+
+    Operation::operand_range initialWriteIndices = writeOp.getIndices();
+    assert(initialWriteIndices.size() == 1 && "write destination is rank-1");
+    Attribute initialIndexAttr;
+    matchPattern(initialWriteIndices[0], m_Constant(&initialIndexAttr));
+    if (!initialIndexAttr) {
+      return rewriter.notifyMatchFailure(writeOp, "index isn't constant");
+    }
+    int64_t initialIndex = cast<IntegerAttr>(initialIndexAttr).getInt();
+
+    VectorType initialVectorType =
+        dyn_cast<VectorType>(writeOp.getVector().getType());
+    // Sanity checks on the vector operand:
+    assert(initialVectorType && "vector must be of vector type");
+    assert(writeDestinationType.getElementType() ==
+               initialVectorType.getElementType() &&
+           "element types must match");
+
+    // Find the arith.constant that the vector operand is a view of, if it is
+    // one.
+    arith::ConstantOp constantVectorSource = [&writeOp]() -> arith::ConstantOp {
+      Value current = writeOp.getVector();
+      while (Operation *op = current.getDefiningOp()) {
+        if (auto cOp = dyn_cast<arith::ConstantOp>(op)) return cOp;
+        if (op->getNumOperands() != 1) return {};
+        current = op->getOperand(0);
+      }
+      return {};
+    }();
+    if (!constantVectorSource) {
+      return rewriter.notifyMatchFailure(
+          writeOp, "vector isn't derived from arith.constant");
+    }
+
+    // Get the splat value of the constant vector.
+    auto maybeSplat = [&]() -> FailureOr<Attribute> {
+      TypedAttr constantValue = constantVectorSource.getValue();
+      auto splatAttr = dyn_cast<SplatElementsAttr>(constantValue);
+      if (!splatAttr || !splatAttr.isSplat()) {
+        return rewriter.notifyMatchFailure(writeOp, "constant isn't a splat");
+      }
+      return splatAttr.getSplatValue<Attribute>();
+    }();
+    if (failed(maybeSplat)) return failure();
+    Attribute splat = maybeSplat.value();
+
+    int64_t bytesPerWrite = deviceModel.getPreferredLoadBytes();
+
+    Type elementType = writeDestinationType.getElementType();
+
+    int64_t nbWriteElements = initialVectorType.getNumElements();
+    int64_t bitsPerElement = elementType.getIntOrFloatBitWidth();
+    int64_t bytesPerElement = bitsPerElement / 8;
+    int64_t totalBytes = nbWriteElements * bytesPerElement;
+    int64_t elementsPerWrite = bytesPerWrite / bytesPerElement;
+    int64_t nbLoopWrites = nbWriteElements / elementsPerWrite;
+    int64_t nbTailBytes = totalBytes % bytesPerWrite;
+    int64_t nbTailElements = nbTailBytes / bytesPerElement;
+    int64_t tailStart = initialIndex + nbLoopWrites * elementsPerWrite;
+
+    if (totalBytes <= bytesPerWrite) {
+      return rewriter.notifyMatchFailure(writeOp,
+                                         "source is smaller than write size");
+    }
+
+    // Mae a transfer_write that writes to the original memref destination,
+    // but with an adjusted number of elements and an adjusted offset index.
+    auto makeTransferWrite = [&](uint32_t n, Value offset) {
+      VectorType type = VectorType::get({n}, elementType);
+      DenseElementsAttr attr = DenseElementsAttr::get(type, splat);
+      auto newConstantOp = rewriter.create<arith::ConstantOp>(
+          constantVectorSource.getLoc(), type, attr);
+      rewriter.create<vector::TransferWriteOp>(
+          writeOp.getLoc(), newConstantOp.getResult(), writeDestination, offset,
+          writeOp.getPermutationMapAttr(), writeOp.getInBoundsAttr());
+    };
+
+    auto getConstant = [&](int64_t v) {
+      return rewriter.create<arith::ConstantIndexOp>(writeOp.getLoc(), v);
+    };
+    // Construct the loop body.
+    rewriter.setInsertionPointAfter(writeOp);
+    Value cStart = getConstant(initialIndex);
+    Value cEnd = getConstant(tailStart);
+    Value cStep = getConstant(elementsPerWrite);
+    scf::ForOp loopOp =
+        rewriter.create<scf::ForOp>(writeOp.getLoc(), cStart, cEnd, cStep);
+
+    // TODO(newling) consider partial unrolling if beneficial, or some smarter
+    // way of deciding whether to attach no unrolling. Perhaps this should even
+    // be a separate pass. Preventing this from unrolling here for now, as I see
+    // it saves 1K PM bytes for a linalg.fill for a matmul.
+    mlir::LLVM::LoopUnrollAttr unrollAttr;
+    mlir::LLVM::LoopAnnotationAttr loopAnnotationAttr;
+    BoolAttr disableAttr = rewriter.getBoolAttr(true);
+    unrollAttr = mlir::LLVM::LoopUnrollAttr::get(
+        rewriter.getContext(), /*disable=*/disableAttr, /*count=*/{},
+        /*runtimeDisable=*/{}, /*full=*/{}, /*followupUnrolled=*/{},
+        /*followupRemainder=*/{}, /*followupAll=*/{});
+
+    loopAnnotationAttr = mlir::LLVM::LoopAnnotationAttr::get(
+        rewriter.getContext(), /*disableNonforced=*/{},
+        /*vectorize=*/{}, /*interleave=*/{}, /*unroll=*/unrollAttr,
+        /*unrollAndJam=*/{}, /*licm=*/{}, /*distribute=*/{},
+        /*pipeline=*/{},
+        /*peeled=*/{}, /*unswitch=*/{}, /*mustProgress=*/{},
+        /*isVectorized=*/{}, /*startLoc=*/{}, /*endLoc=*/{},
+        /*parallelAccesses=*/{});
+
+    // Add the llvm.loop_annotation attribute to the loop.
+    loopOp->setAttr("loop_annotation", loopAnnotationAttr);
+
+    // Create transfer_write inside loop body.
+    rewriter.setInsertionPointToStart(loopOp.getBody());
+    makeTransferWrite(elementsPerWrite, loopOp.getInductionVar());
+
+    // If there are tail elements, create a transfer_write for them.
+    if (nbTailElements > 0) {
+      rewriter.setInsertionPointAfter(loopOp);
+      makeTransferWrite(nbTailElements, cEnd);
+    }
+
+    // erase the original transfer_write
+    rewriter.eraseOp(writeOp);
+    return success();
+  }
+};
+
+/// TODO(newling) upstream this to MLIR.
+///
+/// A simple folder:
+/// ```
+/// %1 = memref.reinterpret_cast %0 ...
+/// %2 = memref.collapse_shape %1 ...
+/// ```
+/// If type of %2 is same as type of %0, replace uses of %2 with %0.
+struct FoldReinterpretCastFollowedByCollapseShapePattern
+    : public OpRewritePattern<memref::CollapseShapeOp> {
+  using OpRewritePattern<memref::CollapseShapeOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(memref::CollapseShapeOp collapseOp,
+                                PatternRewriter &rewriter) const override {
+    auto reinterpretOp = dyn_cast_if_present<memref::ReinterpretCastOp>(
+        collapseOp.getOperand().getDefiningOp());
+    if (!reinterpretOp) return failure();
+    auto reinterpretInputType = reinterpretOp.getSource().getType();
+    if (reinterpretInputType != collapseOp.getType()) return failure();
+    rewriter.replaceOp(collapseOp, reinterpretOp.getSource());
     return success();
   }
 };
@@ -663,9 +883,9 @@ getUnsqueezedShapeAndInBounds(uint64_t inputRank,
   return {newShape, newInBounds};
 }
 
-/// This pattern rewrites a `vector.transfer_write` with a non minor identity
-/// permutation map, with a minor-identity permutation map, if possible. For
-/// example,
+/// This pattern rewrites a `vector.transfer_write` without a minor-identity
+/// permutation map as one with a minor-identity permutation map, if possible.
+/// For example,
 ///
 /// ```
 /// #map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
@@ -1031,13 +1251,23 @@ struct CanonicalizeVectorForAIEVecPass
   }
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<arith::ArithDialect, memref::MemRefDialect,
-                    vector::VectorDialect, affine::AffineDialect>();
+    registry.insert<affine::AffineDialect, arith::ArithDialect,
+                    memref::MemRefDialect, scf::SCFDialect,
+                    vector::VectorDialect, LLVM::LLVMDialect>();
   }
 
   void runOnOperation() override {
     auto op = getOperation();
     MLIRContext *context = &getContext();
+
+    std::optional<AMDAIE::AMDAIEDevice> maybeDevice =
+        AMDAIE::getConfigAMDAIEDeviceFromAncestor(op);
+    if (!maybeDevice.has_value()) {
+      op->emitOpError(
+          "doesn't have target_device specified in a parent module.");
+      return signalPassFailure();
+    }
+    AMDAIE::AMDAIEDevice device = maybeDevice.value();
 
     {
       RewritePatternSet patterns(context);
@@ -1078,6 +1308,9 @@ struct CanonicalizeVectorForAIEVecPass
       // cycles.
       RewritePatternSet patterns(context);
       populateBubbleSignExtensionsLate(patterns);
+      patterns.add<FoldReinterpretCastFollowedByCollapseShapePattern>(context);
+      patterns.add<SerializeSplatTransferReadWithTargetLoadSize>(context,
+                                                                 device);
       (void)applyPatternsGreedily(op, std::move(patterns));
     }
   }
@@ -1236,9 +1469,9 @@ struct AlignTransferReadsPass
   }
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry
-        .insert<arith::ArithDialect, memref::MemRefDialect,
-                vector::VectorDialect, affine::AffineDialect, AIEVecDialect>();
+    registry.insert<affine::AffineDialect, AIEVecDialect, arith::ArithDialect,
+                    LLVM::LLVMDialect, memref::MemRefDialect,
+                    vector::VectorDialect>();
   }
 
   void runOnOperation() override {
@@ -1280,8 +1513,9 @@ struct DetectNonCanonicalOpsPass
   }
 
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<arith::ArithDialect, memref::MemRefDialect,
-                    vector::VectorDialect, affine::AffineDialect>();
+    registry
+        .insert<affine::AffineDialect, arith::ArithDialect, LLVM::LLVMDialect,
+                memref::MemRefDialect, vector::VectorDialect>();
   }
 
   void runOnOperation() override {

--- a/compiler/plugins/target/AMD-AIE/aievec/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(_mlir_files
   align-transfer-reads.mlir
+  canonicalize_transfer_write_for_load.mlir
   fold-ops.mlir
   matmul.mlir
   precanonicalization-aieml-llvmir.mlir
@@ -7,7 +8,6 @@ set(_mlir_files
   test-shuffle.mlir
   test-srs.mlir
   test-ups.mlir
-  canonicalize_transfer_write_for_load.mlir
 )
 
 iree_lit_test_suite(

--- a/compiler/plugins/target/AMD-AIE/aievec/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(_mlir_files
   test-shuffle.mlir
   test-srs.mlir
   test-ups.mlir
+  canonicalize_transfer_write_for_load.mlir
 )
 
 iree_lit_test_suite(

--- a/compiler/plugins/target/AMD-AIE/aievec/test/canonicalize_transfer_write_for_load.mlir
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/canonicalize_transfer_write_for_load.mlir
@@ -27,15 +27,15 @@ module attributes {hal.executable.target = #executable_target_} {
   }
 }
 // CHECK-LABEL: func.func @test_divisible()
-// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
-// CHECK-DAG: %[[C32:.*]] = arith.constant 32 : index
-// CHECK-DAG: %[[C256:.*]] = arith.constant 256 : index
-// CHECK-DAG: %[[CST:.*]] = arith.constant dense<0> : vector<32xi32>
-// CHECK-DAG: %[[ALLOC:.*]] = memref.alloc() : memref<256xi32>
-// CHECK: scf.for %arg0 = %[[C0]] to %[[C256]] step %[[C32]] {
-// CHECK-NEXT: vector.transfer_write %[[CST]], %[[ALLOC]][%arg0] {in_bounds = [true]} : vector<32xi32>, memref<256xi32>
-// CHECK-NEXT: }
-// CHECK-NEXT: return
+// CHECK-DAG:    %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG:    %[[C32:.*]] = arith.constant 32 : index
+// CHECK-DAG:    %[[C256:.*]] = arith.constant 256 : index
+// CHECK-DAG:    %[[CST:.*]] = arith.constant dense<0> : vector<32xi32>
+// CHECK-DAG:    %[[ALLOC:.*]] = memref.alloc() : memref<256xi32>
+// CHECK:        scf.for %arg0 = %[[C0]] to %[[C256]] step %[[C32]] {
+// CHECK-NEXT:    vector.transfer_write %[[CST]], %[[ALLOC]][%arg0] {in_bounds = [true]} : vector<32xi32>, memref<256xi32>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   return
 
 
 // -----
@@ -53,17 +53,17 @@ module attributes {hal.executable.target = #executable_target_} {
   }
 }
 // CHECK-LABEL: func.func @test_non_divisible()
-// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
-// CHECK-DAG: %[[C32:.*]] = arith.constant 32 : index
-// CHECK-DAG: %[[C224:.*]] = arith.constant 224 : index
-// CHECK-DAG: %[[CST_31:.*]] = arith.constant dense<0> : vector<31xi32>
-// CHECK-DAG: %[[CST_32:.*]] = arith.constant dense<0> : vector<32xi32>
-// CHECK-DAG: %[[ALLOC:.*]] = memref.alloc() : memref<255xi32>
-// CHECK: scf.for %arg0 = %[[C0]] to %[[C224]] step %[[C32]] {
-// CHECK-NEXT: vector.transfer_write %[[CST_32]], %[[ALLOC]][%arg0] {in_bounds = [true]} : vector<32xi32>, memref<255xi32>
-// CHECK-NEXT: }
-// CHECK-NEXT: vector.transfer_write %[[CST_31]], %[[ALLOC]][%[[C224]]] {in_bounds = [true]} : vector<31xi32>, memref<255xi32>
-// CHECK-NEXT: return
+// CHECK-DAG:    %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG:    %[[C32:.*]] = arith.constant 32 : index
+// CHECK-DAG:    %[[C224:.*]] = arith.constant 224 : index
+// CHECK-DAG:    %[[CST_31:.*]] = arith.constant dense<0> : vector<31xi32>
+// CHECK-DAG:    %[[CST_32:.*]] = arith.constant dense<0> : vector<32xi32>
+// CHECK-DAG:    %[[ALLOC:.*]] = memref.alloc() : memref<255xi32>
+// CHECK:        scf.for %arg0 = %[[C0]] to %[[C224]] step %[[C32]] {
+// CHECK-NEXT:    vector.transfer_write %[[CST_32]], %[[ALLOC]][%arg0] {in_bounds = [true]} : vector<32xi32>, memref<255xi32>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   vector.transfer_write %[[CST_31]], %[[ALLOC]][%[[C224]]] {in_bounds = [true]} : vector<31xi32>, memref<255xi32>
+// CHECK-NEXT:   return
 
 
 // -----
@@ -80,11 +80,11 @@ module attributes {hal.executable.target = #executable_target_} {
   }
 }
 // CHECK-LABEL: func.func @test_small_non_divisible()
-// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
-// CHECK-DAG: %[[ALLOC:.*]] = memref.alloc() : memref<5xi32>
-// CHECK-DAG: %[[CST:.*]] = arith.constant dense<0> : vector<5xi32>
-// CHECK: vector.transfer_write %[[CST]], %[[ALLOC]][%[[C0]]] {in_bounds = [true]} : vector<5xi32>, memref<5xi32>
-// CHECK: return
+// CHECK-DAG:    %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG:    %[[ALLOC:.*]] = memref.alloc() : memref<5xi32>
+// CHECK-DAG:    %[[CST:.*]] = arith.constant dense<0> : vector<5xi32>
+// CHECK:        vector.transfer_write %[[CST]], %[[ALLOC]][%[[C0]]] {in_bounds = [true]} : vector<5xi32>, memref<5xi32>
+// CHECK:        return
 
 
 // -----
@@ -102,16 +102,16 @@ module attributes {hal.executable.target = #executable_target_} {
   }
 }
 // CHECK-LABEL: func.func @test_non_zero_and_offset()
-// CHECK-DAG: %[[C7:.*]] = arith.constant 7 : index
-// CHECK-DAG: %[[C32:.*]] = arith.constant 32 : index
-// CHECK-DAG: %[[C103:.*]] = arith.constant 103 : index
-// CHECK-DAG: %[[CST_4:.*]] = arith.constant dense<1> : vector<4xi32>
-// CHECK-DAG: %[[CST_32:.*]] = arith.constant dense<1> : vector<32xi32>
-// CHECK-DAG: %[[ALLOC:.*]] = memref.alloc() : memref<256xi32>
-// CHECK: scf.for %arg0 = %[[C7]] to %[[C103]] step %[[C32]] {
-// CHECK-NEXT: vector.transfer_write %[[CST_32]], %[[ALLOC]][%arg0] {in_bounds = [true]} : vector<32xi32>, memref<256xi32>
-// CHECK-NEXT: }
-// CHECK-NEXT: vector.transfer_write %[[CST_4]], %[[ALLOC]][%[[C103]]] {in_bounds = [true]} : vector<4xi32>, memref<256xi32>
+// CHECK-DAG:    %[[C7:.*]] = arith.constant 7 : index
+// CHECK-DAG:    %[[C32:.*]] = arith.constant 32 : index
+// CHECK-DAG:    %[[C103:.*]] = arith.constant 103 : index
+// CHECK-DAG:    %[[CST_4:.*]] = arith.constant dense<1> : vector<4xi32>
+// CHECK-DAG:    %[[CST_32:.*]] = arith.constant dense<1> : vector<32xi32>
+// CHECK-DAG:    %[[ALLOC:.*]] = memref.alloc() : memref<256xi32>
+// CHECK:        scf.for %arg0 = %[[C7]] to %[[C103]] step %[[C32]] {
+// CHECK-NEXT:    vector.transfer_write %[[CST_32]], %[[ALLOC]][%arg0] {in_bounds = [true]} : vector<32xi32>, memref<256xi32>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   vector.transfer_write %[[CST_4]], %[[ALLOC]][%[[C103]]] {in_bounds = [true]} : vector<4xi32>, memref<256xi32>
 
 
 // -----
@@ -128,15 +128,15 @@ module attributes {hal.executable.target = #executable_target_} {
   }
 }
 // CHECK-LABEL: func.func @test_backtrack_to_constant()
-// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
-// CHECK-DAG: %[[C32:.*]] = arith.constant 32 : index
-// CHECK-DAG: %[[C256:.*]] = arith.constant 256 : index
-// CHECK-DAG: %[[CST_32:.*]] = arith.constant dense<0> : vector<32xi32>
-// CHECK-DAG: %[[ALLOC:.*]] = memref.alloc() : memref<256xi32>
-// CHECK: scf.for %arg0 = %[[C0]] to %[[C256]] step %[[C32]] {
-// CHECK-NEXT: vector.transfer_write %[[CST_32]], %[[ALLOC]][%arg0] {in_bounds = [true]} : vector<32xi32>, memref<256xi32>
-// CHECK-NEXT: }
-// CHECK-NEXT: return
+// CHECK-DAG:    %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG:    %[[C32:.*]] = arith.constant 32 : index
+// CHECK-DAG:    %[[C256:.*]] = arith.constant 256 : index
+// CHECK-DAG:    %[[CST_32:.*]] = arith.constant dense<0> : vector<32xi32>
+// CHECK-DAG:    %[[ALLOC:.*]] = memref.alloc() : memref<256xi32>
+// CHECK:        scf.for %arg0 = %[[C0]] to %[[C256]] step %[[C32]] {
+// CHECK-NEXT:    vector.transfer_write %[[CST_32]], %[[ALLOC]][%arg0] {in_bounds = [true]} : vector<32xi32>, memref<256xi32>
+// CHECK-NEXT:   }
+// CHECK-NEXT:   return
 
 
 // -----
@@ -153,6 +153,6 @@ module attributes {hal.executable.target = #executable_target_} {
   }
 }
 // CHECK-LABEL: func.func @test_memref_shape_folding()
-// CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<256xi32>
-// CHECK: %[[USE:.*]] = memref.subview %[[ALLOC]][0] [64] [1] : memref<256xi32> to memref<64xi32>
-// CHECK: return %[[USE]]
+// CHECK:        %[[ALLOC:.*]] = memref.alloc() : memref<256xi32>
+// CHECK:        %[[USE:.*]] = memref.subview %[[ALLOC]][0] [64] [1] : memref<256xi32> to memref<64xi32>
+// CHECK:        return %[[USE]]

--- a/compiler/plugins/target/AMD-AIE/aievec/test/canonicalize_transfer_write_for_load.mlir
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/canonicalize_transfer_write_for_load.mlir
@@ -1,0 +1,158 @@
+// RUN: iree-opt %s --canonicalize-vector-for-aievec --verify-diagnostics -split-input-file | FileCheck %s
+
+
+// expected-error @+1 {{'builtin.module' op doesn't have target_device specified in a parent module.}}
+module {
+  func.func @test_no_device() {
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() : memref<256xi32>
+    %cst = arith.constant dense<0> : vector<256xi32>
+    vector.transfer_write %cst, %alloc[%c0] {in_bounds = [true]} : vector<256xi32>, memref<256xi32>
+    return
+  }
+}
+
+
+// -----
+// Check that that the 256xi32 (1024 byte) transfer_write is converted into
+// a loop of 32xi32 (128 byte) transfer_write operations. Loop count is 8 (256 / 32).
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
+  func.func @test_divisible() {
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() : memref<256xi32>
+    %cst = arith.constant dense<0> : vector<256xi32>
+    vector.transfer_write %cst, %alloc[%c0] {in_bounds = [true]} : vector<256xi32>, memref<256xi32>
+    return
+  }
+}
+// CHECK-LABEL: func.func @test_divisible()
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[C32:.*]] = arith.constant 32 : index
+// CHECK-DAG: %[[C256:.*]] = arith.constant 256 : index
+// CHECK-DAG: %[[CST:.*]] = arith.constant dense<0> : vector<32xi32>
+// CHECK-DAG: %[[ALLOC:.*]] = memref.alloc() : memref<256xi32>
+// CHECK: scf.for %arg0 = %[[C0]] to %[[C256]] step %[[C32]] {
+// CHECK-NEXT: vector.transfer_write %[[CST]], %[[ALLOC]][%arg0] {in_bounds = [true]} : vector<32xi32>, memref<256xi32>
+// CHECK-NEXT: }
+// CHECK-NEXT: return
+
+
+// -----
+// This case is similar to the previous one, except now ther number of elements
+// is 255. so the bytes to write isn't divisible by 128. There is now a loop
+// of 7 (255 / 32 = 224 / 32) writes  and a final transfer_write of 31xi32 (124 bytes).
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu4"}>
+module attributes {hal.executable.target = #executable_target_} {
+  func.func @test_non_divisible() {
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() : memref<255xi32>
+    %cst = arith.constant dense<0> : vector<255xi32>
+    vector.transfer_write %cst, %alloc[%c0] {in_bounds = [true]} : vector<255xi32>, memref<255xi32>
+    return
+  }
+}
+// CHECK-LABEL: func.func @test_non_divisible()
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[C32:.*]] = arith.constant 32 : index
+// CHECK-DAG: %[[C224:.*]] = arith.constant 224 : index
+// CHECK-DAG: %[[CST_31:.*]] = arith.constant dense<0> : vector<31xi32>
+// CHECK-DAG: %[[CST_32:.*]] = arith.constant dense<0> : vector<32xi32>
+// CHECK-DAG: %[[ALLOC:.*]] = memref.alloc() : memref<255xi32>
+// CHECK: scf.for %arg0 = %[[C0]] to %[[C224]] step %[[C32]] {
+// CHECK-NEXT: vector.transfer_write %[[CST_32]], %[[ALLOC]][%arg0] {in_bounds = [true]} : vector<32xi32>, memref<255xi32>
+// CHECK-NEXT: }
+// CHECK-NEXT: vector.transfer_write %[[CST_31]], %[[ALLOC]][%[[C224]]] {in_bounds = [true]} : vector<31xi32>, memref<255xi32>
+// CHECK-NEXT: return
+
+
+// -----
+// When the transfer_write is smaller than than the target device store size (128)
+// the IR is left unchanged.
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
+  func.func @test_small_non_divisible() {
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() : memref<5xi32>
+    %cst = arith.constant dense<0> : vector<5xi32>
+    vector.transfer_write %cst, %alloc[%c0] {in_bounds = [true]} : vector<5xi32>, memref<5xi32>
+    return
+  }
+}
+// CHECK-LABEL: func.func @test_small_non_divisible()
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[ALLOC:.*]] = memref.alloc() : memref<5xi32>
+// CHECK-DAG: %[[CST:.*]] = arith.constant dense<0> : vector<5xi32>
+// CHECK: vector.transfer_write %[[CST]], %[[ALLOC]][%[[C0]]] {in_bounds = [true]} : vector<5xi32>, memref<5xi32>
+// CHECK: return
+
+
+// -----
+// In this test we write 100xi32 elements, this 400 byte write is decomposed
+// 3x128 bytes then 1x16 bytes (3x32 elements, then 1x4 elements). The write
+// is also offset into the memref, and the element written in 1 not 0.
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu4"}>
+module attributes {hal.executable.target = #executable_target_} {
+  func.func @test_non_zero_and_offset() {
+    %c7 = arith.constant 7 : index
+    %alloc = memref.alloc() : memref<256xi32>
+    %cst = arith.constant dense<1> : vector<100xi32>
+    vector.transfer_write %cst, %alloc[%c7] {in_bounds = [true]} : vector<100xi32>, memref<256xi32>
+    return
+  }
+}
+// CHECK-LABEL: func.func @test_non_zero_and_offset()
+// CHECK-DAG: %[[C7:.*]] = arith.constant 7 : index
+// CHECK-DAG: %[[C32:.*]] = arith.constant 32 : index
+// CHECK-DAG: %[[C103:.*]] = arith.constant 103 : index
+// CHECK-DAG: %[[CST_4:.*]] = arith.constant dense<1> : vector<4xi32>
+// CHECK-DAG: %[[CST_32:.*]] = arith.constant dense<1> : vector<32xi32>
+// CHECK-DAG: %[[ALLOC:.*]] = memref.alloc() : memref<256xi32>
+// CHECK: scf.for %arg0 = %[[C7]] to %[[C103]] step %[[C32]] {
+// CHECK-NEXT: vector.transfer_write %[[CST_32]], %[[ALLOC]][%arg0] {in_bounds = [true]} : vector<32xi32>, memref<256xi32>
+// CHECK-NEXT: }
+// CHECK-NEXT: vector.transfer_write %[[CST_4]], %[[ALLOC]][%[[C103]]] {in_bounds = [true]} : vector<4xi32>, memref<256xi32>
+
+
+// -----
+// A case where there is a shape_cast on the vector before the transfer_write.
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
+  func.func @test_backtrack_to_constant() {
+    %c0 = arith.constant 0 : index
+    %alloc = memref.alloc() : memref<256xi32>
+    %cst = arith.constant dense<0> : vector<8x8x4xi32>
+    %0 = vector.shape_cast %cst : vector<8x8x4xi32> to vector<256xi32>
+    vector.transfer_write %0, %alloc[%c0] {in_bounds = [true]} : vector<256xi32>, memref<256xi32>
+    return
+  }
+}
+// CHECK-LABEL: func.func @test_backtrack_to_constant()
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[C32:.*]] = arith.constant 32 : index
+// CHECK-DAG: %[[C256:.*]] = arith.constant 256 : index
+// CHECK-DAG: %[[CST_32:.*]] = arith.constant dense<0> : vector<32xi32>
+// CHECK-DAG: %[[ALLOC:.*]] = memref.alloc() : memref<256xi32>
+// CHECK: scf.for %arg0 = %[[C0]] to %[[C256]] step %[[C32]] {
+// CHECK-NEXT: vector.transfer_write %[[CST_32]], %[[ALLOC]][%arg0] {in_bounds = [true]} : vector<32xi32>, memref<256xi32>
+// CHECK-NEXT: }
+// CHECK-NEXT: return
+
+
+// -----
+// Test of a basic folding opportunity that arises with our current workflow.
+// Notice that %0 and %2 are the same type, so %use can use %0 directly.
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
+  func.func @test_memref_shape_folding() -> memref<64xi32> {
+    %0 = memref.alloc() : memref<256xi32>
+    %1 = memref.reinterpret_cast %0 to offset: [0], sizes : [2, 128], strides: [128, 1] : memref<256xi32> to memref<2x128xi32>
+    %2 = memref.collapse_shape %1 [[0, 1]] : memref<2x128xi32> into memref<256xi32>
+    %use = memref.subview %2[0] [64] [1] : memref<256xi32> to memref<64xi32>
+    return %use : memref<64xi32>
+  }
+}
+// CHECK-LABEL: func.func @test_memref_shape_folding()
+// CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<256xi32>
+// CHECK: %[[USE:.*]] = memref.subview %[[ALLOC]][0] [64] [1] : memref<256xi32> to memref<64xi32>
+// CHECK: return %[[USE]]

--- a/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
@@ -2,6 +2,9 @@
 
 // CHECK-LABEL: @scalar_extsi_to_broadcast_swap(
 // CHECK-SAME: %[[SIN:.*]]: i8
+
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @scalar_extsi_to_broadcast_swap(%s: i8) -> vector<32xi32> {
     // CHECK: %[[SPLAT:.*]] = vector.splat %[[SIN]] : vector<32xi8>
     // CHECK: %[[EXT:.*]] = arith.extsi %[[SPLAT]] : vector<32xi8> to vector<32xi32>
@@ -9,11 +12,15 @@ func.func @scalar_extsi_to_broadcast_swap(%s: i8) -> vector<32xi32> {
     %1 = vector.broadcast %0 : i32 to vector<32xi32>
     return %1 : vector<32xi32>
 }
+}
 
 // -----
 
 // CHECK-LABEL: @scalar_extsi_to_shape_cast_swap(
 // CHECK-SAME: %[[SIN:.*]]: vector<16x2xi8>
+
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @scalar_extsi_to_shape_cast_swap(%s: vector<16x2xi8>) -> vector<32xi32> {
     // CHECK: %[[SHAPE_CAST:.*]] = vector.shape_cast %[[SIN:.*]] : vector<16x2xi8> to vector<32xi8>
     // CHECK: %[[EXT:.*]] = arith.extsi %[[SHAPE_CAST]] : vector<32xi8> to vector<32xi32>
@@ -21,12 +28,16 @@ func.func @scalar_extsi_to_shape_cast_swap(%s: vector<16x2xi8>) -> vector<32xi32
     %1 = vector.shape_cast %0 : vector<16x2xi32> to vector<32xi32>
     return %1 : vector<32xi32>
 }
+}
 
 
 // -----
 
 // CHECK-LABEL: @extsi_to_broadcast_swap(
 // CHECK-SAME: %[[VIN:.*]]: vector<8xi8>
+
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @extsi_to_broadcast_swap(%v: vector<8xi8>) -> vector<4x8xi32> {
     // CHECK: %[[ZV:.*]] = ub.poison : vector<4x8xi8>
     // CHECK: %[[I0:.*]] = vector.insert %[[VIN]], %[[ZV]] [0] : vector<8xi8> into vector<4x8xi8>
@@ -38,11 +49,15 @@ func.func @extsi_to_broadcast_swap(%v: vector<8xi8>) -> vector<4x8xi32> {
     %1 = vector.broadcast %0 : vector<8xi32> to vector<4x8xi32>
     return %1 : vector<4x8xi32>
 }
+}
 
 // -----
 
 // CHECK-LABEL: @broadcast_to_insert(
 // CHECK-SAME: %[[V:.*]]: vector<8xbf16>
+
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @broadcast_to_insert(%v: vector<8xbf16>) -> vector<1x4x8xbf16> {
     // CHECK: %[[ZV:.*]] = ub.poison : vector<4x8xbf16>
     // CHECK: %[[I0:.*]] = vector.insert %[[V]], %[[ZV]] [0] : vector<8xbf16> into vector<4x8xbf16>
@@ -53,6 +68,7 @@ func.func @broadcast_to_insert(%v: vector<8xbf16>) -> vector<1x4x8xbf16> {
     // CHECK: return %[[BC]] : vector<1x4x8xbf16>
     %0 = vector.broadcast %v : vector<8xbf16> to vector<1x4x8xbf16>
     return %0 : vector<1x4x8xbf16>
+}
 }
 
 // -----
@@ -65,12 +81,15 @@ func.func @broadcast_to_insert(%v: vector<8xbf16>) -> vector<1x4x8xbf16> {
 // CHECK: vector.shape_cast
 // CHECK-SAME: vector<32xi8> to vector<4x8xi8>
 #map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @contiguous_read_with_unit_extent_dim() -> vector<4x8xi8> {
     %c0_i8 = arith.constant 0 : i8
     %c0 = arith.constant 0 : index
     %alloc = memref.alloc() : memref<2x4x1x8xi8>
     %0 = vector.transfer_read %alloc[%c0, %c0, %c0, %c0], %c0_i8 {in_bounds = [true, true], permutation_map = #map} : memref<2x4x1x8xi8>, vector<4x8xi8>
     return %0 : vector<4x8xi8>
+}
 }
 
 // -----
@@ -81,12 +100,15 @@ func.func @contiguous_read_with_unit_extent_dim() -> vector<4x8xi8> {
 // CHECK: transfer_read{{.*}} memref<2x4x2x8xi8>
 // CHECK: return
 #map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @noncontiguous_read_cannot_collapse() -> vector<4x8xi8> {
     %c0_i8 = arith.constant 0 : i8
     %c0 = arith.constant 0 : index
     %alloc = memref.alloc() : memref<2x4x2x8xi8>
     %0 = vector.transfer_read %alloc[%c0, %c0, %c0, %c0], %c0_i8 {in_bounds = [true, true], permutation_map = #map} : memref<2x4x2x8xi8>, vector<4x8xi8>
     return %0 : vector<4x8xi8>
+}
 }
 
 // -----
@@ -97,12 +119,15 @@ func.func @noncontiguous_read_cannot_collapse() -> vector<4x8xi8> {
 // CHECK: return
 
 #map = affine_map<(d0, d1) -> (d1, d0)>
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @permutation_read_cannot_collapse() -> vector<8x8xi8> {
     %c0_i8 = arith.constant 0 : i8
     %c0 = arith.constant 0 : index
     %alloc = memref.alloc() : memref<8x8xi8>
     %0 = vector.transfer_read %alloc[%c0, %c0], %c0_i8 {in_bounds = [true, true], permutation_map = #map} : memref<8x8xi8>, vector<8x8xi8>
     return %0 : vector<8x8xi8>
+}
 }
 
 // -----
@@ -113,11 +138,14 @@ func.func @permutation_read_cannot_collapse() -> vector<8x8xi8> {
 // CHECK: vector.transfer_write
 // CHECK: return
 #map = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @contiguous_write_with_unit_extent_dim(%v: vector<4x8xi8>) {
     %c0 = arith.constant 0 : index
     %alloc = memref.alloc() : memref<2x4x1x8xi8>
     vector.transfer_write %v, %alloc[%c0, %c0, %c0, %c0] {permutation_map = #map} : vector<4x8xi8>, memref<2x4x1x8xi8>
     return
+}
 }
 
 // -----
@@ -133,12 +161,15 @@ func.func @contiguous_write_with_unit_extent_dim(%v: vector<4x8xi8>) {
 // CHECK: return
 
 #map = affine_map<(d0, d1, d2, d3, d4) -> (d1, d3)>
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @contiguous_write_with_unit_extent_dim_2(%v: vector<4x8xi8>) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %alloc = memref.alloc() : memref<2x6x1x8x1xi8>
     vector.transfer_write %v, %alloc[%c0, %c1, %c0, %c0, %c0] {permutation_map = #map} : vector<4x8xi8>, memref<2x6x1x8x1xi8>
     return
+}
 }
 
 // -----
@@ -147,17 +178,22 @@ func.func @contiguous_write_with_unit_extent_dim_2(%v: vector<4x8xi8>) {
 // CHECK-NOT: memref.collapse_shape
 // CHECK-NOT: vector.shape_cast
 // CHECK: return
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @noncontiguous_write(%v: vector<4x8xi8>) {
     %c0 = arith.constant 0 : index
     %alloc = memref.alloc() : memref<4x10xi8>
     vector.transfer_write %v, %alloc[%c0, %c0] : vector<4x8xi8>, memref<4x10xi8>
     return
 }
+}
 
 // -----
 
 // CHECK-LABEL: @arith_truncf(
 // CHECK-SAME:      %[[INP:.*]]: vector<2x3xf32>)
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @arith_truncf(%inp: vector<2x3xf32>) -> vector<2x3xbf16> {
     // CHECK:     %[[LINEARIZE:.*]] = vector.shape_cast %[[INP]] : vector<2x3xf32> to vector<6xf32>
     // CHECK:     %[[TRUNCF:.*]] = arith.truncf %[[LINEARIZE]] : vector<6xf32> to vector<6xbf16>
@@ -165,6 +201,7 @@ func.func @arith_truncf(%inp: vector<2x3xf32>) -> vector<2x3xbf16> {
     // CHECK:     return %[[DELINEARIZE]]
     %0 = arith.truncf %inp : vector<2x3xf32> to vector<2x3xbf16>
     return %0 : vector<2x3xbf16>
+}
 }
 
 // -----
@@ -194,12 +231,15 @@ func.func @arith_trunci(%inp: vector<2x3xi32>) -> vector<2x3xi8> {
 // CHECK:         %[[SHAPE_CAST:.*]] = vector.shape_cast %[[READ]]
 // CHECK-SAME:        vector<32xbf16> to vector<1x1x4x8xbf16>
 // CHECK:         return %[[SHAPE_CAST]]
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @trivial_read_access(%arg0: memref<4x8x4x8xbf16, strided<[256, 32, 8, 1]>>, %in: index) -> vector<1x1x4x8xbf16> {
     %c0 = arith.constant 0 : index
     %cst = arith.constant 0.000000e+00 : bf16
     %subview = memref.subview %arg0[%in, 3, 0, 0] [1, 1, 4, 8] [1, 1, 1, 1] : memref<4x8x4x8xbf16, strided<[256, 32, 8, 1]>> to memref<1x1x4x8xbf16, strided<[256, 32, 8, 1], offset: ?>>
     %read = vector.transfer_read %subview[%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x1x4x8xbf16, strided<[256, 32, 8, 1], offset: ?>>, vector<1x1x4x8xbf16>
     return %read : vector<1x1x4x8xbf16>
+}
 }
 
 // -----
@@ -213,12 +253,15 @@ func.func @trivial_read_access(%arg0: memref<4x8x4x8xbf16, strided<[256, 32, 8, 
 // CHECK:         %[[SHAPE_CAST:.*]] = vector.shape_cast %[[READ]]
 // CHECK-SAME:        vector<8xbf16> to vector<1x1x8xbf16>
 // CHECK:         return %[[SHAPE_CAST]]
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @trivial_read_access_rank_reduced(%arg0: memref<4x8x1x8xbf16, strided<[64, 8, 8, 1]>>) -> vector<1x1x8xbf16> {
     %c0 = arith.constant 0 : index
     %cst = arith.constant 0.000000e+00 : bf16
     %subview = memref.subview %arg0[2, 3, 0, 0] [1, 1, 1, 8] [1, 1, 1, 1] : memref<4x8x1x8xbf16, strided<[64, 8, 8, 1]>> to memref<1x1x8xbf16, strided<[8, 8, 1], offset: 152>>
     %read = vector.transfer_read %subview[%c0, %c0, %c0], %cst {in_bounds = [true, true, true]} : memref<1x1x8xbf16, strided<[8, 8, 1], offset: 152>>, vector<1x1x8xbf16>
     return %read : vector<1x1x8xbf16>
+}
 }
 
 // -----
@@ -233,10 +276,13 @@ func.func @trivial_read_access_rank_reduced(%arg0: memref<4x8x1x8xbf16, strided<
 // CHECK-SAME:          : vector<1x1x4x4xf32> to vector<16xf32>
 // CHECK:           vector.transfer_write %[[SHAPE_CAST]], %[[COLLAPSE_SHAPE]]
 // CHECK:           return
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @trivial_write_access(%arg0: memref<8x8x4x4xf32, strided<[128, 16, 4, 1]>>, %arg1: vector<1x1x4x4xf32>) {
     %c0 = arith.constant 0 : index
     %cst = arith.constant 0.000000e+00 : bf16
     %subview = memref.subview %arg0[2, 3, 0, 0] [1, 1, 4, 4] [1, 1, 1, 1] : memref<8x8x4x4xf32, strided<[128, 16, 4, 1]>> to memref<1x1x4x4xf32, strided<[128, 16, 4, 1], offset: 304>>
     vector.transfer_write %arg1, %subview[%c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x4x4xf32>, memref<1x1x4x4xf32, strided<[128, 16, 4, 1], offset: 304>>
     return
+}
 }

--- a/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
@@ -208,6 +208,8 @@ func.func @arith_truncf(%inp: vector<2x3xf32>) -> vector<2x3xbf16> {
 
 // CHECK-LABEL: @arith_trunci(
 // CHECK-SAME:      %[[INP:.*]]: vector<2x3xi32>)
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @arith_trunci(%inp: vector<2x3xi32>) -> vector<2x3xi8> {
     // CHECK:     %[[LINEARIZE:.*]] = vector.shape_cast %[[INP]] : vector<2x3xi32> to vector<6xi32>
     // CHECK:     %[[TRUNCI:.*]] = arith.trunci %[[LINEARIZE]] : vector<6xi32> to vector<6xi8>
@@ -215,6 +217,7 @@ func.func @arith_trunci(%inp: vector<2x3xi32>) -> vector<2x3xi8> {
     // CHECK:     return %[[DELINEARIZE]]
     %0 = arith.trunci %inp : vector<2x3xi32> to vector<2x3xi8>
     return %0 : vector<2x3xi8>
+}
 }
 
 // -----

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEVectorization.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEVectorization.cpp
@@ -65,7 +65,7 @@ void AMDAIEVectorizationPass::runOnOperation() {
   // Collect all operations which must be vectorized.
   SmallVector<Operation *> candidates;
   funcOp.walk([&](Operation *op) {
-    // Only vectorize linalg ops (for now) (return WalkResult::
+    // Only vectorize linalg ops (for now)
     if (!isa<linalg::LinalgOp>(op)) return WalkResult::advance();
 
     // iree-amd-aie's current tiling pipelines use linalg.copy ops to move data
@@ -81,11 +81,7 @@ void AMDAIEVectorizationPass::runOnOperation() {
     // https://github.com/nod-ai/iree-amd-aie/issues/594 for more info.
     if (auto genericOp = dyn_cast<linalg::GenericOp>(op)) {
       if (isElementwise(genericOp)) {
-        // if (!isa<linalg::FillOp>(op) &&
-        // isElementwise(cast<linalg::LinalgOp>(op))) { auto genericOp =
-        // dyn_cast<linalg::GenericOp>(op); if (genericOp) {
         for (Operation &innerOps : genericOp.getBody()->getOperations()) {
-          // cast<linalg::GenericOp>(op).getBody()->getOperations()) {
           if (!isa<arith::TruncFOp, arith::TruncIOp, linalg::YieldOp>(
                   innerOps)) {
             op->emitRemark() << "not vectorizing linalg elementwise op";

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/vectorization.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/vectorization.mlir
@@ -87,3 +87,18 @@ func.func @fill() -> tensor<8xbf16> {
   %1 = linalg.fill ins(%cst : bf16) outs(%0 : tensor<8xbf16>) -> tensor<8xbf16>
   return %1 : tensor<8xbf16>
 }
+
+
+// CHECK-LABEL: @matmul_elementwise_trunci
+//  CHECK-SAME: (%[[ARG0:.*]]: tensor<4240x160xi32>, %[[ARG1:.*]]: tensor<4240x160xi8>)
+func.func @matmul_elementwise_trunci(%arg0: tensor<4240x160xi32>, %arg1: tensor<4240x160xi8>) -> tensor<4240x160xi8> {
+  %0 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%arg0: tensor<4240x160xi32>) outs(%arg1 : tensor<4240x160xi8>) {
+    ^bb0(%in: i32, %out: i8):
+        %1 = arith.trunci %in : i32 to i8
+        linalg.yield %1 : i8
+    } -> tensor<4240x160xi8>
+  return %0 : tensor<4240x160xi8>
+}
+// CHECK: %[[VEC_OPERAND_0:.*]] = vector.transfer_read %[[ARG0]]{{.*}} vector<4240x160xi32>
+// CHECK: %[[TRUNCI:.*]] = arith.trunci %[[VEC_OPERAND_0]]
+// CHECK: vector.transfer_write %[[TRUNCI]], %[[ARG1]]


### PR DESCRIPTION
This PR contains multiple changes to get vectorized assembly through peano, I will split it into multiple PRs. 

Eyeballing the first test in the performance benchmark:

Before:

```
matmul_512_512_4096_bf16_f32_O2_npu1_4col_benchmark
--------------------------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------------
BM_matmul/process_time/real_time_mean         2673 us         66.3 us            5 items_per_second=374.194/s
BM_matmul/process_time/real_time_median       2668 us         63.1 us            5 items_per_second=374.766/s
BM_matmul/process_time/real_time_stddev       19.3 us         16.7 us            5 items_per_second=2.69245/s
--------------------------------------------------------------------------------------------------
The largest program memory size (read from byte 72 of elf files) is 11184 bytes
```


After:

```
matmul_512_512_4096_bf16_f32_O2_npu1_4col_benchmark
--------------------------------------------------------------------------------------------------
Benchmark                                        Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------------
BM_matmul/process_time/real_time_mean         2601 us         48.6 us            5 items_per_second=385.252/s
BM_matmul/process_time/real_time_median       2540 us         39.1 us            5 items_per_second=393.696/s
BM_matmul/process_time/real_time_stddev        132 us         21.0 us            5 items_per_second=18.3503/s
--------------------------------------------------------------------------------------------------
The largest program memory size (read from byte 72 of elf files) is 10112 bytes
```

So a nice saving on program memory, and maybe a marginal throughput boost. There a consistent saving of 1K memory across all (non-ukernel) benchmarks