### PR TITLE
[AssignChannels] Prioritize channel assignment for control packets 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -859,6 +859,8 @@ void addAMDAIEObjectFifoLoweringPasses(
   passManager.addPass(createCanonicalizerPass());
   passManager.addPass(createAMDAIEDmaCSEPass());
 
+  passManager.addPass(createAMDAIEGenerateControlOverlayPass());
+
   passManager.addPass(createAMDAIEAssignChannelsPass());
   passManager.addPass(createCSEPass());
   passManager.addPass(createCanonicalizerPass());
@@ -880,8 +882,6 @@ void addAMDAIEObjectFifoLoweringPasses(
 
   passManager.addPass(createAMDAIEObjFifoBufferizationPass());
   passManager.addPass(createAMDAIETemporaryAllocBufferizationPass());
-
-  passManager.addPass(createAMDAIEGenerateControlOverlayPass());
 
   passManager.addPass(createAMDAIEConnectionToFlowPass());
   passManager.addPass(createAMDAIEAssignPacketIdsPass());

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_channels.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_channels.mlir
@@ -106,3 +106,40 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     return
   }
 }
+
+// -----
+
+// For tile (0,0), its producer (MM2S) channel 0 is already assigned
+// to a control packet flow. Therefore, channel 1 is used to connect to tile (0,1).
+// CHECK-LABEL: @previously_assigned
+// CHECK:       %[[C0:.+]] = arith.constant 0 : index
+// CHECK:       %[[C1:.+]] = arith.constant 1 : index
+// CHECK:       amdaie.workgroup
+// CHECK:         %[[tile_0_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
+// CHECK:         %[[tile_0_1:.+]] = amdaie.tile(%[[C0]], %[[C1]])
+// CHECK:         %[[CHANNEL_0:.+]] = amdaie.channel(%[[tile_0_0]], 1, port_type = DMA, direction = MM2S)
+// CHECK:         %[[CHANNEL_1:.+]] = amdaie.channel(%[[tile_0_1]], 0, port_type = DMA, direction = S2MM)
+// CHECK:         amdaie.connection(%{{.+}} {%[[CHANNEL_1]]}, %{{.+}} {%[[CHANNEL_0]]})
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @previously_assigned(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    amdaie.workgroup {
+      %tile_0_0 = amdaie.tile(%c0, %c0)
+      %tile_0_1 = amdaie.tile(%c0, %c1)
+      %0 = amdaie.logicalobjectfifo.from_memref %arg0, {%tile_0_1} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+      %1 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+      %2 = amdaie.connection(%0, %1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      %channel = amdaie.channel(%tile_0_0, 0, port_type = DMA, direction = MM2S)
+      %channel_0 = amdaie.channel(%tile_0_0, 0, port_type = CTRL, direction = S2MM)
+      %3 = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<?xi32>>
+      %4 = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<?xi32>>
+      %5 = amdaie.connection(%4 {%channel_0}, %3 {%channel}) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<?xi32>>, !amdaie.logicalobjectfifo<memref<?xi32>>)
+      amdaie.controlcode {
+        amdaie.end
+      }
+    }
+    return
+  }
+}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_channels.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_channels.mlir
@@ -109,9 +109,52 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 
 // -----
 
-// For tile (0,0), its producer (MM2S) channel 0 is already assigned
-// to a control packet flow. Therefore, channel 1 is used to connect to tile (0,1).
-// CHECK-LABEL: @previously_assigned
+// In the input IR:
+// - Tile (0,0) has its DMA MM2S channel 0 already assigned to a circuit flow.
+// - Tile (0,1) has its DMA S2MM channel 0 assigned to the same circuit flow.
+// As a result, channel assignment starts from channel 1 for both tiles.
+// CHECK-LABEL: @previously_assigned_circuit
+// CHECK:       %[[C0:.+]] = arith.constant 0 : index
+// CHECK:       %[[C1:.+]] = arith.constant 1 : index
+// CHECK:       amdaie.workgroup
+// CHECK:         %[[tile_0_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
+// CHECK:         %[[tile_0_1:.+]] = amdaie.tile(%[[C0]], %[[C1]])
+// CHECK:         %[[CHANNEL_0:.+]] = amdaie.channel(%[[tile_0_0]], 1, port_type = DMA, direction = MM2S)
+// CHECK:         %[[CHANNEL_1:.+]] = amdaie.channel(%[[tile_0_1]], 1, port_type = DMA, direction = S2MM)
+// CHECK:         amdaie.connection(%{{.+}} {%[[CHANNEL_1]]}, %{{.+}} {%[[CHANNEL_0]]})
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @previously_assigned_circuit(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    amdaie.workgroup {
+      %tile_0_0 = amdaie.tile(%c0, %c0)
+      %tile_0_1 = amdaie.tile(%c0, %c1)
+      %0 = amdaie.logicalobjectfifo.from_memref %arg0, {%tile_0_1} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>
+      %1 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+      %2 = amdaie.connection(%0, %1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      %channel = amdaie.channel(%tile_0_0, 0, port_type = DMA, direction = MM2S)
+      %channel_0 = amdaie.channel(%tile_0_1, 0, port_type = DMA, direction = S2MM)
+      %3 = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<16x8xi32>>
+      %4 = amdaie.logicalobjectfifo.placeholder{%tile_0_1} : !amdaie.logicalobjectfifo<memref<1x1x16x8xi32, 1>>
+      %5 = amdaie.connection(%4 {%channel_0}, %3 {%channel}) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<1x1x16x8xi32, 1>>, !amdaie.logicalobjectfifo<memref<16x8xi32>>)
+      amdaie.controlcode {
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// In the input IR:
+// - Tile (0,0) has its DMA MM2S channel 0 already assigned to a control packet flow.
+// - Tile (0,1) has its CTRL S2MM channel 0 assigned to the same flow.
+// Therefore, the next available channels are:
+//   - Tile (0,0): DMA MM2S channel 1
+//   - Tile (0,1): DMA S2MM channel 0
+// CHECK-LABEL: @previously_assigned_packet
 // CHECK:       %[[C0:.+]] = arith.constant 0 : index
 // CHECK:       %[[C1:.+]] = arith.constant 1 : index
 // CHECK:       amdaie.workgroup
@@ -122,7 +165,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:         amdaie.connection(%{{.+}} {%[[CHANNEL_1]]}, %{{.+}} {%[[CHANNEL_0]]})
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
-  func.func @previously_assigned(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi32>) {
+  func.func @previously_assigned_packet(%arg0: memref<1x1x8x16xi32, 1>, %arg1: memref<8x16xi32>) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     amdaie.workgroup {

--- a/runtime/src/iree-amd-aie/aie_runtime/Utils/CMakeLists.txt
+++ b/runtime/src/iree-amd-aie/aie_runtime/Utils/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_cc_library(
     "LockIdGenerator.h"
   SRCS
     "ChannelBdIdGenerator.cpp"
+    "ChannelGenerator.cpp"
     "LockIdGenerator.cpp"
   DEPS
     iree-amd-aie::aie_runtime::iree_aie_runtime_static

--- a/runtime/src/iree-amd-aie/aie_runtime/Utils/ChannelGenerator.cpp
+++ b/runtime/src/iree-amd-aie/aie_runtime/Utils/ChannelGenerator.cpp
@@ -1,0 +1,149 @@
+// Copyright 2025 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-amd-aie/aie_runtime/Utils/ChannelGenerator.h"
+
+namespace mlir::iree_compiler::AMDAIE {
+
+std::optional<uint8_t> ChannelGenerator::findFirstAvailableChannel(
+    uint8_t numChannels,
+    ArrayRef<llvm::SmallSetVector<uint8_t, 8>> excludeSets) {
+  for (uint8_t channel = 0; channel < numChannels; ++channel) {
+    if (llvm::none_of(excludeSets,
+                      [&](const llvm::SmallSetVector<uint8_t, 8> &excludeSet) {
+                        return excludeSet.count(channel);
+                      })) {
+      return channel;
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<uint8_t> ChannelGenerator::getAndAssignProducerDMAChannel(
+    ChannelAssignmentMode mode) {
+  std::optional<uint8_t> channel;
+  switch (mode) {
+    case ChannelAssignmentMode::FirstAvailableCircuitFlow: {
+      // Select the first available channel for circuit flow.
+      // A channel is valid if it is not already assigned to any circuit or
+      // packet flow.
+      channel = findFirstAvailableChannel(
+          numProducerChannels,
+          {assignedCircuitProducerChannels, assignedPacketProducerChannels});
+      break;
+    }
+    case ChannelAssignmentMode::FirstAvailablePacketFlow: {
+      // Select the first available channel for packet flow.
+      // A channel is valid if it is not already assigned to a circuit flow.
+      channel = findFirstAvailableChannel(numProducerChannels,
+                                          {assignedCircuitProducerChannels});
+      break;
+    }
+    case ChannelAssignmentMode::RoundRobinPacketFlow: {
+      // Select the channel for packet flow, using a round-robin strategy for
+      // load balancing:
+      // 1. Prefer an unused channel (not assigned to any circuit or packet
+      // flow).
+      // 2. If no such channel is available, reuse the least recently used
+      // packet flow channel from `assignedPacketProducerChannels.front()`.
+      channel = findFirstAvailableChannel(
+          numProducerChannels,
+          {assignedCircuitProducerChannels, assignedPacketProducerChannels});
+      if (!channel && !assignedPacketProducerChannels.empty())
+        channel = assignedPacketProducerChannels.front();
+      break;
+    }
+    default:
+      assert(false && "Unsupported ChannelAssignmentMode");
+  }
+  // Assign the channel if found.
+  if (channel.has_value()) assignProducerDMAChannel(channel.value(), mode);
+  return channel;
+}
+
+std::optional<uint8_t> ChannelGenerator::getAndAssignConsumerDMAChannel(
+    ChannelAssignmentMode mode) {
+  std::optional<uint8_t> channel;
+  switch (mode) {
+    case ChannelAssignmentMode::FirstAvailableCircuitFlow: {
+      // Select the first available channel for circuit flow.
+      // A channel is valid if it is not already assigned to any circuit or
+      // packet flow.
+      channel = findFirstAvailableChannel(
+          numConsumerChannels,
+          {assignedCircuitConsumerChannels, assignedPacketConsumerChannels});
+      break;
+    }
+    case ChannelAssignmentMode::FirstAvailablePacketFlow: {
+      // Select the first available channel for packet flow.
+      // A channel is valid if it is not already assigned to a circuit flow.
+      channel = findFirstAvailableChannel(numConsumerChannels,
+                                          {assignedCircuitConsumerChannels});
+      break;
+    }
+    case ChannelAssignmentMode::RoundRobinPacketFlow: {
+      // Select the channel for packet flow, using a round-robin strategy for
+      // load balancing:
+      // 1. Prefer an unused channel (not assigned to any circuit or packet
+      // flow).
+      // 2. If no such channel is available, reuse the least recently used
+      // packet flow channel from `assignedPacketConsumerChannels.front()`.
+      channel = findFirstAvailableChannel(
+          numConsumerChannels,
+          {assignedCircuitConsumerChannels, assignedPacketConsumerChannels});
+      if (!channel && !assignedPacketConsumerChannels.empty())
+        channel = assignedPacketConsumerChannels.front();
+      break;
+    }
+    default:
+      assert(false && "Unsupported ChannelAssignmentMode");
+  }
+  // Assign the channel if found.
+  if (channel.has_value()) assignConsumerDMAChannel(channel.value(), mode);
+  return channel;
+}
+
+void ChannelGenerator::assignProducerDMAChannel(uint8_t channel,
+                                                ChannelAssignmentMode mode) {
+  switch (mode) {
+    case ChannelAssignmentMode::FirstAvailableCircuitFlow:
+      assignedCircuitProducerChannels.insert(channel);
+      break;
+    case ChannelAssignmentMode::FirstAvailablePacketFlow:
+      assignedPacketProducerChannels.insert(channel);
+      break;
+    case ChannelAssignmentMode::RoundRobinPacketFlow:
+      // Remove and reinsert to update the least recently used channel
+      // (front).
+      assignedPacketProducerChannels.remove(channel);
+      assignedPacketProducerChannels.insert(channel);
+      break;
+    default:
+      assert(false && "Unsupported ChannelAssignmentMode");
+  }
+}
+
+void ChannelGenerator::assignConsumerDMAChannel(uint8_t channel,
+                                                ChannelAssignmentMode mode) {
+  switch (mode) {
+    case ChannelAssignmentMode::FirstAvailableCircuitFlow:
+      assignedCircuitConsumerChannels.insert(channel);
+      break;
+    case ChannelAssignmentMode::FirstAvailablePacketFlow:
+      assignedPacketConsumerChannels.insert(channel);
+      break;
+    case ChannelAssignmentMode::RoundRobinPacketFlow:
+      // Remove and reinsert to update the least recently used channel
+      // (front).
+      assignedPacketConsumerChannels.remove(channel);
+      assignedPacketConsumerChannels.insert(channel);
+      break;
+    default:
+      assert(false && "Unsupported ChannelAssignmentMode");
+  }
+}
+
+}  // namespace mlir::iree_compiler::AMDAIE

--- a/runtime/src/iree-amd-aie/aie_runtime/Utils/ChannelGenerator.h
+++ b/runtime/src/iree-amd-aie/aie_runtime/Utils/ChannelGenerator.h
@@ -36,144 +36,21 @@ class ChannelGenerator {
   /// the given exclusion sets.
   std::optional<uint8_t> findFirstAvailableChannel(
       uint8_t numChannels,
-      ArrayRef<llvm::SmallSetVector<uint8_t, 8>> excludeSets) {
-    for (uint8_t channel = 0; channel < numChannels; ++channel) {
-      if (llvm::none_of(
-              excludeSets,
-              [&](const llvm::SmallSetVector<uint8_t, 8> &excludeSet) {
-                return excludeSet.count(channel);
-              })) {
-        return channel;
-      }
-    }
-    return std::nullopt;
-  }
+      ArrayRef<llvm::SmallSetVector<uint8_t, 8>> excludeSets);
 
   /// Retrieves the next producer channel using the specified strategy.
   std::optional<uint8_t> getAndAssignProducerDMAChannel(
-      ChannelAssignmentMode mode) {
-    std::optional<uint8_t> channel;
-    switch (mode) {
-      // Select the first available channel for circuit flow.
-      // A channel is valid if it is not already assigned to any circuit or
-      // packet flow.
-      case ChannelAssignmentMode::FirstAvailableCircuitFlow: {
-        channel = findFirstAvailableChannel(
-            numProducerChannels,
-            {assignedCircuitProducerChannels, assignedPacketProducerChannels});
-        break;
-      }
-      // Select the first available channel for packet flow.
-      // A channel is valid if it is not already assigned to a circuit flow.
-      case ChannelAssignmentMode::FirstAvailablePacketFlow: {
-        channel = findFirstAvailableChannel(numProducerChannels,
-                                            {assignedCircuitProducerChannels});
-        break;
-      }
-      // Select the channel for packet flow, using a round-robin strategy for
-      // load balancing:
-      // 1. Prefer an unused channel (not assigned to any circuit or packet
-      // flow).
-      // 2. If no such channel is available, reuse the least recently used
-      // packet flow channel from `assignedPacketProducerChannels.front()`.
-      case ChannelAssignmentMode::RoundRobinPacketFlow: {
-        channel = findFirstAvailableChannel(
-            numProducerChannels,
-            {assignedCircuitProducerChannels, assignedPacketProducerChannels});
-        if (!channel && !assignedPacketProducerChannels.empty())
-          channel = assignedPacketProducerChannels.front();
-        break;
-      }
-      default:
-        assert(false && "Unsupported ChannelAssignmentMode");
-    }
-    // Assign the channel if found.
-    if (channel.has_value()) assignProducerDMAChannel(channel.value(), mode);
-    return channel;
-  }
+      ChannelAssignmentMode mode);
 
   /// Retrieves the next consumer channel using the specified strategy.
   std::optional<uint8_t> getAndAssignConsumerDMAChannel(
-      ChannelAssignmentMode mode) {
-    std::optional<uint8_t> channel;
-    switch (mode) {
-      // Select the first available channel for circuit flow.
-      // A channel is valid if it is not already assigned to any circuit or
-      // packet flow.
-      case ChannelAssignmentMode::FirstAvailableCircuitFlow: {
-        channel = findFirstAvailableChannel(
-            numConsumerChannels,
-            {assignedCircuitConsumerChannels, assignedPacketConsumerChannels});
-        break;
-      }
-      // Select the first available channel for packet flow.
-      // A channel is valid if it is not already assigned to a circuit flow.
-      case ChannelAssignmentMode::FirstAvailablePacketFlow: {
-        channel = findFirstAvailableChannel(numConsumerChannels,
-                                            {assignedCircuitConsumerChannels});
-        break;
-      }
-      // Select the channel for packet flow, using a round-robin strategy for
-      // load balancing:
-      // 1. Prefer an unused channel (not assigned to any circuit or packet
-      // flow).
-      // 2. If no such channel is available, reuse the least recently used
-      // packet flow channel from `assignedPacketConsumerChannels.front()`.
-      case ChannelAssignmentMode::RoundRobinPacketFlow: {
-        channel = findFirstAvailableChannel(
-            numConsumerChannels,
-            {assignedCircuitConsumerChannels, assignedPacketConsumerChannels});
-        if (!channel && !assignedPacketConsumerChannels.empty())
-          channel = assignedPacketConsumerChannels.front();
-        break;
-      }
-      default:
-        assert(false && "Unsupported ChannelAssignmentMode");
-    }
-    // Assign the channel if found.
-    if (channel.has_value()) assignConsumerDMAChannel(channel.value(), mode);
-    return channel;
-  }
+      ChannelAssignmentMode mode);
 
   /// Assigns the provided producer channel.
-  void assignProducerDMAChannel(uint8_t channel, ChannelAssignmentMode mode) {
-    switch (mode) {
-      case ChannelAssignmentMode::FirstAvailableCircuitFlow:
-        assignedCircuitProducerChannels.insert(channel);
-        break;
-      case ChannelAssignmentMode::FirstAvailablePacketFlow:
-        assignedPacketProducerChannels.insert(channel);
-        break;
-      case ChannelAssignmentMode::RoundRobinPacketFlow:
-        // Remove and reinsert to update the least recently used channel
-        // (front).
-        assignedPacketProducerChannels.remove(channel);
-        assignedPacketProducerChannels.insert(channel);
-        break;
-      default:
-        assert(false && "Unsupported ChannelAssignmentMode");
-    }
-  }
+  void assignProducerDMAChannel(uint8_t channel, ChannelAssignmentMode mode);
 
   /// Assigns the provided consumer channel.
-  void assignConsumerDMAChannel(uint8_t channel, ChannelAssignmentMode mode) {
-    switch (mode) {
-      case ChannelAssignmentMode::FirstAvailableCircuitFlow:
-        assignedCircuitConsumerChannels.insert(channel);
-        break;
-      case ChannelAssignmentMode::FirstAvailablePacketFlow:
-        assignedPacketConsumerChannels.insert(channel);
-        break;
-      case ChannelAssignmentMode::RoundRobinPacketFlow:
-        // Remove and reinsert to update the least recently used channel
-        // (front).
-        assignedPacketConsumerChannels.remove(channel);
-        assignedPacketConsumerChannels.insert(channel);
-        break;
-      default:
-        assert(false && "Unsupported ChannelAssignmentMode");
-    }
-  }
+  void assignConsumerDMAChannel(uint8_t channel, ChannelAssignmentMode mode);
 
  private:
   uint8_t numProducerChannels = 0;

--- a/runtime/src/iree-amd-aie/aie_runtime/Utils/ChannelGenerator.h
+++ b/runtime/src/iree-amd-aie/aie_runtime/Utils/ChannelGenerator.h
@@ -7,8 +7,7 @@
 #ifndef IREE_COMPILER_AMDAIE_UTILS_CHANNEL_GENERATOR_H_
 #define IREE_COMPILER_AMDAIE_UTILS_CHANNEL_GENERATOR_H_
 
-#include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "mlir/Support/LogicalResult.h"
 
@@ -16,7 +15,11 @@ using namespace llvm;
 
 namespace mlir::iree_compiler::AMDAIE {
 
-enum class ChannelAssignmentMode { FirstAvailable, RoundRobin };
+enum class ChannelAssignmentMode {
+  FirstAvailableCircuitFlow,
+  FirstAvailablePacketFlow,
+  RoundRobinPacketFlow
+};
 
 /// Utility to generate valid channels.
 class ChannelGenerator {
@@ -27,75 +30,160 @@ class ChannelGenerator {
         numConsumerChannels(numConsumerChannels) {
     assert(numProducerChannels > 0 && numConsumerChannels > 0 &&
            "Invalid number of producer/consumer channels.");
-    // Initialize to the last channel for round-robin usage.
-    lastRetrievedProducerChannel = numProducerChannels - 1;
-    lastRetrievedConsumerChannel = numConsumerChannels - 1;
+  }
+
+  /// Attempts to find the first available channel that is not present in any of
+  /// the given exclusion sets.
+  std::optional<uint8_t> findFirstAvailableChannel(
+      uint8_t numChannels,
+      ArrayRef<llvm::SmallSetVector<uint8_t, 8>> excludeSets) {
+    for (uint8_t channel = 0; channel < numChannels; ++channel) {
+      if (llvm::none_of(
+              excludeSets,
+              [&](const llvm::SmallSetVector<uint8_t, 8> &excludeSet) {
+                return excludeSet.count(channel);
+              })) {
+        return channel;
+      }
+    }
+    return std::nullopt;
   }
 
   /// Retrieves the next producer channel using the specified strategy.
-  /// Defaults to round-robin for balanced load distribution, using
-  /// `lastRetrievedProducerChannel` to track the last channel accessed.
-  std::optional<uint8_t> getProducerDMAChannel(
-      ChannelAssignmentMode mode = ChannelAssignmentMode::RoundRobin) {
-    for (uint8_t offset = 1; offset <= numProducerChannels; ++offset) {
-      uint8_t i;
-      if (mode == ChannelAssignmentMode::FirstAvailable) {
-        i = offset - 1;
-      } else if (mode == ChannelAssignmentMode::RoundRobin) {
-        i = (lastRetrievedProducerChannel + offset) % numProducerChannels;
-      } else {
+  std::optional<uint8_t> getAndAssignProducerDMAChannel(
+      ChannelAssignmentMode mode) {
+    std::optional<uint8_t> channel;
+    switch (mode) {
+      // Select the first available channel for circuit flow.
+      // A channel is valid if it is not already assigned to any circuit or
+      // packet flow.
+      case ChannelAssignmentMode::FirstAvailableCircuitFlow: {
+        channel = findFirstAvailableChannel(
+            numProducerChannels,
+            {assignedCircuitProducerChannels, assignedPacketProducerChannels});
+        break;
+      }
+      // Select the first available channel for packet flow.
+      // A channel is valid if it is not already assigned to a circuit flow.
+      case ChannelAssignmentMode::FirstAvailablePacketFlow: {
+        channel = findFirstAvailableChannel(numProducerChannels,
+                                            {assignedCircuitProducerChannels});
+        break;
+      }
+      // Select the channel for packet flow, using a round-robin strategy for
+      // load balancing:
+      // 1. Prefer an unused channel (not assigned to any circuit or packet
+      // flow).
+      // 2. If no such channel is available, reuse the least recently used
+      // packet flow channel from `assignedPacketProducerChannels.front()`.
+      case ChannelAssignmentMode::RoundRobinPacketFlow: {
+        channel = findFirstAvailableChannel(
+            numProducerChannels,
+            {assignedCircuitProducerChannels, assignedPacketProducerChannels});
+        if (!channel && !assignedPacketProducerChannels.empty())
+          channel = assignedPacketProducerChannels.front();
+        break;
+      }
+      default:
         assert(false && "Unsupported ChannelAssignmentMode");
-      }
-      if (!assignedProducerChannels.count(i)) {
-        lastRetrievedProducerChannel = i;
-        return i;
-      }
     }
-    return std::nullopt;
+    // Assign the channel if found.
+    if (channel.has_value()) assignProducerDMAChannel(channel.value(), mode);
+    return channel;
   }
 
   /// Retrieves the next consumer channel using the specified strategy.
-  /// Defaults to round-robin for balanced load distribution, using
-  /// `lastRetrievedConsumerChannel` to track the last channel accessed.
-  std::optional<uint8_t> getConsumerDMAChannel(
-      ChannelAssignmentMode mode = ChannelAssignmentMode::RoundRobin) {
-    for (uint8_t offset = 1; offset <= numConsumerChannels; ++offset) {
-      uint8_t i;
-      if (mode == ChannelAssignmentMode::FirstAvailable) {
-        i = offset - 1;
-      } else if (mode == ChannelAssignmentMode::RoundRobin) {
-        i = (lastRetrievedConsumerChannel + offset) % numConsumerChannels;
-      } else {
+  std::optional<uint8_t> getAndAssignConsumerDMAChannel(
+      ChannelAssignmentMode mode) {
+    std::optional<uint8_t> channel;
+    switch (mode) {
+      // Select the first available channel for circuit flow.
+      // A channel is valid if it is not already assigned to any circuit or
+      // packet flow.
+      case ChannelAssignmentMode::FirstAvailableCircuitFlow: {
+        channel = findFirstAvailableChannel(
+            numConsumerChannels,
+            {assignedCircuitConsumerChannels, assignedPacketConsumerChannels});
+        break;
+      }
+      // Select the first available channel for packet flow.
+      // A channel is valid if it is not already assigned to a circuit flow.
+      case ChannelAssignmentMode::FirstAvailablePacketFlow: {
+        channel = findFirstAvailableChannel(numConsumerChannels,
+                                            {assignedCircuitConsumerChannels});
+        break;
+      }
+      // Select the channel for packet flow, using a round-robin strategy for
+      // load balancing:
+      // 1. Prefer an unused channel (not assigned to any circuit or packet
+      // flow).
+      // 2. If no such channel is available, reuse the least recently used
+      // packet flow channel from `assignedPacketConsumerChannels.front()`.
+      case ChannelAssignmentMode::RoundRobinPacketFlow: {
+        channel = findFirstAvailableChannel(
+            numConsumerChannels,
+            {assignedCircuitConsumerChannels, assignedPacketConsumerChannels});
+        if (!channel && !assignedPacketConsumerChannels.empty())
+          channel = assignedPacketConsumerChannels.front();
+        break;
+      }
+      default:
         assert(false && "Unsupported ChannelAssignmentMode");
-      }
-      if (!assignedConsumerChannels.count(i)) {
-        lastRetrievedConsumerChannel = i;
-        return i;
-      }
     }
-    return std::nullopt;
+    // Assign the channel if found.
+    if (channel.has_value()) assignConsumerDMAChannel(channel.value(), mode);
+    return channel;
   }
 
-  /// Assigns the provided producer channel, only used for circuit flow.
-  void assignProducerDMAChannel(uint8_t channel) {
-    assignedProducerChannels.insert(channel);
+  /// Assigns the provided producer channel.
+  void assignProducerDMAChannel(uint8_t channel, ChannelAssignmentMode mode) {
+    switch (mode) {
+      case ChannelAssignmentMode::FirstAvailableCircuitFlow:
+        assignedCircuitProducerChannels.insert(channel);
+        break;
+      case ChannelAssignmentMode::FirstAvailablePacketFlow:
+        assignedPacketProducerChannels.insert(channel);
+        break;
+      case ChannelAssignmentMode::RoundRobinPacketFlow:
+        // Remove and reinsert to update the least recently used channel
+        // (front).
+        assignedPacketProducerChannels.remove(channel);
+        assignedPacketProducerChannels.insert(channel);
+        break;
+      default:
+        assert(false && "Unsupported ChannelAssignmentMode");
+    }
   }
 
-  /// Assigns the provided consumer channel, only used for circuit flow.
-  void assignConsumerDMAChannel(uint8_t channel) {
-    assignedConsumerChannels.insert(channel);
+  /// Assigns the provided consumer channel.
+  void assignConsumerDMAChannel(uint8_t channel, ChannelAssignmentMode mode) {
+    switch (mode) {
+      case ChannelAssignmentMode::FirstAvailableCircuitFlow:
+        assignedCircuitConsumerChannels.insert(channel);
+        break;
+      case ChannelAssignmentMode::FirstAvailablePacketFlow:
+        assignedPacketConsumerChannels.insert(channel);
+        break;
+      case ChannelAssignmentMode::RoundRobinPacketFlow:
+        // Remove and reinsert to update the least recently used channel
+        // (front).
+        assignedPacketConsumerChannels.remove(channel);
+        assignedPacketConsumerChannels.insert(channel);
+        break;
+      default:
+        assert(false && "Unsupported ChannelAssignmentMode");
+    }
   }
 
  private:
   uint8_t numProducerChannels = 0;
   uint8_t numConsumerChannels = 0;
   // Tracks the channels that are used by circuit flows.
-  DenseSet<uint8_t> assignedProducerChannels;
-  DenseSet<uint8_t> assignedConsumerChannels;
-  // Tracks the last retrieved channel in `getProducerDMAChannel` and
-  // `getConsumerDMAChannel` for round-robin usage.
-  uint8_t lastRetrievedProducerChannel = 0;
-  uint8_t lastRetrievedConsumerChannel = 0;
+  llvm::SmallSetVector<uint8_t, 8> assignedCircuitProducerChannels;
+  llvm::SmallSetVector<uint8_t, 8> assignedCircuitConsumerChannels;
+  // Tracks the channels that are used by packet flows.
+  llvm::SmallSetVector<uint8_t, 8> assignedPacketProducerChannels;
+  llvm::SmallSetVector<uint8_t, 8> assignedPacketConsumerChannels;
 };
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/runtime/src/iree-amd-aie/aie_runtime/Utils/test/ChannelGeneratorTest.cpp
+++ b/runtime/src/iree-amd-aie/aie_runtime/Utils/test/ChannelGeneratorTest.cpp
@@ -13,116 +13,68 @@ namespace {
 
 using namespace mlir::iree_compiler::AMDAIE;
 
-TEST(ChannelGeneratorTest, GetFirstAvailable) {
+TEST(ChannelGeneratorTest, GetAssignFirstAvailableCircuitFlow) {
   ChannelGenerator generator(2, 2);
-  EXPECT_EQ(
-      generator.getProducerDMAChannel(ChannelAssignmentMode::FirstAvailable)
-          .value(),
-      0);
-  EXPECT_EQ(
-      generator.getConsumerDMAChannel(ChannelAssignmentMode::FirstAvailable)
-          .value(),
-      0);
-  EXPECT_EQ(
-      generator.getProducerDMAChannel(ChannelAssignmentMode::FirstAvailable)
-          .value(),
-      0);
-  EXPECT_EQ(
-      generator.getConsumerDMAChannel(ChannelAssignmentMode::FirstAvailable)
-          .value(),
-      0);
-  EXPECT_EQ(
-      generator.getProducerDMAChannel(ChannelAssignmentMode::FirstAvailable)
-          .value(),
-      0);
-  EXPECT_EQ(
-      generator.getConsumerDMAChannel(ChannelAssignmentMode::FirstAvailable)
-          .value(),
-      0);
+  // Keep incrementing the channel number until all channels are assigned.
+  ChannelAssignmentMode mode = ChannelAssignmentMode::FirstAvailableCircuitFlow;
+  EXPECT_EQ(generator.getAndAssignProducerDMAChannel(mode).value(), 0);
+  EXPECT_EQ(generator.getAndAssignConsumerDMAChannel(mode).value(), 0);
+  EXPECT_EQ(generator.getAndAssignProducerDMAChannel(mode).value(), 1);
+  EXPECT_EQ(generator.getAndAssignConsumerDMAChannel(mode).value(), 1);
+  EXPECT_EQ(generator.getAndAssignProducerDMAChannel(mode), std::nullopt);
+  EXPECT_EQ(generator.getAndAssignConsumerDMAChannel(mode), std::nullopt);
 }
 
-TEST(ChannelGeneratorTest, GetRoundRobin) {
+TEST(ChannelGeneratorTest, GetAssignFirstAvailablePacketFlow) {
   ChannelGenerator generator(2, 2);
-  EXPECT_EQ(generator.getProducerDMAChannel(ChannelAssignmentMode::RoundRobin)
-                .value(),
-            0);
-  EXPECT_EQ(generator.getConsumerDMAChannel(ChannelAssignmentMode::RoundRobin)
-                .value(),
-            0);
-  EXPECT_EQ(generator.getProducerDMAChannel(ChannelAssignmentMode::RoundRobin)
-                .value(),
-            1);
-  EXPECT_EQ(generator.getConsumerDMAChannel(ChannelAssignmentMode::RoundRobin)
-                .value(),
-            1);
-  EXPECT_EQ(generator.getProducerDMAChannel(ChannelAssignmentMode::RoundRobin)
-                .value(),
-            0);
-  EXPECT_EQ(generator.getConsumerDMAChannel(ChannelAssignmentMode::RoundRobin)
-                .value(),
-            0);
-  EXPECT_EQ(generator.getProducerDMAChannel(ChannelAssignmentMode::RoundRobin)
-                .value(),
-            1);
-  EXPECT_EQ(generator.getConsumerDMAChannel(ChannelAssignmentMode::RoundRobin)
-                .value(),
-            1);
+  // Use the same channel number, as it can be assigned to multiple packet
+  // flows.
+  ChannelAssignmentMode mode = ChannelAssignmentMode::FirstAvailablePacketFlow;
+  EXPECT_EQ(generator.getAndAssignProducerDMAChannel(mode).value(), 0);
+  EXPECT_EQ(generator.getAndAssignConsumerDMAChannel(mode).value(), 0);
+  EXPECT_EQ(generator.getAndAssignProducerDMAChannel(mode).value(), 0);
+  EXPECT_EQ(generator.getAndAssignConsumerDMAChannel(mode).value(), 0);
+  EXPECT_EQ(generator.getAndAssignProducerDMAChannel(mode).value(), 0);
+  EXPECT_EQ(generator.getAndAssignConsumerDMAChannel(mode).value(), 0);
 }
 
-TEST(ChannelGeneratorTest, GetAssign) {
+TEST(ChannelGeneratorTest, GetAssignRoundRobinPacketFlow) {
   ChannelGenerator generator(2, 2);
-  EXPECT_EQ(generator.getProducerDMAChannel().value(), 0);
-  generator.assignProducerDMAChannel(0);
-  EXPECT_EQ(generator.getConsumerDMAChannel().value(), 0);
-  generator.assignConsumerDMAChannel(0);
-  EXPECT_EQ(generator.getProducerDMAChannel().value(), 1);
-  generator.assignProducerDMAChannel(1);
-  EXPECT_EQ(generator.getConsumerDMAChannel().value(), 1);
-  generator.assignConsumerDMAChannel(1);
-  EXPECT_EQ(generator.getProducerDMAChannel(), std::nullopt);
-  EXPECT_EQ(generator.getConsumerDMAChannel(), std::nullopt);
+  // Round-robin between the availble two channels, for load balancing.
+  ChannelAssignmentMode mode = ChannelAssignmentMode::RoundRobinPacketFlow;
+  EXPECT_EQ(generator.getAndAssignProducerDMAChannel(mode).value(), 0);
+  EXPECT_EQ(generator.getAndAssignConsumerDMAChannel(mode).value(), 0);
+  EXPECT_EQ(generator.getAndAssignProducerDMAChannel(mode).value(), 1);
+  EXPECT_EQ(generator.getAndAssignConsumerDMAChannel(mode).value(), 1);
+  EXPECT_EQ(generator.getAndAssignProducerDMAChannel(mode).value(), 0);
+  EXPECT_EQ(generator.getAndAssignConsumerDMAChannel(mode).value(), 0);
+  EXPECT_EQ(generator.getAndAssignProducerDMAChannel(mode).value(), 1);
+  EXPECT_EQ(generator.getAndAssignConsumerDMAChannel(mode).value(), 1);
 }
 
 TEST(ChannelGeneratorTest, Occupied) {
   ChannelGenerator generator(4, 4);
-  generator.assignProducerDMAChannel(0);
-  generator.assignConsumerDMAChannel(0);
-  generator.assignProducerDMAChannel(2);
-  generator.assignConsumerDMAChannel(2);
-  EXPECT_EQ(
-      generator.getProducerDMAChannel(ChannelAssignmentMode::FirstAvailable)
-          .value(),
-      1);
-  EXPECT_EQ(
-      generator.getConsumerDMAChannel(ChannelAssignmentMode::FirstAvailable)
-          .value(),
-      1);
-  EXPECT_EQ(
-      generator.getProducerDMAChannel(ChannelAssignmentMode::FirstAvailable)
-          .value(),
-      1);
-  EXPECT_EQ(
-      generator.getConsumerDMAChannel(ChannelAssignmentMode::FirstAvailable)
-          .value(),
-      1);
-  EXPECT_EQ(generator.getProducerDMAChannel(ChannelAssignmentMode::RoundRobin)
-                .value(),
-            3);
-  EXPECT_EQ(generator.getConsumerDMAChannel(ChannelAssignmentMode::RoundRobin)
-                .value(),
-            3);
-  EXPECT_EQ(generator.getProducerDMAChannel(ChannelAssignmentMode::RoundRobin)
-                .value(),
-            1);
-  EXPECT_EQ(generator.getConsumerDMAChannel(ChannelAssignmentMode::RoundRobin)
-                .value(),
-            1);
-  EXPECT_EQ(generator.getProducerDMAChannel(ChannelAssignmentMode::RoundRobin)
-                .value(),
-            3);
-  EXPECT_EQ(generator.getConsumerDMAChannel(ChannelAssignmentMode::RoundRobin)
-                .value(),
-            3);
+  // Reserve channels 0 for circuit flow.
+  ChannelAssignmentMode mode = ChannelAssignmentMode::FirstAvailableCircuitFlow;
+  generator.assignProducerDMAChannel(0, mode);
+  generator.assignConsumerDMAChannel(0, mode);
+  // Reserve channels 1 for packet flow.
+  mode = ChannelAssignmentMode::FirstAvailablePacketFlow;
+  generator.assignProducerDMAChannel(1, mode);
+  generator.assignConsumerDMAChannel(1, mode);
+  // The next available channel for circuit flow is 2.
+  mode = ChannelAssignmentMode::FirstAvailableCircuitFlow;
+  EXPECT_EQ(generator.getAndAssignProducerDMAChannel(mode).value(), 2);
+  EXPECT_EQ(generator.getAndAssignConsumerDMAChannel(mode).value(), 2);
+  // Channel 0 and 2 are already assigned for circuit flow. Therefore, for
+  // packet flow, the next available channel is round-robin between 1 and 3.
+  mode = ChannelAssignmentMode::RoundRobinPacketFlow;
+  EXPECT_EQ(generator.getAndAssignProducerDMAChannel(mode).value(), 3);
+  EXPECT_EQ(generator.getAndAssignConsumerDMAChannel(mode).value(), 3);
+  EXPECT_EQ(generator.getAndAssignProducerDMAChannel(mode).value(), 1);
+  EXPECT_EQ(generator.getAndAssignConsumerDMAChannel(mode).value(), 1);
+  EXPECT_EQ(generator.getAndAssignProducerDMAChannel(mode).value(), 3);
+  EXPECT_EQ(generator.getAndAssignConsumerDMAChannel(mode).value(), 3);
 }
 
 }  // namespace


### PR DESCRIPTION
Changes in this PR:
- Previously, channels for data flows were assigned first using the `AssignChannels` pass, followed by control flow channel assignment with the `GenerateControlOverla`y pass. This PR reverses the order, ensuring that control flow channels are assigned before data flow channels.
- Previously, in the runtime `ChannelGenerator`, packet flow channels were not explicitly marked as assigned (so that they can be reused), while only circuit flow channels were tracked. However, this could result in a packet flow channel later being mistakenly reused by another circuit flow.  Now, both circuit and packet flows track their assigned channels and store them separately. This ensures that circuit flow channels remain exclusive, while packet flow channels can be reused but only by other packet flows.
