### PR TITLE
[CI] Relax gating on when tests are skipped

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -171,7 +171,7 @@ class BaseTest(ABC):
         # does not).
         if self.use_chess and not config.vitis_dir:
             return False
-        if self.use_kernel and self.use_chess_for_ukernel and not config.vitis_dir:
+        if self.use_ukernel and self.use_chess_for_ukernel and not config.vitis_dir:
             return False
 
         # If use_chess=0, and config has not provided a valid

--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -171,7 +171,7 @@ class BaseTest(ABC):
         # does not).
         if self.use_chess and not config.vitis_dir:
             return False
-        if self.use_chess_for_ukernel and not config.vitis_dir:
+        if self.use_kernel and self.use_chess_for_ukernel and not config.vitis_dir:
             return False
 
         # If use_chess=0, and config has not provided a valid


### PR DESCRIPTION
Without this, if no vitis directory path is specified, the non-ukernel peano tests do not run. 

aka: System alert: dangerously high entropy level detected!
