### PR TITLE
Function to estimate stack size 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
@@ -90,7 +90,7 @@ std::optional<int> safeStoi(std::string_view intString) {
 // Where above function_foo will use a stack of size 224, and function_bar will
 // use a stack of size 92.
 //
-// We assume that function call structure is as possible:
+// We assume that function call structure is as follows:
 // functions with names core_0_0, core_0_1, core_0_2, etc. call into
 // functions with names like generic_matmul_0_outlined. These latter
 // functions do no make any function calls.
@@ -698,7 +698,7 @@ static auto assembleStringUsingPeano =
     std::bind(assembleStringUsing, assembleFileUsingPeano, _1, _2, _3, _4, _5,
               _6, _7, _8, _9);
 
-// Generate the elf files for the core. Return the stack size of success.
+// Generate the elf files for the core.
 LogicalResult generateCoreElfFiles(AIE::DeviceOp deviceOp,
                                    const std::string &objFile, Path &tempDir,
                                    bool useChess, bool useChessForUKernel,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
@@ -137,8 +137,8 @@ FailureOr<int> getStackSize(const std::string &aieAssembly) {
     }
 
     // For example, extract 224 from 'paddb [sp], #224;'
-    auto hashSubstr = line.substr(hashIndex + 1);
-    auto maybeNumber = safeStoi(hashSubstr);
+    std::string hashSubstr = line.substr(hashIndex + 1);
+    std::optional<int> maybeNumber = safeStoi(hashSubstr);
     if (!maybeNumber.has_value()) {
       llvm::errs() << "failed to get number from \n" << hashSubstr << "\n";
       return failure();
@@ -249,7 +249,7 @@ FailureOr<std::vector<std::string>> makePeanoOptArgs(
   // Append the additional flags, unless they conflict with an existing flag,
   // in which case replace the existing flag.
   args.reserve(args.size() + additionalFlags.size());
-  for (const auto &flag : additionalFlags) {
+  for (const std::string &flag : additionalFlags) {
     auto iter = std::find_if(args.begin(), args.end(),
                              std::bind(isContention, _1, flag));
     if (iter == args.end()) {
@@ -349,7 +349,7 @@ FailureOr<Path> findVitis(std::optional<Path> &vitisDir,
   if (!vitisDir) {
     const char *envVitis = ::getenv("VITIS");
     if (!envVitis) {
-      if (auto vpp = sys::findProgramByName("v++")) {
+      if (ErrorOr<std::string> vpp = sys::findProgramByName("v++")) {
         SmallString<64> realVpp;
         std::error_code err = sys::fs::real_path(vpp.get(), realVpp);
         if (!err) {
@@ -543,7 +543,7 @@ LogicalResult runTool(
   {
     std::string prefix{"tmpRunTool"};
     std::string suffix{"Logging"};
-    auto errorCode =
+    std::error_code errorCode =
         llvm::sys::fs::createTemporaryFile(prefix, suffix, temporaryPath);
     if (errorCode) {
       llvm::errs() << "Failed to create temporary file: " << errorCode.message()

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.h
@@ -32,9 +32,17 @@ mlir::LogicalResult emitNpuInstructions(xilinx::AIE::DeviceOp deviceOp,
                                         const std::string &outputNPU);
 
 namespace detail {
+
 FailureOr<std::vector<std::string>> flagStringToVector(
     const std::string &flags);
+
 FailureOr<std::vector<std::string>> makePeanoOptArgs(
     const std::vector<std::string> &additionalPeanoOptFlags);
+
+/// An exception-free version of std::stoi, using C++17's std::from_chars.
+std::optional<int> safeStoi(std::string_view intString);
+
+FailureOr<int> getStackSize(const std::string &aieAssembly);
+
 }  // namespace detail
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.h
@@ -42,6 +42,9 @@ FailureOr<std::vector<std::string>> makePeanoOptArgs(
 /// An exception-free version of std::stoi, using C++17's std::from_chars.
 std::optional<int> safeStoi(std::string_view intString);
 
+/// Get the stack size by analysing AIE assembly code. This function is not
+/// guaranteed to work for all AIE assembly code, and should be used with
+/// caution.
 FailureOr<int> getStackSize(const std::string &aieAssembly);
 
 }  // namespace detail

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.h
@@ -42,10 +42,15 @@ FailureOr<std::vector<std::string>> makePeanoOptArgs(
 /// An exception-free version of std::stoi, using C++17's std::from_chars.
 std::optional<int> safeStoi(std::string_view intString);
 
-/// Get the stack size by analysing AIE assembly code. This function is not
-/// guaranteed to work for all AIE assembly code, and should be used with
-/// caution.
-FailureOr<int> getStackSize(const std::string &aieAssembly);
+/// Get upper-bounds on the maximum stack sizes for the different cores (col,
+/// row) by analysing AIE assembly code. This function is not guaranteed to work
+/// for all AIE assembly code, and should be used with caution.
+///
+/// \return A map from (col, row) to an uppoer bound on maximum stack size for
+///         that core. If the analysis of the assembly code fails, a failure is
+///         returned.
+FailureOr<llvm::DenseMap<std::pair<int, int>, int>> getUpperBoundStackSizes(
+    const std::string &aieAssembly);
 
 }  // namespace detail
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/AMDAIEXCLBinGenTest.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/AMDAIEXCLBinGenTest.cpp
@@ -61,7 +61,8 @@ TEST(XCLBinGenTest, GetStackSize0) {
  nopa ;  paddb [sp], #224;  nopxm ;  nops
  paddb [sp], #-224                     //  Delay Slot 1
 )";
-    auto ubs = detail::getUpperBoundStackSizes(asmStr);
+    mlir::FailureOr<llvm::DenseMap<std::pair<int, int>, int>> ubs =
+        detail::getUpperBoundStackSizes(asmStr);
     EXPECT_TRUE(succeeded(ubs));
     // auto upperBounds = maybeUpperBounds.value();
     auto ub = ubs.value().find({0, 2});
@@ -75,7 +76,8 @@ TEST(XCLBinGenTest, GetStackSize0) {
  nopa ;  paddb [sp], #96;  nopxm ;  nops
 )";
 
-    auto ubs = detail::getUpperBoundStackSizes(asmStr);
+    mlir::FailureOr<llvm::DenseMap<std::pair<int, int>, int>> ubs =
+        detail::getUpperBoundStackSizes(asmStr);
     EXPECT_TRUE(succeeded(ubs));
     // auto upperBounds = maybeUpperBounds.value();
     auto ub = ubs.value().find({0, 2});
@@ -94,7 +96,8 @@ TEST(XCLBinGenTest, GetStackSize0) {
  nopa ;  padda [sp], #224;  nopxm ;  nops
 )";
 
-    auto maybeUpperBounds = detail::getUpperBoundStackSizes(asmStr);
+    mlir::FailureOr<llvm::DenseMap<std::pair<int, int>, int>> maybeUpperBounds =
+        detail::getUpperBoundStackSizes(asmStr);
     EXPECT_TRUE(succeeded(maybeUpperBounds));
     auto upperBounds = maybeUpperBounds.value();
     {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/AMDAIEXCLBinGenTest.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/AMDAIEXCLBinGenTest.cpp
@@ -61,7 +61,12 @@ TEST(XCLBinGenTest, GetStackSize0) {
  nopa ;  paddb [sp], #224;  nopxm ;  nops
  paddb [sp], #-224                     //  Delay Slot 1
 )";
-    EXPECT_TRUE(detail::getStackSize(asmStr) == 224);
+    auto ubs = detail::getUpperBoundStackSizes(asmStr);
+    EXPECT_TRUE(succeeded(ubs));
+    // auto upperBounds = maybeUpperBounds.value();
+    auto ub = ubs.value().find({0, 2});
+    EXPECT_TRUE(ub != ubs.value().end());
+    EXPECT_TRUE(ub->second == 224);
   }
 
   {
@@ -69,7 +74,13 @@ TEST(XCLBinGenTest, GetStackSize0) {
  .type core_0_2,@function
  nopa ;  paddb [sp], #96;  nopxm ;  nops
 )";
-    EXPECT_TRUE(detail::getStackSize(asmStr) == 96);
+
+    auto ubs = detail::getUpperBoundStackSizes(asmStr);
+    EXPECT_TRUE(succeeded(ubs));
+    // auto upperBounds = maybeUpperBounds.value();
+    auto ub = ubs.value().find({0, 2});
+    EXPECT_TRUE(ub != ubs.value().end());
+    EXPECT_TRUE(ub->second == 96);
   }
 
   {
@@ -82,7 +93,26 @@ TEST(XCLBinGenTest, GetStackSize0) {
  .type core_0_3,@function
  nopa ;  padda [sp], #224;  nopxm ;  nops
 )";
-    EXPECT_TRUE(detail::getStackSize(asmStr) == 224 + 20);
+
+    auto maybeUpperBounds = detail::getUpperBoundStackSizes(asmStr);
+    EXPECT_TRUE(succeeded(maybeUpperBounds));
+    auto upperBounds = maybeUpperBounds.value();
+    {
+      auto ub = upperBounds.find({0, 2});
+      EXPECT_TRUE(ub != upperBounds.end());
+      EXPECT_TRUE(ub->second == 224 + 20);
+    }
+
+    {
+      auto ub = upperBounds.find({5, 5});
+      EXPECT_TRUE(ub == upperBounds.end());
+    }
+
+    {
+      auto ub = upperBounds.find({0, 3});
+      EXPECT_TRUE(ub != upperBounds.end());
+      EXPECT_TRUE(ub->second == 224 + 20);
+    }
   }
 }
 


### PR DESCRIPTION
This is a simpler version of https://github.com/nod-ai/iree-amd-aie/pull/1104

In this PR, the stack size is not set based on the assembly analysis, this PR just adds a check that the assigned stack is sufficient. 

I have checked this locally by changing the stack size [here](https://github.com/nod-ai/iree-amd-aie/blob/d2ccc8907e9b867259854d233c70980a26251ac0/compiler/plugins/target/AMD-AIE/aie/AIEOps.td#L128) and it works fine. 

This should help avoid the bad situations like https://github.com/Xilinx/llvm-aie/issues/342

Next steps (I'd like to do these in a separate PR): 
- a flag to manually set the stack size at compile time 
- ability to set the stack's base address after assembly is generated 