### PR TITLE
[AMDAIESinkIntoCore] Generalize sinking for reuse with other regioned ops 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aie/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/aie/CMakeLists.txt
@@ -87,6 +87,8 @@ iree_cc_library(
     MLIRMemRefDialect
     MLIRIR
     MLIREmitCDialect
+    iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::HAL::IR::HALDialect
 )
 
 ###############################################################################

--- a/compiler/plugins/target/AMD-AIE/aie/test/lower_buffer.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/lower_buffer.mlir
@@ -1,9 +1,11 @@
-// RUN: iree-opt --amdaie-standard-lowering %s | FileCheck %s
+// RUN: iree-opt --amdaie-standard-lowering --split-input-file %s | FileCheck %s
 
-// CHECK:         memref.global "public" @a : memref<4xi32>
-// CHECK-LABEL:   func.func @core_4_3() {
+// CHECK-LABEL: @basic_test
+// CHECK-DAG:         memref.global "public" @a : memref<4xi32>
+// CHECK-DAG:         memref.global "public" @b : memref<4xi32>
+// CHECK:        func.func @core_3_4() {
 // CHECK:           %[[C0:.*]] = arith.constant 0 : index
-// CHECK:           %[[VAL_0:.*]] = memref.get_global @a : memref<4xi32>
+// CHECK:           %[[VAL_0:.*]] = memref.get_global @b : memref<4xi32>
 // CHECK:           memref.assume_alignment %[[VAL_0]], 32 : memref<4xi32>
 // CHECK:           %[[VAL_1:.*]] = memref.load %[[VAL_0]]{{\[}}%[[C0]]] : memref<4xi32>
 // CHECK:           return
@@ -18,22 +20,44 @@
 // CHECK:           return
 // CHECK:         }
 
-module @codegen1 {
- aie.device(xcvc1902) {
-  %t33 = aie.tile(3, 3)
-  %a = aie.buffer(%t33) { sym_name = "a" } : memref<4xi32>
-  %core33 = aie.core(%t33) {
-    %0 = arith.constant 0 : index
-    %377 = arith.constant 377 : i32
-    memref.store %377, %a[%0] : memref<4xi32>
-    aie.end
+module @basic_test {
+  aie.device(xcvc1902) {
+    %tile_3_3 = aie.tile(3, 3)
+    %buffer_3_3 = aie.buffer(%tile_3_3) {sym_name = "a"} : memref<4xi32>
+    %core_3_3 = aie.core(%tile_3_3) {
+      %c0 = arith.constant 0 : index
+      %c377_i32 = arith.constant 377 : i32
+      memref.store %c377_i32, %buffer_3_3[%c0] : memref<4xi32>
+      aie.end
+    }
+    %tile_3_4 = aie.tile(3, 4)
+    %buffer_3_4 = aie.buffer(%tile_3_4) {sym_name = "b"} : memref<4xi32>
+    %core_3_4 = aie.core(%tile_3_4) {
+      %c0 = arith.constant 0 : index
+      %0 = memref.load %buffer_3_4[%c0] : memref<4xi32>
+      aie.end
+    }
   }
-  %t34 = aie.tile(4, 3)
+}
 
-  %core34 = aie.core(%t34) {
-    %0 = arith.constant 0 : index
-    %1 = memref.load %a[%0] : memref<4xi32>
-    aie.end
+// -----
+
+// CHECK:     func.func @core_4_3() {
+// CHECK-DAG:   %[[C44:.*]] = arith.constant 44 : index
+// CHECK-DAG:   %[[VAL_0:.*]] = memref.get_global @a : memref<4xi32>
+// CHECK:       %[[VAL_1:.*]] = memref.load %[[VAL_0]]{{\[}}%[[C44]]] : memref<4xi32>
+// CHECK:       return
+// CHECK:     }
+
+// Check that the constant 44 is hoisted into the core/function.
+module @isolation_test {
+  aie.device(xcvc1902) {
+    %tile_4_3 = aie.tile(4, 3)
+    %c44 = arith.constant 44 : index
+    %buffer_4_3 = aie.buffer(%tile_4_3) {sym_name = "a"} : memref<4xi32>
+    %core_4_3 = aie.core(%tile_4_3) {
+      %0 = memref.load %buffer_4_3[%c44] : memref<4xi32>
+      aie.end
+    }
   }
- }
 }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIESinkIntoCore.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIESinkIntoCore.cpp
@@ -8,13 +8,12 @@
 #include "iree-amd-aie/IR/AMDAIEDialect.h"
 #include "iree-amd-aie/IR/AMDAIEOps.h"
 #include "iree-amd-aie/Transforms/Passes.h"
+#include "iree-amd-aie/Transforms/Utils/AMDAIEUtils.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/LoopInvariantCodeMotionUtils.h"
 
 #define DEBUG_TYPE "iree-amdaie-sink-into-core"
@@ -22,62 +21,6 @@
 namespace mlir::iree_compiler::AMDAIE {
 
 namespace {
-
-bool sinkInto(AMDAIE::CoreOp coreOp, PatternRewriter &rewriter) {
-  // Record if any ops are sunk into the core during this iteration.
-  bool changed = false;
-
-  // Collect all ops in the amdaie.core op
-  SmallVector<Operation *> opsInCore;
-  coreOp->walk([&](Operation *op) {
-    if (op == coreOp) return WalkResult::advance();
-    opsInCore.push_back(op);
-    return WalkResult::advance();
-  });
-
-  for (auto opInCore : opsInCore) {
-    for (Value operand : opInCore->getOperands()) {
-      if (!operand || !operand.getDefiningOp()) continue;
-      Operation *dependencyOp = operand.getDefiningOp();
-
-      // Skip if the dependency is already in the core.
-      if (coreOp->isAncestor(dependencyOp)) {
-        continue;
-      }
-
-      // Ops in the amdaie dialect are probably related to data movement
-      // and should not be sunk into the core. This might need adjustment
-      // later.
-      if (dependencyOp->getDialect()->getNamespace() ==
-          AMDAIE::AMDAIEDialect::getDialectNamespace()) {
-        continue;
-      }
-
-      // Create a clone of the dependency op in the core region.
-      Region &r = coreOp->getRegion(0);
-      assert(r.getBlocks().size() == 1 && "expected single block region");
-      rewriter.setInsertionPointToStart(&r.front());
-      Operation *sunkOp = rewriter.clone(*dependencyOp);
-
-      // Replace uses of the dependency op inside the core.
-      dependencyOp->replaceUsesWithIf(sunkOp, [&](OpOperand &use) {
-        return coreOp->isAncestor(use.getOwner());
-      });
-      changed = true;
-    }
-  }
-  return changed;
-}
-
-class SinkingPattern : public OpRewritePattern<AMDAIE::CoreOp> {
- public:
-  using OpRewritePattern<AMDAIE::CoreOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(AMDAIE::CoreOp coreOp,
-                                PatternRewriter &rewriter) const override {
-    return success(sinkInto(coreOp, rewriter));
-  }
-};
 
 class AMDAIESinkIntoCorePass
     : public impl::AMDAIESinkIntoCoreBase<AMDAIESinkIntoCorePass> {
@@ -87,10 +30,23 @@ class AMDAIESinkIntoCorePass
                     xilinx::AIE::AIEDialect, AMDAIE::AMDAIEDialect>();
   }
   void runOnOperation() override {
-    RewritePatternSet patterns(&getContext());
-    patterns.insert<SinkingPattern>(&getContext());
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
-      signalPassFailure();
+    auto shouldSink = [&](Operation *op) -> bool {
+      // Ops in the amdaie dialect are probably related to data movement
+      // and should not be sunk into the core. This might need adjustment
+      // later.
+      if (op->getDialect()->getNamespace() ==
+          AMDAIE::AMDAIEDialect::getDialectNamespace()) {
+        return false;
+      }
+      return true;
+    };
+    IRRewriter rewriter(getOperation());
+    SmallVector<AMDAIE::CoreOp> coreOps;
+
+    getOperation()->walk(
+        [&](AMDAIE::CoreOp coreOp) { coreOps.push_back(coreOp); });
+    for (auto coreOp : coreOps) {
+      sinkInto(coreOp.getRegion(), rewriter, shouldSink);
     }
   }
 };

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEUtils.h
@@ -116,6 +116,20 @@ std::string getArrayString(ArrayRef<T> vs) {
 /// "[not constant integers]".
 std::string getConstantIntValuesString(ArrayRef<OpFoldResult> opFoldResults);
 
+/// Consider all operations in the region, recursively. If the operation
+/// has an operand that is not in the region, and the `shouldSink` function
+/// returns true for that operand's producer, then replace all uses of the
+/// operand inside the region with a clone of the operand in the block.
+///
+/// If `shouldSink` returns true for all operations, then this function will
+/// make the region isolated from above.  So this function essentially makes
+/// the region isolated from above with respect to the set of operation types
+/// defined by `shouldSink`.
+///
+/// \return true if the region was changed.
+bool sinkInto(Region &, IRRewriter &,
+              std::function<bool(Operation *)> shouldSink);
+
 }  // namespace mlir::iree_compiler::AMDAIE
 
 #endif


### PR DESCRIPTION
This is part of the PR to vectorize linalg.fill: https://github.com/nod-ai/iree-amd-aie/pull/1095

Basically one of the patterns introduced in https://github.com/nod-ai/iree-amd-aie/pull/1095 means that in one of the subsequent passes (lowering to llvm dialect) a cast operation is introduced outside of an aie.core, which needs to be inside the aie.core for core-to-standard to work.  i.e. we need to sink an operation into an aie.core. Before this PR, there is already a pass to sink operations into `amdaie.core`. This PR refactors that pass so that it can be reused to sink into `aie.core` (or any other regioned op). 
