### PR TITLE
Function to estimate stack size (using existing tooling)

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.h
@@ -32,9 +32,33 @@ mlir::LogicalResult emitNpuInstructions(xilinx::AIE::DeviceOp deviceOp,
                                         const std::string &outputNPU);
 
 namespace detail {
+
 FailureOr<std::vector<std::string>> flagStringToVector(
     const std::string &flags);
+
 FailureOr<std::vector<std::string>> makePeanoOptArgs(
     const std::vector<std::string> &additionalPeanoOptFlags);
+
+/// An exception-free version of std::stoi, using C++17's std::from_chars.
+std::optional<int> safeStoi(std::string_view intString);
+
+/// Get upper-bounds on the maximum stack sizes for the different cores (col,
+/// row) by parsing a string of the form:
+///
+/// ```
+/// Stack Sizes:
+///      Size     Functions
+///        32     some_func
+///       512     core_1_3
+///        64     some_other_func
+///       288     core_3_5
+/// ```
+///
+/// \return A map from (col, row) to an upper bound on maximum stack size for
+///         that core. If the analysis of the string fails, a failure is
+///         returned.
+FailureOr<llvm::DenseMap<std::pair<uint32_t, uint32_t>, uint32_t>>
+getUpperBoundStackSizes(const std::string &);
+
 }  // namespace detail
 }  // namespace mlir::iree_compiler::AMDAIE


### PR DESCRIPTION
This will replace https://github.com/nod-ai/iree-amd-aie/pull/1116 -- instead of string matching the assembly file, it uses llvm's `llvm-readelf` after adding `--stack-size-section` to the llc call. 