### PR TITLE
[AIEVec] additional flattening of arith ops 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
+++ b/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
@@ -1481,8 +1481,7 @@ FailureOr<Value> getAlignedTransferRead(
     // aligned, and we just couldn't prove it.
     readOp.emitWarning() << "`transfer_read` doesn't have a vector with "
                          << shiftOperandBits / 2 << " or " << shiftOperandBits
-                         << " bits."
-                         << "This case is not currently handled.";
+                         << " bits." << "This case is not currently handled.";
     return readOp.getVector();
   }
 

--- a/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
+++ b/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
@@ -1004,50 +1004,126 @@ struct ToMinorIdentityTransferReadPattern
   }
 };
 
-// clang-format off
-/// Pattern to linearize arith.truncf because later aievec.srs in AIEVecToLLVM is
-/// expected to have 1-D source and target.
-/// Refer: https://github.com/nod-ai/iree-amd-aie/blob/main/compiler/plugins/target/AMD-AIE/aievec/AIEVecToLLVM.cpp#L73-L74
+/// Pattern to linearize/flatten the operands of operations of type `TOp`.
 ///
-/// Example of what this pattern achieves :-
+/// This pattern matches if all operands (multiple operands are permitted) and
+/// the result have the same shape, and are not rank-1. In this case all
+/// the operands are flattened to rank-1 with a vector.shape_cast.
+///
+/// One example where this is required is for arith.truncf, because later
+/// aievec.srs in AIEVecToLLVM is expected to have 1-D source and target.
+///
+/// Example of what this pattern achieves (When TOp is arith::TruncFOp) :-
 /// INPUT
 ///     %0 = arith.truncf %inp : vector<2x3xf32> to vector<2x3xbf16>
 /// OUTPUT
 ///     %0 = vector.shape_cast %inp : vector<2x3xf32> to vector<6xf32>
 ///     %1 = arith.truncf %0 : vector<6xf32> to vector<6xbf16>
 ///     %2 = vector.shape_cast %1 : vector<6xbf16> to vector<2x3xbf16>
-// clang-format on
-template <typename TruncOpTy>
-struct FlattenArithTruncOpPattern : public OpRewritePattern<TruncOpTy> {
-  using OpRewritePattern<TruncOpTy>::OpRewritePattern;
+///
+template <typename TOp>
+struct FlattenOpPattern : public OpRewritePattern<TOp> {
+  using OpRewritePattern<TOp>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(TruncOpTy op,
+  LogicalResult matchAndRewrite(TOp op,
                                 PatternRewriter &rewriter) const override {
-    // Get old shape type.
-    auto oldShapedType = dyn_cast<VectorType>(op.getType());
-    if (!oldShapedType) return failure();
-    // Bail out if it's already linearized.
-    if (oldShapedType.getRank() == 1) return failure();
-    // Linearize the shape.
-    int64_t linearizedSize = oldShapedType.getNumElements();
-    // Fetch input.
-    Value origInputOfTruncFOp = op.getIn();
-    // Form linearized vector shape type for input and output.
-    VectorType newVectorTypeForInput = VectorType::get(
-        {linearizedSize},
-        cast<ShapedType>(origInputOfTruncFOp.getType()).getElementType());
-    VectorType newVectorTypeForOutput =
-        VectorType::get({linearizedSize}, oldShapedType.getElementType());
-    // Shape cast the original input to linearized shape type.
-    Value newInputVector = rewriter.create<vector::ShapeCastOp>(
-        op.getLoc(), newVectorTypeForInput, origInputOfTruncFOp);
-    // Create new base operation with the linearized input/output.
-    Value newTruncFOp = rewriter.create<TruncOpTy>(
-        op.getLoc(), newVectorTypeForOutput, newInputVector);
-    // Delinearize the output back to the original type.
-    rewriter.replaceOpWithNewOp<vector::ShapeCastOp>(op, op.getType(),
-                                                     newTruncFOp);
+    // Obtain the flattend output type, or bail if the output is already
+    // rank-1.
+    if (op->getNumResults() != 1) {
+      return rewriter.notifyMatchFailure(op, "not a single result");
+    }
+    Value result = op->getResult(0);
+    auto outType = dyn_cast<VectorType>(result.getType());
+    if (!outType) {
+      return rewriter.notifyMatchFailure(op, "output not vector");
+    }
+    ArrayRef<int64_t> shape = outType.getShape();
+    if (outType.getRank() == 1) {
+      return rewriter.notifyMatchFailure(op, "already rank-1");
+    }
+    Type outElmType = outType.getElementType();
+    int64_t nElms = outType.getNumElements();
+    VectorType newOutType = VectorType::get({nElms}, outElmType);
+
+    // Obtain the flattened input types, or bail if the shapes do not all
+    // match.
+    SmallVector<VectorType> newInTypes;
+    for (Value input : op->getOperands()) {
+      auto inType = dyn_cast<VectorType>(input.getType());
+      if (!inType) {
+        return rewriter.notifyMatchFailure(op, "input not vector");
+      }
+      if (inType.getShape() != shape) {
+        return rewriter.notifyMatchFailure(op,
+                                           "inputs and output shapes differ");
+      }
+      Type inElmType = inType.getElementType();
+      newInTypes.push_back(VectorType::get({nElms}, inElmType));
+    }
+
+    // Create flattened inputs.
+    SmallVector<Value> newInputs;
+    for (auto enumInput : llvm::enumerate(op->getOperands())) {
+      Value input = enumInput.value();
+      Type newInType = newInTypes[enumInput.index()];
+      auto parent =
+          dyn_cast_if_present<vector::ShapeCastOp>(input.getDefiningOp());
+      if (parent && parent.getOperand().getType() == newInType) {
+        newInputs.push_back(parent.getOperand());
+      } else {
+        newInputs.push_back(rewriter.createOrFold<vector::ShapeCastOp>(
+            op.getLoc(), newInType, input));
+      }
+    }
+
+    // Create a new op with the flattened inputs, and then reshape the result
+    // back to the original rank.
+    Value newOp =
+        rewriter.createOrFold<TOp>(op.getLoc(), newOutType, newInputs);
+    rewriter.replaceOpWithNewOp<vector::ShapeCastOp>(op, outType, newOp);
     return success();
+  }
+};
+
+/// A pattern to fold a `vector.shape_cast` following a splat constant
+/// materialization, with a direct splat constant of the new shape. Example.
+/// INPUT
+///    %cst = arith.constant dense<7> : vector<4x8xi64>
+///    %0 = vector.shape_cast %cst : vector<4x8xi64> to vector<32xi64>
+///    %use = some.use %0
+/// OUTPUT
+///    %cst = arith.constant dense<7> : vector<32xi64>
+///    %use = some.use %cst
+struct ShapeCastSplatPattern : public OpRewritePattern<arith::ConstantOp> {
+  using OpRewritePattern<arith::ConstantOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::ConstantOp cstOp,
+                                PatternRewriter &rewriter) const override {
+    // Check if the constant is a splat value.
+    TypedAttr constantValue = cstOp.getValueAttr();
+    SplatElementsAttr splatAttr = dyn_cast<SplatElementsAttr>(constantValue);
+    if (!splatAttr || !splatAttr.isSplat()) {
+      return rewriter.notifyMatchFailure(cstOp, "constant isn't a splat");
+    }
+    Attribute splat = splatAttr.getSplatValue<Attribute>();
+
+    // Replace all uses of shape_casts of the splat value with direct splat
+    // constants of the new shape.
+    Location loc = cstOp.getLoc();
+    bool changed{false};
+    rewriter.setInsertionPoint(cstOp);
+    for (Operation *user : cstOp->getUsers()) {
+      auto cast = dyn_cast<vector::ShapeCastOp>(user);
+      if (!cast) continue;
+      VectorType type = cast.getResult().getType();
+      DenseElementsAttr attr = DenseElementsAttr::get(type, splat);
+      auto newOp = rewriter.create<arith::ConstantOp>(loc, type, attr);
+      rewriter.replaceAllUsesWith(cast, newOp.getResult());
+      changed = true;
+    }
+
+    if (changed) return success();
+    return rewriter.notifyMatchFailure(cstOp, "no users are vector.shape_cast");
   }
 };
 
@@ -1280,12 +1356,14 @@ struct CanonicalizeVectorForAIEVecPass
 
     {
       RewritePatternSet patterns(context);
-      patterns.add<ExtractTransposeFromContractionOp,
-                   FlattenArithTruncOpPattern<arith::TruncFOp>,
-                   FlattenArithTruncOpPattern<arith::TruncIOp>,
-                   ToMinorIdentityTransferReadPattern,
-                   ToMinorIdentityTransferWritePattern,
-                   ConvertLeadingUnitDimInsertToReshapePattern>(context);
+      patterns.add<
+          ExtractTransposeFromContractionOp, FlattenOpPattern<arith::TruncFOp>,
+          FlattenOpPattern<arith::TruncIOp>, FlattenOpPattern<arith::MulIOp>,
+          FlattenOpPattern<arith::ShRSIOp>, FlattenOpPattern<arith::ExtSIOp>,
+          FlattenOpPattern<arith::ExtUIOp>, FlattenOpPattern<arith::ExtFOp>,
+          ShapeCastSplatPattern, ToMinorIdentityTransferReadPattern,
+          ToMinorIdentityTransferWritePattern,
+          ConvertLeadingUnitDimInsertToReshapePattern>(context);
       patterns.add<ConvertSplatTransferReadToBroadcastPattern>(context);
       patterns
           .add<copied_from_mlir::FlattenContiguousRowMajorTransferReadPattern,

--- a/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
+++ b/compiler/plugins/target/AMD-AIE/aievec/VectorToVectorConversions.cpp
@@ -1027,7 +1027,6 @@ struct FlattenOpPattern : public OpRewritePattern<TOp> {
 
   LogicalResult matchAndRewrite(TOp op,
                                 PatternRewriter &rewriter) const override {
-    // Obtain the flattend output type, or fail if already rank-1.
     if (op->getNumResults() != 1) {
       return rewriter.notifyMatchFailure(op, "not a single result");
     }
@@ -1036,6 +1035,7 @@ struct FlattenOpPattern : public OpRewritePattern<TOp> {
     if (!outType) {
       return rewriter.notifyMatchFailure(op, "output not vector");
     }
+    // Obtain the flattened output type, or fail if already rank-1.
     ArrayRef<int64_t> shape = outType.getShape();
     if (outType.getRank() == 1) {
       return rewriter.notifyMatchFailure(op, "already rank-1");
@@ -1481,7 +1481,8 @@ FailureOr<Value> getAlignedTransferRead(
     // aligned, and we just couldn't prove it.
     readOp.emitWarning() << "`transfer_read` doesn't have a vector with "
                          << shiftOperandBits / 2 << " or " << shiftOperandBits
-                         << " bits." << "This case is not currently handled.";
+                         << " bits."
+                         << "This case is not currently handled.";
     return readOp.getVector();
   }
 

--- a/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
@@ -279,12 +279,16 @@ func.func @trivial_read_access_rank_reduced(%arg0: memref<4x8x1x8xbf16, strided<
 // CHECK-SAME:          : vector<1x1x4x4xf32> to vector<16xf32>
 // CHECK:           vector.transfer_write %[[SHAPE_CAST]], %[[COLLAPSE_SHAPE]]
 // CHECK:           return
+
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @trivial_write_access(%arg0: memref<8x8x4x4xf32, strided<[128, 16, 4, 1]>>, %arg1: vector<1x1x4x4xf32>) {
     %c0 = arith.constant 0 : index
     %cst = arith.constant 0.000000e+00 : bf16
     %subview = memref.subview %arg0[2, 3, 0, 0] [1, 1, 4, 4] [1, 1, 1, 1] : memref<8x8x4x4xf32, strided<[128, 16, 4, 1]>> to memref<1x1x4x4xf32, strided<[128, 16, 4, 1], offset: 304>>
     vector.transfer_write %arg1, %subview[%c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x4x4xf32>, memref<1x1x4x4xf32, strided<[128, 16, 4, 1], offset: 304>>
     return
+}
 }
 
 // -----

--- a/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
+++ b/compiler/plugins/target/AMD-AIE/aievec/test/precanonicalization-aieml-llvmir.mlir
@@ -295,10 +295,13 @@ func.func @trivial_write_access(%arg0: memref<8x8x4x4xf32, strided<[128, 16, 4, 
 // CHECK:       %[[CST:.*]] = arith.constant dense<7> : vector<32xi64>
 // CHECK:       return %[[CST]]
 
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @splatConstantReshape() -> vector<32xi64> {
   %cst = arith.constant dense<7> : vector<4x8xi64>
   %flat = vector.shape_cast %cst : vector<4x8xi64> to vector<32xi64>
   return %flat : vector<32xi64>
+}
 }
 
 // -----
@@ -321,6 +324,8 @@ func.func @splatConstantReshape() -> vector<32xi64> {
 // CHECK:         vector.transfer_write %[[TRUNC]], %[[ALLOC_1]][%[[C0]]]
 // CHECK:         return
 // CHECK:       }
+#executable_target_ = #hal.executable.target<"", "", {target_device = "npu1_4col"}>
+module attributes {hal.executable.target = #executable_target_} {
 func.func @multiflatten() {
   %cst = arith.constant dense<7> : vector<4x8xi64>
   %cst_0 = arith.constant dense<10> : vector<4x8xi64>
@@ -337,4 +342,5 @@ func.func @multiflatten() {
   %6 = arith.trunci %5 : vector<32xi64> to vector<32xi8>
   vector.transfer_write %6, %alloc_1[%c0] {in_bounds = [true]} : vector<32xi8>, memref<1024xi8>
   return
+}
 }


### PR DESCRIPTION
As with `arith.truncf` and `trunci`, this pattern is useful when lowering other ops. 