### PR TITLE
[CtrlPkt] Add pipeline to dump control packet binaries to files

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -407,11 +407,6 @@ LogicalResult AIETargetBackend::serializeExecutable(
   SmallVector<uint32_t> indices(ordinalCount);
   SmallVector<uint32_t> asmInstrIndices(ordinalCount);
 
-  auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(moduleOp);
-  if (!targetAttr) {
-    return moduleOp.emitOpError("missing target attribute");
-  }
-
   for (size_t i = 0; i < entryPointNames.size(); i++) {
     uint64_t ordinal = entryPointOrdinals.at(entryPointNames[i]);
     entryPointNamesFb[ordinal] = entryPointNames[i];
@@ -508,8 +503,7 @@ LogicalResult AIETargetBackend::serializeExecutable(
             /*amdAIEInstallDir=*/options.amdAieInstallDir,
             /*InputXCLBin=*/std::nullopt,
             /*ukernel=*/options.enableAMDAIEUkernels,
-            /*additionalPeanoOptFlags=*/options.additionalPeanoOptFlags,
-            /*targetAttr=*/targetAttr))) {
+            /*additionalPeanoOptFlags=*/options.additionalPeanoOptFlags))) {
       return failure();
     }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -237,7 +237,7 @@ class AIETargetBackend final : public IREE::HAL::TargetBackend {
         options.enablePacketFlow, options.enableCoalescingLoops,
         options.enableCollapsingUnitDims, options.enableFunctionOutlining,
         options.replaceOutlinedFunctionsWithEmpty,
-        options.insertLoopAroundCoreBlock);
+        options.insertLoopAroundCoreBlock, options.emitCtrlPkt);
   }
 
   void buildLinkingPassPipeline(OpPassManager &passManager) override {
@@ -407,6 +407,11 @@ LogicalResult AIETargetBackend::serializeExecutable(
   SmallVector<uint32_t> indices(ordinalCount);
   SmallVector<uint32_t> asmInstrIndices(ordinalCount);
 
+  auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(moduleOp);
+  if (!targetAttr) {
+    return moduleOp.emitOpError("missing target attribute");
+  }
+
   for (size_t i = 0; i < entryPointNames.size(); i++) {
     uint64_t ordinal = entryPointOrdinals.at(entryPointNames[i]);
     entryPointNamesFb[ordinal] = entryPointNames[i];
@@ -503,7 +508,8 @@ LogicalResult AIETargetBackend::serializeExecutable(
             /*amdAIEInstallDir=*/options.amdAieInstallDir,
             /*InputXCLBin=*/std::nullopt,
             /*ukernel=*/options.enableAMDAIEUkernels,
-            /*additionalPeanoOptFlags=*/options.additionalPeanoOptFlags))) {
+            /*additionalPeanoOptFlags=*/options.additionalPeanoOptFlags,
+            /*targetAttr=*/targetAttr))) {
       return failure();
     }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
@@ -16,6 +16,7 @@
 #include "AMDAIETargets.h"
 #include "aie/Passes.h"
 #include "air/Conversion/AIRToAIEPass.h"
+#include "iree-amd-aie/IR/AMDAIEOps.h"
 #include "iree-amd-aie/Transforms/Passes.h"
 #include "iree-dialects/Dialect/LinalgTransform/Passes.h"
 #include "iree/compiler/Utils/ToolUtils.h"
@@ -1375,69 +1376,116 @@ LogicalResult generateUnifiedObject(
   return success();
 }
 
-/// Assume the ELF files have already been generated and are stored in the
-/// `tempDirPath`. This function converts `xilinx::aie::device` to
-/// `amdaie.npu.control_packets` by calling the
-/// `AMDAIEConvertDeviceToControlPacketsPass`.
-LogicalResult generateControlPackets(MLIRContext *context,
-                                     AIE::DeviceOp deviceOp,
-                                     const Path &tempDirPath,
-                                     bool printIRBeforeAll,
-                                     bool printIRAfterAll,
-                                     bool printIRModuleScope, bool timing) {
+}  // namespace
+
+namespace mlir::iree_compiler::AMDAIE {
+
+/// Pipeline to generate control packets from `xilinx::aie::device`, and dump
+/// them into files.
+LogicalResult generateControlPackets(
+    MLIRContext *context, AIE::DeviceOp deviceOp,
+    const IREE::HAL::ExecutableTargetAttr &targetAttr, const Path &tempDirPath,
+    bool printIRBeforeAll, bool printIRAfterAll, bool printIRModuleScope,
+    bool timing) {
   assert(deviceOp->getParentOp() && isa<ModuleOp>(deviceOp->getParentOp()) &&
          "DeviceOp must be in a module parent");
   PassManager pm(context, ModuleOp::getOperationName());
   applyConfigToPassManager(pm, printIRBeforeAll, printIRAfterAll,
                            printIRModuleScope, timing);
-  mlir::iree_compiler::AMDAIE::AMDAIEConvertDeviceToControlPacketsOptions
-      options;
-  options.pathToElfs = tempDirPath.string();
-  pm.addPass(mlir::iree_compiler::AMDAIE::
-                 createAMDAIEConvertDeviceToControlPacketsPass(options));
-  pm.addPass(
-      mlir::iree_compiler::AMDAIE::createAMDAIESplitControlPacketDataPass());
-  return pm.run(deviceOp->getParentOp());
+  // Assuming the ELF files have already been generated and are stored in
+  // `tempDirPath`, use aie-rt to generate control packets.
+  {
+    AMDAIEConvertDeviceToControlPacketsOptions options;
+    options.pathToElfs = tempDirPath.string();
+    pm.addPass(createAMDAIEConvertDeviceToControlPacketsPass(options));
+  }
+  // Regenerate the overlay for sending control packets.
+  {
+    AMDAIEGenerateControlOverlayOptions options;
+    options.routeShimToTileCtrl = true;
+    pm.addPass(createAMDAIEGenerateControlOverlayPass(options));
+    pm.addPass(createCSEPass());
+    pm.addPass(createCanonicalizerPass());
+  }
+  // Regenerate the flows and packet ids.
+  pm.addPass(createAMDAIEConnectionToFlowPass());
+  pm.addPass(createAMDAIEAssignPacketIdsPass());
+  // Extract the DMA instructions and the DMA data from the control packets.
+  pm.addPass(createAMDAIESplitControlPacketDataPass());
+  pm.addPass(createAMDAIEControlPacketToHalfDmaCpyNdPass());
+  pm.addPass(createCSEPass());
+  pm.addPass(createCanonicalizerPass());
+  // Lower the DMA instructions for sending control packets.
+  {
+    AMDAIEControlCodeLoweringOptions options;
+    options.lowerCtrlpktDma = true;
+    pm.addPass(createAMDAIEControlCodeLoweringPass(options));
+  }
+  pm.addPass(createAMDAIEControlCodeToTransactionPass());
+
+  // Run the pipeline.
+  ModuleOp moduleOpCopy = cast<ModuleOp>(deviceOp->getParentOp()).clone();
+  moduleOpCopy->setAttr("hal.executable.target", targetAttr);
+  if (failed(pm.run(moduleOpCopy))) {
+    llvm::errs() << "Failed to lower to control packets \n";
+    return failure();
+  }
+
+  SmallVector<AMDAIE::WorkgroupOp> workgroupOps;
+  moduleOpCopy.walk([&](AMDAIE::WorkgroupOp workgroupOp) {
+    workgroupOps.push_back(workgroupOp);
+  });
+  if (workgroupOps.size() != 1) {
+    llvm::errs() << "Expected exactly one workgroup op, found "
+                 << workgroupOps.size() << "\n";
+    return failure();
+  }
+  // Dump the control packets sequence (i.e., the data inside the control
+  // packets) to a file.
+  Path ctrlPktSequence = tempDirPath / "ctrlpkt_sequence.txt";
+  if (failed(emitDenseArrayAttrToFile(workgroupOps[0], "ctrlpkt_sequence",
+                                      ctrlPktSequence.string()))) {
+    llvm::errs() << "Failed to emit control packets sequence \n";
+    return failure();
+  }
+  // Dump the control packets DMA instructions to a file.
+  Path ctrlPktInstructions = tempDirPath / "ctrlpkt_instructions.txt";
+  if (failed(emitDenseArrayAttrToFile(workgroupOps[0], "npu_instructions",
+                                      ctrlPktInstructions.string()))) {
+    llvm::errs() << "Failed to emit control packets instructions \n";
+    return failure();
+  }
+  return success();
 }
 
-}  // namespace
-
-namespace mlir::iree_compiler::AMDAIE {
-LogicalResult emitNpuInstructions(AIE::DeviceOp deviceOp,
-                                  const std::string &outputNPU) {
-  MLIRContext *ctx = deviceOp.getContext();
-  mlir::Attribute maybeNpuInstructions = deviceOp->getAttr("npu_instructions");
-  if (!maybeNpuInstructions) {
-    return emitError(UnknownLoc::get(ctx),
-                     "Expected npu_instructions attribute on aie.device");
-  }
-
-  DenseUI32ResourceElementsAttr npuInstructions =
-      dyn_cast<DenseUI32ResourceElementsAttr>(maybeNpuInstructions);
-  if (!npuInstructions) {
-    return emitError(
-        UnknownLoc::get(ctx),
-        "Failed to cast npu_instructions to DenseUI32ResourceElementsAttr");
-  }
-
+LogicalResult emitDenseArrayAttrToFile(Operation *op, StringRef attrName,
+                                       StringRef fileName) {
+  // Get the attribute from the operation.
+  auto maybeAttr = op->getAttrOfType<DenseUI32ResourceElementsAttr>(attrName);
+  if (!maybeAttr)
+    return op->emitError() << "Failed to get attribute " << attrName << "\n";
+  // Get the array ref from the attribute.
   std::optional<ArrayRef<uint32_t>> maybeArrayRef =
-      npuInstructions.tryGetAsArrayRef();
-  assert(maybeArrayRef &&
-         "Failed getting values for npu_instructions in tryGetAsArrayRef");
+      maybeAttr.tryGetAsArrayRef();
+  if (!maybeArrayRef) {
+    return op->emitError() << "Failed to get values for " << attrName
+                           << " in tryGetAsArrayRef \n";
+  }
+  // Open the output file.
   std::string errorMessage;
   std::unique_ptr<llvm::ToolOutputFile> output =
-      openOutputFile(outputNPU, &errorMessage);
+      openOutputFile(fileName, &errorMessage);
   if (!output) {
-    llvm::errs() << "Failed to open npu_instructions.txt for writing because: "
-                 << errorMessage << "\n";
+    llvm::errs() << "Failed to open " << fileName
+                 << " for writing because: " << errorMessage << "\n";
     return failure();
   }
   output->keep();
-
+  // Write the values to the output file.
   for (int i = 0; i < maybeArrayRef->size() - 1; ++i) {
     output->os() << llvm::format("%08X\n", maybeArrayRef->operator[](i));
   }
-  // don't emit empty line at the end
+  // Don't emit empty line at the end.
   output->os() << llvm::format("%08X", maybeArrayRef->back());
 
   return success();
@@ -1457,9 +1505,11 @@ LogicalResult aie2xclbin(
     const std::string &xclBinInstanceName, const std::string &amdAIEInstallDir,
     const std::optional<std::string> &InputXCLBin,
     const std::optional<std::string> &ukernel,
-    const std::string &additionalPeanoOptFlags) {
+    const std::string &additionalPeanoOptFlags,
+    const IREE::HAL::ExecutableTargetAttr &targetAttr) {
   if (outputNPU.has_value() &&
-      failed(emitNpuInstructions(deviceOp, outputNPU.value()))) {
+      failed(emitDenseArrayAttrToFile(deviceOp, "npu_instructions",
+                                      outputNPU.value()))) {
     return failure();
   }
 
@@ -1488,9 +1538,10 @@ LogicalResult aie2xclbin(
     return failure();
   }
 
-  if (emitCtrlPkt && failed(generateControlPackets(
-                         ctx, deviceOp, tempDirPath, printIRBeforeAll,
-                         printIRAfterAll, printIRModuleScope, timing))) {
+  if (emitCtrlPkt &&
+      failed(generateControlPackets(ctx, deviceOp, targetAttr, tempDirPath,
+                                    printIRBeforeAll, printIRAfterAll,
+                                    printIRModuleScope, timing))) {
     llvm::errs() << "Failed to generate control packets MLIR file\n";
     return failure();
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.h
@@ -9,6 +9,8 @@
 
 #include "AIETarget.h"
 #include "aie/AIEDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "mlir/Support/LogicalResult.h"
 
 namespace mlir::iree_compiler::AMDAIE {
@@ -26,10 +28,11 @@ mlir::LogicalResult aie2xclbin(
     const std::string &xclBinInstanceName, const std::string &amdAIEInstallDir,
     const std::optional<std::string> &InputXCLBin,
     const std::optional<std::string> &ukernel,
-    const std::string &additionalPeanoOptFlags);
+    const std::string &additionalPeanoOptFlags,
+    const IREE::HAL::ExecutableTargetAttr &targetAttr);
 
-mlir::LogicalResult emitNpuInstructions(xilinx::AIE::DeviceOp deviceOp,
-                                        const std::string &outputNPU);
+mlir::LogicalResult emitDenseArrayAttrToFile(Operation *op, StringRef attrName,
+                                             StringRef fileName);
 
 namespace detail {
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.h
@@ -28,8 +28,7 @@ mlir::LogicalResult aie2xclbin(
     const std::string &xclBinInstanceName, const std::string &amdAIEInstallDir,
     const std::optional<std::string> &InputXCLBin,
     const std::optional<std::string> &ukernel,
-    const std::string &additionalPeanoOptFlags,
-    const IREE::HAL::ExecutableTargetAttr &targetAttr);
+    const std::string &additionalPeanoOptFlags);
 
 mlir::LogicalResult emitDenseArrayAttrToFile(Operation *op, StringRef attrName,
                                              StringRef fileName);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/aie2xclbin_test.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/aie2xclbin_test.cpp
@@ -62,7 +62,8 @@ int main(int argc, char **argv) {
 
   std::string npuInstFilePath = (workDir / mlirFilePath.filename()).string();
   npuInstFilePath += ".npu.txt";
-  LogicalResult status = emitNpuInstructions(deviceOp, npuInstFilePath);
+  LogicalResult status =
+      emitDenseArrayAttrToFile(deviceOp, "npu_instructions", npuInstFilePath);
   std::vector<std::string> diagnostics;
   ScopedDiagnosticHandler handler(moduleOp.getContext(), [&](Diagnostic &d) {
     llvm::raw_string_ostream(diagnostics.emplace_back())

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/aie_elf_files_gen_test.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/aie_elf_files_gen_test.cpp
@@ -106,13 +106,6 @@ int main(int argc, char **argv) {
   }
   std::string peanoDirStr = peanoDir;
 
-  auto targetAttr =
-      mlir::iree_compiler::IREE::HAL::ExecutableTargetAttr::lookup(moduleOp);
-  if (!targetAttr) {
-    llvm::errs() << "Error: HAL target attribute not found\n";
-    return 1;
-  }
-
   // Use `aie2xclbin` to generate the elf files.
   if (failed(aie2xclbin(
           /*ctx=*/&context,
@@ -139,8 +132,7 @@ int main(int argc, char **argv) {
           /*amdAIEInstallDir=*/"",
           /*InputXCLBin=*/std::nullopt,
           /*ukernel=*/std::nullopt,
-          /*additionalPeanoOptFlags=*/"",
-          /*targetAttr=*/targetAttr))) {
+          /*additionalPeanoOptFlags=*/""))) {
     llvm::errs() << "Error: failed to generate xclbin\n";
     return 1;
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/ctrlpkt_gen.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/ctrlpkt_gen.mlir
@@ -1,0 +1,460 @@
+// RUN: aie_elf_files_gen_test %s %T true
+// RUN: FileCheck %s --check-prefix=CTRLPKT-SEQUENCE < %T/ctrlpkt_sequence.txt
+// RUN: FileCheck %s --check-prefix=CTRLPKT-INSTRUCTIONS < %T/ctrlpkt_instructions.txt
+
+// To check both files are not empty
+// CTRLPKT-SEQUENCE: {{[0-9]+}}
+// CTRLPKT-INSTRUCTIONS: {{[0-9]+}}
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  aie.device(npu1_4col) {
+    memref.global "public" @shim_2 : memref<8x8xi32>
+    func.func private @generic_matmul_0_outlined(%arg0: memref<1x1x1x2x4x8xi8> {llvm.noalias}, %arg1: memref<1x1x1x1x8x8xi8> {llvm.noalias}, %arg2: memref<1x1x1x2x4x8xi32> {llvm.noalias}) attributes {llvm.bareptr = true} {
+      %0 = llvm.mlir.constant(2 : index) : i64
+      %1 = llvm.mlir.constant(776 : i32) : i32
+      %2 = llvm.mlir.constant(0 : i32) : i32
+      %3 = llvm.mlir.constant(32 : index) : i64
+      %4 = llvm.mlir.constant(1 : index) : i64
+      %5 = llvm.mlir.constant(0 : index) : i64
+      %6 = builtin.unrealized_conversion_cast %5 : i64 to index
+      %base_buffer, %offset, %sizes:6, %strides:6 = memref.extract_strided_metadata %arg0 : memref<1x1x1x2x4x8xi8> -> memref<i8>, index, index, index, index, index, index, index, index, index, index, index, index, index
+      %reinterpret_cast = memref.reinterpret_cast %base_buffer to offset: [0], sizes: [64], strides: [1] : memref<i8> to memref<64xi8>
+      %7 = builtin.unrealized_conversion_cast %reinterpret_cast : memref<64xi8> to !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+      %base_buffer_21, %offset_22, %sizes_23:6, %strides_24:6 = memref.extract_strided_metadata %arg1 : memref<1x1x1x1x8x8xi8> -> memref<i8>, index, index, index, index, index, index, index, index, index, index, index, index, index
+      %reinterpret_cast_25 = memref.reinterpret_cast %base_buffer_21 to offset: [0], sizes: [64], strides: [1] : memref<i8> to memref<64xi8>
+      %8 = builtin.unrealized_conversion_cast %reinterpret_cast_25 : memref<64xi8> to !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+      %base_buffer_26, %offset_27, %sizes_28:6, %strides_29:6 = memref.extract_strided_metadata %arg2 : memref<1x1x1x2x4x8xi32> -> memref<i32>, index, index, index, index, index, index, index, index, index, index, index, index, index
+      %reinterpret_cast_30 = memref.reinterpret_cast %base_buffer_26 to offset: [0], sizes: [64], strides: [1] : memref<i32> to memref<64xi32>
+      %9 = builtin.unrealized_conversion_cast %reinterpret_cast_30 : memref<64xi32> to !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+      cf.br ^bb1(%6 : index)
+    ^bb1(%10: index):  // 2 preds: ^bb0, ^bb2
+      %11 = builtin.unrealized_conversion_cast %10 : index to i64
+      %12 = llvm.icmp "slt" %11, %0 : i64
+      cf.cond_br %12, ^bb2, ^bb3
+    ^bb2:  // pred: ^bb1
+      %13 = llvm.mul %11, %3 overflow<nsw> : i64
+      %14 = llvm.extractvalue %7[1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+      %15 = llvm.getelementptr %14[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+      %16 = llvm.load %15 : !llvm.ptr -> vector<32xi8>
+      %17 = llvm.extractvalue %8[1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+      %18 = llvm.load %17 : !llvm.ptr -> vector<128xi8>
+      %19 = llvm.bitcast %18 : vector<128xi8> to vector<32xi32>
+      %20 = "xllvm.intr.aie2.ext.I512.I1024"(%19, %2) : (vector<32xi32>, i32) -> vector<16xi32>
+      %21 = llvm.extractvalue %9[1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+      %22 = llvm.getelementptr %21[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+      %23 = llvm.load %22 : !llvm.ptr -> vector<32xi32>
+      %24 = llvm.bitcast %16 : vector<32xi8> to vector<8xi32>
+      %25 = "xllvm.intr.aie2.set.I512.I256"(%24, %2) : (vector<8xi32>, i32) -> vector<16xi32>
+      %26 = llvm.bitcast %25 : vector<16xi32> to vector<64xi8>
+      %27 = llvm.bitcast %23 : vector<32xi32> to vector<16xi64>
+      %28 = "xllvm.intr.aie2.I512.I512.ACC1024.acc32.mac.conf"(%26, %20, %27, %1) : (vector<64xi8>, vector<16xi32>, vector<16xi64>, i32) -> vector<16xi64>
+      %29 = llvm.bitcast %28 : vector<16xi64> to vector<32xi32>
+      llvm.store %29, %22 : vector<32xi32>, !llvm.ptr
+      %30 = llvm.add %11, %4 : i64
+      %31 = builtin.unrealized_conversion_cast %30 : i64 to index
+      cf.br ^bb1(%31 : index)
+    ^bb3:  // pred: ^bb1
+      return
+    }
+    %tile_0_2 = aie.tile(0, 2)
+    %switchbox_0_2 = aie.switchbox(%tile_0_2) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.amsel<1> (0)
+      %2 = aie.amsel<2> (0)
+      %3 = aie.amsel<3> (0)
+      %4 = aie.masterset(CTRL : 0, %0)
+      %5 = aie.masterset(DMA : 0, %2)
+      %6 = aie.masterset(DMA : 1, %3)
+      %7 = aie.masterset(SOUTH : 0, %1)
+      aie.packet_rules(DMA : 0) {
+        aie.rule(31, 0, %1) {packet_ids = array<i32: 0>}
+      }
+      aie.packet_rules(SOUTH : 0) {
+        aie.rule(31, 0, %2) {packet_ids = array<i32: 0>}
+      }
+      aie.packet_rules(SOUTH : 1) {
+        aie.rule(31, 1, %0) {packet_ids = array<i32: 1>}
+      }
+      aie.packet_rules(SOUTH : 5) {
+        aie.rule(31, 0, %3) {packet_ids = array<i32: 0>}
+      }
+    }
+    memref.global "public" @shim_1 : memref<8x8xi8>
+    memref.global "public" @shim_0 : memref<8x8xi8>
+    %tile_0_0 = aie.tile(0, 0)
+    %shim_mux_0_0 = aie.shim_mux(%tile_0_0) {
+      aie.connect<DMA : 0, NORTH : 3>
+      aie.connect<DMA : 1, NORTH : 7>
+      aie.connect<NORTH : 2, DMA : 0>
+    }
+    %tile_0_1 = aie.tile(0, 1)
+    %switchbox_0_1 = aie.switchbox(%tile_0_1) {
+      %0 = aie.amsel<0> (0)
+      %1 = aie.amsel<1> (0)
+      %2 = aie.amsel<2> (0)
+      %3 = aie.amsel<3> (0)
+      %4 = aie.amsel<4> (0)
+      %5 = aie.amsel<5> (0)
+      %6 = aie.amsel<0> (1)
+      %7 = aie.amsel<0> (2)
+      %8 = aie.masterset(CTRL : 0, %1)
+      %9 = aie.masterset(NORTH : 1, %0)
+      %10 = aie.masterset(DMA : 0, %6)
+      %11 = aie.masterset(DMA : 1, %5)
+      %12 = aie.masterset(DMA : 2, %7)
+      %13 = aie.masterset(SOUTH : 1, %4)
+      %14 = aie.masterset(NORTH : 0, %2)
+      %15 = aie.masterset(NORTH : 5, %3)
+      aie.packet_rules(DMA : 0) {
+        aie.rule(31, 0, %2) {packet_ids = array<i32: 0>}
+      }
+      aie.packet_rules(DMA : 1) {
+        aie.rule(31, 0, %3) {packet_ids = array<i32: 0>}
+      }
+      aie.packet_rules(DMA : 2) {
+        aie.rule(31, 0, %4) {packet_ids = array<i32: 0>}
+      }
+      aie.packet_rules(SOUTH : 1) {
+        aie.rule(31, 1, %0) {packet_ids = array<i32: 1>}
+      }
+      aie.packet_rules(SOUTH : 3) {
+        aie.rule(31, 2, %5) {packet_ids = array<i32: 2>}
+      }
+      aie.packet_rules(SOUTH : 4) {
+        aie.rule(31, 0, %1) {packet_ids = array<i32: 0>}
+        aie.rule(31, 1, %6) {packet_ids = array<i32: 1>}
+      }
+      aie.packet_rules(NORTH : 0) {
+        aie.rule(31, 0, %7) {packet_ids = array<i32: 0>}
+      }
+    }
+    %buffer_0_1 = aie.buffer(%tile_0_1) {address = 0 : i32, sym_name = "buff_0"} : memref<64xi8>
+    %buffer_0_1_0 = aie.buffer(%tile_0_1) {address = 64 : i32, sym_name = "buff_1"} : memref<64xi8>
+    %lock_0_1 = aie.lock(%tile_0_1, 4) {init = 2 : i8, sym_name = "lock_0"}
+    %lock_0_1_1 = aie.lock(%tile_0_1, 5) {init = 0 : i8, sym_name = "lock_1"}
+    %buffer_0_1_2 = aie.buffer(%tile_0_1) {address = 128 : i32, sym_name = "buff_2"} : memref<64xi8>
+    %buffer_0_1_3 = aie.buffer(%tile_0_1) {address = 192 : i32, sym_name = "buff_3"} : memref<64xi8>
+    %lock_0_1_4 = aie.lock(%tile_0_1, 2) {init = 2 : i8, sym_name = "lock_2"}
+    %lock_0_1_5 = aie.lock(%tile_0_1, 3) {init = 0 : i8, sym_name = "lock_3"}
+    %buffer_0_1_6 = aie.buffer(%tile_0_1) {address = 256 : i32, sym_name = "buff_4"} : memref<64xi32>
+    %buffer_0_1_7 = aie.buffer(%tile_0_1) {address = 512 : i32, sym_name = "buff_5"} : memref<64xi32>
+    %lock_0_1_8 = aie.lock(%tile_0_1, 0) {init = 2 : i8, sym_name = "lock_4"}
+    %lock_0_1_9 = aie.lock(%tile_0_1, 1) {init = 0 : i8, sym_name = "lock_5"}
+    aie.shim_dma_allocation @shim_0(MM2S, 1, 0)
+    aie.shim_dma_allocation @shim_1(MM2S, 0, 0)
+    %buffer_0_2 = aie.buffer(%tile_0_2) {address = 1024 : i32, sym_name = "buff_6"} : memref<64xi32>
+    %buffer_0_2_10 = aie.buffer(%tile_0_2) {address = 1280 : i32, sym_name = "buff_7"} : memref<64xi8>
+    %buffer_0_2_11 = aie.buffer(%tile_0_2) {address = 1344 : i32, sym_name = "buff_8"} : memref<64xi8>
+    %lock_0_2 = aie.lock(%tile_0_2, 4) {init = 2 : i8, sym_name = "lock_6"}
+    %lock_0_2_12 = aie.lock(%tile_0_2, 5) {init = 0 : i8, sym_name = "lock_7"}
+    %buffer_0_2_13 = aie.buffer(%tile_0_2) {address = 1408 : i32, sym_name = "buff_9"} : memref<64xi8>
+    %buffer_0_2_14 = aie.buffer(%tile_0_2) {address = 1472 : i32, sym_name = "buff_10"} : memref<64xi8>
+    %lock_0_2_15 = aie.lock(%tile_0_2, 2) {init = 2 : i8, sym_name = "lock_8"}
+    %lock_0_2_16 = aie.lock(%tile_0_2, 3) {init = 0 : i8, sym_name = "lock_9"}
+    %buffer_0_2_17 = aie.buffer(%tile_0_2) {address = 1536 : i32, sym_name = "buff_11"} : memref<64xi32>
+    %buffer_0_2_18 = aie.buffer(%tile_0_2) {address = 1792 : i32, sym_name = "buff_12"} : memref<64xi32>
+    %lock_0_2_19 = aie.lock(%tile_0_2, 0) {init = 2 : i8, sym_name = "lock_10"}
+    %lock_0_2_20 = aie.lock(%tile_0_2, 1) {init = 0 : i8, sym_name = "lock_11"}
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+    ^bb1:  // 2 preds: ^bb0, ^bb2
+      aie.use_lock(%lock_0_2, AcquireGreaterEqual, 1)
+      aie.dma_bd(%buffer_0_2_10 : memref<64xi8>) {bd_id = 0 : i32, len = 64 : i32, next_bd_id = 1 : i32}
+      aie.use_lock(%lock_0_2_12, Release, 1)
+      aie.next_bd ^bb2
+    ^bb2:  // pred: ^bb1
+      aie.use_lock(%lock_0_2, AcquireGreaterEqual, 1)
+      aie.dma_bd(%buffer_0_2_11 : memref<64xi8>) {bd_id = 1 : i32, len = 64 : i32, next_bd_id = 0 : i32}
+      aie.use_lock(%lock_0_2_12, Release, 1)
+      aie.next_bd ^bb1
+    ^bb3:  // pred: ^bb0
+      %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb6)
+    ^bb4:  // 2 preds: ^bb3, ^bb5
+      aie.use_lock(%lock_0_2_15, AcquireGreaterEqual, 1)
+      aie.dma_bd(%buffer_0_2_13 : memref<64xi8>) {bd_id = 2 : i32, len = 64 : i32, next_bd_id = 3 : i32}
+      aie.use_lock(%lock_0_2_16, Release, 1)
+      aie.next_bd ^bb5
+    ^bb5:  // pred: ^bb4
+      aie.use_lock(%lock_0_2_15, AcquireGreaterEqual, 1)
+      aie.dma_bd(%buffer_0_2_14 : memref<64xi8>) {bd_id = 3 : i32, len = 64 : i32, next_bd_id = 2 : i32}
+      aie.use_lock(%lock_0_2_16, Release, 1)
+      aie.next_bd ^bb4
+    ^bb6:  // pred: ^bb3
+      %2 = aie.dma_start(MM2S, 0, ^bb7, ^bb9)
+    ^bb7:  // 2 preds: ^bb6, ^bb8
+      aie.use_lock(%lock_0_2_20, AcquireGreaterEqual, 1)
+      aie.dma_bd_packet(0, 0)
+      aie.dma_bd(%buffer_0_2_17 : memref<64xi32>) {bd_id = 4 : i32, len = 64 : i32, next_bd_id = 5 : i32}
+      aie.use_lock(%lock_0_2_19, Release, 1)
+      aie.next_bd ^bb8
+    ^bb8:  // pred: ^bb7
+      aie.use_lock(%lock_0_2_20, AcquireGreaterEqual, 1)
+      aie.dma_bd_packet(0, 0)
+      aie.dma_bd(%buffer_0_2_18 : memref<64xi32>) {bd_id = 5 : i32, len = 64 : i32, next_bd_id = 4 : i32}
+      aie.use_lock(%lock_0_2_19, Release, 1)
+      aie.next_bd ^bb7
+    ^bb9:  // pred: ^bb6
+      aie.end
+    }
+    %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+    ^bb1:  // 2 preds: ^bb0, ^bb2
+      aie.use_lock(%lock_0_1, AcquireGreaterEqual, 1)
+      aie.dma_bd(%buffer_0_1 : memref<64xi8>) {bd_id = 0 : i32, len = 64 : i32, next_bd_id = 1 : i32}
+      aie.use_lock(%lock_0_1_1, Release, 1)
+      aie.next_bd ^bb2
+    ^bb2:  // pred: ^bb1
+      aie.use_lock(%lock_0_1, AcquireGreaterEqual, 1)
+      aie.dma_bd(%buffer_0_1_0 : memref<64xi8>) {bd_id = 1 : i32, len = 64 : i32, next_bd_id = 0 : i32}
+      aie.use_lock(%lock_0_1_1, Release, 1)
+      aie.next_bd ^bb1
+    ^bb3:  // pred: ^bb0
+      %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb6)
+    ^bb4:  // 2 preds: ^bb3, ^bb5
+      aie.use_lock(%lock_0_1_4, AcquireGreaterEqual, 1)
+      aie.dma_bd(%buffer_0_1_2 : memref<64xi8>) {bd_id = 24 : i32, len = 64 : i32, next_bd_id = 25 : i32}
+      aie.use_lock(%lock_0_1_5, Release, 1)
+      aie.next_bd ^bb5
+    ^bb5:  // pred: ^bb4
+      aie.use_lock(%lock_0_1_4, AcquireGreaterEqual, 1)
+      aie.dma_bd(%buffer_0_1_3 : memref<64xi8>) {bd_id = 25 : i32, len = 64 : i32, next_bd_id = 24 : i32}
+      aie.use_lock(%lock_0_1_5, Release, 1)
+      aie.next_bd ^bb4
+    ^bb6:  // pred: ^bb3
+      %2 = aie.dma_start(MM2S, 0, ^bb7, ^bb9)
+    ^bb7:  // 2 preds: ^bb6, ^bb8
+      aie.use_lock(%lock_0_1_5, AcquireGreaterEqual, 1)
+      aie.dma_bd_packet(0, 0)
+      aie.dma_bd(%buffer_0_1_2 : memref<64xi8>) {bd_id = 2 : i32, len = 64 : i32, next_bd_id = 3 : i32}
+      aie.use_lock(%lock_0_1_4, Release, 1)
+      aie.next_bd ^bb8
+    ^bb8:  // pred: ^bb7
+      aie.use_lock(%lock_0_1_5, AcquireGreaterEqual, 1)
+      aie.dma_bd_packet(0, 0)
+      aie.dma_bd(%buffer_0_1_3 : memref<64xi8>) {bd_id = 3 : i32, len = 64 : i32, next_bd_id = 2 : i32}
+      aie.use_lock(%lock_0_1_4, Release, 1)
+      aie.next_bd ^bb7
+    ^bb9:  // pred: ^bb6
+      %3 = aie.dma_start(MM2S, 1, ^bb10, ^bb12)
+    ^bb10:  // 2 preds: ^bb9, ^bb11
+      aie.use_lock(%lock_0_1_1, AcquireGreaterEqual, 1)
+      aie.dma_bd_packet(0, 0)
+      aie.dma_bd(%buffer_0_1 : memref<64xi8>) {bd_id = 26 : i32, len = 64 : i32, next_bd_id = 27 : i32}
+      aie.use_lock(%lock_0_1, Release, 1)
+      aie.next_bd ^bb11
+    ^bb11:  // pred: ^bb10
+      aie.use_lock(%lock_0_1_1, AcquireGreaterEqual, 1)
+      aie.dma_bd_packet(0, 0)
+      aie.dma_bd(%buffer_0_1_0 : memref<64xi8>) {bd_id = 27 : i32, len = 64 : i32, next_bd_id = 26 : i32}
+      aie.use_lock(%lock_0_1, Release, 1)
+      aie.next_bd ^bb10
+    ^bb12:  // pred: ^bb9
+      %4 = aie.dma_start(S2MM, 2, ^bb13, ^bb15)
+    ^bb13:  // 2 preds: ^bb12, ^bb14
+      aie.use_lock(%lock_0_1_8, AcquireGreaterEqual, 1)
+      aie.dma_bd(%buffer_0_1_6 : memref<64xi32>) {bd_id = 4 : i32, len = 64 : i32, next_bd_id = 5 : i32}
+      aie.use_lock(%lock_0_1_9, Release, 1)
+      aie.next_bd ^bb14
+    ^bb14:  // pred: ^bb13
+      aie.use_lock(%lock_0_1_8, AcquireGreaterEqual, 1)
+      aie.dma_bd(%buffer_0_1_7 : memref<64xi32>) {bd_id = 5 : i32, len = 64 : i32, next_bd_id = 4 : i32}
+      aie.use_lock(%lock_0_1_9, Release, 1)
+      aie.next_bd ^bb13
+    ^bb15:  // pred: ^bb12
+      %5 = aie.dma_start(MM2S, 2, ^bb16, ^bb18)
+    ^bb16:  // 2 preds: ^bb15, ^bb17
+      aie.use_lock(%lock_0_1_9, AcquireGreaterEqual, 1)
+      aie.dma_bd_packet(0, 0)
+      aie.dma_bd(%buffer_0_1_6 : memref<64xi32>) {bd_id = 6 : i32, len = 64 : i32, next_bd_id = 7 : i32}
+      aie.use_lock(%lock_0_1_8, Release, 1)
+      aie.next_bd ^bb17
+    ^bb17:  // pred: ^bb16
+      aie.use_lock(%lock_0_1_9, AcquireGreaterEqual, 1)
+      aie.dma_bd_packet(0, 0)
+      aie.dma_bd(%buffer_0_1_7 : memref<64xi32>) {bd_id = 7 : i32, len = 64 : i32, next_bd_id = 6 : i32}
+      aie.use_lock(%lock_0_1_8, Release, 1)
+      aie.next_bd ^bb16
+    ^bb18:  // pred: ^bb15
+      aie.end
+    }
+    aie.shim_dma_allocation @shim_2(S2MM, 0, 0)
+    %switchbox_0_0 = aie.switchbox(%tile_0_0) {
+      aie.connect<CTRL : 0, SOUTH : 0>
+      %0 = aie.amsel<0> (0)
+      %1 = aie.amsel<1> (0)
+      %2 = aie.amsel<2> (0)
+      %3 = aie.amsel<3> (0)
+      %4 = aie.amsel<4> (0)
+      %5 = aie.masterset(CTRL : 0, %0)
+      %6 = aie.masterset(NORTH : 1, %1)
+      %7 = aie.masterset(NORTH : 4, %2)
+      %8 = aie.masterset(SOUTH : 2, %4)
+      %9 = aie.masterset(NORTH : 3, %3)
+      aie.packet_rules(SOUTH : 3) {
+        aie.rule(31, 0, %0) {packet_ids = array<i32: 0>}
+        aie.rule(31, 1, %1) {packet_ids = array<i32: 1>}
+        aie.rule(31, 2, %3) {packet_ids = array<i32: 2>}
+      }
+      aie.packet_rules(SOUTH : 7) {
+        aie.rule(30, 0, %2) {packet_ids = array<i32: 0, 1>}
+      }
+      aie.packet_rules(NORTH : 1) {
+        aie.rule(31, 0, %4) {packet_ids = array<i32: 0>}
+      }
+    }
+    %core_0_2 = aie.core(%tile_0_2) {
+      %0 = llvm.mlir.constant(32 : index) : i64
+      %1 = llvm.mlir.constant(0 : i32) : i32
+      %2 = llvm.mlir.constant(1 : i32) : i32
+      %3 = llvm.mlir.constant(0 : index) : i64
+      %4 = llvm.mlir.constant(2 : index) : i64
+      %5 = llvm.mlir.constant(1 : index) : i64
+      %6 = llvm.mlir.constant(4 : index) : i64
+      %7 = llvm.mlir.constant(8 : index) : i64
+      %8 = llvm.mlir.constant(49 : index) : i64
+      %9 = llvm.mlir.constant(48 : index) : i64
+      %10 = llvm.mlir.constant(51 : index) : i64
+      %11 = llvm.mlir.constant(50 : index) : i64
+      %12 = llvm.mlir.constant(53 : index) : i64
+      %13 = llvm.mlir.constant(52 : index) : i64
+      %14 = builtin.unrealized_conversion_cast %13 : i64 to index
+      %15 = builtin.unrealized_conversion_cast %12 : i64 to index
+      %16 = builtin.unrealized_conversion_cast %11 : i64 to index
+      %17 = builtin.unrealized_conversion_cast %10 : i64 to index
+      %18 = builtin.unrealized_conversion_cast %9 : i64 to index
+      %19 = builtin.unrealized_conversion_cast %8 : i64 to index
+      %20 = builtin.unrealized_conversion_cast %3 : i64 to index
+      %reinterpret_cast = memref.reinterpret_cast %buffer_0_2 to offset: [0], sizes: [1, 1, 1, 2, 4, 8], strides: [64, 64, 64, 32, 8, 1] : memref<64xi32> to memref<1x1x1x2x4x8xi32>
+      cf.br ^bb1(%20 : index)
+    ^bb1(%21: index):  // 2 preds: ^bb0, ^bb12
+      %22 = builtin.unrealized_conversion_cast %21 : index to i64
+      %23 = llvm.icmp "slt" %22, %5 : i64
+      cf.cond_br %23, ^bb2(%20 : index), ^bb13
+    ^bb2(%24: index):  // 2 preds: ^bb1, ^bb11
+      %25 = builtin.unrealized_conversion_cast %24 : index to i64
+      %26 = llvm.icmp "slt" %25, %5 : i64
+      cf.cond_br %26, ^bb3(%20 : index), ^bb12
+    ^bb3(%27: index):  // 2 preds: ^bb2, ^bb10
+      %28 = builtin.unrealized_conversion_cast %27 : index to i64
+      %29 = llvm.icmp "slt" %28, %5 : i64
+      cf.cond_br %29, ^bb4(%20 : index), ^bb11
+    ^bb4(%30: index):  // 2 preds: ^bb3, ^bb9
+      %31 = builtin.unrealized_conversion_cast %30 : index to i64
+      %32 = llvm.icmp "slt" %31, %4 : i64
+      cf.cond_br %32, ^bb5(%20 : index), ^bb10
+    ^bb5(%33: index):  // 2 preds: ^bb4, ^bb8
+      %34 = builtin.unrealized_conversion_cast %33 : index to i64
+      %35 = llvm.icmp "slt" %34, %6 : i64
+      cf.cond_br %35, ^bb6(%20 : index), ^bb9
+    ^bb6(%36: index):  // 2 preds: ^bb5, ^bb7
+      %37 = builtin.unrealized_conversion_cast %36 : index to i64
+      %38 = llvm.icmp "slt" %37, %7 : i64
+      cf.cond_br %38, ^bb7, ^bb8
+    ^bb7:  // pred: ^bb6
+      memref.store %1, %reinterpret_cast[%21, %24, %27, %30, %33, %36] : memref<1x1x1x2x4x8xi32>
+      %39 = llvm.add %37, %5 : i64
+      %40 = builtin.unrealized_conversion_cast %39 : i64 to index
+      cf.br ^bb6(%40 : index)
+    ^bb8:  // pred: ^bb6
+      %41 = llvm.add %34, %5 : i64
+      %42 = builtin.unrealized_conversion_cast %41 : i64 to index
+      cf.br ^bb5(%42 : index)
+    ^bb9:  // pred: ^bb5
+      %43 = llvm.add %31, %5 : i64
+      %44 = builtin.unrealized_conversion_cast %43 : i64 to index
+      cf.br ^bb4(%44 : index)
+    ^bb10:  // pred: ^bb4
+      %45 = llvm.add %28, %5 : i64
+      %46 = builtin.unrealized_conversion_cast %45 : i64 to index
+      cf.br ^bb3(%46 : index)
+    ^bb11:  // pred: ^bb3
+      %47 = llvm.add %25, %5 : i64
+      %48 = builtin.unrealized_conversion_cast %47 : i64 to index
+      cf.br ^bb2(%48 : index)
+    ^bb12:  // pred: ^bb2
+      %49 = llvm.add %22, %5 : i64
+      %50 = builtin.unrealized_conversion_cast %49 : i64 to index
+      cf.br ^bb1(%50 : index)
+    ^bb13:  // pred: ^bb1
+      aie.use_lock(%17, AcquireGreaterEqual, 1)
+      %reinterpret_cast_21 = memref.reinterpret_cast %buffer_0_2_13 to offset: [0], sizes: [1, 1, 1, 2, 4, 8], strides: [64, 64, 64, 32, 8, 1] : memref<64xi8> to memref<1x1x1x2x4x8xi8>
+      aie.use_lock(%15, AcquireGreaterEqual, 1)
+      %reinterpret_cast_22 = memref.reinterpret_cast %buffer_0_2_10 to offset: [0], sizes: [1, 1, 1, 1, 8, 8], strides: [64, 64, 64, 64, 8, 1] : memref<64xi8> to memref<1x1x1x1x8x8xi8>
+      func.call @generic_matmul_0_outlined(%reinterpret_cast_21, %reinterpret_cast_22, %reinterpret_cast) : (memref<1x1x1x2x4x8xi8>, memref<1x1x1x1x8x8xi8>, memref<1x1x1x2x4x8xi32>) -> ()
+      aie.use_lock(%18, AcquireGreaterEqual, 1)
+      cf.br ^bb14(%20 : index)
+    ^bb14(%51: index):  // 2 preds: ^bb13, ^bb28
+      %52 = builtin.unrealized_conversion_cast %51 : index to i64
+      %53 = llvm.icmp "slt" %52, %4 : i64
+      cf.cond_br %53, ^bb15, ^bb29
+    ^bb15:  // pred: ^bb14
+      %base_buffer, %offset, %sizes, %strides = memref.extract_strided_metadata %buffer_0_2 : memref<64xi32> -> memref<i32>, index, index, index
+      %54 = llvm.mul %52, %0 overflow<nsw> : i64
+      %55 = builtin.unrealized_conversion_cast %54 : i64 to index
+      %reinterpret_cast_23 = memref.reinterpret_cast %base_buffer to offset: [%55], sizes: [1, 1, 1, 1, 4, 8], strides: [64, 64, 64, 32, 8, 1] : memref<i32> to memref<1x1x1x1x4x8xi32, strided<[64, 64, 64, 32, 8, 1], offset: ?>>
+      %base_buffer_24, %offset_25, %sizes_26, %strides_27 = memref.extract_strided_metadata %buffer_0_2_17 : memref<64xi32> -> memref<i32>, index, index, index
+      %reinterpret_cast_28 = memref.reinterpret_cast %base_buffer_24 to offset: [%55], sizes: [1, 1, 1, 1, 4, 8], strides: [64, 64, 64, 32, 8, 1] : memref<i32> to memref<1x1x1x1x4x8xi32, strided<[64, 64, 64, 32, 8, 1], offset: ?>>
+      cf.br ^bb16(%20 : index)
+    ^bb16(%56: index):  // 2 preds: ^bb15, ^bb27
+      %57 = builtin.unrealized_conversion_cast %56 : index to i64
+      %58 = llvm.icmp "slt" %57, %5 : i64
+      cf.cond_br %58, ^bb17(%20 : index), ^bb28
+    ^bb17(%59: index):  // 2 preds: ^bb16, ^bb26
+      %60 = builtin.unrealized_conversion_cast %59 : index to i64
+      %61 = llvm.icmp "slt" %60, %5 : i64
+      cf.cond_br %61, ^bb18(%20 : index), ^bb27
+    ^bb18(%62: index):  // 2 preds: ^bb17, ^bb25
+      %63 = builtin.unrealized_conversion_cast %62 : index to i64
+      %64 = llvm.icmp "slt" %63, %5 : i64
+      cf.cond_br %64, ^bb19(%20 : index), ^bb26
+    ^bb19(%65: index):  // 2 preds: ^bb18, ^bb24
+      %66 = builtin.unrealized_conversion_cast %65 : index to i64
+      %67 = llvm.icmp "slt" %66, %5 : i64
+      cf.cond_br %67, ^bb20(%20 : index), ^bb25
+    ^bb20(%68: index):  // 2 preds: ^bb19, ^bb23
+      %69 = builtin.unrealized_conversion_cast %68 : index to i64
+      %70 = llvm.icmp "slt" %69, %6 : i64
+      cf.cond_br %70, ^bb21(%20 : index), ^bb24
+    ^bb21(%71: index):  // 2 preds: ^bb20, ^bb22
+      %72 = builtin.unrealized_conversion_cast %71 : index to i64
+      %73 = llvm.icmp "slt" %72, %7 : i64
+      cf.cond_br %73, ^bb22, ^bb23
+    ^bb22:  // pred: ^bb21
+      %74 = memref.load %reinterpret_cast_23[%56, %59, %62, %65, %68, %71] : memref<1x1x1x1x4x8xi32, strided<[64, 64, 64, 32, 8, 1], offset: ?>>
+      %75 = llvm.add %74, %2 : i32
+      memref.store %75, %reinterpret_cast_28[%56, %59, %62, %65, %68, %71] : memref<1x1x1x1x4x8xi32, strided<[64, 64, 64, 32, 8, 1], offset: ?>>
+      %76 = llvm.add %72, %5 : i64
+      %77 = builtin.unrealized_conversion_cast %76 : i64 to index
+      cf.br ^bb21(%77 : index)
+    ^bb23:  // pred: ^bb21
+      %78 = llvm.add %69, %5 : i64
+      %79 = builtin.unrealized_conversion_cast %78 : i64 to index
+      cf.br ^bb20(%79 : index)
+    ^bb24:  // pred: ^bb20
+      %80 = llvm.add %66, %5 : i64
+      %81 = builtin.unrealized_conversion_cast %80 : i64 to index
+      cf.br ^bb19(%81 : index)
+    ^bb25:  // pred: ^bb19
+      %82 = llvm.add %63, %5 : i64
+      %83 = builtin.unrealized_conversion_cast %82 : i64 to index
+      cf.br ^bb18(%83 : index)
+    ^bb26:  // pred: ^bb18
+      %84 = llvm.add %60, %5 : i64
+      %85 = builtin.unrealized_conversion_cast %84 : i64 to index
+      cf.br ^bb17(%85 : index)
+    ^bb27:  // pred: ^bb17
+      %86 = llvm.add %57, %5 : i64
+      %87 = builtin.unrealized_conversion_cast %86 : i64 to index
+      cf.br ^bb16(%87 : index)
+    ^bb28:  // pred: ^bb16
+      %88 = llvm.add %52, %5 : i64
+      %89 = builtin.unrealized_conversion_cast %88 : i64 to index
+      cf.br ^bb14(%89 : index)
+    ^bb29:  // pred: ^bb14
+      aie.use_lock(%16, Release, 1)
+      aie.use_lock(%14, Release, 1)
+      aie.use_lock(%19, Release, 1)
+      aie.end
+    }
+  }
+}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/ctrlpkt_gen.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/ctrlpkt_gen.mlir
@@ -2,60 +2,13 @@
 // RUN: FileCheck %s --check-prefix=CTRLPKT-SEQUENCE < %T/ctrlpkt_sequence.txt
 // RUN: FileCheck %s --check-prefix=CTRLPKT-INSTRUCTIONS < %T/ctrlpkt_instructions.txt
 
-// To check both files are not empty
+// To check that both files are not empty
 // CTRLPKT-SEQUENCE: {{[0-9]+}}
 // CTRLPKT-INSTRUCTIONS: {{[0-9]+}}
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   aie.device(npu1_4col) {
     memref.global "public" @shim_2 : memref<8x8xi32>
-    func.func private @generic_matmul_0_outlined(%arg0: memref<1x1x1x2x4x8xi8> {llvm.noalias}, %arg1: memref<1x1x1x1x8x8xi8> {llvm.noalias}, %arg2: memref<1x1x1x2x4x8xi32> {llvm.noalias}) attributes {llvm.bareptr = true} {
-      %0 = llvm.mlir.constant(2 : index) : i64
-      %1 = llvm.mlir.constant(776 : i32) : i32
-      %2 = llvm.mlir.constant(0 : i32) : i32
-      %3 = llvm.mlir.constant(32 : index) : i64
-      %4 = llvm.mlir.constant(1 : index) : i64
-      %5 = llvm.mlir.constant(0 : index) : i64
-      %6 = builtin.unrealized_conversion_cast %5 : i64 to index
-      %base_buffer, %offset, %sizes:6, %strides:6 = memref.extract_strided_metadata %arg0 : memref<1x1x1x2x4x8xi8> -> memref<i8>, index, index, index, index, index, index, index, index, index, index, index, index, index
-      %reinterpret_cast = memref.reinterpret_cast %base_buffer to offset: [0], sizes: [64], strides: [1] : memref<i8> to memref<64xi8>
-      %7 = builtin.unrealized_conversion_cast %reinterpret_cast : memref<64xi8> to !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
-      %base_buffer_21, %offset_22, %sizes_23:6, %strides_24:6 = memref.extract_strided_metadata %arg1 : memref<1x1x1x1x8x8xi8> -> memref<i8>, index, index, index, index, index, index, index, index, index, index, index, index, index
-      %reinterpret_cast_25 = memref.reinterpret_cast %base_buffer_21 to offset: [0], sizes: [64], strides: [1] : memref<i8> to memref<64xi8>
-      %8 = builtin.unrealized_conversion_cast %reinterpret_cast_25 : memref<64xi8> to !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
-      %base_buffer_26, %offset_27, %sizes_28:6, %strides_29:6 = memref.extract_strided_metadata %arg2 : memref<1x1x1x2x4x8xi32> -> memref<i32>, index, index, index, index, index, index, index, index, index, index, index, index, index
-      %reinterpret_cast_30 = memref.reinterpret_cast %base_buffer_26 to offset: [0], sizes: [64], strides: [1] : memref<i32> to memref<64xi32>
-      %9 = builtin.unrealized_conversion_cast %reinterpret_cast_30 : memref<64xi32> to !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
-      cf.br ^bb1(%6 : index)
-    ^bb1(%10: index):  // 2 preds: ^bb0, ^bb2
-      %11 = builtin.unrealized_conversion_cast %10 : index to i64
-      %12 = llvm.icmp "slt" %11, %0 : i64
-      cf.cond_br %12, ^bb2, ^bb3
-    ^bb2:  // pred: ^bb1
-      %13 = llvm.mul %11, %3 overflow<nsw> : i64
-      %14 = llvm.extractvalue %7[1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
-      %15 = llvm.getelementptr %14[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i8
-      %16 = llvm.load %15 : !llvm.ptr -> vector<32xi8>
-      %17 = llvm.extractvalue %8[1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
-      %18 = llvm.load %17 : !llvm.ptr -> vector<128xi8>
-      %19 = llvm.bitcast %18 : vector<128xi8> to vector<32xi32>
-      %20 = "xllvm.intr.aie2.ext.I512.I1024"(%19, %2) : (vector<32xi32>, i32) -> vector<16xi32>
-      %21 = llvm.extractvalue %9[1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
-      %22 = llvm.getelementptr %21[%13] : (!llvm.ptr, i64) -> !llvm.ptr, i32
-      %23 = llvm.load %22 : !llvm.ptr -> vector<32xi32>
-      %24 = llvm.bitcast %16 : vector<32xi8> to vector<8xi32>
-      %25 = "xllvm.intr.aie2.set.I512.I256"(%24, %2) : (vector<8xi32>, i32) -> vector<16xi32>
-      %26 = llvm.bitcast %25 : vector<16xi32> to vector<64xi8>
-      %27 = llvm.bitcast %23 : vector<32xi32> to vector<16xi64>
-      %28 = "xllvm.intr.aie2.I512.I512.ACC1024.acc32.mac.conf"(%26, %20, %27, %1) : (vector<64xi8>, vector<16xi32>, vector<16xi64>, i32) -> vector<16xi64>
-      %29 = llvm.bitcast %28 : vector<16xi64> to vector<32xi32>
-      llvm.store %29, %22 : vector<32xi32>, !llvm.ptr
-      %30 = llvm.add %11, %4 : i64
-      %31 = builtin.unrealized_conversion_cast %30 : i64 to index
-      cf.br ^bb1(%31 : index)
-    ^bb3:  // pred: ^bb1
-      return
-    }
     %tile_0_2 = aie.tile(0, 2)
     %switchbox_0_2 = aie.switchbox(%tile_0_2) {
       %0 = aie.amsel<0> (0)
@@ -303,157 +256,10 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       }
     }
     %core_0_2 = aie.core(%tile_0_2) {
-      %0 = llvm.mlir.constant(32 : index) : i64
-      %1 = llvm.mlir.constant(0 : i32) : i32
-      %2 = llvm.mlir.constant(1 : i32) : i32
-      %3 = llvm.mlir.constant(0 : index) : i64
-      %4 = llvm.mlir.constant(2 : index) : i64
-      %5 = llvm.mlir.constant(1 : index) : i64
-      %6 = llvm.mlir.constant(4 : index) : i64
-      %7 = llvm.mlir.constant(8 : index) : i64
-      %8 = llvm.mlir.constant(49 : index) : i64
-      %9 = llvm.mlir.constant(48 : index) : i64
-      %10 = llvm.mlir.constant(51 : index) : i64
-      %11 = llvm.mlir.constant(50 : index) : i64
-      %12 = llvm.mlir.constant(53 : index) : i64
-      %13 = llvm.mlir.constant(52 : index) : i64
-      %14 = builtin.unrealized_conversion_cast %13 : i64 to index
-      %15 = builtin.unrealized_conversion_cast %12 : i64 to index
-      %16 = builtin.unrealized_conversion_cast %11 : i64 to index
-      %17 = builtin.unrealized_conversion_cast %10 : i64 to index
-      %18 = builtin.unrealized_conversion_cast %9 : i64 to index
-      %19 = builtin.unrealized_conversion_cast %8 : i64 to index
-      %20 = builtin.unrealized_conversion_cast %3 : i64 to index
-      %reinterpret_cast = memref.reinterpret_cast %buffer_0_2 to offset: [0], sizes: [1, 1, 1, 2, 4, 8], strides: [64, 64, 64, 32, 8, 1] : memref<64xi32> to memref<1x1x1x2x4x8xi32>
-      cf.br ^bb1(%20 : index)
-    ^bb1(%21: index):  // 2 preds: ^bb0, ^bb12
-      %22 = builtin.unrealized_conversion_cast %21 : index to i64
-      %23 = llvm.icmp "slt" %22, %5 : i64
-      cf.cond_br %23, ^bb2(%20 : index), ^bb13
-    ^bb2(%24: index):  // 2 preds: ^bb1, ^bb11
-      %25 = builtin.unrealized_conversion_cast %24 : index to i64
-      %26 = llvm.icmp "slt" %25, %5 : i64
-      cf.cond_br %26, ^bb3(%20 : index), ^bb12
-    ^bb3(%27: index):  // 2 preds: ^bb2, ^bb10
-      %28 = builtin.unrealized_conversion_cast %27 : index to i64
-      %29 = llvm.icmp "slt" %28, %5 : i64
-      cf.cond_br %29, ^bb4(%20 : index), ^bb11
-    ^bb4(%30: index):  // 2 preds: ^bb3, ^bb9
-      %31 = builtin.unrealized_conversion_cast %30 : index to i64
-      %32 = llvm.icmp "slt" %31, %4 : i64
-      cf.cond_br %32, ^bb5(%20 : index), ^bb10
-    ^bb5(%33: index):  // 2 preds: ^bb4, ^bb8
-      %34 = builtin.unrealized_conversion_cast %33 : index to i64
-      %35 = llvm.icmp "slt" %34, %6 : i64
-      cf.cond_br %35, ^bb6(%20 : index), ^bb9
-    ^bb6(%36: index):  // 2 preds: ^bb5, ^bb7
-      %37 = builtin.unrealized_conversion_cast %36 : index to i64
-      %38 = llvm.icmp "slt" %37, %7 : i64
-      cf.cond_br %38, ^bb7, ^bb8
-    ^bb7:  // pred: ^bb6
-      memref.store %1, %reinterpret_cast[%21, %24, %27, %30, %33, %36] : memref<1x1x1x2x4x8xi32>
-      %39 = llvm.add %37, %5 : i64
-      %40 = builtin.unrealized_conversion_cast %39 : i64 to index
-      cf.br ^bb6(%40 : index)
-    ^bb8:  // pred: ^bb6
-      %41 = llvm.add %34, %5 : i64
-      %42 = builtin.unrealized_conversion_cast %41 : i64 to index
-      cf.br ^bb5(%42 : index)
-    ^bb9:  // pred: ^bb5
-      %43 = llvm.add %31, %5 : i64
-      %44 = builtin.unrealized_conversion_cast %43 : i64 to index
-      cf.br ^bb4(%44 : index)
-    ^bb10:  // pred: ^bb4
-      %45 = llvm.add %28, %5 : i64
-      %46 = builtin.unrealized_conversion_cast %45 : i64 to index
-      cf.br ^bb3(%46 : index)
-    ^bb11:  // pred: ^bb3
-      %47 = llvm.add %25, %5 : i64
-      %48 = builtin.unrealized_conversion_cast %47 : i64 to index
-      cf.br ^bb2(%48 : index)
-    ^bb12:  // pred: ^bb2
-      %49 = llvm.add %22, %5 : i64
-      %50 = builtin.unrealized_conversion_cast %49 : i64 to index
-      cf.br ^bb1(%50 : index)
-    ^bb13:  // pred: ^bb1
-      aie.use_lock(%17, AcquireGreaterEqual, 1)
-      %reinterpret_cast_21 = memref.reinterpret_cast %buffer_0_2_13 to offset: [0], sizes: [1, 1, 1, 2, 4, 8], strides: [64, 64, 64, 32, 8, 1] : memref<64xi8> to memref<1x1x1x2x4x8xi8>
-      aie.use_lock(%15, AcquireGreaterEqual, 1)
-      %reinterpret_cast_22 = memref.reinterpret_cast %buffer_0_2_10 to offset: [0], sizes: [1, 1, 1, 1, 8, 8], strides: [64, 64, 64, 64, 8, 1] : memref<64xi8> to memref<1x1x1x1x8x8xi8>
-      func.call @generic_matmul_0_outlined(%reinterpret_cast_21, %reinterpret_cast_22, %reinterpret_cast) : (memref<1x1x1x2x4x8xi8>, memref<1x1x1x1x8x8xi8>, memref<1x1x1x2x4x8xi32>) -> ()
-      aie.use_lock(%18, AcquireGreaterEqual, 1)
-      cf.br ^bb14(%20 : index)
-    ^bb14(%51: index):  // 2 preds: ^bb13, ^bb28
-      %52 = builtin.unrealized_conversion_cast %51 : index to i64
-      %53 = llvm.icmp "slt" %52, %4 : i64
-      cf.cond_br %53, ^bb15, ^bb29
-    ^bb15:  // pred: ^bb14
-      %base_buffer, %offset, %sizes, %strides = memref.extract_strided_metadata %buffer_0_2 : memref<64xi32> -> memref<i32>, index, index, index
-      %54 = llvm.mul %52, %0 overflow<nsw> : i64
-      %55 = builtin.unrealized_conversion_cast %54 : i64 to index
-      %reinterpret_cast_23 = memref.reinterpret_cast %base_buffer to offset: [%55], sizes: [1, 1, 1, 1, 4, 8], strides: [64, 64, 64, 32, 8, 1] : memref<i32> to memref<1x1x1x1x4x8xi32, strided<[64, 64, 64, 32, 8, 1], offset: ?>>
-      %base_buffer_24, %offset_25, %sizes_26, %strides_27 = memref.extract_strided_metadata %buffer_0_2_17 : memref<64xi32> -> memref<i32>, index, index, index
-      %reinterpret_cast_28 = memref.reinterpret_cast %base_buffer_24 to offset: [%55], sizes: [1, 1, 1, 1, 4, 8], strides: [64, 64, 64, 32, 8, 1] : memref<i32> to memref<1x1x1x1x4x8xi32, strided<[64, 64, 64, 32, 8, 1], offset: ?>>
-      cf.br ^bb16(%20 : index)
-    ^bb16(%56: index):  // 2 preds: ^bb15, ^bb27
-      %57 = builtin.unrealized_conversion_cast %56 : index to i64
-      %58 = llvm.icmp "slt" %57, %5 : i64
-      cf.cond_br %58, ^bb17(%20 : index), ^bb28
-    ^bb17(%59: index):  // 2 preds: ^bb16, ^bb26
-      %60 = builtin.unrealized_conversion_cast %59 : index to i64
-      %61 = llvm.icmp "slt" %60, %5 : i64
-      cf.cond_br %61, ^bb18(%20 : index), ^bb27
-    ^bb18(%62: index):  // 2 preds: ^bb17, ^bb25
-      %63 = builtin.unrealized_conversion_cast %62 : index to i64
-      %64 = llvm.icmp "slt" %63, %5 : i64
-      cf.cond_br %64, ^bb19(%20 : index), ^bb26
-    ^bb19(%65: index):  // 2 preds: ^bb18, ^bb24
-      %66 = builtin.unrealized_conversion_cast %65 : index to i64
-      %67 = llvm.icmp "slt" %66, %5 : i64
-      cf.cond_br %67, ^bb20(%20 : index), ^bb25
-    ^bb20(%68: index):  // 2 preds: ^bb19, ^bb23
-      %69 = builtin.unrealized_conversion_cast %68 : index to i64
-      %70 = llvm.icmp "slt" %69, %6 : i64
-      cf.cond_br %70, ^bb21(%20 : index), ^bb24
-    ^bb21(%71: index):  // 2 preds: ^bb20, ^bb22
-      %72 = builtin.unrealized_conversion_cast %71 : index to i64
-      %73 = llvm.icmp "slt" %72, %7 : i64
-      cf.cond_br %73, ^bb22, ^bb23
-    ^bb22:  // pred: ^bb21
-      %74 = memref.load %reinterpret_cast_23[%56, %59, %62, %65, %68, %71] : memref<1x1x1x1x4x8xi32, strided<[64, 64, 64, 32, 8, 1], offset: ?>>
-      %75 = llvm.add %74, %2 : i32
-      memref.store %75, %reinterpret_cast_28[%56, %59, %62, %65, %68, %71] : memref<1x1x1x1x4x8xi32, strided<[64, 64, 64, 32, 8, 1], offset: ?>>
-      %76 = llvm.add %72, %5 : i64
-      %77 = builtin.unrealized_conversion_cast %76 : i64 to index
-      cf.br ^bb21(%77 : index)
-    ^bb23:  // pred: ^bb21
-      %78 = llvm.add %69, %5 : i64
-      %79 = builtin.unrealized_conversion_cast %78 : i64 to index
-      cf.br ^bb20(%79 : index)
-    ^bb24:  // pred: ^bb20
-      %80 = llvm.add %66, %5 : i64
-      %81 = builtin.unrealized_conversion_cast %80 : i64 to index
-      cf.br ^bb19(%81 : index)
-    ^bb25:  // pred: ^bb19
-      %82 = llvm.add %63, %5 : i64
-      %83 = builtin.unrealized_conversion_cast %82 : i64 to index
-      cf.br ^bb18(%83 : index)
-    ^bb26:  // pred: ^bb18
-      %84 = llvm.add %60, %5 : i64
-      %85 = builtin.unrealized_conversion_cast %84 : i64 to index
-      cf.br ^bb17(%85 : index)
-    ^bb27:  // pred: ^bb17
-      %86 = llvm.add %57, %5 : i64
-      %87 = builtin.unrealized_conversion_cast %86 : i64 to index
-      cf.br ^bb16(%87 : index)
-    ^bb28:  // pred: ^bb16
-      %88 = llvm.add %52, %5 : i64
-      %89 = builtin.unrealized_conversion_cast %88 : i64 to index
-      cf.br ^bb14(%89 : index)
-    ^bb29:  // pred: ^bb14
-      aie.use_lock(%16, Release, 1)
-      aie.use_lock(%14, Release, 1)
-      aie.use_lock(%19, Release, 1)
+      %0 = llvm.mlir.constant(1 : i32) : i32
+      %1 = llvm.mlir.constant(0 : index) : i64
+      %2 = builtin.unrealized_conversion_cast %1 : i64 to index
+      memref.store %0, %buffer_0_2[%2] : memref<64xi32>
       aie.end
     }
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlCodeLowering.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlCodeLowering.cpp
@@ -45,19 +45,16 @@ struct HalfDmaCpyNdToNpuConverter final
     uint8_t numAddrDim =
         numIntraAddrDim + deviceModel.deviceConfig.dmaNbInterDims;
 
-    int64_t argIdx;
-    int64_t elemWidthInBits;
-    uint8_t memSpace;
-    if (lowerCtrlpktDma) {
-      // Control packet DMAs require special handling.
-      // The `argIdx` must match the driver and is assumed to be 0.
-      // The `elemWidthInBits` is fixed at 32 for control packet data.
-      // The `memSpace` is set to 0, indicating storage in global memory.
-      argIdx = 0;
-      elemWidthInBits = 32;
-      memSpace = 0;
-    } else {
-      // Normal DMAs.
+    // Default values, used for control packet DMAs only.
+    // The `argIdx` must match the driver and is assumed to be 0.
+    // The `elemWidthInBits` is fixed at 32 for control packet data.
+    // The `memSpace` is set to 0, indicating storage in global memory.
+    int64_t argIdx = 0;
+    int64_t elemWidthInBits = 32;
+    uint8_t memSpace = 0;
+    if (!lowerCtrlpktDma) {
+      // Normal DMAs, update `argIdx`, `elemWidthInBits`, and `memSpace` based
+      // on the memref.
       auto logicalObjFifo =
           dyn_cast_if_present<AMDAIE::LogicalObjectFifoFromMemrefOp>(
               op.getInput().getDefiningOp());

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -21,7 +21,7 @@ void addAMDAIEObjectFifoLoweringPasses(
     bool enableCoalescingLoops, bool enableCollapsingUnitDims,
     OutliningStrategy enableFunctionOutlining,
     bool replaceOutlinedFunctionsWithEmpty, bool insertLoopAroundCoreBlock,
-    uint32_t numCols);
+    uint32_t numCols, bool emitCtrlPkt);
 
 /// Add passes to lower from MLIR-AIR through AIE. This is
 /// currently the default passes used for lowering after IREEs tiling.
@@ -44,7 +44,8 @@ void buildAMDAIETransformPassPipeline(
     bool enableVectorizationPasses, const std::string &pathToUkernels,
     bool enablePacketFlow, bool enableCoalescingLoops,
     bool enableCollapsingUnitDims, OutliningStrategy enableFunctionOutlining,
-    bool replaceOutlinedFunctionsWithEmpty, bool insertLoopAroundCoreBlock);
+    bool replaceOutlinedFunctionsWithEmpty, bool insertLoopAroundCoreBlock,
+    bool emitCtrlPkt);
 
 /// Populates passes needed to lower the IR via a Pack-Peel based approach.
 void addPackPeelBasedPassPipeline(OpPassManager &passManager,
@@ -121,7 +122,8 @@ std::unique_ptr<Pass> createAMDAIEControlCodeLoopUnrollPass();
 
 /// Pass to convert control code HalfDmaCpyNd into NPU WriteBd, AddressPatch,
 /// PushToQueue operations.
-std::unique_ptr<Pass> createAMDAIEControlCodeLoweringPass();
+std::unique_ptr<Pass> createAMDAIEControlCodeLoweringPass(
+    AMDAIEControlCodeLoweringOptions options = {});
 
 /// Pass to convert control code into a transaction binary.
 std::unique_ptr<Pass> createAMDAIEControlCodeToTransactionPass(

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -173,6 +173,10 @@ def AMDAIEControlCodeLowering :
     Pass<"iree-amdaie-controlcode-lowering", ""> {
   let summary = "Lower control code ops to the most basic NPU write/sync/patch instructions";
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIEControlCodeLoweringPass()";
+  let options = [
+    Option<"lowerCtrlpktDma", "lower-ctrlpkt-dma", "bool", /*default=*/"false",
+      "Enable the special handling for lowering the control packet DMA operations.">
+  ];
 }
 
 def AMDAIEControlCodeToTransaction :

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
@@ -28,6 +28,7 @@ iree_lit_test_suite(
     "controlcode_forall_to_for.mlir"
     "controlcode_loop_unrolling.mlir"
     "controlcode_lowering.mlir"
+    "controlcode_lowering_ctrlpkt.mlir"
     "controlcode_to_transaction.mlir"
     "control_packet_to_half_dma_cpy_nd.mlir"
     "convert_core_forall_to_for.mlir"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/controlcode_lowering_ctrlpkt.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/controlcode_lowering_ctrlpkt.mlir
@@ -1,0 +1,48 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-controlcode-lowering{lower-ctrlpkt-dma=true})" --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: @reconfigure
+#executable_target_amdaie_pdi_fb = #hal.executable.target<"amd-aie", "amdaie-pdi-fb", {num_cols = 1 : i32, num_rows = 1 : i32, target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_pdi_fb} {
+  func.func @reconfigure() {
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c0 = arith.constant 0 : index
+    amdaie.workgroup {
+      %tile_0_2 = amdaie.tile(%c0, %c2)
+      %tile_0_0 = amdaie.tile(%c0, %c0)
+      %tile_0_1 = amdaie.tile(%c0, %c1)
+      %channel = amdaie.channel(%tile_0_0, 0, port_type = DMA, direction = MM2S)
+      %channel_0 = amdaie.channel(%tile_0_0, 0, port_type = CTRL, direction = S2MM)
+      %0 = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<?xi32>>
+      %1 = amdaie.flow({%channel} -> {%channel_0}) {is_packet_flow = true, packet_id = 0 : ui8}
+      %2 = amdaie.connection(%0 {%channel_0}, %0 {%channel}, flow = %1) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<?xi32>>, !amdaie.logicalobjectfifo<memref<?xi32>>)
+      %channel_1 = amdaie.channel(%tile_0_0, 1, port_type = DMA, direction = MM2S)
+      %channel_2 = amdaie.channel(%tile_0_1, 0, port_type = CTRL, direction = S2MM)
+      %3 = amdaie.logicalobjectfifo.placeholder{%tile_0_1} : !amdaie.logicalobjectfifo<memref<?xi32>>
+      %4 = amdaie.flow({%channel_1} -> {%channel_2}) {is_packet_flow = true, packet_id = 0 : ui8}
+      %5 = amdaie.connection(%3 {%channel_2}, %0 {%channel_1}, flow = %4) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<?xi32>>, !amdaie.logicalobjectfifo<memref<?xi32>>)
+      %channel_3 = amdaie.channel(%tile_0_2, 0, port_type = CTRL, direction = S2MM)
+      %6 = amdaie.logicalobjectfifo.placeholder{%tile_0_2} : !amdaie.logicalobjectfifo<memref<?xi32>>
+      %7 = amdaie.flow({%channel} -> {%channel_3}) {is_packet_flow = true, packet_id = 1 : ui8}
+      %8 = amdaie.connection(%6 {%channel_3}, %0 {%channel}, flow = %7) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<?xi32>>, !amdaie.logicalobjectfifo<memref<?xi32>>)
+      %channel_4 = amdaie.channel(%tile_0_0, 0, port_type = CTRL, direction = MM2S)
+      %channel_5 = amdaie.channel(%tile_0_0, 0, port_type = SOUTH, direction = S2MM)
+      %9 = amdaie.flow({%channel_4} -> {%channel_5}) {is_packet_flow = false}
+      %10 = amdaie.connection(%0 {%channel_5}, %0 {%channel_4}, flow = %9) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<?xi32>>, !amdaie.logicalobjectfifo<memref<?xi32>>)
+      amdaie.controlcode {
+        %bd_id = amdaie.bd_id(%tile_0_0, %c0)
+// CHECK:  amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 0 : ui32, col = 0 : ui32, offset = 0 : ui32}
+        %11 = amdaie.npu.half_dma_cpy_nd async %8(%0 [0, 0, 0, 0] [1, 1, 1, 2] [0, 0, 0, 1] bd_id = %bd_id channel = %channel) : !amdaie.logicalobjectfifo<memref<?xi32>>
+        amdaie.npu.dma_wait(%11 : !amdaie.async_token)
+// CHECK:  amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 0 : ui32, col = 0 : ui32, offset = 1776 : ui32}        
+        %107 = amdaie.npu.half_dma_cpy_nd async %5(%0 [0, 0, 0, 444] [1, 1, 1, 2] [0, 0, 0, 1] bd_id = %bd_id channel = %channel_1) : !amdaie.logicalobjectfifo<memref<?xi32>>
+        amdaie.npu.dma_wait(%107 : !amdaie.async_token)
+// CHECK:  amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 0 : ui32, col = 0 : ui32, offset = 2968 : ui32} 
+        %208 = amdaie.npu.half_dma_cpy_nd async %2(%0 [0, 0, 0, 742] [1, 1, 1, 2] [0, 0, 0, 1] bd_id = %bd_id channel = %channel) : !amdaie.logicalobjectfifo<memref<?xi32>>
+        amdaie.npu.dma_wait(%208 : !amdaie.async_token)
+        amdaie.end
+      }
+    }
+    return
+  }
+}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/controlcode_lowering_ctrlpkt.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/controlcode_lowering_ctrlpkt.mlir
@@ -34,10 +34,10 @@ module attributes {hal.executable.target = #executable_target_amdaie_pdi_fb} {
 // CHECK:  amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 0 : ui32, col = 0 : ui32, offset = 0 : ui32}
         %11 = amdaie.npu.half_dma_cpy_nd async %8(%0 [0, 0, 0, 0] [1, 1, 1, 2] [0, 0, 0, 1] bd_id = %bd_id channel = %channel) : !amdaie.logicalobjectfifo<memref<?xi32>>
         amdaie.npu.dma_wait(%11 : !amdaie.async_token)
-// CHECK:  amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 0 : ui32, col = 0 : ui32, offset = 1776 : ui32}        
+// CHECK:  amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 0 : ui32, col = 0 : ui32, offset = 1776 : ui32}
         %107 = amdaie.npu.half_dma_cpy_nd async %5(%0 [0, 0, 0, 444] [1, 1, 1, 2] [0, 0, 0, 1] bd_id = %bd_id channel = %channel_1) : !amdaie.logicalobjectfifo<memref<?xi32>>
         amdaie.npu.dma_wait(%107 : !amdaie.async_token)
-// CHECK:  amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 0 : ui32, col = 0 : ui32, offset = 2968 : ui32} 
+// CHECK:  amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 0 : ui32, col = 0 : ui32, offset = 2968 : ui32}
         %208 = amdaie.npu.half_dma_cpy_nd async %2(%0 [0, 0, 0, 742] [1, 1, 1, 2] [0, 0, 0, 1] bd_id = %bd_id channel = %channel) : !amdaie.logicalobjectfifo<memref<?xi32>>
         amdaie.npu.dma_wait(%208 : !amdaie.async_token)
         amdaie.end

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/convert_device_to_control_packets.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/convert_device_to_control_packets.mlir
@@ -6,6 +6,9 @@
 // CHECK-NEXT: module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb}
 // CHECK-NEXT:   func.func @reconfigure() {
 // CHECK-NEXT:     amdaie.workgroup {
+// CHECK-NEXT:       %[[C0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:       %[[C2:.*]] = arith.constant 2 : index
+// CHECK-NEXT:       %[[TILE_0_2:.*]] = amdaie.tile(%[[C0]], %[[C2]])
 // CHECK-NEXT:       amdaie.controlcode {
 
 // Generated from `XAie_CoreDisable`.


### PR DESCRIPTION
This PR implements a pipeline in `XCLBinGen` for the generation and conversion of control packets. The `aie.device` is converted into `ctrlpkt_sequence.txt` and `ctrlpkt_instructions.txt`, which store the contents and instructions for control packet DMAs, respectively. These files will later be used by the driver to perform the reconfiguration.

Changes related to the driver and a new on-device test will be submitted in follow-up PRs.
