### PR TITLE
Fix typos in error message when insufficient stack size 

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
@@ -1231,10 +1231,12 @@ LogicalResult checkStackSize(const std::string &outputFile, bool verbose,
     }
     auto stackSize = coreOp.getStackSize();
     if (stackSize < iter->second) {
-      llvm::errs() << "An upper bound of the stack size, inferred from "
-                      "dumper stack size file, is"
-                   << iter->second << " bytes. The assigned stack size is "
-                   << stackSize << " bytes, which is insufficient. ";
+      llvm::errs() << "An upper bound for the stack size of the core (col="
+                   << col << ", row=" << row
+                   << "), inferred from the object file, is " << iter->second
+                   << " bytes. The assigned memory for the stack is "
+                   << stackSize << " bytes, which is insufficient ("
+                   << iter->second << " > " << stackSize << ").\n";
       return failure();
     }
   }


### PR DESCRIPTION
Now

```
An upper bound for the stack size of the core (col=0, row=2), inferred from the object file, is 1448 bytes. The assigned memory for the stack is 1024 bytes, which is insufficient (1448 > 1024).
```