### PR TITLE
[CanonicalizeDoublyStridedOp] Add expansion of dimensions exceeding max sizes

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -1796,6 +1796,25 @@ class Tests:
 
         self.register(
             Matmul(
+                32,
+                128,
+                128,
+                "i32",
+                "i32",
+                test_params=TestParams(
+                    run_on_target=["npu4"],
+                    use_chess=False,
+                    tile_pipeline="pack-peel-4-level-tiling",
+                    aie_compilation_flags=[
+                        "--iree-amdaie-num-rows=4",
+                        "--iree-amdaie-num-cols=2",
+                    ],
+                ),
+            )
+        )
+
+        self.register(
+            Matmul(
                 1024,
                 1024,
                 1024,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeDoublyStridedOp.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECanonicalizeDoublyStridedOp.cpp
@@ -21,6 +21,84 @@ using mlir::OpTrait::iree_compiler::AMDAIE::CircularDmaOp;
 
 namespace {
 
+/// Expand dimensions that exceed the maximum size into a sequence of linear
+/// dimensions.
+class ExpandSingleDimIntoLinearDims
+    : public OpInterfaceRewritePattern<AMDAIE::DoublyStridedOpInterface> {
+  using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
+
+ public:
+  ExpandSingleDimIntoLinearDims(
+      MLIRContext *ctx,
+      std::optional<std::reference_wrapper<const AMDAIEDeviceModel>>
+          deviceModel = std::nullopt)
+      : OpInterfaceRewritePattern<AMDAIE::DoublyStridedOpInterface>(ctx),
+        deviceModel(deviceModel) {}
+
+  LogicalResult matchAndRewrite(AMDAIE::DoublyStridedOpInterface op,
+                                PatternRewriter &rewriter) const override {
+    if (!deviceModel.has_value()) {
+      return rewriter.notifyMatchFailure(
+          op, "no device model passed, so won't expand linear dimensions");
+    }
+    OpBuilder::InsertionGuard guard(rewriter);
+    std::optional<uint8_t> sourceMemSpace = op.getSourceMemorySpaceAsUInt();
+    std::optional<uint8_t> targetMemSpace = op.getTargetMemorySpaceAsUInt();
+    if (!sourceMemSpace || !targetMemSpace) {
+      return rewriter.notifyMatchFailure(
+          op,
+          "expected a source and target memory space for hardware aware "
+          "linear dimension expansion");
+    }
+    SmallVector<OpFoldResult> sourceOffsets = op.getSourceMixedOffsets();
+    SmallVector<OpFoldResult> sourceSizes = op.getSourceMixedSizes();
+    SmallVector<OpFoldResult> sourceStrides = op.getSourceMixedStrides();
+    SmallVector<OpFoldResult> targetOffsets = op.getTargetMixedOffsets();
+    SmallVector<OpFoldResult> targetSizes = op.getTargetMixedSizes();
+    SmallVector<OpFoldResult> targetStrides = op.getTargetMixedStrides();
+    SmallVector<int64_t> maxSourceSizes, maxTargetSizes;
+    if (op->hasTrait<CircularDmaOp>()) {
+      CircularDmaDimConfig sourceDmaDimConfig(deviceModel.value(),
+                                              sourceMemSpace.value());
+      maxSourceSizes = sourceDmaDimConfig.getMaxSizes(sourceOffsets.size());
+      CircularDmaDimConfig targetDmaDimConfig(deviceModel.value(),
+                                              targetMemSpace.value());
+      maxTargetSizes = targetDmaDimConfig.getMaxSizes(targetOffsets.size());
+    } else {
+      DmaDimConfig sourceDmaDimConfig(deviceModel.value(),
+                                      sourceMemSpace.value());
+      maxSourceSizes = sourceDmaDimConfig.getMaxSizes(sourceOffsets.size());
+      DmaDimConfig targetDmaDimConfig(deviceModel.value(),
+                                      targetMemSpace.value());
+      maxTargetSizes = targetDmaDimConfig.getMaxSizes(targetOffsets.size());
+    }
+    SmallVector<OpFoldResult> newSourceOffsets, newSourceSizes,
+        newSourceStrides, newTargetOffsets, newTargetSizes, newTargetStrides;
+    LogicalResult sourceRes = expandLargeDimIntoLinearDims(
+        op.getContext(), sourceOffsets, sourceSizes, sourceStrides,
+        newSourceOffsets, newSourceSizes, newSourceStrides, maxSourceSizes);
+    LogicalResult targetRes = expandLargeDimIntoLinearDims(
+        op.getContext(), targetOffsets, targetSizes, targetStrides,
+        newTargetOffsets, newTargetSizes, newTargetStrides, maxTargetSizes);
+    if (failed(sourceRes) && failed(targetRes)) {
+      return rewriter.notifyMatchFailure(
+          op, "neither a source nor a target change");
+    }
+
+    rewriter.setInsertionPointAfter(op);
+    auto newDoublyStridedOp = op.createDoublyStridedOp(
+        rewriter, newTargetOffsets, newTargetSizes, newTargetStrides,
+        newSourceOffsets, newSourceSizes, newSourceStrides);
+    rewriter.replaceOp(op, newDoublyStridedOp.getOperation());
+    return success();
+  }
+
+ private:
+  /// If the device model is set, this rewriter will use the device model to
+  /// keep hardware stride/size limitations into account.
+  std::optional<std::reference_wrapper<const AMDAIEDeviceModel>> deviceModel;
+};
+
 /// Recognize linear accesses across multiple DMA access dimensions and fold
 /// them.
 class FoldDmaOpLinearDims
@@ -221,6 +299,8 @@ void populateCanonicalizeDoublyStridedOpPatterns(
   patterns.add<FoldDmaOpUnitDims>(patterns.getContext());
   patterns.add<FoldDmaOpLinearDims>(patterns.getContext(),
                                     std::move(deviceModel));
+  patterns.add<ExpandSingleDimIntoLinearDims>(patterns.getContext(),
+                                              std::move(deviceModel));
   if (foldSingleDims) {
     patterns.add<FoldDmaOpSingleDims>(patterns.getContext());
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.h
@@ -137,6 +137,10 @@ std::optional<int64_t> getGlobalOffsetDifference(
     ArrayRef<OpFoldResult> offsetsX, ArrayRef<OpFoldResult> stridesX,
     ArrayRef<OpFoldResult> offsetsY, ArrayRef<OpFoldResult> stridesY);
 
+/// Find the smallest factor of `size` that results in a quotient less than or
+/// equal to `maxSize`.
+int64_t findFactorResultingInSmallerSize(int64_t size, int64_t maxSize);
+
 }  // namespace detail
 
 /// Combine two access patterns into a single one. Assumes that access pattern A
@@ -168,6 +172,17 @@ LogicalResult foldLinearDims(
     SmallVector<OpFoldResult> &newStrides,
     function_ref<bool(size_t, int64_t)> checkValidSize =
         [](size_t idxFromEnd, int64_t size) { return true; });
+
+/// Expand dimensions within a strided access pattern that exceed a maximum
+/// size. Returns `success` if expansion took place. The `maxSizes` array is
+/// expected to be provided in the same order as `sizes` and they are compared
+/// from right to left (innermost to outermost).
+LogicalResult expandLargeDimIntoLinearDims(
+    MLIRContext *ctx, const SmallVector<OpFoldResult> &offsets,
+    const SmallVector<OpFoldResult> &sizes,
+    const SmallVector<OpFoldResult> &strides,
+    SmallVector<OpFoldResult> &newOffsets, SmallVector<OpFoldResult> &newSizes,
+    SmallVector<OpFoldResult> &newStrides, ArrayRef<int64_t> maxSizes);
 
 /// Utility to fold a provided repetition count from the front of the access
 /// pattern (dimensions with `size > 1` and `stride == 0` indicate a


### PR DESCRIPTION
This PR adds a dimension expansion rewrite to the doubly-strided op canonicalizer, which is effectively the reverse of the `FoldDmaOpLinearDims` transformation. This fixes: #1137 (see test being added).

Example:

```
offsets: [0], sizes: [8], strides: [1], maxSizes: [5]
```

is expanded into:

```
offsets: [0, 0], sizes: [2, 4], strides: [4, 1]
```

Here, all the sizes are smaller or equal to the max size. This helps with enabling more DMA composition transformations, and this is needed to avoid nested `npu.circular_dma_cpy_nd` ops after `DmaComposition`, which is why it fixes #1137. Note that we should probably add some checks that all `npu.circular_dma_cpy_nd`  ops are combined and subsumed correctly to help with debugging issues. I will address that in a follow-up.