### PR TITLE
Add CSE to aie-opt pipeline to improve -O2 performance

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
@@ -247,6 +247,46 @@ FailureOr<std::vector<std::string>> makePeanoOptArgs(
       *iter = flag;
     }
   }
+
+  // Some background to this opt pass finetuning/hack.
+  // currently performance (function outlining, phoenix, matmul) is much better
+  // with -O3 than -O2. But the memory used with -O3 is much higher than with
+  // -O2. This is because with -O3, the outlined function is inlined at most
+  // call sites and in the the process of inlining for some reason the integer
+  // arithmetic is rearranged, and in particular there are fewer common
+  // sub-expressions. For example in the -O2 case, the outlined function after
+  // optimization contains
+  //
+  //    ```
+  //    ...
+  //    %45 = trunc i64 %38 to i20
+  //    ...
+  //    %49 = trunc i64 %38 to i20
+  //    ...
+  //    ```
+  //
+  // whereas the inlined (with -O3) does not. So inlining has found a roundabout
+  // way to improve the code which has nothing to do with any actual traditional
+  // advantages of inlining (fewer function calls etc).
+  //
+  // Can we get this improvement without the memory overhead of -O3? I have
+  // found that running the -O2 pass pipeline, followed by a basic llvm cse pass
+  // gets us almost all the way there.
+  //
+  // early-cse information:
+  //    https://llvm.org/doxygen/structllvm_1_1EarlyCSEPass.html#details
+  //
+  // I have experimented with adding gvn too (gvn is a more powerful version of
+  // cse), but it results in vector loads being merged, which results in spills
+  // from registers, which results in performance degredation.
+  //
+  for (auto &flag : args) {
+    if (isOptLevelFlag(flag)) {
+      auto optLevel = flag.substr(1);
+      auto passes = "default<" + optLevel + ">,early-cse,dce";
+      flag = "-passes=" + passes;
+    }
+  }
   return args;
 }
 }  // namespace detail

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/AMDAIEXCLBinGenTest.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/AMDAIEXCLBinGenTest.cpp
@@ -22,14 +22,19 @@ TEST(XCLBinGenTest, makePeanoOptArgs) {
       detail::makePeanoOptArgs(maybeAdditionalFlags.value());
   EXPECT_TRUE(succeeded(maybeOptArgs));
   std::vector<std::string> optArgs = std::move(maybeOptArgs.value());
-  // We expect to find 1 -O4 flag, and 0 flags for -On for all other n.
-  // Why -O4? because it's the flag which appears last in `additionalFlags`.
+  // We expect to find 1 flag corresponding to -O4, and 0 flags corresponding to
+  // -On for all other n. Why -O4? because it's the flag which appears last in
+  // `additionalFlags`.
   for (uint32_t i = 0; i < 10; ++i) {
     std::string optFlag = "-O" + std::to_string(i);
+    std::string defaultOptFlag = "-passes=default<O" + std::to_string(i) +
+                                 ">,gvn,instcombine,early-cse,dce";
     if (i == 4) {
-      EXPECT_EQ(std::count(optArgs.begin(), optArgs.end(), optFlag), 1);
+      EXPECT_EQ(std::count(optArgs.begin(), optArgs.end(), optFlag), 0);
+      EXPECT_EQ(std::count(optArgs.begin(), optArgs.end(), defaultOptFlag), 1);
     } else {
       EXPECT_EQ(std::count(optArgs.begin(), optArgs.end(), optFlag), 0);
+      EXPECT_EQ(std::count(optArgs.begin(), optArgs.end(), defaultOptFlag), 0);
     }
   }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/AMDAIEXCLBinGenTest.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/AMDAIEXCLBinGenTest.cpp
@@ -27,8 +27,8 @@ TEST(XCLBinGenTest, makePeanoOptArgs) {
   // `additionalFlags`.
   for (uint32_t i = 0; i < 10; ++i) {
     std::string optFlag = "-O" + std::to_string(i);
-    std::string defaultOptFlag = "-passes=default<O" + std::to_string(i) +
-                                 ">,gvn,instcombine,early-cse,dce";
+    std::string defaultOptFlag =
+        "-passes=default<O" + std::to_string(i) + ">,early-cse,dce";
     if (i == 4) {
       EXPECT_EQ(std::count(optArgs.begin(), optArgs.end(), optFlag), 0);
       EXPECT_EQ(std::count(optArgs.begin(), optArgs.end(), defaultOptFlag), 1);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/fuse_fill_into_forall.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/fuse_fill_into_forall.mlir
@@ -60,7 +60,7 @@ func.func @fuse_without_slice(%arg0: tensor<8xi8>) -> tensor<8xi8> {
 // CHECK: %[[NEWFILL:.*]] = linalg.fill
 // CHECK-SAME: outs(%[[ARG2]] : tensor<8xi8>) -> tensor<8xi8>
 // CHECK: linalg.generic
-// check the the parallel_insert_slice still happens on arg2, not the filled
+// check the parallel_insert_slice still happens on arg2, not the filled
 // tensor. This is because it must match the shared_outs of the scf.forall:
 // CHECK: tensor.parallel_insert_slice
 // CHECK-SAME: into %[[ARG2]]


### PR DESCRIPTION
This PR extends the aie-opt pipeline with Common Subexpression Elimination (CSE) to achieve better scalar arithmetic without increasing Program Memory (PM) usage.

Background:
- Currently, -O3 optimization provides better performance than -O2  (function outlining, phoenix, and matmul). 
- However, -O3 significantly increases program memory usage compared to -O2.
- The performance improvement in -O3 is largely due to unintended effects of function inlining, which rearranges integer arithmetic and reduces common subexpressions.

Problem:
- In -O2, the outlined function after optimization contains redundant operations, e.g.:

%45 = trunc i64 %38 to i20
...
%49 = trunc i64 %38 to i20

- -O3 eliminates these redundancies indirectly through inlining, but at the cost of increased memory usage.

Solution:
- Add a basic LLVM CSE pass after the -O* pass pipeline.
- This approach achieves most/all of the performance benefits of -O3 without the memory overhead.

Implementation:
- Extended aie-opt pipeline with CSE.
- Considered adding Global Value Numbering (GVN) but found it merged vector loads, causing register spills and performance degradation.

References:
- Early CSE information: https://llvm.org/doxygen/structllvm_1_1EarlyCSEPass.html#details

Below I've scraped all the benchmark numbers from CI, for this PR and top of main (ToM). Table summary: it looks like we can match the performance of -O3 (line 4) now with -O2 (line 2), but with much less PM usage (8474 bytes -> 2608 bytes). 

### Time Comparison
| Benchmark | Before (us) | After (us) |
| --- | --- | --- |
| matmul_512_512_4096_bf16_f32_O2_npu1_4col | 2585.0 | 1817.0 |
| matmul_512_512_4096_bf16_f32_O2_npu1_4col_outline | 2714.0 | **1807.0** |
| matmul_512_512_4096_bf16_f32_O3_npu1_4col | 2625.0 | 1801.0 |
| matmul_512_512_4096_bf16_f32_O3_npu1_4col_outline | **1775.0** | 1804.0 |
| matmul_512_512_4096_bf16_f32_O3_npu1_4col_outline_ukernel_chess | 1771.0 | 1832.0 |


### Memory Comparison
| Benchmark | Before (bytes) | After (bytes) |
| --- | --- | --- |
| matmul_512_512_4096_bf16_f32_O2_npu1_4col | 10112 | 8800 |
| matmul_512_512_4096_bf16_f32_O2_npu1_4col_outline | 2784 | **2608** |
| matmul_512_512_4096_bf16_f32_O3_npu1_4col | 10112 | 8800 |
| matmul_512_512_4096_bf16_f32_O3_npu1_4col_outline | **8464** | 8464 |
| matmul_512_512_4096_bf16_f32_O3_npu1_4col_outline_ukernel_chess | 3328 | 3328 |
