### PR TITLE
[ControlCodeToTransaction] Fix controlcode size printing

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlCodeToTransaction.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlCodeToTransaction.cpp
@@ -46,6 +46,8 @@ class TransactionBuilder {
     // Resize instructions and copy data.
     instructions.resize(instructionCount);
     memcpy(instructions.data(), txn_ptr.get(), sizeInBytes);
+    LLVM_DEBUG(llvm::dbgs()
+               << "Instruction size: " << getInstructionSize() << "\n");
     // Clear the transaction.
     TRY_XAIE_API_FATAL_ERROR(XAie_ClearTransaction, &deviceModel.devInst);
     return ArrayRef<uint32_t>(instructions.data(), instructions.size());
@@ -268,8 +270,6 @@ void AMDAIEControlCodeToTransactionPass::runOnOperation() {
                                         transactionBuilder))) {
       return WalkResult::interrupt();
     }
-    LLVM_DEBUG(llvm::dbgs() << "Instruction size: "
-                            << transactionBuilder.getInstructionSize() << "\n");
     ArrayRef<uint32_t> instructions =
         transactionBuilder.finalizeAndReturnInstructions();
     workgroupOp.setNpuInstructionsAttr(DenseUI32ResourceElementsAttr::get(


### PR DESCRIPTION
This PR fixes a bug introduced by #1002, where the instruction count printing was incorrect because it occurred before resizing the instructions vector. The logging is now moved inside `finalizeAndReturnInstructions` after `instructions.resize(instructionCount)`, ensuring the correct count is printed instead of zero.