### PR TITLE
[Testing] Generalize matmul truncation numerical testing

### DIFF
--- a/build_tools/ci/cpu_comparison/matmul_template/matmul_generator.py
+++ b/build_tools/ci/cpu_comparison/matmul_template/matmul_generator.py
@@ -10,7 +10,19 @@ def get_higher_order_element_type(element_type):
 
 
 def generate_matmul_test(
-    output_fn, input_fn, m, n, k, lhs_rhs_type, acc_type, b=0, m0=0, n0=0, k0=0
+    output_fn,
+    input_fn,
+    m,
+    n,
+    k,
+    lhs_rhs_type,
+    acc_type,
+    b=0,
+    m0=0,
+    n0=0,
+    k0=0,
+    trunci_scale=None,
+    trunci_shift=None,
 ):
     """
     Generate mlir file (output_fn) from the template file (input_fn).
@@ -33,6 +45,9 @@ def generate_matmul_test(
 
     # This is only used for batch matmul.
     replace["B"] = b
+
+    replace["TRUNCI_SCALE"] = trunci_scale
+    replace["TRUNCI_SHIFT"] = trunci_shift
 
     # m0, n0, k0 are only used for matmul4d as inner dim sizes.
     replace["M0"] = m0

--- a/build_tools/ci/cpu_comparison/matmul_template/matmul_trunci_scaling_MxK_KxN.mlir
+++ b/build_tools/ci/cpu_comparison/matmul_template/matmul_trunci_scaling_MxK_KxN.mlir
@@ -2,15 +2,16 @@
 // input ${K}x${N}x${TYPE1}
 
 // Matmul + Trunci variant with scaling.
-// In an actual quantized model, truncating from a higher bitwidth to a lower precision bitwidth
-// won't work and we need to scale.
-// Since the output of the Matmul here is an integer cannot be multiplied with a floating point
-// scale factor, we need to represent the scale factor with a multiplier and a shift operator instead.
+// In an actual quantized model, truncating from a higher bitwidth to a lower
+// precision bitwidth won't work and we need to scale. Since the output of the
+// matmul here is an integer cannot be multiplied with a floating point
+// scale factor, we need to represent the scale factor with a multiplier and a
+// shift operator instead.
 func.func @matmul_trunci(%arg0: tensor<${M}x${K}x${TYPE1}>, %arg1: tensor<${K}x${N}x${TYPE1}>) -> tensor<${M}x${N}x${TYPE1}>
 {
   %cst = arith.constant ${ZERO} : ${TYPE2}
-  %cst_mul = arith.constant 10 : ${TYPE_MUL_RESULT}
-  %cst_shift = arith.constant 7 : ${TYPE_MUL_RESULT}
+  %cst_mul = arith.constant ${TRUNCI_SCALE} : ${TYPE_MUL_RESULT}
+  %cst_shift = arith.constant ${TRUNCI_SHIFT} : ${TYPE_MUL_RESULT}
   %0 = tensor.empty() : tensor<${M}x${N}x${TYPE2}>
   %i8out = tensor.empty() : tensor<${M}x${N}x${TYPE1}>
   %1 = linalg.fill ins(%cst : ${TYPE2}) outs(%0 : tensor<${M}x${N}x${TYPE2}>) -> tensor<${M}x${N}x${TYPE2}>


### PR DESCRIPTION
1)  Show the working in code (where does the 60 come from?), useful for future debugging. 
2) Make numerical test more robust: it's better to not do numerical testing with tensors where all the elements have the same value unless there is no alternative -- this opens gaps where bugs can slip through numerical tests unnoticed. So in this PR I use random numpy tensors instead of np.ones 