### PR TITLE
Do not explicitly use `--iree-amdaie-num-rows` if it is default 

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -1583,10 +1583,6 @@ class Tests:
                     name_suffix="scaling",
                     tile_pipeline="pack-peel-4-level-tiling",
                     run_on_target=["npu1_4col"],
-                    aie_compilation_flags=[
-                        "--iree-amdaie-num-rows=4",
-                        "--iree-amdaie-num-cols=4",
-                    ],
                     use_ukernel=True,
                 ),
             )
@@ -1605,10 +1601,6 @@ class Tests:
                 test_params=TestParams(
                     tile_pipeline="pack-peel-4-level-tiling",
                     run_on_target=["npu1_4col"],
-                    aie_compilation_flags=[
-                        "--iree-amdaie-num-rows=4",
-                        "--iree-amdaie-num-cols=4",
-                    ],
                 ),
             )
         )
@@ -1626,10 +1618,6 @@ class Tests:
                 test_params=TestParams(
                     tile_pipeline="pack-peel-4-level-tiling",
                     run_on_target=["npu4"],
-                    aie_compilation_flags=[
-                        "--iree-amdaie-num-rows=4",
-                        "--iree-amdaie-num-cols=8",
-                    ],
                     use_chess=False,
                     use_ukernel=True,
                     use_chess_for_ukernel=False,
@@ -1707,10 +1695,6 @@ class Tests:
                     tile_pipeline="pack-peel-4-level-tiling",
                     run_on_target=["npu4"],
                     name_suffix="4x8_npu4",
-                    aie_compilation_flags=[
-                        "--iree-amdaie-num-rows=4",
-                        "--iree-amdaie-num-cols=8",
-                    ],
                     n_repeats=10,
                 ),
             )
@@ -1728,10 +1712,6 @@ class Tests:
                     tile_pipeline="pack-peel-4-level-tiling",
                     run_on_target=["npu4"],
                     name_suffix="4x8_npu4",
-                    aie_compilation_flags=[
-                        "--iree-amdaie-num-rows=4",
-                        "--iree-amdaie-num-cols=8",
-                    ],
                     n_repeats=10,
                 ),
             )
@@ -1823,10 +1803,6 @@ class Tests:
                 test_params=TestParams(
                     name_suffix="4rows_8cols_npu4",
                     run_on_target=["npu4"],
-                    aie_compilation_flags=[
-                        "--iree-amdaie-num-rows=4",
-                        "--iree-amdaie-num-cols=8",
-                    ],
                     use_chess=False,
                 ),
             )
@@ -1842,10 +1818,6 @@ class Tests:
                     name_suffix="4rows_8cols_npu4_pack_peel_4_level_tiling",
                     tile_pipeline="pack-peel-4-level-tiling",
                     run_on_target=["npu4"],
-                    aie_compilation_flags=[
-                        "--iree-amdaie-num-rows=4",
-                        "--iree-amdaie-num-cols=8",
-                    ],
                 ),
             )
         )
@@ -1896,10 +1868,6 @@ class Tests:
                     use_ukernel=True,
                     use_chess=False,
                     use_chess_for_ukernel=False,
-                    aie_compilation_flags=[
-                        "--iree-amdaie-num-rows=4",
-                        "--iree-amdaie-num-cols=8",
-                    ],
                     run_on_target=["npu4"],
                 ),
             )
@@ -1917,10 +1885,6 @@ class Tests:
                     use_chess_for_ukernel=False,
                     run_on_target=["npu4"],
                     tile_pipeline="pack-peel-4-level-tiling",
-                    aie_compilation_flags=[
-                        "--iree-amdaie-num-rows=4",
-                        "--iree-amdaie-num-cols=8",
-                    ],
                 ),
                 additional_labels=["I8UKernel"],
             )
@@ -1937,10 +1901,6 @@ class Tests:
                     use_ukernel=True,
                     tile_pipeline="pack-peel-4-level-tiling",
                     run_on_target=["npu4"],
-                    aie_compilation_flags=[
-                        "--iree-amdaie-num-rows=4",
-                        "--iree-amdaie-num-cols=8",
-                    ],
                     use_chess=False,
                     use_chess_for_ukernel=False,
                 ),
@@ -1958,10 +1918,6 @@ class Tests:
                     use_ukernel=True,
                     tile_pipeline="pack-peel-4-level-tiling",
                     run_on_target=["npu4"],
-                    aie_compilation_flags=[
-                        "--iree-amdaie-num-rows=4",
-                        "--iree-amdaie-num-cols=8",
-                    ],
                     use_chess=False,
                     use_chess_for_ukernel=False,
                 ),
@@ -2231,10 +2187,6 @@ class Tests:
                 outlining_string,
                 f"--iree-amd-aie-additional-peano-opt-flags={peano_opt_level_string}",
             ]
-
-            if run_on_target == "npu4":
-                aie_compilation_flags.append("--iree-amdaie-num-rows=4")
-                aie_compilation_flags.append("--iree-amdaie-num-cols=8")
 
             outline_to_empty_function = False
             empty_key = "outline_to_empty_function"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -154,21 +154,22 @@ class AIETargetBackend final : public IREE::HAL::TargetBackend {
     // number of rows/cols from the device.
     AMDAIEDeviceModel deviceModel =
         AMDAIE::getDeviceModel(options.AMDAIETargetDevice);
+    uint32_t nRows = options.getNumRows(deviceModel);
+    uint32_t nCols = options.getNumCols(deviceModel);
     uint32_t maxCoreRows = deviceModel.getNumCoreRows();
     uint32_t maxCoreCols = deviceModel.getNumCoreCols();
-    if (options.AMDAIENumRows <= 0 || options.AMDAIENumRows > maxCoreRows) {
-      llvm::report_fatal_error(llvm::Twine("Invalid number of core rows (") +
-                               std::to_string(options.AMDAIENumRows) +
-                               "), must be in the range [1, " +
-                               std::to_string(maxCoreRows) + "] for device " +
-                               stringifyEnum(deviceModel.device));
+
+    if (nRows <= 0 || nRows > maxCoreRows) {
+      llvm::report_fatal_error(
+          llvm::Twine("Invalid number of core rows (") + std::to_string(nRows) +
+          "), must be in the range [1, " + std::to_string(maxCoreRows) +
+          "] for device " + stringifyEnum(deviceModel.device));
     }
-    if (options.AMDAIENumCols <= 0 || options.AMDAIENumCols > maxCoreCols) {
-      llvm::report_fatal_error(llvm::Twine("Invalid number of core cols (") +
-                               std::to_string(options.AMDAIENumCols) +
-                               "), must be in the range [1, " +
-                               std::to_string(maxCoreCols) + "] for device " +
-                               stringifyEnum(deviceModel.device));
+    if (nCols <= 0 || nCols > maxCoreCols) {
+      llvm::report_fatal_error(
+          llvm::Twine("Invalid number of core cols (") + std::to_string(nCols) +
+          "), must be in the range [1, " + std::to_string(maxCoreCols) +
+          "] for device " + stringifyEnum(deviceModel.device));
     }
 
     // Add some configurations to the `hal.executable.target` attribute.
@@ -183,10 +184,10 @@ class AIETargetBackend final : public IREE::HAL::TargetBackend {
     addConfig("ukernels",
               StringAttr::get(context, options.enableAMDAIEUkernels));
     // Set number of rows/cols used in an AIE array.
-    addConfig("num_rows", IntegerAttr::get(IntegerType::get(context, 32),
-                                           options.AMDAIENumRows));
-    addConfig("num_cols", IntegerAttr::get(IntegerType::get(context, 32),
-                                           options.AMDAIENumCols));
+    addConfig("num_rows",
+              IntegerAttr::get(IntegerType::get(context, 32), nRows));
+    addConfig("num_cols",
+              IntegerAttr::get(IntegerType::get(context, 32), nCols));
     auto configAttr = b.getDictionaryAttr(configItems);
 
     switch (options.deviceHal) {
@@ -229,13 +230,16 @@ class AIETargetBackend final : public IREE::HAL::TargetBackend {
 
   void buildTranslationPassPipeline(IREE::HAL::ExecutableTargetAttr,
                                     OpPassManager &passManager) override {
+    AMDAIEDeviceModel deviceModel =
+        AMDAIE::getDeviceModel(options.AMDAIETargetDevice);
     buildAMDAIETransformPassPipeline(
-        passManager, options.AMDAIETargetDevice, options.AMDAIENumRows,
-        options.AMDAIENumCols, options.useTilePipeline,
-        options.useLowerToAIEPipeline, options.matmulElementwiseFusion,
-        options.enableVectorizationPasses, options.pathToUkernels,
-        options.enablePacketFlow, options.enableCoalescingLoops,
-        options.enableCollapsingUnitDims, options.enableFunctionOutlining,
+        passManager, options.AMDAIETargetDevice,
+        options.getNumRows(deviceModel), options.getNumCols(deviceModel),
+        options.useTilePipeline, options.useLowerToAIEPipeline,
+        options.matmulElementwiseFusion, options.enableVectorizationPasses,
+        options.pathToUkernels, options.enablePacketFlow,
+        options.enableCoalescingLoops, options.enableCollapsingUnitDims,
+        options.enableFunctionOutlining,
         options.replaceOutlinedFunctionsWithEmpty,
         options.insertLoopAroundCoreBlock, options.emitCtrlPkt);
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
@@ -64,8 +64,25 @@ struct AMDAIEOptions {
   bool insertLoopAroundCoreBlock{false};
   bool matmulElementwiseFusion{false};
   AMDAIEDevice AMDAIETargetDevice{AMDAIEDevice::npu1_4col};
-  unsigned AMDAIENumRows{getDeviceModel(AMDAIETargetDevice).getNumCoreRows()};
-  unsigned AMDAIENumCols{getDeviceModel(AMDAIETargetDevice).getNumCoreCols()};
+
+  // The number of rows for the compiler to target. '0' denotes 'all'.
+ private:
+  unsigned AMDAIENumRows{0};
+
+ public:
+  unsigned getNumRows(const AMDAIEDeviceModel &model) const {
+    return AMDAIENumRows == 0 ? model.getNumCoreRows() : AMDAIENumRows;
+  }
+
+  // The number of rows for the compiler to target. '0' denotes 'all'.
+ private:
+  unsigned AMDAIENumCols{0};
+
+ public:
+  unsigned getNumCols(const AMDAIEDeviceModel &model) const {
+    return AMDAIENumCols == 0 ? model.getNumCoreCols() : AMDAIENumCols;
+  }
+
   std::string enableAMDAIEUkernels{"none"};
   bool enablePacketFlow{false};
   std::string dirToLoadCtrlPktFiles{""};

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pack_peel_objectfifo_ukernel_e2e.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Test/samples/matmul_pack_peel_objectfifo_ukernel_e2e.mlir
@@ -27,7 +27,7 @@
 
 // STRIX-LABEL: hal.executable.export public @matmul_dispatch_0_matmul_128x128x256_bf16xbf16xf32
 // STRIX:       aie.device(npu4) {
-// STRIX-DAG:   @matmul_bf16_bf16_f32_32x32x32_8x8x8
+// STRIX-DAG:   @matmul_bf16_bf16_f32_32x16x32_8x8x8
 // STRIX-DAG:   %[[TILE_0_2:.+]] = aie.tile(0, 2)
 // STRIX-DAG:   %[[TILE_0_3:.+]] = aie.tile(0, 3)
 // STRIX-DAG:   %[[TILE_1_2:.+]] = aie.tile(1, 2)


### PR DESCRIPTION
I expect/hope the C++ code will use defaults if not provided

![{3FDAD5D8-CA6B-4571-9B97-868FD1A79F90}](https://github.com/user-attachments/assets/06ae648f-a301-4230-8677-6ca8e5f1ea0c)


My guess is that we need to update the default for strix, might not be 8 columns 

UPDATE:

My guess was wrong. The issue was related to this: https://github.com/nod-ai/iree-amd-aie/pull/955#discussion_r1870234195

The default number of rows and columns wasn't based on the provided device, it was based on the default device! I suggested this to Vivian (see above), but in retrospect I don't think it was a good design choice. In this PR I've improved it, so that the default number of rows and columns is just 'all', where the actual number is determined after the device is known. 