### PR TITLE
[AssignBufferAddresses] Remove warning

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aie/AMDAIEAssignBufferAddresses.cpp
+++ b/compiler/plugins/target/AMD-AIE/aie/AMDAIEAssignBufferAddresses.cpp
@@ -288,13 +288,10 @@ struct AMDAIEAssignBufferAddressesPass
           return signalPassFailure();
         break;
       default:
-        emitWarning(UnknownLoc::get(ctx))
-            << "Buffer assignment scheme is unrecognized. Defaulting to "
-               "bank-aware scheme.";
         if (failed(bankAwareAllocation(tileToBuffers, deviceModel))) {
           emitWarning(UnknownLoc::get(ctx))
-              << "Bank-aware scheme is failed. Try the basic sequential "
-                 "scheme.";
+              << "Bank-aware scheme for buffer address assignment is failed. "
+                 "Try the basic sequential scheme.";
           if (failed(basicAllocation(tileToBuffers, deviceModel)))
             return signalPassFailure();
         }


### PR DESCRIPTION
Remove the unnecessary warning to be less noisy in ci.