### PR TITLE
[PktFlow] Disable packet flows on kernel output to allow loop subsumption

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -649,7 +649,7 @@ class MatmulConstBiasCtrlpkt(BaseMatmul):
         self.aie_compilation_flags += [
             "--iree-amdaie-num-rows=1",
             "--iree-amdaie-num-cols=1",
-            "--iree-amdaie-enable-packet-flow=true",
+            "--iree-amdaie-enable-input-packet-flow=true",
             "--iree-amdaie-emit-control-packet=true",
             "--mlir-disable-threading",
         ]

--- a/build_tools/ci/run_matmul_test.sh
+++ b/build_tools/ci/run_matmul_test.sh
@@ -371,7 +371,7 @@ function run_matmul_test() {
                       --iree-amdaie-tile-pipeline=${tile_pipeline} \
                       --iree-amd-aie-peano-install-dir=${peano_install_path} \
                       --iree-amd-aie-install-dir=${amd_aie_install_path} \
-                      --iree-amdaie-enable-packet-flow=${enable_packet_flow} \
+                      --iree-amdaie-enable-input-packet-flow=${enable_packet_flow} \
                       --iree-hal-dump-executable-files-to=$PWD \
                       --iree-amdaie-device-hal=${DEVICE_HAL} \
                       --iree-hal-memoization=false \

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -237,10 +237,11 @@ class AIETargetBackend final : public IREE::HAL::TargetBackend {
         options.getNumRows(deviceModel), options.getNumCols(deviceModel),
         options.useTilePipeline, options.useLowerToAIEPipeline,
         options.matmulElementwiseFusion, options.enableVectorizationPasses,
-        options.pathToUkernels, options.enablePacketFlow,
-        options.enableCoalescingLoops, options.enableCollapsingUnitDims,
-        options.enableFunctionOutlining, options.outliningCallReplication,
-        options.insertLoopAroundCoreBlock, options.emitCtrlPkt);
+        options.pathToUkernels, options.enableInputPacketFlow,
+        options.enableOutputPacketFlow, options.enableCoalescingLoops,
+        options.enableCollapsingUnitDims, options.enableFunctionOutlining,
+        options.outliningCallReplication, options.insertLoopAroundCoreBlock,
+        options.emitCtrlPkt);
   }
 
   void buildLinkingPassPipeline(OpPassManager &passManager) override {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
@@ -84,7 +84,8 @@ struct AMDAIEOptions {
   }
 
   std::string enableAMDAIEUkernels{"none"};
-  bool enablePacketFlow{false};
+  bool enableInputPacketFlow{false};
+  bool enableOutputPacketFlow{false};
   std::string dirToLoadCtrlPktFiles{""};
 
   enum class DeviceHAL { XRT, XRT_LITE };
@@ -298,9 +299,17 @@ struct AMDAIEOptions {
             "columns. However, some workloads (like convolution) currently "
             "ignore this flag, and use a hardcoded number of cols."));
 
-    binder.opt<bool>("iree-amdaie-enable-packet-flow", enablePacketFlow,
-                     llvm::cl::cat(category),
-                     llvm::cl::desc("Enable packet routing data movement."));
+    binder.opt<bool>(
+        "iree-amdaie-enable-input-packet-flow", enableInputPacketFlow,
+        llvm::cl::cat(category),
+        llvm::cl::desc(
+            "Enable packet routing data movement for kernel inputs"));
+
+    binder.opt<bool>(
+        "iree-amdaie-enable-output-packet-flow", enableOutputPacketFlow,
+        llvm::cl::cat(category),
+        llvm::cl::desc(
+            "Enable packet routing data movement for kernel outputs"));
 
     binder.opt<DeviceHAL>(
         "iree-amdaie-device-hal", deviceHal, llvm::cl::cat(category),

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaLoopSubsumption.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaLoopSubsumption.cpp
@@ -497,16 +497,26 @@ struct SubsumeLoopIntoDMA
         return rewriter.notifyMatchFailure(
             op, "should operate on an `amdaie.connection` op");
       }
-      std::optional<AMDAIE::ConnectionType> connectionType =
-          connectionOp.getConnectionType();
-      if (connectionType &&
-          connectionType.value() == AMDAIE::ConnectionType::Packet) {
-        return rewriter.notifyMatchFailure(
-            op,
-            "operating on a packet connection, which can potentially still be "
-            "merged with other connections, so abort loop subsumption as it "
-            "could potentially lead to deadlocks");
-      }
+
+      // The following check on packet flows is disabled at the moment,
+      // to reduce control code size and improve the performance. However,
+      // this is at the risk of potential deadlocks, if multiple packet flows
+      // share the arbitors.
+      //
+      // TODO(zhewen): resolve this issue more properly by improving the router
+      // or utilizing reconfiguration?
+
+      // std::optional<AMDAIE::ConnectionType> connectionType =
+      //     connectionOp.getConnectionType();
+      // if (connectionType &&
+      //     connectionType.value() == AMDAIE::ConnectionType::Packet) {
+      //   return rewriter.notifyMatchFailure(
+      //       op,
+      //       "operating on a packet connection, which can potentially still be
+      //       " "merged with other connections, so abort loop subsumption as it
+      //       " "could potentially lead to deadlocks");
+      // }
+
       if (hasOtherUsersInSameScope(connectionOp.getResult())) {
         return rewriter.notifyMatchFailure(
             op,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -15,11 +15,12 @@ namespace mlir::iree_compiler::AMDAIE {
 
 /// Add passes to lower to AIE objectFifos.
 void addAMDAIEObjectFifoLoweringPasses(
-    OpPassManager &passManager, bool enablePacketFlow,
-    TilePassPipeline useTilePipeline, bool enableVectorizationPasses,
-    bool enableCoalescingLoops, bool enableCollapsingUnitDims,
-    OutliningStrategy enableFunctionOutlining, int outliningLoopInCallCount,
-    bool insertLoopAroundCoreBlock, uint32_t numCols, bool emitCtrlPkt);
+    OpPassManager &passManager, bool enableInputPacketFlow,
+    bool enableOutputPacketFlow, TilePassPipeline useTilePipeline,
+    bool enableVectorizationPasses, bool enableCoalescingLoops,
+    bool enableCollapsingUnitDims, OutliningStrategy enableFunctionOutlining,
+    int outliningLoopInCallCount, bool insertLoopAroundCoreBlock,
+    uint32_t numCols, bool emitCtrlPkt);
 
 /// Add passes to lower from MLIR-AIR through AIE. This is
 /// currently the default passes used for lowering after IREEs tiling.
@@ -40,10 +41,10 @@ void buildAMDAIETransformPassPipeline(
     uint32_t numCols, TilePassPipeline useTilePipeline,
     LowerToAIEPassPipeline useLowerToAIEPipeline, bool matmulElementwiseFusion,
     bool enableVectorizationPasses, const std::string &pathToUkernels,
-    bool enablePacketFlow, bool enableCoalescingLoops,
-    bool enableCollapsingUnitDims, OutliningStrategy enableFunctionOutlining,
-    int outliningLoopInCallCount, bool insertLoopAroundCoreBlock,
-    bool emitCtrlPkt);
+    bool enableInputPacketFlow, bool enableOutputPacketFlow,
+    bool enableCoalescingLoops, bool enableCollapsingUnitDims,
+    OutliningStrategy enableFunctionOutlining, int outliningLoopInCallCount,
+    bool insertLoopAroundCoreBlock, bool emitCtrlPkt);
 
 /// Populates passes needed to lower the IR via a Pack-Peel based approach.
 void addPackPeelBasedPassPipeline(OpPassManager &passManager,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -36,8 +36,10 @@ def AMDAIEAssignConnectionTypes :
   let constructor =
     "mlir::iree_compiler::AMDAIE::createAMDAIEAssignConnectionTypesPass()";
   let options = [
-    Option<"enablePacketFlow", "enable-packet-flow", "bool", /*default=*/"false",
-      "Enable packet routing for connections.">
+    Option<"enableInputPacketFlow", "enable-input-packet-flow", "bool", /*default=*/"false",
+      "Enable packet routing for connections belonging to send kernel inputs.">,
+    Option<"enableOutputPacketFlow", "enable-output-packet-flow", "bool", /*default=*/"false",
+      "Enable packet routing for connections belonging to send kernel outputs.">,
   ];
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_connection_types.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_connection_types.mlir
@@ -1,5 +1,7 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-assign-connection-types)" --split-input-file --verify-diagnostics %s | FileCheck %s
-// RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-assign-connection-types{enable-packet-flow=true})" --split-input-file --verify-diagnostics %s | FileCheck %s -check-prefix=PACKET
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-assign-connection-types{enable-input-packet-flow=true})" --split-input-file --verify-diagnostics %s | FileCheck %s -check-prefix=INPUT-PACKET
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-assign-connection-types{enable-output-packet-flow=true})" --split-input-file --verify-diagnostics %s | FileCheck %s -check-prefix=OUTPUT-PACKET
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-assign-connection-types{enable-input-packet-flow=true enable-output-packet-flow=true})" --split-input-file --verify-diagnostics %s | FileCheck %s -check-prefix=ALL-PACKET
 
 // CHECK-LABEL: @assign_connection_types
 // CHECK-SAME:  %[[ARG0:.+]]: memref<8x16xi32>, %[[ARG1:.+]]: memref<1x1x8x16xi32, 1>, %[[ARG2:.+]]: memref<1x1x8x16xi32, 2>
@@ -11,15 +13,35 @@
 // CHECK:         amdaie.connection(%[[OBJ0]], %[[OBJ1]]) {connection_type = #amdaie<connection_type Circuit>}
 // CHECK:         amdaie.connection(%[[OBJ2]], %[[OBJ1]]) {connection_type = #amdaie<connection_type Circuit>}
 
-// PACKET-LABEL: @assign_connection_types
-// PACKET-SAME:  %[[ARG0:.+]]: memref<8x16xi32>, %[[ARG1:.+]]: memref<1x1x8x16xi32, 1>, %[[ARG2:.+]]: memref<1x1x8x16xi32, 2>
-// PACKET:       amdaie.workgroup
-// PACKET:         %[[OBJ0:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]]
-// PACKET:         %[[OBJ1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG1]]
-// PACKET:         %[[OBJ2:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG2]]
-// PACKET:         amdaie.connection(%[[OBJ1]], %[[OBJ0]]) {connection_type = #amdaie<connection_type Packet>}
-// PACKET:         amdaie.connection(%[[OBJ0]], %[[OBJ1]]) {connection_type = #amdaie<connection_type Packet>}
-// PACKET:         amdaie.connection(%[[OBJ2]], %[[OBJ1]]) {connection_type = #amdaie<connection_type Packet>}
+// INPUT-PACKET-LABEL: @assign_connection_types
+// INPUT-PACKET-SAME:  %[[ARG0:.+]]: memref<8x16xi32>, %[[ARG1:.+]]: memref<1x1x8x16xi32, 1>, %[[ARG2:.+]]: memref<1x1x8x16xi32, 2>
+// INPUT-PACKET:       amdaie.workgroup
+// INPUT-PACKET:         %[[OBJ0:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]]
+// INPUT-PACKET:         %[[OBJ1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG1]]
+// INPUT-PACKET:         %[[OBJ2:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG2]]
+// INPUT-PACKET:         amdaie.connection(%[[OBJ1]], %[[OBJ0]]) {connection_type = #amdaie<connection_type Packet>}
+// INPUT-PACKET:         amdaie.connection(%[[OBJ0]], %[[OBJ1]]) {connection_type = #amdaie<connection_type Circuit>}
+// INPUT-PACKET:         amdaie.connection(%[[OBJ2]], %[[OBJ1]]) {connection_type = #amdaie<connection_type Packet>}
+
+// OUTPUT-PACKET-LABEL: @assign_connection_types
+// OUTPUT-PACKET-SAME:  %[[ARG0:.+]]: memref<8x16xi32>, %[[ARG1:.+]]: memref<1x1x8x16xi32, 1>, %[[ARG2:.+]]: memref<1x1x8x16xi32, 2>
+// OUTPUT-PACKET:       amdaie.workgroup
+// OUTPUT-PACKET:         %[[OBJ0:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]]
+// OUTPUT-PACKET:         %[[OBJ1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG1]]
+// OUTPUT-PACKET:         %[[OBJ2:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG2]]
+// OUTPUT-PACKET:         amdaie.connection(%[[OBJ1]], %[[OBJ0]]) {connection_type = #amdaie<connection_type Circuit>}
+// OUTPUT-PACKET:         amdaie.connection(%[[OBJ0]], %[[OBJ1]]) {connection_type = #amdaie<connection_type Packet>}
+// OUTPUT-PACKET:         amdaie.connection(%[[OBJ2]], %[[OBJ1]]) {connection_type = #amdaie<connection_type Circuit>}
+
+// ALL-PACKET-LABEL: @assign_connection_types
+// ALL-PACKET-SAME:  %[[ARG0:.+]]: memref<8x16xi32>, %[[ARG1:.+]]: memref<1x1x8x16xi32, 1>, %[[ARG2:.+]]: memref<1x1x8x16xi32, 2>
+// ALL-PACKET:       amdaie.workgroup
+// ALL-PACKET:         %[[OBJ0:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG0]]
+// ALL-PACKET:         %[[OBJ1:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG1]]
+// ALL-PACKET:         %[[OBJ2:.+]] = amdaie.logicalobjectfifo.from_memref %[[ARG2]]
+// ALL-PACKET:         amdaie.connection(%[[OBJ1]], %[[OBJ0]]) {connection_type = #amdaie<connection_type Packet>}
+// ALL-PACKET:         amdaie.connection(%[[OBJ0]], %[[OBJ1]]) {connection_type = #amdaie<connection_type Packet>}
+// ALL-PACKET:         amdaie.connection(%[[OBJ2]], %[[OBJ1]]) {connection_type = #amdaie<connection_type Packet>}
 
 module {
   func.func @assign_connection_types(%arg0: memref<8x16xi32>, %arg1: memref<1x1x8x16xi32, 1>, %arg2: memref<1x1x8x16xi32, 2>) {


### PR DESCRIPTION
The DMA loop subsumption optimization is crucial for unlocking packet flow performance.

Without  loop subsumption:
```ll
for i = 0 to 16
  dma_cpy arg_0[i]
  dma_cpy arg_1[i]
  sync
```
When unrolled, this generates a large number of DMA operations in the control code.

However, with loop subsumption:
```ll
 dma_cpy arg_0
 dma_cpy arg_1
 sync
```
Here, the loops are absorbed by strides in `dma_cpy`, significantly reducing control code size.

However, enabling this optimization for packet flows may introduce deadlocks if `arg_0` and `arg_1` share an arbiter at any point along their routed path.  Since arbitration order is not guaranteed, a deadlock can occur if two tiles of `arg_0` are sent from shim, but zero tiles of `arg_1`, while the core is waiting for `arg_1` before accepting the second tile of `arg_0`.

#806 introduced the concept of `packetGroupId` for this deadlock issue, which tries to separate the channels for `arg_0` and `arg_1` to reduce the chance for them to go through the same arbiter. However, this solution does not fully guarantee the exclusion of deadlocks, especially when we need to merge the usage of arbiters [here](https://github.com/nod-ai/iree-amd-aie/blob/b720c20b1e61759b8fd30261c5c7430c06354a17/runtime/src/iree-amd-aie/aie_runtime/amsel_generator.cc#L173). 

Solving this deadlock issue in a robust way may require significant effort to modify the router logic or exploit partial reconfiguration in the future. 

As a temporary workaround, this PR limits the packet flow usage only for transferring kernel input (L3->L2->L1), while disabling that for the outputs. This change helps to free up some arbiters, so that deadlocks won't happen after loop subsumption, at least not on the following matmul test cases.

Another (kind of) rationale for this workaround is, the current need for using packet flows is mainly on the kernel input side, as we also want to send control packets into the device. 

Finally, performance results:

M: 512, N: 512, K: 4096

|                       | Latency(us) | Instructions |
|-----------------------|-------------|--------------|
| circuit               | 2816        | 1096         |
| packet before this PR | 40761      | 503176       |
| packet (only input) after this PR  | 2901       | 1096       |

M: 512, N: 4096, K: 512

|                       | Latency(us) | Instructions |
|-----------------------|-------------|--------------|
| circuit               | 3640        | 736         |
| packet before this PR | 39025      | 511400       |
| packet (only input) after this PR  | 3705       | 736       |

M: 4096, N: 512, K: 512

|                       | Latency(us) | Instructions |
|-----------------------|-------------|--------------|
| circuit               | 2805        | 4124         |
| packet before this PR | 45004      | 513032       |
| packet (only input) after this PR  | 2849       | 4124       |