### PR TITLE
[AMDAIEPad] Refactor the pass to pad elementwise op

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.h
@@ -29,6 +29,9 @@ enum class TilePassPipeline {
 /// Enum for types of loop peeling.
 enum class PeelingType { First, Last, FirstLast };
 
+/// Enum for operands to be padded.
+enum class PadOperand { InputOutput, Input, Output };
+
 /// Enum for operands to be bufferized to allocation.
 enum class BufferizeOperand {
   LinalgInputOutput,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -708,8 +708,19 @@ def AMDAIEPad :
   let constructor =
       "mlir::iree_compiler::AMDAIE::createAMDAIEPadPass()";
   let options = [
-    Option<"paddingLevel", "padding-level", "int64_t", /*default=*/"-1",
-      "A temporary workaround to figure the config for padding">
+    Option<"padElementwise", "pad-elementwise", "bool", /*default=*/"false",
+      "Indicator of whether the target op for padding is an elementwise op">,
+    Option<"padOperand", "pad-operand", "mlir::iree_compiler::AMDAIE::PadOperand",
+      /*default=*/"mlir::iree_compiler::AMDAIE::PadOperand::InputOutput",
+      "Select which operands of a linalg op to be padded",
+      [{::llvm::cl::values(
+        clEnumValN(mlir::iree_compiler::AMDAIE::PadOperand::InputOutput, "input-output",
+                   "Pad the input and output of a linalg op."),
+        clEnumValN(mlir::iree_compiler::AMDAIE::PadOperand::Input, "input",
+                   "Only pad the input of a linalg op."),
+        clEnumValN(mlir::iree_compiler::AMDAIE::PadOperand::Output, "output",
+                   "Only pad the output of a linalg op.")
+    )}]>,
   ];
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEUtils.cpp
@@ -342,6 +342,21 @@ bool isElementwiseWithMatmulProducer(linalg::LinalgOp linalgOp) {
   return false;
 }
 
+/// Utility to identify if `linalgOp` is a matmul-like operation with an
+/// elementwise op as its consumer.
+bool isMatmulWithElementwiseConsumer(linalg::LinalgOp linalgOp) {
+  if (!isMatmul(linalgOp)) return false;
+  // Check if the user is an elementwise op but not fill or copy op.
+  for (Operation *userOp : linalgOp->getUsers()) {
+    if (auto linalgUser = dyn_cast<linalg::LinalgOp>(userOp)) {
+      if (isElementwise(linalgUser) &&
+          !isa<linalg::FillOp, linalg::CopyOp>(linalgUser))
+        return true;
+    }
+  }
+  return false;
+}
+
 std::string utohexstr(uint32_t value, size_t width, bool header,
                       bool lowercase) {
   std::string res = "";

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEUtils.h
@@ -82,6 +82,10 @@ bool isMatmulInDefChain(Value operand);
 /// matmul-like op upstream in its computation tree.
 bool isElementwiseWithMatmulProducer(linalg::LinalgOp linalgOp);
 
+/// Utility to identify if `linalgOp` is a matmul-like operation with an
+/// elementwise op as its consumer.
+bool isMatmulWithElementwiseConsumer(linalg::LinalgOp linalgOp);
+
 /// Utility to convert a `uint32_t` value into a hex string.
 std::string utohexstr(uint32_t value, size_t width, bool header = true,
                       bool lowercase = false);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pad.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/pad.mlir
@@ -1,6 +1,12 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-pad{padding-level=0}))' --split-input-file %s | FileCheck %s --check-prefix=PAD-LEVEL-0
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-pad{padding-level=1}))' --split-input-file %s | FileCheck %s --check-prefix=PAD-LEVEL-1
-// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-pad{padding-level=2}))' --split-input-file %s | FileCheck %s --check-prefix=PAD-LEVEL-2
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-pad{pad-operand=input-output}))' --split-input-file %s | FileCheck %s --check-prefix=PAD-INPUT-OUTPUT
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-pad{pad-operand=input}))' --split-input-file %s | FileCheck %s --check-prefix=PAD-INPUT
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-pad{pad-operand=output}))' --split-input-file %s | FileCheck %s --check-prefix=PAD-OUTPUT
+// RUN: iree-opt --pass-pipeline='builtin.module(func.func(iree-amdaie-pad{pad-elementwise=true pad-operand=output}))' --split-input-file %s | FileCheck %s --check-prefix=PAD-ELEMENTWISE-OUTPUT
+
+// Test pad matmul operands with three options:
+// 1) pad all input and output operands
+// 2) only pad input operands
+// 3) only pad output operand
 
 func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> tensor<8x8xi32> {
   %c0 = arith.constant 0 : index
@@ -23,168 +29,103 @@ func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> 
   } {mapping = [#gpu.block<y>, #gpu.block<x>]}
   return %6 : tensor<8x8xi32>
 }
-//      PAD-LEVEL-0:   scf.forall
-// PAD-LEVEL-0-SAME:   {
-//      PAD-LEVEL-0:       linalg.fill
-//      PAD-LEVEL-0:       bufferization.alloc_tensor
-//      PAD-LEVEL-0:       linalg.copy
-//      PAD-LEVEL-0:       bufferization.alloc_tensor
-//      PAD-LEVEL-0:       linalg.copy
-//      PAD-LEVEL-0:       bufferization.alloc_tensor
-//      PAD-LEVEL-0:       linalg.copy
-//      PAD-LEVEL-0:       linalg.matmul
-//      PAD-LEVEL-0:       linalg.copy
-//      PAD-LEVEL-0:       memref.dealloc
-//      PAD-LEVEL-0:       memref.dealloc
-//      PAD-LEVEL-0:       memref.dealloc
-//      PAD-LEVEL-0:   }
+//      PAD-INPUT-OUTPUT:   scf.forall
+// PAD-INPUT-OUTPUT-SAME:   {
+//      PAD-INPUT-OUTPUT:       linalg.fill
+//      PAD-INPUT-OUTPUT:       bufferization.alloc_tensor
+//      PAD-INPUT-OUTPUT:       linalg.copy
+//      PAD-INPUT-OUTPUT:       bufferization.alloc_tensor
+//      PAD-INPUT-OUTPUT:       linalg.copy
+//      PAD-INPUT-OUTPUT:       bufferization.alloc_tensor
+//      PAD-INPUT-OUTPUT:       linalg.copy
+//      PAD-INPUT-OUTPUT:       linalg.matmul
+//      PAD-INPUT-OUTPUT:       linalg.copy
+//      PAD-INPUT-OUTPUT:   }
+
+//      PAD-INPUT:   scf.forall
+// PAD-INPUT-SAME:   {
+//      PAD-INPUT:       linalg.fill
+//      PAD-INPUT:       bufferization.alloc_tensor
+//      PAD-INPUT:       linalg.copy
+//      PAD-INPUT:       bufferization.alloc_tensor
+//      PAD-INPUT:       linalg.copy
+//      PAD-INPUT:       linalg.matmul
+//  PAD-INPUT-NOT:       linalg.copy
+//      PAD-INPUT:   }
+
+//      PAD-OUTPUT:   scf.forall
+// PAD-OUTPUT-SAME:   {
+//      PAD-OUTPUT:       linalg.fill
+//      PAD-OUTPUT:       bufferization.alloc_tensor
+//      PAD-OUTPUT:       linalg.copy
+//  PAD-OUTPUT-NOT:       bufferization.alloc_tensor
+//  PAD-OUTPUT-NOT:       linalg.copy
+//      PAD-OUTPUT:       linalg.matmul
+//      PAD-OUTPUT:       linalg.copy
+//      PAD-OUTPUT:   }
 
 // -----
 
-func.func @matmul_static(%arg0: tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> tensor<8x8xi32> {
+// Test matmul4d-elementwise dispatch with two situations:
+// 1) pad output operand for elementwise op (second linalg.generic in the following test)
+// 2) pad input operands for matmul op (first linalg.generic in the following test)
+// Note: we don't want to pad the matmul output and elementwise input.
+
+func.func @matmul4d_elementwise(%arg0 : tensor<16x8x32x64xi8>, %arg1 : tensor<128x8x64x32xi8>) -> tensor<128x16x32x32xi8> {
   %c0 = arith.constant 0 : index
   %c0_i32 = arith.constant 0 : i32
-  %5 = tensor.empty() : tensor<8x8xi32>
-  %6 = scf.forall (%iv0, %iv1) = (0, 0) to (8, 8) step (8, 8) shared_outs(%arg2 = %5) -> (tensor<8x8xi32>) {
-    %extracted_slice = tensor.extract_slice %arg0[%iv0, 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
-    %extracted_slice_0 = tensor.extract_slice %arg1[0, %iv1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
-    %extracted_slice_1 = tensor.extract_slice %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
-    %7 = bufferization.alloc_tensor() : tensor<8x16xi32>
-    %alloc = memref.alloc() : memref<8x16xi32, 1 : i32>
-    %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1 : i32> to tensor<8x16xi32>
-    %9 = linalg.copy ins(%extracted_slice : tensor<8x16xi32>) outs(%8 : tensor<8x16xi32>) -> tensor<8x16xi32>
-    %10 = bufferization.alloc_tensor() : tensor<16x8xi32>
-    %alloc_2 = memref.alloc() : memref<16x8xi32, 1 : i32>
-    %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1 : i32> to tensor<16x8xi32>
-    %12 = linalg.copy ins(%extracted_slice_0 : tensor<16x8xi32>) outs(%11 : tensor<16x8xi32>) -> tensor<16x8xi32>
-    %13 = bufferization.alloc_tensor() : tensor<8x8xi32>
-    %alloc_3 = memref.alloc() : memref<8x8xi32, 1 : i32>
-    %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1 : i32> to tensor<8x8xi32>
-    %17 = scf.forall (%arg3, %arg4) = (0, 0) to (8, 8) step (4, 4) shared_outs(%arg5 = %14) -> (tensor<8x8xi32>) {
-      %extracted_slice_4 = tensor.extract_slice %9[%arg3, 0] [4, 16] [1, 1] : tensor<8x16xi32> to tensor<4x16xi32>
-      %extracted_slice_5 = tensor.extract_slice %12[0, %arg4] [16, 4] [1, 1] : tensor<16x8xi32> to tensor<16x4xi32>
-      %19 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1 : i32> to tensor<8x8xi32>
-      %extracted_slice_6 = tensor.extract_slice %19[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
-      %extracted_slice_7 = tensor.extract_slice %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
-      %20 = linalg.fill ins(%c0_i32 : i32) outs(%extracted_slice_7 : tensor<4x4xi32>) -> tensor<4x4xi32>
-      %extracted_slice_8 = tensor.extract_slice %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
-      %21 = linalg.matmul ins(%extracted_slice_4, %extracted_slice_5 : tensor<4x16xi32>, tensor<16x4xi32>) outs(%20 : tensor<4x4xi32>) -> tensor<4x4xi32>
-      scf.forall.in_parallel {
-        tensor.parallel_insert_slice %21 into %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<4x4xi32> into tensor<8x8xi32>
-      }
-    } {mapping = [#gpu.block<y>, #gpu.block<x>]}
-    %18 = linalg.copy ins(%17 : tensor<8x8xi32>) outs(%extracted_slice_1 : tensor<8x8xi32>) -> tensor<8x8xi32>
-    memref.dealloc %alloc : memref<8x16xi32, 1 : i32>
-    memref.dealloc %alloc_2 : memref<16x8xi32, 1 : i32>
-    memref.dealloc %alloc_3 : memref<8x8xi32, 1 : i32>
+  %c10_i64 = arith.constant 10 : i64
+  %c7_i64 = arith.constant 7 : i64
+  %5 = tensor.empty() : tensor<128x16x32x32xi8>
+  %6 = scf.forall (%arg2, %arg3) = (0, 0) to (128, 16) step (8, 8) shared_outs(%arg4 = %5) -> (tensor<128x16x32x32xi8>) {
+    %extracted_slice = tensor.extract_slice %arg0[%arg3, 0, 0, 0] [8, 8, 32, 64] [1, 1, 1, 1] : tensor<16x8x32x64xi8> to tensor<8x8x32x64xi8>
+    %extracted_slice_0 = tensor.extract_slice %arg1[%arg2, 0, 0, 0] [8, 8, 64, 32] [1, 1, 1, 1] : tensor<128x8x64x32xi8> to tensor<8x8x64x32xi8>
+    %7 = tensor.empty() : tensor<8x8x32x32xi32>
+    %8 = linalg.fill ins(%c0_i32 : i32) outs(%7 : tensor<8x8x32x32xi32>) -> tensor<8x8x32x32xi32>
+    %9 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d4, d2, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d4, d5, d3)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel", "reduction", "reduction"]} ins(%extracted_slice, %extracted_slice_0 : tensor<8x8x32x64xi8>, tensor<8x8x64x32xi8>) outs(%8 : tensor<8x8x32x32xi32>) attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[8, 8, 0, 0, 0, 0], [4, 4, 0, 0, 0, 0], [0, 0, 0, 0, 1, 0], [1, 1, 0, 0, 0, 0]]>, packing_config = #amdaie.packing_config<packing_config = [{packedSizes = [0, 0, 4, 8, 0, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>} {
+    ^bb0(%in: i8, %in_2: i8, %out: i32):
+      %11 = arith.extsi %in : i8 to i32
+      %12 = arith.extsi %in_2 : i8 to i32
+      %13 = arith.muli %11, %12 : i32
+      %14 = arith.addi %out, %13 : i32
+      linalg.yield %14 : i32
+    } -> tensor<8x8x32x32xi32>
+    %extracted_slice_1 = tensor.extract_slice %arg4[%arg2, %arg3, 0, 0] [8, 8, 32, 32] [1, 1, 1, 1] : tensor<128x16x32x32xi8> to tensor<8x8x32x32xi8>
+    %10 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%9 : tensor<8x8x32x32xi32>) outs(%extracted_slice_1 : tensor<8x8x32x32xi8>) {
+    ^bb0(%in: i32, %out: i8):
+      %11 = arith.extsi %in : i32 to i64
+      %12 = arith.muli %11, %c10_i64 : i64
+      %13 = arith.shrsi %12, %c7_i64 : i64
+      %14 = arith.trunci %13 : i64 to i8
+      linalg.yield %14 : i8
+    } -> tensor<8x8x32x32xi8>
     scf.forall.in_parallel {
-      tensor.parallel_insert_slice %18 into %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
+      tensor.parallel_insert_slice %10 into %arg4[%arg2, %arg3, 0, 0] [8, 8, 32, 32] [1, 1, 1, 1] : tensor<8x8x32x32xi8> into tensor<128x16x32x32xi8>
     }
-  } {mapping = [#gpu.block<y>, #gpu.block<x>]}
-  return %6 : tensor<8x8xi32>
+  }
+  return %6 : tensor<128x16x32x32xi8>
 }
-//      PAD-LEVEL-1:   scf.forall
-// PAD-LEVEL-1-SAME:   {
-//      PAD-LEVEL-1:       linalg.fill
-//      PAD-LEVEL-1:       memref.alloc() : memref<8x16xi32, 1 : i32>
-//      PAD-LEVEL-1:       bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-1:       linalg.copy
-//      PAD-LEVEL-1:       memref.alloc() : memref<16x8xi32, 1 : i32>
-//      PAD-LEVEL-1:       bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-1:       linalg.copy
-//      PAD-LEVEL-1:       memref.alloc() : memref<8x8xi32, 1 : i32>
-//      PAD-LEVEL-1:       bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-1:       scf.forall
-// PAD-LEVEL-1-SAME:       {
-//      PAD-LEVEL-1:            linalg.fill
-//      PAD-LEVEL-1:            bufferization.alloc_tensor
-//      PAD-LEVEL-1:            linalg.copy
-//      PAD-LEVEL-1:            linalg.matmul
-//      PAD-LEVEL-1:            linalg.copy
-//      PAD-LEVEL-1:       }
-//      PAD-LEVEL-1:       memref.dealloc
-//      PAD-LEVEL-1:       memref.dealloc
-//      PAD-LEVEL-1:       memref.dealloc
-//      PAD-LEVEL-1:   }
 
-// -----
+//      PAD-ELEMENTWISE-OUTPUT:   scf.forall
+// PAD-ELEMENTWISE-OUTPUT-SAME:   {
+//      PAD-ELEMENTWISE-OUTPUT:       linalg.fill
+//  PAD-ELEMENTWISE-OUTPUT-NOT:       bufferization.alloc_tensor
+//  PAD-ELEMENTWISE-OUTPUT-NOT:       linalg.copy
+//      PAD-ELEMENTWISE-OUTPUT:       linalg.generic
+//      PAD-ELEMENTWISE-OUTPUT:       bufferization.alloc_tensor
+//      PAD-ELEMENTWISE-OUTPUT:       linalg.copy
+//      PAD-ELEMENTWISE-OUTPUT:       linalg.generic
+//      PAD-ELEMENTWISE-OUTPUT:       linalg.copy
+//      PAD-ELEMENTWISE-OUTPUT:   }
 
-func.func @matmul_static(%arg0 : tensor<8x16xi32>, %arg1 : tensor<16x8xi32>) -> tensor<8x8xi32> {
-    %c16 = arith.constant 16 : index
-    %c4 = arith.constant 4 : index
-    %c0 = arith.constant 0 : index
-    %c0_i32 = arith.constant 0 : i32
-    %5 = tensor.empty() : tensor<8x8xi32>
-    %6 = scf.forall (%iv0, %iv1) = (0, 0) to (8, 8) step (8, 8) shared_outs(%arg2 = %5) -> (tensor<8x8xi32>) {
-      %extracted_slice = tensor.extract_slice %arg0[%iv0, 0] [8, 16] [1, 1] : tensor<8x16xi32> to tensor<8x16xi32>
-      %extracted_slice_0 = tensor.extract_slice %arg1[0, %iv1] [16, 8] [1, 1] : tensor<16x8xi32> to tensor<16x8xi32>
-      %extracted_slice_1 = tensor.extract_slice %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> to tensor<8x8xi32>
-      %7 = bufferization.alloc_tensor() : tensor<8x16xi32>
-      %alloc = memref.alloc() : memref<8x16xi32, 1 : i32>
-      %8 = bufferization.to_tensor %alloc restrict writable : memref<8x16xi32, 1 : i32> to tensor<8x16xi32>
-      %9 = linalg.copy ins(%extracted_slice : tensor<8x16xi32>) outs(%8 : tensor<8x16xi32>) -> tensor<8x16xi32>
-      %10 = bufferization.alloc_tensor() : tensor<16x8xi32>
-      %alloc_2 = memref.alloc() : memref<16x8xi32, 1 : i32>
-      %11 = bufferization.to_tensor %alloc_2 restrict writable : memref<16x8xi32, 1 : i32> to tensor<16x8xi32>
-      %12 = linalg.copy ins(%extracted_slice_0 : tensor<16x8xi32>) outs(%11 : tensor<16x8xi32>) -> tensor<16x8xi32>
-      %13 = bufferization.alloc_tensor() : tensor<8x8xi32>
-      %alloc_3 = memref.alloc() : memref<8x8xi32, 1 : i32>
-      %14 = bufferization.to_tensor %alloc_3 restrict writable : memref<8x8xi32, 1 : i32> to tensor<8x8xi32>
-      %15 = scf.forall (%arg3, %arg4) = (0, 0) to (8, 8) step (4, 4) shared_outs(%arg5 = %14) -> (tensor<8x8xi32>) {
-        %extracted_slice_4 = tensor.extract_slice %9[%arg3, 0] [4, 16] [1, 1] : tensor<8x16xi32> to tensor<4x16xi32>
-        %extracted_slice_5 = tensor.extract_slice %12[0, %arg4] [16, 4] [1, 1] : tensor<16x8xi32> to tensor<16x4xi32>
-        %extracted_slice_6 = tensor.extract_slice %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<8x8xi32> to tensor<4x4xi32>
-        %17 = bufferization.alloc_tensor() : tensor<4x4xi32>
-        %alloc_7 = memref.alloc() : memref<4x4xi32, 2 : i32>
-        %18 = bufferization.to_tensor %alloc_7 restrict writable : memref<4x4xi32, 2 : i32> to tensor<4x4xi32>
-        %19 = linalg.fill ins(%c0_i32 : i32) outs(%18 : tensor<4x4xi32>) -> tensor<4x4xi32>
-        %20 = scf.for %arg6 = %c0 to %c16 step %c4 iter_args(%arg7 = %19) -> (tensor<4x4xi32>) {
-          %extracted_slice_8 = tensor.extract_slice %extracted_slice_4[0, %arg6] [4, 4] [1, 1] : tensor<4x16xi32> to tensor<4x4xi32>
-          %extracted_slice_9 = tensor.extract_slice %extracted_slice_5[%arg6, 0] [4, 4] [1, 1] : tensor<16x4xi32> to tensor<4x4xi32>
-          %22 = linalg.matmul ins(%extracted_slice_8, %extracted_slice_9 : tensor<4x4xi32>, tensor<4x4xi32>) outs(%arg7 : tensor<4x4xi32>) -> tensor<4x4xi32>
-          scf.yield %22 : tensor<4x4xi32>
-        }
-        %21 = linalg.copy ins(%20 : tensor<4x4xi32>) outs(%extracted_slice_6 : tensor<4x4xi32>) -> tensor<4x4xi32>
-        memref.dealloc %alloc_7 : memref<4x4xi32, 2 : i32>
-        scf.forall.in_parallel {
-          tensor.parallel_insert_slice %21 into %arg5[%arg3, %arg4] [4, 4] [1, 1] : tensor<4x4xi32> into tensor<8x8xi32>
-        }
-    } {mapping = [#gpu.block<y>, #gpu.block<x>]}
-    %16 = linalg.copy ins(%15 : tensor<8x8xi32>) outs(%extracted_slice_1 : tensor<8x8xi32>) -> tensor<8x8xi32>
-    memref.dealloc %alloc : memref<8x16xi32, 1 : i32>
-    memref.dealloc %alloc_2 : memref<16x8xi32, 1 : i32>
-    memref.dealloc %alloc_3 : memref<8x8xi32, 1 : i32>
-    scf.forall.in_parallel {
-      tensor.parallel_insert_slice %16 into %arg2[%iv0, %iv1] [8, 8] [1, 1] : tensor<8x8xi32> into tensor<8x8xi32>
-    }
-  } {mapping = [#gpu.block<y>, #gpu.block<x>]}
-  return %6 : tensor<8x8xi32>
-}
-//      PAD-LEVEL-2:   scf.forall
-// PAD-LEVEL-2-SAME:   {
-//      PAD-LEVEL-2:       memref.alloc() : memref<8x16xi32, 1 : i32>
-//      PAD-LEVEL-2:       bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-2:       linalg.copy
-//      PAD-LEVEL-2:       memref.alloc() : memref<16x8xi32, 1 : i32>
-//      PAD-LEVEL-2:       bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-2:       linalg.copy
-//      PAD-LEVEL-2:       memref.alloc() : memref<8x8xi32, 1 : i32>
-//      PAD-LEVEL-2:       bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-2:       scf.forall
-// PAD-LEVEL-2-SAME:       {
-//      PAD-LEVEL-2:            memref.alloc() : memref<4x4xi32, 2 : i32>
-//      PAD-LEVEL-2:            bufferization.to_tensor %{{.*}} restrict writable
-//      PAD-LEVEL-2:            scf.for
-// PAD-LEVEL-2-SAME:            {
-//      PAD-LEVEL-2:                bufferization.alloc_tensor
-//      PAD-LEVEL-2:                linalg.copy
-//      PAD-LEVEL-2:                bufferization.alloc_tensor
-//      PAD-LEVEL-2:                linalg.copy
-//      PAD-LEVEL-2:                linalg.matmul
-//      PAD-LEVEL-2:                linalg.copy
-//      PAD-LEVEL-2:            }
-//      PAD-LEVEL-2:       }
-//      PAD-LEVEL-2:       memref.dealloc
-//      PAD-LEVEL-2:       memref.dealloc
-//      PAD-LEVEL-2:       memref.dealloc
-//      PAD-LEVEL-2:   }
+//      PAD-INPUT:   scf.forall
+// PAD-INPUT-SAME:   {
+//      PAD-INPUT:       linalg.fill
+//      PAD-INPUT:       bufferization.alloc_tensor
+//      PAD-INPUT:       linalg.copy
+//      PAD-INPUT:       bufferization.alloc_tensor
+//      PAD-INPUT:       linalg.copy
+//      PAD-INPUT:       linalg.generic
+//  PAD-INPUT-NOT:       linalg.copy
+//      PAD-INPUT:       linalg.generic
+//      PAD-INPUT:   }


### PR DESCRIPTION
Before this PR, if we use pad operation for data movement, only the operands from root computation op were padded/copied. However, for matmul-elementwise dispatch, we want to generate copies for the matmul inputs and elementwise output but not matmul output or elementwise input.

This PR adds option `pad-elementwise` to deal with matmul and elementwise operations separately. In addition, it removes option `padding-level`, instead use a more direct name `pad-operand` to be clear about what operands are padded. These option settings and logic of applying them are similar to [BufferizeToAllocationPass](https://github.com/nod-ai/iree-amd-aie/blob/b569da497fba0c2840bae42fd0c3bb8380c4953f/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEBufferizeToAllocation.cpp#L166).

This is a fix for matmul4d + Trunci task https://github.com/nod-ai/iree-amd-aie/issues/1130.