### PR TITLE
Add performance test for Matmul4d + Trunci

### DIFF
--- a/build_tools/ci/cpu_comparison/matmul_template/matmul4d_trunci_scaling.mlir
+++ b/build_tools/ci/cpu_comparison/matmul_template/matmul4d_trunci_scaling.mlir
@@ -1,0 +1,35 @@
+// input ${M1}x${K1}x${M0}x${K0}x${TYPE1}
+// input ${N1}x${K1}x${K0}x${N0}x${TYPE1}
+
+func.func @matmul4d_trunci(%arg0: tensor<${M1}x${K1}x${M0}x${K0}x${TYPE1}>, %arg1: tensor<${N1}x${K1}x${K0}x${N0}x${TYPE1}>) -> tensor<${N1}x${M1}x${M0}x${N0}x${TYPE1}> {
+  %r = flow.dispatch.region -> (tensor<${N1}x${M1}x${M0}x${N0}x${TYPE1}>) {
+    %cst = arith.constant ${ZERO} : ${TYPE2}
+    %cst_mul = arith.constant 10 : ${TYPE_MUL_RESULT}
+    %cst_shift = arith.constant 7 : ${TYPE_MUL_RESULT}
+    %0 = tensor.empty() : tensor<${N1}x${M1}x${M0}x${N0}x${TYPE2}>
+    %i8out = tensor.empty() : tensor<${N1}x${M1}x${M0}x${N0}x${TYPE1}>
+    %1 = linalg.fill ins(%cst : ${TYPE2}) outs(%0 : tensor<${N1}x${M1}x${M0}x${N0}x${TYPE2}>) -> tensor<${N1}x${M1}x${M0}x${N0}x${TYPE2}>
+    %2 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d5, d4)>, affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d3, d4)>],
+                         iterator_types = ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction"]
+                         } ins(%arg0, %arg1 : tensor<${M1}x${K1}x${M0}x${K0}x${TYPE1}>, tensor<${N1}x${K1}x${K0}x${N0}x${TYPE1}>) outs(%1 : tensor<${N1}x${M1}x${M0}x${N0}x${TYPE2}>) {
+      ^bb0(%in: ${TYPE1}, %in_1: ${TYPE1}, %out: ${TYPE2}):
+        %12 = ${EXT} %in : ${TYPE1} to ${TYPE2}
+        %13 = ${EXT} %in_1 : ${TYPE1} to ${TYPE2}
+        %14 = ${MUL} %12, %13 : ${TYPE2}
+        %15 = ${ADD} %out, %14 : ${TYPE2}
+        linalg.yield %15 : ${TYPE2}
+      } -> tensor<${N1}x${M1}x${M0}x${N0}x${TYPE2}>
+    %3 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+                         iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+                        } ins(%2 : tensor<${N1}x${M1}x${M0}x${N0}x${TYPE2}>) outs(%i8out : tensor<${N1}x${M1}x${M0}x${N0}x${TYPE1}>) {
+      ^bb0(%in: ${TYPE2}, %out: ${TYPE1}):
+        %4 = arith.extsi %in : ${TYPE2} to ${TYPE_MUL_RESULT}
+        %5 = arith.muli %4, %cst_mul : ${TYPE_MUL_RESULT}
+        %6 = arith.shrsi %5, %cst_shift : ${TYPE_MUL_RESULT}
+        %7 = arith.trunci %6 : ${TYPE_MUL_RESULT} to ${TYPE1}
+        linalg.yield %7 : ${TYPE1}
+    } -> tensor<${N1}x${M1}x${M0}x${N0}x${TYPE1}>
+    flow.return %3 : tensor<${N1}x${M1}x${M0}x${N0}x${TYPE1}>
+  }
+  return %r : tensor<${N1}x${M1}x${M0}x${N0}x${TYPE1}>
+}

--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -927,6 +927,70 @@ class MatmulScaleTrunci(BaseMatmul):
         return True
 
 
+class Matmul4dScaleTrunci(BaseMatmul):
+    """
+    A test of the form C = matmul4d(A,B) + scale(C) + trunci(C)
+    where A:M1xK1xM0xK0, B:N1xK1xK0xN0, C:N1xM1xM0xN0
+    """
+
+    def __init__(
+        self,
+        M,
+        N,
+        K,
+        input_type,
+        acc_type,
+        M0=32,
+        N0=32,
+        K0=64,
+        additional_labels=None,
+        n_kernel_runs=1,
+        test_params=None,
+    ):
+        super().__init__(
+            name=f"matmul4d_scale_trunci_{M}_{N}_{K}_{input_type}_{acc_type}",
+            test_params=test_params,
+            M=M,
+            N=N,
+            K=K,
+            input_type=input_type,
+            acc_type=acc_type,
+            function_name="matmul4d_trunci",
+            n_kernel_runs=n_kernel_runs,
+        )
+        self.M0 = M0
+        self.N0 = N0
+        self.K0 = K0
+        self.labels.append("Matmul4dScaleTrunci")
+        if additional_labels:
+            self.labels += additional_labels
+        if self.run_benchmark:
+            self.aie_compilation_flags += [
+                "--iree-amdaie-enable-infinite-loop-around-core-block=true"
+            ]
+            self.labels.append("Matmul4dScaleTrunciBenchmark")
+
+    def _execute(self, config):
+        matmul_template_dir = config.file_dir / "matmul_template"
+        template_name = matmul_template_dir / "matmul4d_trunci_scaling.mlir"
+        generate_matmul_test(
+            self.get_filename(config),
+            template_name,
+            m=self.M,
+            n=self.N,
+            k=self.K,
+            lhs_rhs_type=self.input_type,
+            acc_type=self.acc_type,
+            m0=self.M0,
+            n0=self.N0,
+            k0=self.K0,
+        )
+        if self.run_benchmark:
+            return self.benchmark(config)
+
+        return self.vs_cpu(config)
+
+
 def find_executable(install_dir: Path, executable_name):
     """
     Search for an executable in the given directory and its subdirectories
@@ -2304,6 +2368,17 @@ class Tests:
                 "N": 4096,
                 "K": 512,
                 "in_dtype": "i8",
+                "use_ukernel": True,
+                "matmul4d": True,
+                "scale_trunc": True,
+                "tile_pipeline": "pack-peel-4-level-tiling",
+                "run_on_target": "npu4",
+            },
+            {
+                "M": 512,
+                "N": 4096,
+                "K": 512,
+                "in_dtype": "i8",
                 "outline": "all",
                 "outline_call_replication": 0,
                 "tile_pipeline": "pack-peel-4-level-tiling",
@@ -2335,6 +2410,7 @@ class Tests:
             use_ukernel = test.get("use_ukernel", False)
             tile_pipeline = test.get("tile_pipeline", "pack-peel")
             matmul4d = test.get("matmul4d", False)
+            scale_trunc = test.get("scale_trunc", False)
             use_chess_for_ukernel = test.get("use_chess_for_ukernel", True)
             run_on_target = test.get("run_on_target", "npu1_4col")
             in_dtype = test.get("in_dtype", "bf16")
@@ -2375,7 +2451,7 @@ class Tests:
                 name_suffix += "_outline"
 
             if matmul4d:
-                TestClass = Matmul4d
+                TestClass = Matmul4d if scale_trunc is False else Matmul4dScaleTrunci
             elif (transpose_a, transpose_b) == (False, False):
                 TestClass = Matmul
             elif (transpose_a, transpose_b) == (True, False):


### PR DESCRIPTION
This PR adds an example test for `matmul4d + scaled_trunci` ops. 

- Since currently the upstream IREE doesn't support the transposed matmul and elementwise ops to be fused in a single dispatch, we manually add these ops to `flow.dispatch.region`.
- Currently, the performance for `matmul4d + trunci` is much worse than `matmul4d i8->i32` alone, mostly likely due to the elementwise ops are scalarized instead of vectorized.