### PR TITLE
Add core performance for 4-level tiling pipeline 

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -2220,6 +2220,31 @@ class Tests:
                 }
             )
 
+            # Like the above except with pipeline pack-peel-4-level-tiling. 
+            # Pack-peel-4-level-tiling segfaults with 1x1 AIE array, so using 2x2, 
+            # and so increasing the call replication to 400 so that we're comparing 
+            # apples to apples.
+            performance_tests.append(
+                {
+                    "M": 512,
+                    "N": 512,
+                    "K": 512,
+                    "use_ukernel": False,
+                    "peano_opt_level": opt_level,
+                    "additional_labels": ["CorePerformance", "CorePerformance4Level"],
+                    "aie_compilation_flags": [
+                        "--iree-amdaie-num-rows=2",
+                        "--iree-amdaie-num-cols=2",
+                    ],
+                    "outline_call_replication": 400,
+                    "n_performance_repeats": 3,
+                    "n_performance_kernel_runs": 1,
+                    "tile_pipeline": "pack-peel-4-level-tiling",
+                }
+            )
+
+
+
         performance_tests += [
             {
                 "M": 512,

--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -2220,9 +2220,9 @@ class Tests:
                 }
             )
 
-            # Like the above except with pipeline pack-peel-4-level-tiling. 
-            # Pack-peel-4-level-tiling segfaults with 1x1 AIE array, so using 2x2, 
-            # and so increasing the call replication to 400 so that we're comparing 
+            # Like the above except with pipeline pack-peel-4-level-tiling.
+            # Pack-peel-4-level-tiling segfaults with 1x1 AIE array, so using 2x2,
+            # and so increasing the call replication to 400 so that we're comparing
             # apples to apples.
             performance_tests.append(
                 {
@@ -2242,8 +2242,6 @@ class Tests:
                     "tile_pipeline": "pack-peel-4-level-tiling",
                 }
             )
-
-
 
         performance_tests += [
             {


### PR DESCRIPTION
The existing test uses the pack-peel pipeline and results in a function call to a matmul with m=n=64 and *k=32*, different to the existing function call resulting from the pack-peel-4-level-tiling pipeline, which is m=n=64 and *k=64*. 

Core performance with k=64 is better. However performance with k=32 with jam-and-unroll is even better ( see https://github.com/nod-ai/iree-amd-aie/pull/1167 ). Unfortunately k=64 with jam-and-unroll results in using the stack / stack overflow -- either very slow or compilation failure. 

So I guess the options are 

1) decompose the linalg.generic with the 64x64x64 matmul just before function outlining, to 2 (or maybe 4) smaller linalg.generics, and then outline that smaller generic. Pros: (1) can unroll and jam, and get best currently observed performance (2) even better PM foot-print, as smaller outlined function.  Cons : (1) complexity (2) potentially dodging the more serious problem of not controlling aie-opt (3) isn't ukernel approach with64x64x64 optimal, what does that look like? 

2) don't unroll-and-jam with this pipeline