### PR TITLE
[UKernel] Add shift and trunc ukernel

### DIFF
--- a/build_tools/ci/cpu_comparison/matmul_template/matmul4d_trunci_scaling.mlir
+++ b/build_tools/ci/cpu_comparison/matmul_template/matmul4d_trunci_scaling.mlir
@@ -4,8 +4,7 @@
 func.func @matmul4d_trunci(%arg0: tensor<${M1}x${K1}x${M0}x${K0}x${TYPE1}>, %arg1: tensor<${N1}x${K1}x${K0}x${N0}x${TYPE1}>) -> tensor<${N1}x${M1}x${M0}x${N0}x${TYPE1}> {
   %r = flow.dispatch.region -> (tensor<${N1}x${M1}x${M0}x${N0}x${TYPE1}>) {
     %cst = arith.constant ${ZERO} : ${TYPE2}
-    %cst_mul = arith.constant 10 : ${TYPE_MUL_RESULT}
-    %cst_shift = arith.constant 7 : ${TYPE_MUL_RESULT}
+    %cst_shift = arith.constant 5 : ${TYPE2}
     %0 = tensor.empty() : tensor<${N1}x${M1}x${M0}x${N0}x${TYPE2}>
     %i8out = tensor.empty() : tensor<${N1}x${M1}x${M0}x${N0}x${TYPE1}>
     %1 = linalg.fill ins(%cst : ${TYPE2}) outs(%0 : tensor<${N1}x${M1}x${M0}x${N0}x${TYPE2}>) -> tensor<${N1}x${M1}x${M0}x${N0}x${TYPE2}>
@@ -23,11 +22,9 @@ func.func @matmul4d_trunci(%arg0: tensor<${M1}x${K1}x${M0}x${K0}x${TYPE1}>, %arg
                          iterator_types = ["parallel", "parallel", "parallel", "parallel"]
                         } ins(%2 : tensor<${N1}x${M1}x${M0}x${N0}x${TYPE2}>) outs(%i8out : tensor<${N1}x${M1}x${M0}x${N0}x${TYPE1}>) {
       ^bb0(%in: ${TYPE2}, %out: ${TYPE1}):
-        %4 = arith.extsi %in : ${TYPE2} to ${TYPE_MUL_RESULT}
-        %5 = arith.muli %4, %cst_mul : ${TYPE_MUL_RESULT}
-        %6 = arith.shrsi %5, %cst_shift : ${TYPE_MUL_RESULT}
-        %7 = arith.trunci %6 : ${TYPE_MUL_RESULT} to ${TYPE1}
-        linalg.yield %7 : ${TYPE1}
+        %4 = arith.shrsi %in, %cst_shift : ${TYPE2}
+        %5 = arith.trunci %4 : ${TYPE2} to ${TYPE1}
+        linalg.yield %5 : ${TYPE1}
     } -> tensor<${N1}x${M1}x${M0}x${N0}x${TYPE1}>
     flow.return %3 : tensor<${N1}x${M1}x${M0}x${N0}x${TYPE1}>
   }

--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -2374,6 +2374,7 @@ class Tests:
                 "scale_trunc": True,
                 "tile_pipeline": "pack-peel-4-level-tiling",
                 "run_on_target": "npu4",
+                "use_chess_for_ukernel": False,
             },
             {
                 "M": 512,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEUtils.cpp
@@ -114,9 +114,9 @@ static mlir::AffineExpr getAffineMapDim(ArrayAttr indexingMaps,
   return affineMap.getResult(nResults - 2 + mnkIndex);
 }
 
-/// Returns the BlockArgument that leads to `val`. Traverses optional ext*
-/// ops.
-static BlockArgument checkOptionalExtOps(Value val) {
+/// Returns the BlockArgument that leads to `val`, if any. Traverses optional
+/// ext* ops.
+BlockArgument getBlockArgumentWithOptionalExtOps(Value val) {
   BlockArgument blockArg;
   if (!(blockArg = dyn_cast<BlockArgument>(val))) {
     Operation *defOp = val.getDefiningOp();
@@ -138,9 +138,12 @@ static bool bodyMatcherForMatmulLikeOps(Value yieldVal, Block *body) {
   Operation *mulOp = addOp->getOperand(1).getDefiningOp();
   if (!isa_and_present<arith::MulIOp, arith::MulFOp>(mulOp)) return false;
 
-  BlockArgument lhsBlockArg = checkOptionalExtOps(mulOp->getOperand(0));
-  BlockArgument rhsBlockArg = checkOptionalExtOps(mulOp->getOperand(1));
-  BlockArgument outBlockArg = checkOptionalExtOps(addOp->getOperand(0));
+  BlockArgument lhsBlockArg =
+      getBlockArgumentWithOptionalExtOps(mulOp->getOperand(0));
+  BlockArgument rhsBlockArg =
+      getBlockArgumentWithOptionalExtOps(mulOp->getOperand(1));
+  BlockArgument outBlockArg =
+      getBlockArgumentWithOptionalExtOps(addOp->getOperand(0));
   if (!lhsBlockArg || !rhsBlockArg || !outBlockArg ||
       lhsBlockArg.getOwner() != body || rhsBlockArg.getOwner() != body ||
       outBlockArg.getOwner() != body || lhsBlockArg.getArgNumber() != 0 ||

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEUtils.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEUtils.h
@@ -15,6 +15,10 @@
 
 namespace mlir::iree_compiler::AMDAIE {
 
+/// Returns the BlockArgument that leads to `val`, if any. Traverses optional
+/// ext* ops.
+BlockArgument getBlockArgumentWithOptionalExtOps(Value val);
+
 /// Returns the target AMDAIE device.
 std::optional<AMDAIEDevice> getConfigAMDAIEDevice(
     IREE::HAL::ExecutableTargetAttr targetAttr);


### PR DESCRIPTION
This PR adds a ukernel for performing shift + truncation from i32 to i8 and updates the `matmul4d_trunci_scaling` test to use this ukernel. This should improve performance by +- 20% compared with the same matmul test without truncation (i32 output). The new best number is 360us now for truncation to i8, compared with 490us for just i32:

```
matmul4d_512_4096_512_i8_i32_O3_npu4_outline_4_level_tiling_ukernel_chess_benchmark
----------------------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------------
BM_matmul4d/process_time/real_time_mean          490 us         28.9 us            5 items_per_second=2.04056k/s
BM_matmul4d/process_time/real_time_median        490 us         28.6 us            5 items_per_second=2.04113k/s
BM_matmul4d/process_time/real_time_stddev       1.27 us        0.714 us            5 items_per_second=5.28219/s
----------------------------------------------------------------------------------------------------
```

```
matmul4d_scale_trunci_512_4096_512_i8_i32_O3_npu4_outline_4_level_tiling_ukernel_peano_benchmark
-----------------------------------------------------------------------------------------------------------
Benchmark                                                 Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------------------
BM_matmul4d_trunci/process_time/real_time_mean          360 us         15.3 us            5 items_per_second=2.77408k/s
BM_matmul4d_trunci/process_time/real_time_median        360 us         15.3 us            5 items_per_second=2.77529k/s
BM_matmul4d_trunci/process_time/real_time_stddev      0.627 us        0.397 us            5 items_per_second=4.81691/s
-----------------------------------------------------------------------------------------------------------
```