### PR TITLE
[CI] Add benchmark test for reconfiguration time measurement

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -2245,7 +2245,7 @@ class Tests:
         )
         # Test on the phoenix 4x4 array.
         self.register(MatmulConstBiasCtrlpkt(1024, 1024, 1024, "i8", "i32", 1, 2))
-        # Benchmark reconfguration time only, do not run the kernel.
+        # Benchmark reconfiguration time only, do not run the kernel.
         self.register(
             MatmulConstBiasCtrlpkt(
                 1024,
@@ -2256,6 +2256,7 @@ class Tests:
                 1,
                 2,
                 test_params=TestParams(run_benchmark=True, n_repeats=2),
+                additional_labels=["Performance"],
                 n_kernel_runs=0,
                 n_reconfigure_runs=50,
             )

--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -264,6 +264,7 @@ class BaseMatmul(BaseTest):
         self.input_type = input_type
         self.acc_type = acc_type
         self.n_kernel_runs = n_kernel_runs
+        self.n_reconfigure_runs = 0
 
         self.labels.append(self.tile_pipeline)
 
@@ -299,6 +300,7 @@ class BaseMatmul(BaseTest):
             function_name=self.function_name,
             n_repeats=self.n_repeats,
             n_kernel_runs=self.n_kernel_runs,
+            n_reconfigure_runs=self.n_reconfigure_runs,
         )
 
         return True
@@ -631,6 +633,7 @@ class MatmulConstBiasCtrlpkt(BaseMatmul):
         constant_bias_D,
         additional_labels=None,
         n_kernel_runs=1,
+        n_reconfigure_runs=1,
         test_params=None,
     ):
         super().__init__(
@@ -641,6 +644,7 @@ class MatmulConstBiasCtrlpkt(BaseMatmul):
             K=K,
             input_type=input_type,
             acc_type=acc_type,
+            function_name="matmul_constant_bias",
             n_kernel_runs=n_kernel_runs,
         )
         self.labels.append("MatmulConstBiasCtrlPacket")
@@ -660,6 +664,8 @@ class MatmulConstBiasCtrlpkt(BaseMatmul):
 
         self.constant_bias_C = constant_bias_C
         self.constant_bias_D = constant_bias_D
+
+        self.n_reconfigure_runs = n_reconfigure_runs
 
     def generate_vmfb_with_ctrlpkts(self, config, constant_bias, aie_ctrlpkt_flags=[]):
         # Make a copy of the original name, and append the bias value to differentiate test directories.
@@ -708,6 +714,22 @@ class MatmulConstBiasCtrlpkt(BaseMatmul):
         input_args = generate_inputs(
             test_file_D, config.get_test_dir(test_name_D), seed=1
         )
+
+        if self.run_benchmark:
+            print(f"Performance benchmark: {test_file_D}")
+            benchmark_aie_kernel_time(
+                config,
+                aie_vmfb_C,
+                input_args,
+                self.function_name,
+                test_name_C,
+                self.n_repeats,
+                self.n_kernel_runs,
+                self.n_reconfigure_runs,
+                time_unit="ms",
+            )
+            return True
+
         output_type = get_output_type(test_file_D)
         cpu_output = generate_llvm_cpu_output(
             config,
@@ -1211,6 +1233,7 @@ def benchmark_aie_kernel_time(
     name,
     n_repeats,
     n_kernel_runs,
+    n_reconfigure_runs,
     time_unit,
 ):
     """
@@ -1224,8 +1247,9 @@ def benchmark_aie_kernel_time(
         *input_args,
         f"--device={config.device_hal}",
         f"--benchmark_repetitions={n_repeats}",
-        f"--batch_size={n_kernel_runs}",
+        f"--batch_size={max(n_kernel_runs, n_reconfigure_runs)}",
         f"--xrt_lite_n_kernel_runs={n_kernel_runs}",
+        f"--xrt_lite_n_reconfigure_runs={n_reconfigure_runs}",
         f"--time_unit={time_unit}",
     ]
     if function_name:
@@ -1595,6 +1619,7 @@ def benchmark_aie(
     function_name,
     n_repeats,
     n_kernel_runs,
+    n_reconfigure_runs,
     seed=1,
     time_unit="us",
 ):
@@ -1617,6 +1642,8 @@ def benchmark_aie(
         The number of repetitions to be used for getting statistics (mean, median, stddev)
     n_kernel_runs:
         The number of invocations of the kernel, for averaging.
+    n_reconfigure_runs:
+        The number of reconfiguration invocations, for averaging.
     function_name:
         The name of the function to run (the test file may contain multiple
         functions).
@@ -1663,6 +1690,7 @@ def benchmark_aie(
         name,
         n_repeats,
         n_kernel_runs,
+        n_reconfigure_runs,
         time_unit,
     )
 
@@ -2217,6 +2245,21 @@ class Tests:
         )
         # Test on the phoenix 4x4 array.
         self.register(MatmulConstBiasCtrlpkt(1024, 1024, 1024, "i8", "i32", 1, 2))
+        # Benchmark reconfguration time only, do not run the kernel.
+        self.register(
+            MatmulConstBiasCtrlpkt(
+                1024,
+                1024,
+                1024,
+                "i8",
+                "i32",
+                1,
+                2,
+                test_params=TestParams(run_benchmark=True, n_repeats=2),
+                n_kernel_runs=0,
+                n_reconfigure_runs=50,
+            )
+        )
 
         performance_tests = []
 

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/executable.h
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/executable.h
@@ -23,6 +23,7 @@ struct iree_hal_xrt_lite_kernel_params {
   std::vector<std::vector<uint32_t>> reconf_data_runlist;
   std::string kernel_name;
   uint32_t n_kernel_runs{1};
+  uint32_t n_reconfigure_runs{1};
   IREE_TRACE(iree_string_view_t source_filename;)
   IREE_TRACE(uint32_t source_line;)
 };


### PR DESCRIPTION
This PR adds support for reconfiguration time measurement, with results being logged on the performance tracking webpage once merged:
https://nod-ai.github.io/iree-amd-aie/results_history_npu1.html

Observations on my local machine: The current reconfiguration time for the whole array is quite poor (~110ms), whereas the ideal target is < 100µs. After discussing with @jtuyls, the top optimization priority should be reducing the control code size for control packet DMAs.

Note: Due to the current bad performance, this newly added benchmark test will increase phoenix CI time by ~10s, but this should get optimized soon.