### PR TITLE
[AssignBufferAddresses] Enable buffer sorting and disable bank-aware scheme for Conv

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aie/AMDAIEAssignBufferAddresses.cpp
+++ b/compiler/plugins/target/AMD-AIE/aie/AMDAIEAssignBufferAddresses.cpp
@@ -223,13 +223,12 @@ LogicalResult bankAwareAllocation(
         preAllocatedBuffers.push_back(buffer);
     }
 
-    // Note: This is currently disabled to avoid numerical error in ci for
-    // depthwise_conv2d op.
-    // // Sort by largest allocation size before allocating.
-    // std::sort(buffersToAlloc.begin(), buffersToAlloc.end(),
-    //           [](BufferOp a, BufferOp b) {
-    //             return getAllocationSize(a) > getAllocationSize(b);
-    //           });
+    // Sort by largest allocation size before allocating.
+    // Note: The sorting may cause numerical error for depthwise conv2d op.
+    std::sort(buffersToAlloc.begin(), buffersToAlloc.end(),
+              [](BufferOp a, BufferOp b) {
+                return getAllocationSize(a) > getAllocationSize(b);
+              });
 
     // Set addresses for remaining buffers.
     SmallVector<BufferOp> allocatedBuffers;

--- a/compiler/plugins/target/AMD-AIE/aie/test/bank_aware_buffer_alloc.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/bank_aware_buffer_alloc.mlir
@@ -3,9 +3,9 @@
 
 // CHECK-LABEL:   aie.device(xcvc1902) {
 // CHECK:           %[[TILE_3_3:.*]] = aie.tile(3, 3)
-// CHECK:           aie.buffer(%[[TILE_3_3]]) {address = 1024 : i32, mem_bank = 0 : i32, sym_name = "a"} : memref<16xi8>
-// CHECK:           aie.buffer(%[[TILE_3_3]]) {address = 8192 : i32, mem_bank = 1 : i32, sym_name = "b"} : memref<512xi32>
-// CHECK:           aie.buffer(%[[TILE_3_3]]) {address = 16384 : i32, mem_bank = 2 : i32, sym_name = "c"} : memref<16xi16>
+// CHECK:           aie.buffer(%[[TILE_3_3]]) {address = 16384 : i32, mem_bank = 2 : i32, sym_name = "a"} : memref<16xi8>
+// CHECK:           aie.buffer(%[[TILE_3_3]]) {address = 1024 : i32, mem_bank = 0 : i32, sym_name = "b"} : memref<512xi32>
+// CHECK:           aie.buffer(%[[TILE_3_3]]) {address = 8192 : i32, mem_bank = 1 : i32, sym_name = "c"} : memref<16xi16>
 // CHECK:           %[[TILE_4_4:.*]] = aie.tile(4, 4)
 // CHECK:           aie.buffer(%[[TILE_4_4]]) {address = 1024 : i32, mem_bank = 0 : i32, sym_name = "_anonymous0"} : memref<500xi32>
 // CHECK:           aie.core(%[[TILE_3_3]]) {
@@ -72,13 +72,13 @@ module @prealloc_conflict {
 
 // CHECK-LABEL:   aie.device(npu1) {
 // CHECK:           %[[TILE:.*]] = aie.tile(4, 4)
-// CHECK:           aie.buffer(%[[TILE]]) {address = 28192 : i32, mem_bank = 1 : i32, sym_name = "_anonymous0"} : memref<200xi32>
-// CHECK:           aie.buffer(%[[TILE]]) {address = 32768 : i32, mem_bank = 2 : i32, sym_name = "_anonymous1"} : memref<100xi32>
+// CHECK:           aie.buffer(%[[TILE]]) {address = 32768 : i32, mem_bank = 2 : i32, sym_name = "_anonymous0"} : memref<200xi32>
+// CHECK:           aie.buffer(%[[TILE]]) {address = 49152 : i32, mem_bank = 3 : i32, sym_name = "_anonymous1"} : memref<100xi32>
 // CHECK:           aie.buffer(%[[TILE]]) {address = 4096 : i32, mem_bank = 0 : i32, sym_name = "a"} : memref<1024xi32>
 // CHECK:           aie.buffer(%[[TILE]]) {address = 12288 : i32, mem_bank = 0 : i32, sym_name = "b"} : memref<1024xi32>
 // CHECK:           aie.buffer(%[[TILE]]) {address = 20000 : i32, mem_bank = 1 : i32, sym_name = "c"} : memref<1024xi32>
 // CHECK:           aie.buffer(%[[TILE]]) {address = 24096 : i32, mem_bank = 1 : i32, sym_name = "d"} : memref<1024xi32>
-// CHECK:           aie.buffer(%[[TILE]]) {address = 49152 : i32, mem_bank = 3 : i32, sym_name = "_anonymous2"} : memref<800xi32>
+// CHECK:           aie.buffer(%[[TILE]]) {address = 28192 : i32, mem_bank = 1 : i32, sym_name = "_anonymous2"} : memref<800xi32>
 // CHECK:         }
 
 module @mix_prealloc {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -797,17 +797,25 @@ void addAMDAIEObjectFifoLoweringPasses(
   addAMDAIEToAIEPasses(passManager, insertLoopAroundCoreBlock);
 
   // Now lower using the AIE passes from MLIR-AIE.
-  addMLIRAIELoweringPasses(passManager);
+  addMLIRAIELoweringPasses(passManager, useTilePipeline);
 }
 
-void addMLIRAIELoweringPasses(OpPassManager &pm) {
+void addMLIRAIELoweringPasses(OpPassManager &pm,
+                              TilePassPipeline useTilePipeline) {
   mlir::iree_compiler::aievec::buildConvertVectorToAIEVec(pm);
 
   {
     OpPassManager &devicePM = pm.nest<xilinx::AIE::DeviceOp>();
     devicePM.addPass(createCanonicalizerPass());
     devicePM.addPass(createAMDAIEAssignBufferDescriptorIDsPass());
-    devicePM.addPass(createAMDAIEAssignBufferAddressesPass());
+    {
+      // For Conv ops use basic sequential scheme to avoid numerical error.
+      // TODO: Find a better working scheme for Conv ops
+      AMDAIEAssignBufferAddressesOptions options;
+      if (useTilePipeline == TilePassPipeline::ConvDecomposePipeline)
+        options.allocScheme = AllocScheme::Sequential;
+      devicePM.addPass(createAMDAIEAssignBufferAddressesPass(options));
+    }
     {
       // Route control and data flows separately, prioritizing control flows
       // first to ensure their deterministic routing results.
@@ -1050,7 +1058,7 @@ void addMLIRAIRLoweringPasses(OpPassManager &passManager, AMDAIEDevice device,
   }
 
   // Now lower using the AIE passes from MLIR-AIE.
-  addMLIRAIELoweringPasses(passManager);
+  addMLIRAIELoweringPasses(passManager, useTilePipeline);
 }
 
 // NOTE: this runs on the top-level program module containing all hal.executable

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -31,7 +31,8 @@ void addMLIRAIRLoweringPasses(OpPassManager &passManager, AMDAIEDevice device,
 
 /// Add lowering passes from MLIR-AIE. This is
 /// currently the default passes used for lowering from AIE dialect.
-void addMLIRAIELoweringPasses(OpPassManager &passManager);
+void addMLIRAIELoweringPasses(OpPassManager &passManager,
+                              TilePassPipeline useTilePipeline);
 
 /// Populates passes needed to lower linalg/arith/math ops to LLVM dialect via
 /// the structured ops path. The pass manager `pm` here operate on the module


### PR DESCRIPTION
Sorting the buffer by largest allocation and assigning those larger buffers first would help for better bank assignment and avoid conflicts. However, this was disabled previously because `depthwise_conv2d` op had numerical error after sorting. I haven't found the reason behind that and couldn't find a better solution. This PR temporarily disable the bank-aware scheme for conv ops as I continue looking into the [issue](https://github.com/nod-ai/iree-amd-aie/issues/1192) for depthwise ops.