### PR TITLE
[CtrlPkt] Improve reconfiguration time by broadcasting core configurations

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AMDAIERT.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AMDAIERT.cpp
@@ -244,7 +244,7 @@ LogicalResult configureLocksAndBd(Block &block, const TileLoc &tileLoc,
 }
 
 LogicalResult addInitConfig(const AMDAIEDeviceModel &deviceModel,
-                            DeviceOp &device) {
+                            DeviceOp &device, bool configureSwitches) {
   // Reset and unreset all cores.
   for (auto tileOp : device.getOps<TileOp>()) {
     TileLoc tileLoc = {tileOp.getCol(), tileOp.getRow()};
@@ -308,6 +308,8 @@ LogicalResult addInitConfig(const AMDAIEDeviceModel &deviceModel,
   }
 
   // StreamSwitch (switchbox) configuration.
+  if (!configureSwitches) return success();
+
   for (auto switchboxOp : device.getOps<SwitchboxOp>()) {
     TileOp t = xilinx::AIE::getTileOp(*switchboxOp.getOperation());
     TileLoc tileLoc = {t.getCol(), t.getRow()};

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AMDAIERT.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AMDAIERT.h
@@ -31,7 +31,8 @@ LogicalResult addAllCoreEnable(const AMDAIEDeviceModel &deviceModel,
 /// Utility function to reset all cores, initialize hardware locks,
 /// and configure all switchboxes.
 LogicalResult addInitConfig(const AMDAIEDeviceModel &deviceModel,
-                            xilinx::AIE::DeviceOp &device);
+                            xilinx::AIE::DeviceOp &device,
+                            bool configureSwitches = true);
 
 }  // namespace mlir::iree_compiler::AMDAIE
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlPacketToNpuDma.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlPacketToNpuDma.cpp
@@ -47,20 +47,21 @@ struct ControlPacketDmaBuilder {
     DenseMap<TileLoc, AMDAIE::ConnectionOp> tileLocToCtrlConnect;
     DenseMap<TileLoc, AMDAIE::TileOp> tileLocToTileOp;
     auto res = workgroupOp->walk([&](AMDAIE::ConnectionOp connectionOp) {
-      if (connectionOp.getTargetChannels().size() != 1) {
-        connectionOp.emitOpError() << "expected a single target channel";
-        return WalkResult::interrupt();
-      }
-
-      auto targetChannelOp = dyn_cast<AMDAIE::ChannelOp>(
-          connectionOp.getTargetChannels()[0].getDefiningOp());
-      if (targetChannelOp.getPortType() == StrmSwPortType::CTRL) {
-        TileOp tileOp = targetChannelOp.getTileOp();
-        TileLoc tileLoc = {
-            static_cast<int>(getConstantIndexOrAssert(tileOp.getCol())),
-            static_cast<int>(getConstantIndexOrAssert(tileOp.getRow()))};
-        tileLocToCtrlConnect[tileLoc] = connectionOp;
-        tileLocToTileOp[tileLoc] = tileOp;
+      for (Value target : connectionOp.getTargetChannels()) {
+        AMDAIE::ChannelOp targetChannelOp =
+            dyn_cast<AMDAIE::ChannelOp>(target.getDefiningOp());
+        if (!targetChannelOp) {
+          connectionOp.emitOpError() << "expected a `amdaie.channel` op target";
+          return WalkResult::interrupt();
+        }
+        if (targetChannelOp.getPortType() == StrmSwPortType::CTRL) {
+          TileOp tileOp = targetChannelOp.getTileOp();
+          TileLoc tileLoc = {
+              static_cast<int>(getConstantIndexOrAssert(tileOp.getCol())),
+              static_cast<int>(getConstantIndexOrAssert(tileOp.getRow()))};
+          tileLocToCtrlConnect[tileLoc] = connectionOp;
+          tileLocToTileOp[tileLoc] = tileOp;
+        }
       }
       return WalkResult::advance();
     });

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIENpuDmaToHalfDmaCpyNd.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIENpuDmaToHalfDmaCpyNd.cpp
@@ -55,7 +55,11 @@ struct NpuDmaToHalfDmaCpyNdConverter final
     // Convert target half.
     Value target =
         dmaOp.getTarget() ? dmaOp.getTarget() : connectionOp.getTarget();
-    if (connectionOp.getTargetChannels().size() != 1)
+    // Broadcasting is allowed only when the NPU DMA operation does not specify
+    // a target LogicalObjectFifo, meaning the data flow is directed into the
+    // AIE array. Otherwise, if a target is specified, ensure there is exactly
+    // one target channel.
+    if (dmaOp.getTarget() && connectionOp.getTargetChannels().size() != 1)
       return connectionOp.emitOpError() << "expected a single target channel";
     auto targetChannelOp = dyn_cast<AMDAIE::ChannelOp>(
         connectionOp.getTargetChannels()[0].getDefiningOp());

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -212,6 +212,8 @@ def AMDAIEConvertDeviceToControlPackets: Pass<"iree-amdaie-convert-device-to-con
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIEConvertDeviceToControlPacketsPass()";
   let options = [
     Option<"pathToElfs", "path-to-elfs", "std::string", /*default=*/"", "Path to ELF files.">,
+    Option<"broadcastCoreConfig", "broadcast-core-config", "bool", /*default=*/"true",
+      "Broadcast the core configuration to all cores.">,
   ];
 }
 
@@ -382,7 +384,10 @@ def AMDAIEGenerateControlOverlay : Pass<"iree-amdaie-generate-control-overlay"> 
     Option<"routeShimCtrlToTct", "route-shim-to-tct", "bool", /*default=*/"true",
       "Flag to generate TCT routing between tile CTRL and shim SOUTH ports.">,
     Option<"routeShimToTileCtrl", "route-shim-to-tile-ctrl", "bool", /*default=*/"false",
-      "Flag to generate routing between shim dma DMA and tile CTRL ports, for configuration.">
+      "Flag to generate routing between shim dma DMA and tile CTRL ports, for configuration.">,
+    Option<"broadcastShimToTileCtrl", "broadcast-shim-to-tile-ctrl", "bool", /*default=*/"true",
+      "Flag to indicate if the shim DMA is connected to all tile core CTRL ports in broadcast mode. "
+      "This option is only effective if `route-shim-to-tile-ctrl` is also enabled">
   ];
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/convert_device_to_control_packets.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/convert_device_to_control_packets.mlir
@@ -1,5 +1,6 @@
 // RUN: aie_elf_files_gen_test %s %T
-// RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-convert-device-to-control-packets{path-to-elfs=%T})" %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-convert-device-to-control-packets{path-to-elfs=%T broadcast-core-config=false})" %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-convert-device-to-control-packets{path-to-elfs=%T broadcast-core-config=true})" %s | FileCheck %s --check-prefix=BROADCAST
 
 // Make sure the `target` attribute is copied over to the new module.
 // CHECK:      #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
@@ -12,6 +13,9 @@
 // CHECK-NEXT:       %[[C0:.*]] = arith.constant 0 : index
 // CHECK-NEXT:       %[[C2:.*]] = arith.constant 2 : index
 // CHECK-NEXT:       %[[TILE_0_2:.*]] = amdaie.tile(%[[C0]], %[[C2]])
+// CHECK-NEXT:       %[[C0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:       %[[C3:.*]] = arith.constant 3 : index
+// CHECK-NEXT:       %[[TILE_0_3:.*]] = amdaie.tile(%[[C0]], %[[C3]])
 // CHECK-NEXT:       amdaie.controlcode {
 
 // Generated from `XAie_CoreDisable`, for tile(0, 2).
@@ -20,11 +24,23 @@
 // Generated from `XAie_LoadElf`, for tile(0, 2).
 // CHECK-NEXT:         amdaie.npu.control_packet write {address = 2228224 : ui32, data = dense_resource<ctrl_pkt_data_0> : tensor<[[LEN:[0-9]+]]xi32>, length = [[LEN]] : ui32, stream_id = 0 : ui32}
 
+// Generated from `XAie_CoreDisable`, for tile(0, 3).
+// CHECK-NEXT:         amdaie.npu.control_packet write {address = 3350528 : ui32, data = array<i32: 0>, length = 1 : ui32, stream_id = 0 : ui32}
+
+// Generated from `XAie_LoadElf`, for tile(0, 3).
+// CHECK-NEXT:         amdaie.npu.control_packet write {address = 3276800 : ui32, data = dense_resource<ctrl_pkt_data_1> : tensor<[[LEN:[0-9]+]]xi32>, length = [[LEN]] : ui32, stream_id = 0 : ui32}
+
 // Generated from `XAie_CoreReset`, for tile(0, 2).
 // CHECK-NEXT:         amdaie.npu.control_packet write {address = 2301952 : ui32, data = array<i32: 2>, length = 1 : ui32, stream_id = 0 : ui32}
 
 // Generated from `XAie_CoreUnreset`, for tile(0, 2).
 // CHECK-NEXT:         amdaie.npu.control_packet write {address = 2301952 : ui32, data = array<i32: 0>, length = 1 : ui32, stream_id = 0 : ui32}
+
+// Generated from `XAie_CoreReset`, for tile(0, 3).
+// CHECK-NEXT:         amdaie.npu.control_packet write {address = 3350528 : ui32, data = array<i32: 2>, length = 1 : ui32, stream_id = 0 : ui32}
+
+// Generated from `XAie_CoreUnreset`, for tile(0, 3).
+// CHECK-NEXT:         amdaie.npu.control_packet write {address = 3350528 : ui32, data = array<i32: 0>, length = 1 : ui32, stream_id = 0 : ui32}
 
 // Generated from `XAie_DmaChannelResetAll` (reset), for tile(0, 2).
 // CHECK-NEXT:         amdaie.npu.control_packet write {address = 2219536 : ui32, data = array<i32: 2>, length = 1 : ui32, stream_id = 0 : ui32}
@@ -37,6 +53,18 @@
 // CHECK-NEXT:         amdaie.npu.control_packet write {address = 2219544 : ui32, data = array<i32: 0>, length = 1 : ui32, stream_id = 0 : ui32}
 // CHECK-NEXT:         amdaie.npu.control_packet write {address = 2219520 : ui32, data = array<i32: 0>, length = 1 : ui32, stream_id = 0 : ui32}
 // CHECK-NEXT:         amdaie.npu.control_packet write {address = 2219528 : ui32, data = array<i32: 0>, length = 1 : ui32, stream_id = 0 : ui32}
+
+// Generated from `XAie_DmaChannelResetAll` (reset), for tile(0, 3).
+// CHECK-NEXT:         amdaie.npu.control_packet write {address = 3268112 : ui32, data = array<i32: 2>, length = 1 : ui32, stream_id = 0 : ui32}
+// CHECK-NEXT:         amdaie.npu.control_packet write {address = 3268120 : ui32, data = array<i32: 2>, length = 1 : ui32, stream_id = 0 : ui32}
+// CHECK-NEXT:         amdaie.npu.control_packet write {address = 3268096 : ui32, data = array<i32: 2>, length = 1 : ui32, stream_id = 0 : ui32}
+// CHECK-NEXT:         amdaie.npu.control_packet write {address = 3268104 : ui32, data = array<i32: 2>, length = 1 : ui32, stream_id = 0 : ui32}
+
+// Generated from `XAie_DmaChannelResetAll` (unreset), for tile(0, 3).
+// CHECK-NEXT:         amdaie.npu.control_packet write {address = 3268112 : ui32, data = array<i32: 0>, length = 1 : ui32, stream_id = 0 : ui32}
+// CHECK-NEXT:         amdaie.npu.control_packet write {address = 3268120 : ui32, data = array<i32: 0>, length = 1 : ui32, stream_id = 0 : ui32}
+// CHECK-NEXT:         amdaie.npu.control_packet write {address = 3268096 : ui32, data = array<i32: 0>, length = 1 : ui32, stream_id = 0 : ui32}
+// CHECK-NEXT:         amdaie.npu.control_packet write {address = 3268104 : ui32, data = array<i32: 0>, length = 1 : ui32, stream_id = 0 : ui32}
 
 // Generated from `XAie_DmaChannelResetAll` (reset), for tile(0, 1).
 // CHECK-NEXT:         amdaie.npu.control_packet write {address = 1705520 : ui32, data = array<i32: 2>, length = 1 : ui32, stream_id = 0 : ui32}
@@ -68,13 +96,18 @@
 
 // Generated from `XAie_CoreEnable`, for tile(0, 2).
 // CHECK-NEXT:         amdaie.npu.control_packet write {address = 2301952 : ui32, data = array<i32: 1>, length = 1 : ui32, stream_id = 0 : ui32}
+
+// Generated from `XAie_CoreEnable`, for tile(0, 3).
+// CHECK-NEXT:         amdaie.npu.control_packet write {address = 3350528 : ui32, data = array<i32: 1>, length = 1 : ui32, stream_id = 0 : ui32}
 // CHECK-NEXT:         amdaie.end
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   aie.device(npu1_4col) {
     %tile_0_1 = aie.tile(0, 1)
     %tile_0_2 = aie.tile(0, 2)
+    %tile_0_3 = aie.tile(0, 3)
     %buf = aie.buffer(%tile_0_2) {address = 0 : i32, sym_name = "buf"} : memref<256xi32>
+    %buf_1 = aie.buffer(%tile_0_3) {address = 0 : i32, sym_name = "buf_1"} : memref<256xi32>
     %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
       aie.end
     }
@@ -87,5 +120,20 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       memref.store %0, %buf[%1] : memref<256xi32>
       aie.end
     }
+    %mem_0_3 = aie.mem(%tile_0_3) {
+      aie.end
+    }
+    %core_0_3 = aie.core(%tile_0_3)  {
+      %0 = arith.constant 0 : i32
+      %1 = arith.constant 0 : index
+      memref.store %0, %buf_1[%1] : memref<256xi32>
+      aie.end
+    }
   }
 }
+
+// Generated from `XAie_LoadElf`, for tile(0, 2).
+// BROADCAST:          amdaie.npu.control_packet write {address = 2228224 : ui32, data = dense_resource<ctrl_pkt_data_0> : tensor<[[LEN:[0-9]+]]xi32>, length = [[LEN]] : ui32, stream_id = 0 : ui32}
+
+// Do not generate `XAie_LoadElf` for tile(0, 3) as the core configuraion is broadcasted.
+// BROADCAST-NOT:         amdaie.npu.control_packet write {address = 3276800 : ui32, data = dense_resource<ctrl_pkt_data_1> : tensor<[[LEN:[0-9]+]]xi32>, length = [[LEN]] : ui32, stream_id = 0 : ui32}


### PR DESCRIPTION
During device reconfiguration, instead of performing separate memory copies for each core, this PR broadcasts the configuration sequence to all cores via the control overlay.

This optimization further reduces reconfiguration time from 15ms (#1185) to 1.3ms.