### PR TITLE
Bump mlir-air to e19dd32108a1d55132bbc115384dc493e3126af4

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aie/AIEX.td
+++ b/compiler/plugins/target/AMD-AIE/aie/AIEX.td
@@ -44,9 +44,7 @@ def AIE_NpuDmaMemcpyNdOp: AIEX_Op<"npu.dma_memcpy_nd", [
   ]> {
   let summary = "half DMA operator";
   let arguments = (
-    ins I64Attr:$x,
-        I64Attr:$y,
-        AnyMemRef:$memref,
+    ins AnyMemRef:$memref,
         // NOTE: these are in reverse order: offset3, offset2, ...
         Variadic<I64>:$offsets,
         Variadic<I64>:$sizes,
@@ -67,7 +65,7 @@ def AIE_NpuDmaMemcpyNdOp: AIEX_Op<"npu.dma_memcpy_nd", [
   );
 
   let assemblyFormat = [{
-    `(` $x `,` $y `,` $memref ``
+    `(` $memref ``
     custom<DynamicIndexList>($offsets, $static_offsets) ``
     custom<DynamicIndexList>($sizes, $static_sizes) ``
     custom<DynamicIndexList>($strides, $static_strides) ``

--- a/compiler/plugins/target/AMD-AIE/aie/test/aiert_insts.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/aiert_insts.mlir
@@ -28,8 +28,8 @@ module {
       %c8 = arith.constant 8 : i64
       %c16 = arith.constant 16 : i64
       %c32 = arith.constant 32 : i64
-      aiex.npu.dma_memcpy_nd(0, 0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c32][%c0,%c0,%c0,%c1]) { metadata = @of_toMem, id = 1 : i64 } : memref<64xi32>
-      aiex.npu.dma_memcpy_nd(0, 0, %in[%c0,%c2,%c0,%c0][%c1,%c2,%c2,%c8][%c0,%c16,%c8,%c1]) { metadata = @of_fromMem, id = 0 : i64 } : memref<4x2x8xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c32][%c0,%c0,%c0,%c1]) { metadata = @of_toMem, id = 1 : i64 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c2,%c0,%c0][%c1,%c2,%c2,%c8][%c0,%c16,%c8,%c1]) { metadata = @of_fromMem, id = 0 : i64 } : memref<4x2x8xi32>
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)
     aie.shim_dma_allocation @of_toMem (S2MM, 0, 0)

--- a/compiler/plugins/target/AMD-AIE/aie/test/dma_to_npu.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/dma_to_npu.mlir
@@ -12,8 +12,8 @@ module  {
     memref.global "public" @toMem : memref<16xi32>
     memref.global "public" @fromMem : memref<16xi32>
     aiex.runtime_sequence @dma_memcpy_nd_0(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
-      aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(0, 1, %arg1[0, 0, 0, 16][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @fromMem, id = 0 : i64 } : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 16][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @fromMem, id = 0 : i64 } : memref<16xi32>
     }
     aie.shim_dma_allocation @fromMem (MM2S, 0, 0)
     aie.shim_dma_allocation @toMem (S2MM, 0, 0)
@@ -30,7 +30,7 @@ module  {
   aie.device(npu1_4col) {
     memref.global "public" @toMem : memref<16xi32>
     aiex.runtime_sequence @dma_wait_s2mm(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
-      aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
       aiex.npu.dma_wait {symbol = @toMem}
     }
     aie.shim_dma_allocation @toMem (S2MM, 0, 0)
@@ -47,7 +47,7 @@ module  {
   aie.device(npu1_4col) {
     memref.global "public" @toMem : memref<16xi32>
     aiex.runtime_sequence @dma_wait_mm2s(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
-      aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
       aiex.npu.dma_wait {symbol = @toMem}
     }
     aie.shim_dma_allocation @toMem (MM2S, 1, 1)
@@ -70,7 +70,7 @@ module  {
     }
 
     aiex.runtime_sequence @explicit_sym_name(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
-      aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
       aiex.npu.dma_wait {symbol = @toMem}
     }
     aie.shim_dma_allocation @toMem (MM2S, 1, 1)
@@ -88,7 +88,7 @@ module {
   aie.device(npu1_4col) {
     memref.global "public" @toMem : memref<16xi32>
     aiex.runtime_sequence @packet_enable(%arg0: memref<16xi32>) {
-      aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1], packet = <pkt_id = 2, pkt_type = 3>) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
+      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1], packet = <pkt_id = 2, pkt_type = 3>) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
     }
     aie.shim_dma_allocation @toMem (S2MM, 0, 0)
   }

--- a/compiler/plugins/target/AMD-AIE/aie/test/dma_to_npu_issue_token.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/dma_to_npu_issue_token.mlir
@@ -12,8 +12,8 @@ module  {
     memref.global "public" @toMem : memref<16xi32>
     memref.global "public" @fromMem : memref<16xi32>
     aiex.runtime_sequence @test1(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
-        aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64, issue_token = true } : memref<16xi32>
-        aiex.npu.dma_memcpy_nd(0, 1, %arg1[0, 0, 0, 16][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @fromMem, id = 0 : i64 } : memref<16xi32>
+        aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64, issue_token = true } : memref<16xi32>
+        aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 16][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @fromMem, id = 0 : i64 } : memref<16xi32>
     }
     aie.shim_dma_allocation @fromMem (MM2S, 0, 0)
     aie.shim_dma_allocation @toMem (S2MM, 0, 0)

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/bd_chaining.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/bd_chaining.mlir
@@ -168,9 +168,9 @@ aie.device(npu1_4col) {
     memref.assume_alignment %arg0, 64 : memref<8x16xi32>
     memref.assume_alignment %arg1, 64 : memref<16x32xi32>
     memref.assume_alignment %arg2, 64 : memref<8x32xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 8, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<8x16xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][1, 1, 16, 32][0, 0, 32, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x32xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 8, 32][0, 0, 32, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<8x32xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 8, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<8x16xi32>
+    aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 0][1, 1, 16, 32][0, 0, 32, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x32xi32>
+    aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 0][1, 1, 8, 32][0, 0, 32, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<8x32xi32>
     aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
     return
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/matmul_16x16_8xi32__dispatch_0_matmul_16x1_0.aiecc.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/matmul_16x16_8xi32__dispatch_0_matmul_16x1_0.aiecc.mlir
@@ -155,9 +155,9 @@ aie.device(npu1_4col) {
     memref.assume_alignment %arg0, 64 : memref<16x8xi32>
     memref.assume_alignment %arg1, 64 : memref<8x16xi32>
     memref.assume_alignment %arg2, 64 : memref<16x16xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 8][0, 0, 8, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<16x8xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][1, 1, 8, 16][0, 0, 16, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<8x16xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<16x16xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 16, 8][0, 0, 8, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<16x8xi32>
+    aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 0][1, 1, 8, 16][0, 0, 16, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<8x16xi32>
+    aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<16x16xi32>
     aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
     return
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/matmul_16x64_32xi8__dispatch_0_matmul_tran_0.aiecc.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/matmul_16x64_32xi8__dispatch_0_matmul_tran_0.aiecc.mlir
@@ -155,9 +155,9 @@ aie.device(npu1_4col) {
     memref.assume_alignment %arg0, 64 : memref<256xi32>
     memref.assume_alignment %arg1, 64 : memref<512xi32>
     memref.assume_alignment %arg2, 64 : memref<16x32xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<256xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][1, 1, 32, 16][0, 0, 16, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 16, 32][0, 0, 32, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<16x32xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<256xi32>
+    aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 0][1, 1, 32, 16][0, 0, 16, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<512xi32>
+    aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 0][1, 1, 16, 32][0, 0, 32, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<16x32xi32>
     aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
     return
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/matmul_512x512_512xi32__dispatch_0_matmul__0.aiecc.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/matmul_512x512_512xi32__dispatch_0_matmul__0.aiecc.mlir
@@ -1428,30 +1428,30 @@ aie.device(npu1_4col) {
     memref.assume_alignment %arg0, 64 : memref<512x512xi32>
     memref.assume_alignment %arg1, 64 : memref<512x512xi32>
     memref.assume_alignment %arg2, 64 : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId13} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 128, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId13} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 256, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId13} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 384, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId13} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 32, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId15} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 160, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId15} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 288, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 6 : i64, metadata = @airMemcpyId15} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 416, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 7 : i64, metadata = @airMemcpyId15} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 64, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId17} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 192, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId17} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 320, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId17} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 448, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId17} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 96, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId19} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 224, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId19} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 352, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 6 : i64, metadata = @airMemcpyId19} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 480, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 7 : i64, metadata = @airMemcpyId19} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][4, 4, 512, 32][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId21} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 32][4, 4, 512, 32][0, 128, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId23} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 64][4, 4, 512, 32][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId25} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 96][4, 4, 512, 32][0, 128, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId27} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][4, 4, 32, 128][65536, 128, 512, 1]) {id = 8 : i64, metadata = @airMemcpyId78} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 32, 0][4, 4, 32, 128][65536, 128, 512, 1]) {id = 9 : i64, metadata = @airMemcpyId79} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 64, 0][4, 4, 32, 128][65536, 128, 512, 1]) {id = 8 : i64, metadata = @airMemcpyId80} : memref<512x512xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 96, 0][4, 4, 32, 128][65536, 128, 512, 1]) {id = 9 : i64, metadata = @airMemcpyId81} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId13} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 128, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId13} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 256, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId13} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 384, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId13} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 32, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId15} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 160, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId15} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 288, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 6 : i64, metadata = @airMemcpyId15} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 416, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 7 : i64, metadata = @airMemcpyId15} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 64, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId17} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 192, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId17} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 320, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 2 : i64, metadata = @airMemcpyId17} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 448, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 3 : i64, metadata = @airMemcpyId17} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 96, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 4 : i64, metadata = @airMemcpyId19} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 224, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 5 : i64, metadata = @airMemcpyId19} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 352, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 6 : i64, metadata = @airMemcpyId19} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 480, 0][4, 2, 32, 256][0, 256, 512, 1]) {id = 7 : i64, metadata = @airMemcpyId19} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 0][4, 4, 512, 32][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId21} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 32][4, 4, 512, 32][0, 128, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId23} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 64][4, 4, 512, 32][0, 128, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId25} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 96][4, 4, 512, 32][0, 128, 512, 1]) {id = 1 : i64, metadata = @airMemcpyId27} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 0][4, 4, 32, 128][65536, 128, 512, 1]) {id = 8 : i64, metadata = @airMemcpyId78} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg2[0, 0, 32, 0][4, 4, 32, 128][65536, 128, 512, 1]) {id = 9 : i64, metadata = @airMemcpyId79} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg2[0, 0, 64, 0][4, 4, 32, 128][65536, 128, 512, 1]) {id = 8 : i64, metadata = @airMemcpyId80} : memref<512x512xi32>
+    aiex.npu.dma_memcpy_nd(%arg2[0, 0, 96, 0][4, 4, 32, 128][65536, 128, 512, 1]) {id = 9 : i64, metadata = @airMemcpyId81} : memref<512x512xi32>
     aiex.npu.sync {channel = 0 : i32, column = 1 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
     aiex.npu.sync {channel = 1 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
     aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/matmul_64x64_64xbf16__dispatch_0_matmul_64_0.aiecc.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/matmul_64x64_64xbf16__dispatch_0_matmul_64_0.aiecc.mlir
@@ -155,9 +155,9 @@ aie.device(npu1_4col) {
     memref.assume_alignment %arg0, 64 : memref<2048xi32>
     memref.assume_alignment %arg1, 64 : memref<2048xi32>
     memref.assume_alignment %arg2, 64 : memref<64x64xf32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 64, 32][0, 0, 32, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<2048xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][1, 1, 64, 32][0, 0, 32, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<2048xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 64, 64][0, 0, 64, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<64x64xf32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 64, 32][0, 0, 32, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<2048xi32>
+    aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 0][1, 1, 64, 32][0, 0, 32, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<2048xi32>
+    aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 0][1, 1, 64, 64][0, 0, 64, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<64x64xf32>
     aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
     return
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/matmul_64x64_64xi8__dispatch_0_matmul_64x6_0.aiecc.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/matmul_64x64_64xi8__dispatch_0_matmul_64x6_0.aiecc.mlir
@@ -155,9 +155,9 @@ aie.device(npu1_4col) {
     memref.assume_alignment %arg0, 64 : memref<1024xi32>
     memref.assume_alignment %arg1, 64 : memref<1024xi32>
     memref.assume_alignment %arg2, 64 : memref<64x64xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 64, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<1024xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][1, 1, 64, 16][0, 0, 16, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<1024xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 64, 64][0, 0, 64, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<64x64xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 64, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<1024xi32>
+    aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 0][1, 1, 64, 16][0, 0, 16, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<1024xi32>
+    aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 0][1, 1, 64, 64][0, 0, 64, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<64x64xi32>
     aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
     return
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/matmul_8x32_16xi32__dispatch_0_matmul_8x32_0.aiecc.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/test/matmul_8x32_16xi32__dispatch_0_matmul_8x32_0.aiecc.mlir
@@ -155,9 +155,9 @@ aie.device(npu1_4col) {
     memref.assume_alignment %arg0, 64 : memref<8x16xi32>
     memref.assume_alignment %arg1, 64 : memref<16x32xi32>
     memref.assume_alignment %arg2, 64 : memref<8x32xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 8, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<8x16xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][1, 1, 16, 32][0, 0, 32, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x32xi32>
-    aiex.npu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 8, 32][0, 0, 32, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<8x32xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 8, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<8x16xi32>
+    aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 0][1, 1, 16, 32][0, 0, 32, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x32xi32>
+    aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 0][1, 1, 8, 32][0, 0, 32, 1]) {id = 2 : i64, metadata = @airMemcpyId12} : memref<8x32xi32>
     aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
     return
   }


### PR DESCRIPTION
- Remove more assertions to potentially fix the random CI failures.