### PR TITLE
[FuseProducerIntoLoop] Fix materializing the operand

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -2238,6 +2238,26 @@ class Tests:
 
         self.register(
             Matmul(
+                32,
+                32,
+                128,
+                "i32",
+                "i32",
+                test_params=TestParams(
+                    tile_pipeline="pack-peel-4-level-tiling",
+                    aie_compilation_flags=[
+                        "--iree-amdaie-num-rows=1",
+                        "--iree-amdaie-num-cols=1",
+                    ],
+                    name_suffix="OneCore_npu4",
+                    run_on_target=["npu4"],
+                ),
+                additional_labels=["OneCore"],
+            )
+        )
+
+        self.register(
+            Matmul(
                 64,
                 128,
                 128,


### PR DESCRIPTION
To be merged after https://github.com/nod-ai/iree-amd-aie/pull/1189

- This commit adds a fix for materializing the operand of the compute
   op inside `iree-amdaie-fuse-producer-into-loop`.
-- Whenever the defining op of an operand is a linalg.pack/copy and is
   not defined in the same block, we simply move that inside the block.
-- Else we try to find a tensor.extract_slice through the use-def chain
   and tile/fuse it.
-- This makes 32x32x128 i32->i32 work on 1x1 for `pack-peel-4-level-tiling`.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>