### PR TITLE
[SplitLogicalObjFifo] Add fix for new offset in case of no splits

### DIFF
--- a/build_tools/ci/cpu_comparison/matmul_test_config.py
+++ b/build_tools/ci/cpu_comparison/matmul_test_config.py
@@ -73,6 +73,20 @@ npu4_matmul_tests = [
         ],
     },
     {
+        "M": 32,
+        "N": 32,
+        "K": 256,
+        "input_type": "i32",
+        "acc_type": "i32",
+        "tile_pipeline": "pack-peel-4-level-tiling",
+        "name_suffix": "OneCore_npu4",
+        "additional_labels": ["OneCore"],
+        "aie_compilation_flags": [
+            "--iree-amdaie-num-rows=1",
+            "--iree-amdaie-num-cols=1",
+        ],
+    },
+    {
         "M": 64,
         "N": 128,
         "K": 128,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIELogicalObjFifoSplittingUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIELogicalObjFifoSplittingUtils.cpp
@@ -653,6 +653,10 @@ FailureOr<OffsetConfig> getNewOffsetConfig(
                                  applyOp.getLoc(), newAffineMap, operand)
                              .getResult();
         objFifoIndex /= dmaPerSplit;
+      } else if (splitFactor == 1) {
+        // In case of no split, we reuse the affine.apply SSA value for the
+        // offset.
+        newOffsetValue = offsetValue;
       } else {
         newOffsetValue = operand;
       }


### PR DESCRIPTION
-- This commit adds a fix in `iree-amdaie-split-logicalobjfifo` to address those case when there's no splitting of a logicalobjfifo and the producer/consumer DMAs have affine.apply in offset at the inferred splitting dimension.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>

NOTE: Although I've added an e2e test but since strix machine is currently not accessible, the only thing verified is the compilation. Without the fix that this PR is trying to add, `32 x 32 256` for `1x1` for `pack-peel-4-level-tiling` on Strix leads to a compilation failure wherein `amdaie.connection` op ends up having multiple users. This was happening because `DMAComposition` failed to combine the strided ops, which in turn was happening because of incorrect offset on the L2 buffer in L2->L1 DMACpyNd.

Here is the [e2e compilation log of 32x32x256](https://gist.github.com/Abhishek-Varma/7691531b8ba0f9bcafdec26b5a4d29f1)

To be merged after https://github.com/nod-ai/iree-amd-aie/pull/1206 (contingent on the refactor proposal's acceptance) and as well as the e2e test being added is run on Strix and confirmed.