### PR TITLE
Move objFifo depth assignment pass up in pipeline

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEFlattenLogicalObjectFifo.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEFlattenLogicalObjectFifo.cpp
@@ -45,8 +45,9 @@ void AMDAIEFlattenLogicalObjectFifoPass::runOnOperation() {
     rewriter.setInsertionPoint(op);
     auto newLogicalObjectFifo =
         rewriter.create<AMDAIE::LogicalObjectFifoFromMemrefOp>(
-            rewriter.getUnknownLoc(), LogicalObjectFifoType::get(newType),
-            op.getMemref(), op.getTiles());
+            rewriter.getUnknownLoc(),
+            LogicalObjectFifoType::get(newType, op.getDepth()), op.getMemref(),
+            op.getTiles());
     rewriter.replaceOp(op, newLogicalObjectFifo);
 
     // Replace the access op and insert `memref.reinterpret_cast` to get to the

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -723,6 +723,7 @@ void addAMDAIEObjectFifoLoweringPasses(
 
   passManager.addPass(createCSEPass());
   passManager.addPass(createCanonicalizerPass());
+  passManager.addPass(createAMDAIEAssignLogicalObjectFifoDepthPass());
 
   passManager.addPass(createAMDAIEAssignTilesPass());
   passManager.addPass(createCSEPass());
@@ -736,7 +737,6 @@ void addAMDAIEObjectFifoLoweringPasses(
   passManager.addPass(createAMDAIEHoistLogicalObjFifoPass());
   passManager.addPass(createAMDAIECanonicalizeDoublyStridedOpPass());
   passManager.addPass(createAMDAIEFlattenLogicalObjectFifoPass());
-  passManager.addPass(createAMDAIEAssignLogicalObjectFifoDepthPass());
   passManager.addPass(createAMDAIEAccessToAcquireReleasePass());
   passManager.addPass(createAMDAIENoneAccessToTemporaryBufferPass());
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/flatten_logical_objectfifo.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/flatten_logical_objectfifo.mlir
@@ -4,16 +4,16 @@
 // CHECK:       %[[FROM_MEMREF_0:.*]] = amdaie.logicalobjectfifo.from_memref
 // CHECK-SAME:    memref<1x1x8x4x8x4xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>>
 // CHECK:       %[[FROM_MEMREF_1:.*]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x2x32x32xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2048xi32, 1 : i32>>
+// CHECK-SAME:    memref<1x2x32x32xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2048xi32, 1 : i32>, 2>
 // CHECK:       %[[DMA_0:.*]] = amdaie.circular_dma_cpy_nd
-// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>>, !amdaie.logicalobjectfifo<memref<2048xi32, 1 : i32>>)
+// CHECK-SAME:    (!amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>>, !amdaie.logicalobjectfifo<memref<2048xi32, 1 : i32>, 2>)
 // CHECK:       %[[FROM_MEMREF_2:.*]] = amdaie.logicalobjectfifo.from_memref
-// CHECK-SAME:    memref<1x1x8x8x4x4xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>>
+// CHECK-SAME:    memref<1x1x8x8x4x4xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>, 2>
 // CHECK:       amdaie.core
 // CHECK:         %[[ACCESS:.*]]= amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_0]], Read) : !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>> -> memref<1024xi32, 2 : i32>
 // CHECK:         %[[CAST:.*]] = memref.reinterpret_cast %[[ACCESS]]
 // CHECK-SAME:      memref<1024xi32, 2 : i32> to memref<1x1x8x4x8x4xi32, 2 : i32>
-// CHECK:         %[[ACCESS_2:.*]]= amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_2]], None) : !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>> -> memref<1024xi32, 2 : i32>
+// CHECK:         %[[ACCESS_2:.*]]= amdaie.logicalobjectfifo.access(%[[FROM_MEMREF_2]], None) : !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>, 2> -> memref<1024xi32, 2 : i32>
 // CHECK:         %[[CAST_2:.*]] = memref.reinterpret_cast %[[ACCESS_2]]
 // CHECK-SAME:      memref<1024xi32, 2 : i32> to memref<1x1x8x8x4x4xi32, 2 : i32>
 // CHECK:         linalg.fill ins(%{{.+}} : i32) outs(%[[CAST_2]]
@@ -34,13 +34,13 @@ module {
       %tile = amdaie.tile(%c0, %c1)
       %tile_2 = amdaie.tile(%c0, %c2)
       %0 = amdaie.logicalobjectfifo.from_memref %alloc, {%tile_2} : memref<1x1x8x4x8x4xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<1x1x8x4x8x4xi32, 2 : i32>>
-      %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {%tile} : memref<1x2x32x32xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1x2x32x32xi32, 1 : i32>>
-      %2 = amdaie.circular_dma_cpy_nd(%0[%c0] [%c1024] [%c1], %1[%c0, %c0, %c0] [%c8, %c32, %c4] [%c4, %c32, %c1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x4x8x4xi32, 2 : i32>>, !amdaie.logicalobjectfifo<memref<1x2x32x32xi32, 1 : i32>>)
-      %3 = amdaie.logicalobjectfifo.from_memref %alloc_1, {%tile_2} : memref<1x1x8x8x4x4xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<1x1x8x8x4x4xi32, 2 : i32>>
+      %1 = amdaie.logicalobjectfifo.from_memref %alloc_0, {%tile} : memref<1x2x32x32xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1x2x32x32xi32, 1 : i32>, 2>
+      %2 = amdaie.circular_dma_cpy_nd(%0[%c0] [%c1024] [%c1], %1[%c0, %c0, %c0] [%c8, %c32, %c4] [%c4, %c32, %c1]) : (!amdaie.logicalobjectfifo<memref<1x1x8x4x8x4xi32, 2 : i32>>, !amdaie.logicalobjectfifo<memref<1x2x32x32xi32, 1 : i32>, 2>)
+      %3 = amdaie.logicalobjectfifo.from_memref %alloc_1, {%tile_2} : memref<1x1x8x8x4x4xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<1x1x8x8x4x4xi32, 2 : i32>, 2>
       %4 = amdaie.core(%tile_2, in : [%2], out : []) {
         scf.forall (%arg0, %arg1) in (2, 2) {
-          %5 = amdaie.logicalobjectfifo.access(%0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x4x8x4xi32, 2 : i32>> -> memref<1x1x8x4x8x4xi32, 2 : i32>
-          %6 = amdaie.logicalobjectfifo.access(%3, None) : !amdaie.logicalobjectfifo<memref<1x1x8x8x4x4xi32, 2 : i32>> -> memref<1x1x8x8x4x4xi32, 2 : i32>
+          %5 = amdaie.logicalobjectfifo.access(%0, Read) : !amdaie.logicalobjectfifo<memref<1x1x8x4x8x4xi32, 2 : i32>, 1> -> memref<1x1x8x4x8x4xi32, 2 : i32>
+          %6 = amdaie.logicalobjectfifo.access(%3, None) : !amdaie.logicalobjectfifo<memref<1x1x8x8x4x4xi32, 2 : i32>, 2> -> memref<1x1x8x8x4x4xi32, 2 : i32>
           linalg.fill ins(%c0_i32 : i32) outs(%6 : memref<1x1x8x8x4x4xi32, 2 : i32>)
         }
         amdaie.end


### PR DESCRIPTION
Moves `AMDAIEAssignLogicalObjectFifoDepthPass` up in the pipeline so that the depth (double buffering) information is available as soon as possible and before the `AMDAIEAssignTiles` pass. Also fixes a bug in `AMDAIEFlattenLogicalObjectFifo` that would remove the depth. 