### PR TITLE
[InsertDmaBdChain] Do not insert interleaved BD chains to maintain control packet order

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
@@ -1467,7 +1467,14 @@ LogicalResult generateControlPackets(
   pm.addPass(createCanonicalizerPass());
   // Optimize the controlcode size.
   pm.addPass(createAMDAIENpuDmaToHalfDmaCpyNdPass());
-  pm.addPass(createAMDAIEInsertDmaBdChainPass());
+  {
+    // Building multple BD chains in an interleaved way can disrupt the ordering
+    // of the reconfiguration data. Disabled for now.
+    // TODO (zhewen): check if possible to (partially) enable this.
+    AMDAIEInsertDmaBdChainOptions options;
+    options.enableInterleave = false;
+    pm.addPass(createAMDAIEInsertDmaBdChainPass(options));
+  }
   pm.addPass(createAMDAIEFoldDmaWaitsPass());
   // Lower the DMA instructions for sending control packets.
   {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertDmaBdChain.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertDmaBdChain.cpp
@@ -64,7 +64,7 @@ LogicalResult updateChainOperands(
 }
 
 /// Utility function to determine if chains can grow further
-/// or require breaking.
+/// or require breaking, depending on if there is any duplicate BD ID.
 ///
 /// Example:
 /// - Chain X currently holds BD IDs: [4, 5, 6, 7]
@@ -82,18 +82,16 @@ LogicalResult updateChainOperands(
 /// - Break both chains X and Y.
 ///   - Chain X: [0] (the newly added BD ID).
 ///   - Chain Y: [] (emptied after breaking).
-void checkForChainsToBeBroken(
+void checkForChainsWithDuplicateBdId(
     uint32_t currBdId, const DmaChain &currDmaChain,
     const DenseMap<DmaChain, DenseSet<uint32_t>> &dmaChainToBdIds,
-    SmallVector<DmaChain> &chainsToBreak) {
+    llvm::SmallSetVector<DmaChain, 4> &chainsToBreak) {
   for (auto &[entry, bdIds] : dmaChainToBdIds) {
     if (entry.first == currDmaChain.first && bdIds.contains(currBdId)) {
       // Break the chain that contains the duplicate BD ID.
-      chainsToBreak.push_back(entry);
-      if (entry != currDmaChain) {
-        // Break the current chain as well.
-        chainsToBreak.push_back(currDmaChain);
-      }
+      chainsToBreak.insert(entry);
+      // Break the current chain as well.
+      if (entry != currDmaChain) chainsToBreak.insert(currDmaChain);
       break;
     }
   }
@@ -103,7 +101,8 @@ void checkForChainsToBeBroken(
 /// traversal simplifies handling duplicate BD IDs, preventing the need to
 /// revisit and modify earlier operations after processing later ones.
 LogicalResult insertDmaBdChain(const AMDAIE::AMDAIEDeviceModel &deviceModel,
-                               AMDAIE::ControlCodeOp controlCodeOp) {
+                               AMDAIE::ControlCodeOp controlCodeOp,
+                               bool enableInterleave) {
   IRRewriter rewriter(controlCodeOp->getContext());
 
   // Move all BdIdOps to the beginning of the control code.
@@ -184,13 +183,19 @@ LogicalResult insertDmaBdChain(const AMDAIE::AMDAIEDeviceModel &deviceModel,
         return WalkResult::interrupt();
       }
 
+      llvm::SmallSetVector<DmaChain, 4> chainsToBreak;
+      DmaChain currDmaChain = {tileOp, connectionOp};
+      // Check if there are other chains being built in an interleaved way.
+      if (!enableInterleave) {
+        for (auto &entry : dmaChainToBdIds) {
+          if (entry.first != currDmaChain) chainsToBreak.insert(entry.first);
+        }
+      }
       // Any duplicate BD ID from the same tile indicates that the chain
       // cannot grow further and requires breaking to release the
       // conflicting BD ID.
-      SmallVector<DmaChain> chainsToBreak;
-      DmaChain currDmaChain = {tileOp, connectionOp};
-      checkForChainsToBeBroken(bdId, currDmaChain, dmaChainToBdIds,
-                               chainsToBreak);
+      checkForChainsWithDuplicateBdId(bdId, currDmaChain, dmaChainToBdIds,
+                                      chainsToBreak);
 
       // If the chains are not to be continued, update DMA operands using
       // the `updateChainOperands` function.
@@ -202,8 +207,8 @@ LogicalResult insertDmaBdChain(const AMDAIE::AMDAIEDeviceModel &deviceModel,
                        dmaChainToDmaOps[entry].end());
           if (failed(updateChainOperands(rewriter, dmaChainToDmaOps[entry])))
             WalkResult::interrupt();
-          dmaChainToBdIds[entry].clear();
-          dmaChainToDmaOps[entry].clear();
+          dmaChainToBdIds.erase(entry);
+          dmaChainToDmaOps.erase(entry);
         }
       }
       dmaChainToBdIds[currDmaChain].insert(bdId);
@@ -235,6 +240,8 @@ class AMDAIEInsertDmaBdChainPass
 
   AMDAIEInsertDmaBdChainPass() = default;
   AMDAIEInsertDmaBdChainPass(const AMDAIEInsertDmaBdChainPass &pass){};
+  AMDAIEInsertDmaBdChainPass(const AMDAIEInsertDmaBdChainOptions &options)
+      : AMDAIEInsertDmaBdChainBase(options) {}
   void runOnOperation() override;
 };
 
@@ -255,7 +262,8 @@ void AMDAIEInsertDmaBdChainPass::runOnOperation() {
 
   WalkResult res = parentOp->walk([&](AMDAIE::WorkgroupOp workgroupOp) {
     AMDAIE::ControlCodeOp controlCodeOp = workgroupOp.getControlCode();
-    if (failed(insertDmaBdChain(deviceModel, controlCodeOp))) {
+    if (failed(
+            insertDmaBdChain(deviceModel, controlCodeOp, enableInterleave))) {
       return WalkResult::interrupt();
     }
     return WalkResult::advance();
@@ -265,8 +273,9 @@ void AMDAIEInsertDmaBdChainPass::runOnOperation() {
 
 }  // namespace
 
-std::unique_ptr<Pass> createAMDAIEInsertDmaBdChainPass() {
-  return std::make_unique<AMDAIEInsertDmaBdChainPass>();
+std::unique_ptr<Pass> createAMDAIEInsertDmaBdChainPass(
+    AMDAIEInsertDmaBdChainOptions options) {
+  return std::make_unique<AMDAIEInsertDmaBdChainPass>(options);
 }
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -217,7 +217,8 @@ std::unique_ptr<Pass> createAMDAIEHoistForLoopAffineApplyPass();
 std::unique_ptr<Pass> createAMDAIEHoistLogicalObjFifoPass();
 
 /// Create pass to chain DMA BD IDs by updating next_bd operands.
-std::unique_ptr<Pass> createAMDAIEInsertDmaBdChainPass();
+std::unique_ptr<Pass> createAMDAIEInsertDmaBdChainPass(
+    AMDAIEInsertDmaBdChainOptions options = {});
 
 /// Create a pass to transform linalg.generics into a form which benefits later
 /// vectorization passes (to vector and aievec dialects).

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -406,6 +406,10 @@ def AMDAIEInsertDmaBdChain :
     Pass<"iree-amdaie-insert-dma-bd-chain"> {
   let summary = "Chain DMA BD IDs by updating next_bd operands.";
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIEInsertDmaBdChainPass()";
+  let options = [
+    Option<"enableInterleave", "enable-interleave", "bool", /*default=*/"true",
+      "Enable multiple BD chains to be built in an interleaved way.">,
+  ];
 }
 
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
@@ -55,6 +55,7 @@ iree_lit_test_suite(
     "hoist_logical_obj_fifo.mlir"
     "insert_cores.mlir"
     "insert_dma_bd_chain.mlir"
+    "insert_dma_bd_chain_disable_interleave.mlir"
     "insert_infinite_loop_around_core_block.mlir"
     "insert_loops_for_vectorization.mlir"
     "load_store_alignment_reset.mlir"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_dma_bd_chain_disable_interleave.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_dma_bd_chain_disable_interleave.mlir
@@ -1,0 +1,154 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-insert-dma-bd-chain{enable-interleave=false})" --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// Even when the `enable-interleave` flag is false, there is only a single BD chain anyway.
+// As a result, the outcome remains the same as when `enable-interleave` is true. 
+// CHECK-LABEL: @single_bd_chain
+// CHECK-COUNT-1: amdaie.npu.dma_wait
+// CHECK-NOT: amdaie.npu.dma_wait
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @single_bd_chain() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    amdaie.workgroup {
+      %tile = amdaie.tile(%c0, %c0)
+      %tile_0 = amdaie.tile(%c0, %c1)
+      %buffer = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_2 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %lock = amdaie.lock(%tile_0(0), 0)
+      %lock_3 = amdaie.lock(%tile_0(1), 0)
+      %channel = amdaie.channel(%tile, 0, port_type = DMA, direction = MM2S)
+      %channel_4 = amdaie.channel(%tile_0, 0, port_type = DMA, direction = S2MM)
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<512x512xbf16>
+      %1 = amdaie.logicalobjectfifo.from_buffers({%buffer, %buffer_2}, {%lock}, {%lock_3}) : memref<1024xbf16, 1 : i32>, memref<1024xbf16, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>
+      %2 = amdaie.logicalobjectfifo.placeholder{%tile} : !amdaie.logicalobjectfifo<memref<512x512xbf16>>
+      %3 = amdaie.flow({%channel} -> {%channel_4}) {is_packet_flow = false}
+      %4 = amdaie.connection(%1 {%channel_4}, %2 {%channel}, flow = %3) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<512x512xbf16>>)
+      amdaie.controlcode {
+        memref.assume_alignment %0, 64 : memref<512x512xbf16>
+        %5 = amdaie.logicalobjectfifo.from_memref %0, {%tile} : memref<512x512xbf16> -> !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %bd_id = amdaie.bd_id(%tile, %c0)
+        %6 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id channel = %channel start_bd = %bd_id) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%6 : !amdaie.async_token)
+        %bd_id_1 = amdaie.bd_id(%tile, %c1)
+        %7 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id_1 channel = %channel start_bd = %bd_id_1) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%7 : !amdaie.async_token)
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Two BD chains are inserted without any interleaving. Same results no matter `enable-interleave` is true or false.
+// CHECK-LABEL: @duplicate_bd_id
+// CHECK-COUNT-2: amdaie.npu.dma_wait
+// CHECK-NOT: amdaie.npu.dma_wait
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @duplicate_bd_id() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    amdaie.workgroup {
+      %tile = amdaie.tile(%c0, %c0)
+      %tile_0 = amdaie.tile(%c0, %c1)
+      %buffer = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_2 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %lock = amdaie.lock(%tile_0(0), 0)
+      %lock_3 = amdaie.lock(%tile_0(1), 0)
+      %channel = amdaie.channel(%tile, 0, port_type = DMA, direction = MM2S)
+      %channel_4 = amdaie.channel(%tile_0, 0, port_type = DMA, direction = S2MM)
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<512x512xbf16>
+      %1 = amdaie.logicalobjectfifo.from_buffers({%buffer, %buffer_2}, {%lock}, {%lock_3}) : memref<1024xbf16, 1 : i32>, memref<1024xbf16, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>
+      %2 = amdaie.logicalobjectfifo.placeholder{%tile} : !amdaie.logicalobjectfifo<memref<512x512xbf16>>
+      %3 = amdaie.flow({%channel} -> {%channel_4}) {is_packet_flow = false}
+      %4 = amdaie.connection(%1 {%channel_4}, %2 {%channel}, flow = %3) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<512x512xbf16>>)
+      amdaie.controlcode {
+        memref.assume_alignment %0, 64 : memref<512x512xbf16>
+        %5 = amdaie.logicalobjectfifo.from_memref %0, {%tile} : memref<512x512xbf16> -> !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %bd_id = amdaie.bd_id(%tile, %c0)
+        %6 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id channel = %channel start_bd = %bd_id) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%6 : !amdaie.async_token)
+        %bd_id_1 = amdaie.bd_id(%tile, %c1)
+        %7 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id_1 channel = %channel start_bd = %bd_id_1) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%7 : !amdaie.async_token)
+        %bd_id_2 = amdaie.bd_id(%tile, %c2)
+        %8 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id_2 channel = %channel start_bd = %bd_id_2) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%8 : !amdaie.async_token)
+        %9 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id_1 channel = %channel start_bd = %bd_id_1) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%9 : !amdaie.async_token)
+        %10 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id_2 channel = %channel start_bd = %bd_id_2) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%10 : !amdaie.async_token)
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// There could be two interleaved BD chains. However, since the `enable-interleave` flag is false, no chain can be finally inserted.
+// CHECK-LABEL: @two_connections
+// CHECK-COUNT-4: amdaie.npu.dma_wait
+// CHECK-NOT: amdaie.npu.dma_wait
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @two_connections() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    amdaie.workgroup {
+      %tile = amdaie.tile(%c0, %c0)
+      %tile_0 = amdaie.tile(%c0, %c1)
+      %buffer = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_4 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_5 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_6 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %lock = amdaie.lock(%tile_0(0), 0)
+      %lock_7 = amdaie.lock(%tile_0(1), 0)
+      %lock_8 = amdaie.lock(%tile_0(2), 0)
+      %lock_9 = amdaie.lock(%tile_0(3), 0)
+      %channel = amdaie.channel(%tile, 0, port_type = DMA, direction = MM2S)
+      %channel_10 = amdaie.channel(%tile_0, 0, port_type = DMA, direction = S2MM)
+      %channel_11 = amdaie.channel(%tile, 1, port_type = DMA, direction = MM2S)
+      %channel_12 = amdaie.channel(%tile_0, 1, port_type = DMA, direction = S2MM)
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<512x512xbf16>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<512x512xbf16>
+      %2 = amdaie.logicalobjectfifo.from_buffers({%buffer, %buffer_4}, {%lock}, {%lock_7}) : memref<1024xbf16, 1 : i32>, memref<1024xbf16, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>
+      %3 = amdaie.logicalobjectfifo.placeholder{%tile} : !amdaie.logicalobjectfifo<memref<512x512xbf16>>
+      %4 = amdaie.flow({%channel} -> {%channel_10}) {is_packet_flow = false}
+      %5 = amdaie.connection(%2 {%channel_10}, %3 {%channel}, flow = %4) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<512x512xbf16>>)
+      %6 = amdaie.logicalobjectfifo.from_buffers({%buffer_5, %buffer_6}, {%lock_8}, {%lock_9}) : memref<1024xbf16, 1 : i32>, memref<1024xbf16, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>
+      %7 = amdaie.logicalobjectfifo.placeholder{%tile} : !amdaie.logicalobjectfifo<memref<512x512xbf16>>
+      %8 = amdaie.flow({%channel_11} -> {%channel_12}) {is_packet_flow = false}
+      %9 = amdaie.connection(%6 {%channel_11}, %7 {%channel_12}, flow = %8) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<512x512xbf16>>)
+      amdaie.controlcode {
+        memref.assume_alignment %0, 64 : memref<512x512xbf16>
+        %10 = amdaie.logicalobjectfifo.from_memref %0, {%tile} : memref<512x512xbf16> -> !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %11 = amdaie.logicalobjectfifo.from_memref %1, {%tile} : memref<512x512xbf16> -> !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %bd_id = amdaie.bd_id(%tile, %c0)
+        %12 = amdaie.npu.half_dma_cpy_nd async %5(%10 [] [] [] bd_id = %bd_id channel = %channel start_bd = %bd_id) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %bd_id_1 = amdaie.bd_id(%tile, %c1)
+        %13 = amdaie.npu.half_dma_cpy_nd async %9(%11 [] [] [] bd_id = %bd_id_1 channel = %channel_11 start_bd = %bd_id_1) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%12 : !amdaie.async_token)
+        amdaie.npu.dma_wait(%13 : !amdaie.async_token)
+        %bd_id_2 = amdaie.bd_id(%tile, %c2)
+        %14 = amdaie.npu.half_dma_cpy_nd async %5(%10 [] [] [] bd_id = %bd_id_2 channel = %channel start_bd = %bd_id_2) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %bd_id_3 = amdaie.bd_id(%tile, %c3)
+        %15 = amdaie.npu.half_dma_cpy_nd async %9(%11 [] [] [] bd_id = %bd_id_3 channel = %channel_11 start_bd = %bd_id_3) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%14 : !amdaie.async_token)
+        amdaie.npu.dma_wait(%15 : !amdaie.async_token)
+        amdaie.end
+      }
+    }
+    return
+  }
+}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_dma_bd_chain_disable_interleave.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_dma_bd_chain_disable_interleave.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-insert-dma-bd-chain{enable-interleave=false})" --split-input-file --verify-diagnostics %s | FileCheck %s
 
-// Even when the `enable-interleave` flag is false, there is only a single BD chain anyway.
-// As a result, the outcome remains the same as when `enable-interleave` is true. 
+// There is only a single BD chain anyway.
+// Same results no matter `enable-interleave` is true or false.
 // CHECK-LABEL: @single_bd_chain
 // CHECK-COUNT-1: amdaie.npu.dma_wait
 // CHECK-NOT: amdaie.npu.dma_wait
@@ -43,7 +43,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 
 // -----
 
-// Two BD chains are inserted without any interleaving. Same results no matter `enable-interleave` is true or false.
+// Two BD chains are inserted without any interleaving. 
+// Same results no matter `enable-interleave` is true or false.
 // CHECK-LABEL: @duplicate_bd_id
 // CHECK-COUNT-2: amdaie.npu.dma_wait
 // CHECK-NOT: amdaie.npu.dma_wait
@@ -93,7 +94,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 
 // -----
 
-// There could be two interleaved BD chains. However, since the `enable-interleave` flag is false, no chain can be finally inserted.
+// There could be two interleaved BD chains. 
+// However, since the `enable-interleave` flag is false, no chain can be finally inserted.
 // CHECK-LABEL: @two_connections
 // CHECK-COUNT-4: amdaie.npu.dma_wait
 // CHECK-NOT: amdaie.npu.dma_wait


### PR DESCRIPTION
Interleaved BD chains may alter the issuing order of control packets, potentially leading to incorrect configurations. Disabled for now to ensure correctness.