### PR TITLE
[CtrlPkt] Transfer multiple control packets per DMA BD on Strix

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
@@ -1467,7 +1467,14 @@ LogicalResult generateControlPackets(
   pm.addPass(createCanonicalizerPass());
   // Optimize the controlcode size.
   pm.addPass(createAMDAIENpuDmaToHalfDmaCpyNdPass());
-  pm.addPass(createAMDAIEInsertDmaBdChainPass());
+  {
+    // Building multple BD chains in an interleaved way can disrupt the ordering
+    // of the reconfiguration data. Disabled for now.
+    // TODO (zhewen): check if possible to (partially) enable this.
+    AMDAIEInsertDmaBdChainOptions options;
+    options.enableInterleave = false;
+    pm.addPass(createAMDAIEInsertDmaBdChainPass(options));
+  }
   pm.addPass(createAMDAIEFoldDmaWaitsPass());
   // Lower the DMA instructions for sending control packets.
   {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlPacketToNpuDma.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlPacketToNpuDma.cpp
@@ -7,6 +7,7 @@
 #include "iree-amd-aie/IR/AMDAIEDialect.h"
 #include "iree-amd-aie/IR/AMDAIEOps.h"
 #include "iree-amd-aie/Transforms/Passes.h"
+#include "iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.h"
 #include "iree-amd-aie/Transforms/Utils/AMDAIEUtils.h"
 #include "iree-amd-aie/aie_runtime/iree_aie_runtime.h"
 #include "mlir/IR/AsmState.h"
@@ -17,6 +18,13 @@
 namespace mlir::iree_compiler::AMDAIE {
 
 namespace {
+
+struct CtrlPktBdTransfer {
+  AMDAIE::ConnectionOp connectionOp;
+  SmallVector<int64_t> offsets;
+  SmallVector<int64_t> sizes;
+  SmallVector<int64_t> strides;
+};
 
 struct ControlPacketDmaBuilder {
   AMDAIE::AMDAIEDeviceModel deviceModel;
@@ -69,74 +77,161 @@ struct ControlPacketDmaBuilder {
     if (res.wasInterrupted()) return failure();
 
     std::vector<AMDAIE::NpuControlPacketOp> ctrlPktOps;
-    // Convert `NpuControlPacketOp` to `NpuDmaCpyNdOp` + `NpuDmaWaitOp`.
+    std::vector<CtrlPktBdTransfer> ctrlPktBdTransfers;
+    // Convert `NpuControlPacketOp` to BD transfers.
     res = workgroupOp->walk([&](AMDAIE::NpuControlPacketOp ctrlPktOp) {
       ctrlPktOps.push_back(ctrlPktOp);
       // Get `ConnectionOp` for the `CTRL` port.
       uint32_t address = ctrlPktOp.getAddress();
       uint32_t addrOffset = deviceModel.getOffsetFromAddress(address);
-      int32_t col = deviceModel.getColumnFromAddress(address);
-      int32_t row = deviceModel.getRowFromAddress(address);
-      if (!tileLocToCtrlConnect.count({col, row})) {
+      int32_t destCol = deviceModel.getColumnFromAddress(address);
+      int32_t destRow = deviceModel.getRowFromAddress(address);
+      if (!tileLocToCtrlConnect.count({destCol, destRow})) {
         ctrlPktOp.emitOpError()
-            << "tries to write to tile (col=" << col << ", row=" << row
-            << "), but it's `CTRL` port is not routed.";
+            << "tries to configure the tile (col=" << destCol
+            << ", row=" << destRow << "), but it's `CTRL` port is not routed.";
         return WalkResult::interrupt();
       }
-      AMDAIE::ConnectionOp connectionOp = tileLocToCtrlConnect[{col, row}];
-
-      // Get the source offsets, sizes, and strides.
+      AMDAIE::ConnectionOp connectionOp =
+          tileLocToCtrlConnect[{destCol, destRow}];
+      // Get the source tile location.
+      SmallVector<Value> srcChannels = connectionOp.getSourceChannels();
+      if (srcChannels.size() != 1) {
+        ctrlPktOp.emitOpError() << "expected exactly one source channel";
+        return WalkResult::interrupt();
+      }
+      AMDAIE::ChannelOp srcChannelOp =
+          dyn_cast<AMDAIE::ChannelOp>(srcChannels[0].getDefiningOp());
+      if (!srcChannelOp) {
+        ctrlPktOp.emitOpError() << "expected an `amdaie.channel` op source";
+        return WalkResult::interrupt();
+      }
+      AMDAIE::TileOp srcTileOp = srcChannelOp.getTileOp();
+      int32_t srcCol = getConstantIndexOrAssert(srcTileOp.getCol());
+      int32_t srcRow = getConstantIndexOrAssert(srcTileOp.getRow());
+      // Get the control packet data length.
       uint32_t dataLength = ctrlPktOp.getLength();
+      // Plus one for the control header, which is always present.
       int64_t headerAndDataLength = dataLength + 1;
-      SmallVector<int64_t> dmaSourceOffsets{
-          0, 0, 0, static_cast<long>(ctrlPktSequence.size())};
-      SmallVector<int64_t> dmaSourceSizes{1, 1, 1, headerAndDataLength};
-      SmallVector<int64_t> dmaSourceStrides{0, 0, 0, 1};
-      // Target offsets, sizes, and strides are left empty.
-      SmallVector<int64_t> dmaTargetOffsets;
-      SmallVector<int64_t> dmaTargetSizes;
-      SmallVector<int64_t> dmaTargetStrides;
 
-      // Store the control packet header.
+      // If the AIE device has the control packet TLAST error enabled,
+      // shim DMA can only issue one control packet per BD transfer. Otherwise,
+      // we may pack multiple control packets into a single BD transfer.
+      FailureOr<bool> tlastErrorEnabled =
+          deviceModel.hasCtrlPktTlastErrorEnabled();
+      if (failed(tlastErrorEnabled)) {
+        ctrlPktOp.emitOpError()
+            << "failed to check if the control packet TLAST "
+               "error is enabled.";
+        return WalkResult::interrupt();
+      }
+      // Check if the packing is feasible.
+      bool packIntoLastBdTransfer = false;
+      if (!(*tlastErrorEnabled) && ctrlPktBdTransfers.size() > 0) {
+        const CtrlPktBdTransfer &lastBdTransfer = ctrlPktBdTransfers.back();
+        // Check if the same connection is used.
+        if (lastBdTransfer.connectionOp == connectionOp) {
+          if (!deviceModel.isShimTile(srcCol, srcRow)) {
+            ctrlPktOp.emitOpError()
+                << "expected the source tile to be a shim tile";
+            return WalkResult::interrupt();
+          }
+          uint32_t maxIntraSize = deviceModel.getDmaBdProp<uint16_t>(
+              AMDAIE::AMDAIETileType::SHIMNOC, 0,
+              AMDAIE::AMDAIEDmaBdProp::WrapMax);
+          // Check if the new sizes are still valid.
+          SmallVector<int64_t> newBdTransferSizes = lastBdTransfer.sizes;
+          // Plus one for the extra packet header.
+          newBdTransferSizes.back() += (headerAndDataLength + 1);
+          // TODO(zhewen): use all dimensions available.
+          packIntoLastBdTransfer = newBdTransferSizes.back() <= maxIntraSize;
+        }
+      }
+      if (packIntoLastBdTransfer) {
+        // Pack into the last BD transfer.
+        // Plus one for the extra packet header.
+        headerAndDataLength++;
+        ctrlPktBdTransfers.back().sizes.back() += headerAndDataLength;
+      } else {
+        // Create a new BD transfer.
+        ctrlPktBdTransfers.push_back(
+            {connectionOp,
+             /*offsets=*/
+             {0, 0, 0, static_cast<int64_t>(ctrlPktSequence.size())},
+             /*sizes=*/{1, 1, 1, headerAndDataLength},
+             /*strides=*/{0, 0, 0, 1}});
+      }
+
       llvm::MutableArrayRef<uint32_t> words =
           reserveAndGetTail(headerAndDataLength);
-      FailureOr<uint32_t> header = deviceModel.getCtrlPktHeader(
+      size_t idx = 0;
+      // Store the optional packet header.
+      if (packIntoLastBdTransfer) {
+        // Each control packet requires a packet header, but only the
+        // first control packet in a BD transfer has its header automatically
+        // inserted by the shim DMA. For all subsequent control packets in the
+        // same BD transfer, we must "manually" insert the packet header.
+        std::optional<AMDAIE::FlowOp> maybeFlowOp = connectionOp.getFlowOp();
+        if (!maybeFlowOp) {
+          ctrlPktOp.emitOpError()
+              << "expected a flow operation for the connection";
+          return WalkResult::interrupt();
+        }
+        std::optional<uint8_t> maybePacketId = maybeFlowOp->getPacketId();
+        if (!maybePacketId) {
+          ctrlPktOp.emitOpError() << "expected a packet ID for the flow";
+          return WalkResult::interrupt();
+        }
+        FailureOr<uint32_t> packetHeader = deviceModel.getPacketHeader(
+            *maybePacketId, /*packetType=*/0, srcRow, srcCol);
+        if (failed(packetHeader)) {
+          ctrlPktOp.emitOpError() << "failed to get packet header.";
+          return WalkResult::interrupt();
+        }
+        words[idx++] = *packetHeader;
+      }
+      // Store the control header.
+      FailureOr<uint32_t> ctrlPktHeader = deviceModel.getCtrlPktHeader(
           addrOffset, dataLength, static_cast<uint32_t>(ctrlPktOp.getOpcode()),
           ctrlPktOp.getStreamId());
-      if (failed(header)) {
-        ctrlPktOp.emitOpError() << "failed to get control packet header.";
+      if (failed(ctrlPktHeader)) {
+        ctrlPktOp.emitOpError() << "failed to get control header.";
         return WalkResult::interrupt();
       }
-
-      words[0] = *header;
+      words[idx++] = *ctrlPktHeader;
       // Store the control packet data.
       std::optional<ArrayRef<int32_t>> maybeData =
           ctrlPktOp.getDataFromArrayOrResource();
-      if (maybeData.has_value()) {
-        for (uint32_t i = 0; i < dataLength; ++i) {
-          int32_t data = maybeData.value()[i];
-          words[i + 1] = reinterpret_cast<uint32_t &>(data);
-        }
-      }
-
-      rewriter.setInsertionPoint(ctrlPktOp);
-      // Create token.
-      SmallVector<Type> resultTypes = {
-          rewriter.getType<AMDAIE::AsyncSourceTokenType>()};
-      TypeRange sourceResultTypes = TypeRange{resultTypes};
-
-      // Create `NpuDmaCpyNdOp` and `NpuDmaWaitOp`.
-      auto dmaOp = rewriter.create<AMDAIE::NpuDmaCpyNdOp>(
-          rewriter.getUnknownLoc(), sourceResultTypes, connectionOp, nullptr,
-          dmaTargetOffsets, dmaTargetSizes, dmaTargetStrides,
-          /*target_bd_id=*/nullptr, connectionOp.getSource(), dmaSourceOffsets,
-          dmaSourceSizes, dmaSourceStrides, /*source_bd_id=*/nullptr);
-      rewriter.create<AMDAIE::NpuDmaWaitOp>(rewriter.getUnknownLoc(),
-                                            dmaOp.getResult(0));
+      for (int32_t data : maybeData.value())
+        words[idx++] = reinterpret_cast<uint32_t &>(data);
 
       return WalkResult::advance();
     });
     if (res.wasInterrupted()) return failure();
+
+    // Convert each control packet BD transfer to a `NpuDmaCpyNdOp` and
+    // `NpuDmaWaitOp`.
+    Block *controlCodeBlock = workgroupOp.getControlCode().getBody();
+    rewriter.setInsertionPoint(controlCodeBlock->getTerminator());
+    for (CtrlPktBdTransfer &stream : ctrlPktBdTransfers) {
+      // Target offsets, sizes, and strides are left empty.
+      SmallVector<int64_t> dmaTargetOffsets;
+      SmallVector<int64_t> dmaTargetSizes;
+      SmallVector<int64_t> dmaTargetStrides;
+      // Create token.
+      SmallVector<Type> resultTypes = {
+          rewriter.getType<AMDAIE::AsyncSourceTokenType>()};
+      TypeRange sourceResultTypes = TypeRange{resultTypes};
+      // Create `NpuDmaCpyNdOp` and `NpuDmaWaitOp`.
+      auto dmaOp = rewriter.create<AMDAIE::NpuDmaCpyNdOp>(
+          rewriter.getUnknownLoc(), sourceResultTypes, stream.connectionOp,
+          nullptr, dmaTargetOffsets, dmaTargetSizes, dmaTargetStrides,
+          /*target_bd_id=*/nullptr, stream.connectionOp.getSource(),
+          stream.offsets, stream.sizes, stream.strides,
+          /*source_bd_id=*/nullptr);
+      rewriter.create<AMDAIE::NpuDmaWaitOp>(rewriter.getUnknownLoc(),
+                                            dmaOp.getResult(0));
+    }
 
     // Erase all the `NpuControlPacketOp`.
     for (AMDAIE::NpuControlPacketOp ctrlPktOp : ctrlPktOps)

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertDmaBdChain.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertDmaBdChain.cpp
@@ -64,7 +64,7 @@ LogicalResult updateChainOperands(
 }
 
 /// Utility function to determine if chains can grow further
-/// or require breaking.
+/// or require breaking, depending on if there is any duplicate BD ID.
 ///
 /// Example:
 /// - Chain X currently holds BD IDs: [4, 5, 6, 7]
@@ -82,18 +82,16 @@ LogicalResult updateChainOperands(
 /// - Break both chains X and Y.
 ///   - Chain X: [0] (the newly added BD ID).
 ///   - Chain Y: [] (emptied after breaking).
-void checkForChainsToBeBroken(
+void checkForChainsWithDuplicateBdId(
     uint32_t currBdId, const DmaChain &currDmaChain,
     const DenseMap<DmaChain, DenseSet<uint32_t>> &dmaChainToBdIds,
-    SmallVector<DmaChain> &chainsToBreak) {
+    llvm::SmallSetVector<DmaChain, 4> &chainsToBreak) {
   for (auto &[entry, bdIds] : dmaChainToBdIds) {
     if (entry.first == currDmaChain.first && bdIds.contains(currBdId)) {
       // Break the chain that contains the duplicate BD ID.
-      chainsToBreak.push_back(entry);
-      if (entry != currDmaChain) {
-        // Break the current chain as well.
-        chainsToBreak.push_back(currDmaChain);
-      }
+      chainsToBreak.insert(entry);
+      // Break the current chain as well.
+      if (entry != currDmaChain) chainsToBreak.insert(currDmaChain);
       break;
     }
   }
@@ -103,7 +101,8 @@ void checkForChainsToBeBroken(
 /// traversal simplifies handling duplicate BD IDs, preventing the need to
 /// revisit and modify earlier operations after processing later ones.
 LogicalResult insertDmaBdChain(const AMDAIE::AMDAIEDeviceModel &deviceModel,
-                               AMDAIE::ControlCodeOp controlCodeOp) {
+                               AMDAIE::ControlCodeOp controlCodeOp,
+                               bool enableInterleave) {
   IRRewriter rewriter(controlCodeOp->getContext());
 
   // Move all BdIdOps to the beginning of the control code.
@@ -184,13 +183,19 @@ LogicalResult insertDmaBdChain(const AMDAIE::AMDAIEDeviceModel &deviceModel,
         return WalkResult::interrupt();
       }
 
+      llvm::SmallSetVector<DmaChain, 4> chainsToBreak;
+      DmaChain currDmaChain = {tileOp, connectionOp};
+      // Check if there are other chains being built in an interleaved way.
+      if (!enableInterleave) {
+        for (auto &entry : dmaChainToBdIds) {
+          if (entry.first != currDmaChain) chainsToBreak.insert(entry.first);
+        }
+      }
       // Any duplicate BD ID from the same tile indicates that the chain
       // cannot grow further and requires breaking to release the
       // conflicting BD ID.
-      SmallVector<DmaChain> chainsToBreak;
-      DmaChain currDmaChain = {tileOp, connectionOp};
-      checkForChainsToBeBroken(bdId, currDmaChain, dmaChainToBdIds,
-                               chainsToBreak);
+      checkForChainsWithDuplicateBdId(bdId, currDmaChain, dmaChainToBdIds,
+                                      chainsToBreak);
 
       // If the chains are not to be continued, update DMA operands using
       // the `updateChainOperands` function.
@@ -202,8 +207,8 @@ LogicalResult insertDmaBdChain(const AMDAIE::AMDAIEDeviceModel &deviceModel,
                        dmaChainToDmaOps[entry].end());
           if (failed(updateChainOperands(rewriter, dmaChainToDmaOps[entry])))
             WalkResult::interrupt();
-          dmaChainToBdIds[entry].clear();
-          dmaChainToDmaOps[entry].clear();
+          dmaChainToBdIds.erase(entry);
+          dmaChainToDmaOps.erase(entry);
         }
       }
       dmaChainToBdIds[currDmaChain].insert(bdId);
@@ -235,6 +240,8 @@ class AMDAIEInsertDmaBdChainPass
 
   AMDAIEInsertDmaBdChainPass() = default;
   AMDAIEInsertDmaBdChainPass(const AMDAIEInsertDmaBdChainPass &pass){};
+  AMDAIEInsertDmaBdChainPass(const AMDAIEInsertDmaBdChainOptions &options)
+      : AMDAIEInsertDmaBdChainBase(options) {}
   void runOnOperation() override;
 };
 
@@ -255,7 +262,8 @@ void AMDAIEInsertDmaBdChainPass::runOnOperation() {
 
   WalkResult res = parentOp->walk([&](AMDAIE::WorkgroupOp workgroupOp) {
     AMDAIE::ControlCodeOp controlCodeOp = workgroupOp.getControlCode();
-    if (failed(insertDmaBdChain(deviceModel, controlCodeOp))) {
+    if (failed(
+            insertDmaBdChain(deviceModel, controlCodeOp, enableInterleave))) {
       return WalkResult::interrupt();
     }
     return WalkResult::advance();
@@ -265,8 +273,9 @@ void AMDAIEInsertDmaBdChainPass::runOnOperation() {
 
 }  // namespace
 
-std::unique_ptr<Pass> createAMDAIEInsertDmaBdChainPass() {
-  return std::make_unique<AMDAIEInsertDmaBdChainPass>();
+std::unique_ptr<Pass> createAMDAIEInsertDmaBdChainPass(
+    AMDAIEInsertDmaBdChainOptions options) {
+  return std::make_unique<AMDAIEInsertDmaBdChainPass>(options);
 }
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -217,7 +217,8 @@ std::unique_ptr<Pass> createAMDAIEHoistForLoopAffineApplyPass();
 std::unique_ptr<Pass> createAMDAIEHoistLogicalObjFifoPass();
 
 /// Create pass to chain DMA BD IDs by updating next_bd operands.
-std::unique_ptr<Pass> createAMDAIEInsertDmaBdChainPass();
+std::unique_ptr<Pass> createAMDAIEInsertDmaBdChainPass(
+    AMDAIEInsertDmaBdChainOptions options = {});
 
 /// Create a pass to transform linalg.generics into a form which benefits later
 /// vectorization passes (to vector and aievec dialects).

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -406,6 +406,10 @@ def AMDAIEInsertDmaBdChain :
     Pass<"iree-amdaie-insert-dma-bd-chain"> {
   let summary = "Chain DMA BD IDs by updating next_bd operands.";
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIEInsertDmaBdChainPass()";
+  let options = [
+    Option<"enableInterleave", "enable-interleave", "bool", /*default=*/"true",
+      "Enable multiple BD chains to be built in an interleaved way.">,
+  ];
 }
 
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
@@ -55,6 +55,7 @@ iree_lit_test_suite(
     "hoist_logical_obj_fifo.mlir"
     "insert_cores.mlir"
     "insert_dma_bd_chain.mlir"
+    "insert_dma_bd_chain_disable_interleave.mlir"
     "insert_infinite_loop_around_core_block.mlir"
     "insert_loops_for_vectorization.mlir"
     "load_store_alignment_reset.mlir"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/control_packet_to_npu_dma.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/control_packet_to_npu_dma.mlir
@@ -21,7 +21,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     amdaie.workgroup {
       %tile_0_0 = amdaie.tile(%c0, %c0)
       amdaie.controlcode {
-        // expected-error @+1 {{op tries to write to tile (col=0, row=0), but it's `CTRL` port is not routed}}
+        // expected-error @+1 {{op tries to configure the tile (col=0, row=0), but it's `CTRL` port is not routed}}
         amdaie.npu.control_packet write {address = 126976 : ui32, data = array<i32: 1024>, length = 1 : ui32, stream_id = 0 : ui32}
         amdaie.end
       }
@@ -44,7 +44,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:         %[[CHANNEL_0:.*]] = amdaie.channel(%[[TILE_0_2]], 0, port_type = CTRL, direction = S2MM)
 // CHECK:         %[[PLACE_HOLDER:.*]] = amdaie.logicalobjectfifo.placeholder{%[[TILE_0_0]]} : !amdaie.logicalobjectfifo<memref<?xi32>>
 // CHECK:         %[[PLACE_HOLDER_0:.*]] = amdaie.logicalobjectfifo.placeholder{%[[TILE_0_2]]} : !amdaie.logicalobjectfifo<memref<?xi32>>
-// CHECK:         %[[CONNECTION:.*]] = amdaie.connection(%[[PLACE_HOLDER_0]] {%[[CHANNEL_0]]}, %[[PLACE_HOLDER]] {%[[CHANNEL]]}) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<?xi32>>, !amdaie.logicalobjectfifo<memref<?xi32>>)
+// CHECK:         %[[FLOW:.*]] = amdaie.flow({%[[CHANNEL]]} -> {%[[CHANNEL_0]]}) {is_packet_flow = true, packet_id = 2 : ui8}
+// CHECK:         %[[CONNECTION:.*]] = amdaie.connection(%[[PLACE_HOLDER_0]] {%[[CHANNEL_0]]}, %[[PLACE_HOLDER]] {%[[CHANNEL]]}, flow = %[[FLOW]]) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<?xi32>>, !amdaie.logicalobjectfifo<memref<?xi32>>)
 // CHECK:         amdaie.controlcode {
 // CHECK:           %[[TOKEN:.*]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION]]([] [] [], %[[PLACE_HOLDER]][0, 0, 0, 0] [1, 1, 1, 2] [0, 0, 0, 1]) : source_type = !amdaie.logicalobjectfifo<memref<?xi32>>
 // CHECK:           amdaie.npu.dma_wait(%[[TOKEN]] : !amdaie.async_source_token)
@@ -63,7 +64,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %channel_0 = amdaie.channel(%tile_0_2, 0, port_type = CTRL, direction = S2MM)
       %0 = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<?xi32>>
       %1 = amdaie.logicalobjectfifo.placeholder{%tile_0_2} : !amdaie.logicalobjectfifo<memref<?xi32>>
-      %2 = amdaie.connection(%1 {%channel_0}, %0 {%channel}) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<?xi32>>, !amdaie.logicalobjectfifo<memref<?xi32>>)
+      %2 = amdaie.flow({%channel} -> {%channel_0}) {is_packet_flow = true, packet_id = 2 : ui8}
+      %3 = amdaie.connection(%1 {%channel_0}, %0 {%channel}, flow = %2) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<?xi32>>, !amdaie.logicalobjectfifo<memref<?xi32>>)
       amdaie.controlcode {
         amdaie.npu.control_packet write {address = 2301952 : ui32, data = array<i32: 0>, length = 1 : ui32, stream_id = 0 : ui32}
         amdaie.end
@@ -88,9 +90,10 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %channel_0 = amdaie.channel(%tile_0_2, 0, port_type = CTRL, direction = S2MM)
       %0 = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<?xi32>>
       %1 = amdaie.logicalobjectfifo.placeholder{%tile_0_2} : !amdaie.logicalobjectfifo<memref<?xi32>>
-      %2 = amdaie.connection(%1 {%channel_0}, %0 {%channel}) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<?xi32>>, !amdaie.logicalobjectfifo<memref<?xi32>>)
+      %2 = amdaie.flow({%channel} -> {%channel_0}) {is_packet_flow = true, packet_id = 2 : ui8}
+      %3 = amdaie.connection(%1 {%channel_0}, %0 {%channel}, flow = %2) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<?xi32>>, !amdaie.logicalobjectfifo<memref<?xi32>>)
       amdaie.controlcode {
-        // expected-error @+1 {{op failed to get control packet header}}
+        // expected-error @+1 {{op failed to get control header}}
         amdaie.npu.control_packet write {address = 2228224 : ui32, data = array<i32: 0, 1, 2, 3, 4>, length = 5 : ui32, stream_id = 0 : ui32}
         amdaie.end
       }
@@ -126,7 +129,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %channel_0 = amdaie.channel(%tile_0_2, 0, port_type = CTRL, direction = S2MM)
       %0 = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<?xi32>>
       %1 = amdaie.logicalobjectfifo.placeholder{%tile_0_2} : !amdaie.logicalobjectfifo<memref<?xi32>>
-      %2 = amdaie.connection(%1 {%channel_0}, %0 {%channel}) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<?xi32>>, !amdaie.logicalobjectfifo<memref<?xi32>>)
+      %2 = amdaie.flow({%channel} -> {%channel_0}) {is_packet_flow = true, packet_id = 2 : ui8}
+      %3 = amdaie.connection(%1 {%channel_0}, %0 {%channel}, flow = %2) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<?xi32>>, !amdaie.logicalobjectfifo<memref<?xi32>>)
       amdaie.controlcode {
 // CHECK: 0x00032000
 // CHECK: 0x00000000
@@ -228,3 +232,41 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK-COUNT-21: amdaie.npu.dma_cpy_nd
 // CHECK-NOT:      amdaie.npu.dma_cpy_nd
 // CHECK:       {ctrlpkt_sequence = dense_resource<ctrlpkt_sequence> : tensor<69xui32>}
+
+// -----
+
+// NPU4 can transfer multiple control packets per BD.
+// Expect only one DMA copy operation is generated.
+// CHECK-LABEL: @tlast_error_suppress
+// CHECK-COUNT-1: amdaie.npu.dma_cpy_nd
+// CHECK-NOT:     amdaie.npu.dma_cpy_nd
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu4", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @tlast_error_suppress() {
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : index
+    amdaie.workgroup {
+      %tile_0_0 = amdaie.tile(%c0, %c0)
+      %tile_0_2 = amdaie.tile(%c0, %c2)
+      %channel = amdaie.channel(%tile_0_0, 0, port_type = DMA, direction = MM2S)
+      %channel_0 = amdaie.channel(%tile_0_2, 0, port_type = CTRL, direction = S2MM)
+      %0 = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<?xi32>>
+      %1 = amdaie.logicalobjectfifo.placeholder{%tile_0_2} : !amdaie.logicalobjectfifo<memref<?xi32>>
+      %2 = amdaie.flow({%channel} -> {%channel_0}) {is_packet_flow = true, packet_id = 2 : ui8}
+      %3 = amdaie.connection(%1 {%channel_0}, %0 {%channel}, flow = %2) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<?xi32>>, !amdaie.logicalobjectfifo<memref<?xi32>>)
+      amdaie.controlcode {
+        amdaie.npu.control_packet write {address = 2228224 : ui32, data = array<i32: 536871189, 5570560, 462048, 65537>, length = 4 : ui32, stream_id = 0 : ui32}
+        amdaie.npu.control_packet write {address = 2228240 : ui32, data = array<i32: 65537, 231479, 0, 0>, length = 4 : ui32, stream_id = 0 : ui32}
+        amdaie.npu.control_packet write {address = 2228256 : ui32, data = array<i32: 231607, 192, 0, 65537>, length = 4 : ui32, stream_id = 0 : ui32}
+        amdaie.npu.control_packet write {address = 2228272 : ui32, data = array<i32: 402657467, 134218176, -2145845248, 67586>, length = 4 : ui32, stream_id = 0 : ui32}
+        amdaie.npu.control_packet write {address = 2228288 : ui32, data = array<i32: 268435733, 538509312, 2123970563, -1030156292>, length = 4 : ui32, stream_id = 0 : ui32}
+        amdaie.npu.control_packet write {address = 2228304 : ui32, data = array<i32: -161935364, 1220222780, 268965891, -3772416>, length = 4 : ui32, stream_id = 0 : ui32}
+        amdaie.npu.control_packet write {address = 2228320 : ui32, data = array<i32: 268437529, 65537, 65537, -1025966079>, length = 4 : ui32, stream_id = 0 : ui32}
+        amdaie.npu.control_packet write {address = 2228336 : ui32, data = array<i32: 67580, 65537, 65537, 133988057>, length = 4 : ui32, stream_id = 0 : ui32}
+        amdaie.npu.control_packet write {address = 2228352 : ui32, data = array<i32: 268441625, 65537, 65537, 1073733657>, length = 4 : ui32, stream_id = 0 : ui32}
+        amdaie.end
+      }
+    }
+    return
+  }
+}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_dma_bd_chain_disable_interleave.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_dma_bd_chain_disable_interleave.mlir
@@ -1,0 +1,156 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-insert-dma-bd-chain{enable-interleave=false})" --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// There is only a single BD chain anyway.
+// Same results no matter `enable-interleave` is true or false.
+// CHECK-LABEL: @single_bd_chain
+// CHECK-COUNT-1: amdaie.npu.dma_wait
+// CHECK-NOT: amdaie.npu.dma_wait
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @single_bd_chain() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    amdaie.workgroup {
+      %tile = amdaie.tile(%c0, %c0)
+      %tile_0 = amdaie.tile(%c0, %c1)
+      %buffer = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_2 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %lock = amdaie.lock(%tile_0(0), 0)
+      %lock_3 = amdaie.lock(%tile_0(1), 0)
+      %channel = amdaie.channel(%tile, 0, port_type = DMA, direction = MM2S)
+      %channel_4 = amdaie.channel(%tile_0, 0, port_type = DMA, direction = S2MM)
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<512x512xbf16>
+      %1 = amdaie.logicalobjectfifo.from_buffers({%buffer, %buffer_2}, {%lock}, {%lock_3}) : memref<1024xbf16, 1 : i32>, memref<1024xbf16, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>
+      %2 = amdaie.logicalobjectfifo.placeholder{%tile} : !amdaie.logicalobjectfifo<memref<512x512xbf16>>
+      %3 = amdaie.flow({%channel} -> {%channel_4}) {is_packet_flow = false}
+      %4 = amdaie.connection(%1 {%channel_4}, %2 {%channel}, flow = %3) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<512x512xbf16>>)
+      amdaie.controlcode {
+        memref.assume_alignment %0, 64 : memref<512x512xbf16>
+        %5 = amdaie.logicalobjectfifo.from_memref %0, {%tile} : memref<512x512xbf16> -> !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %bd_id = amdaie.bd_id(%tile, %c0)
+        %6 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id channel = %channel start_bd = %bd_id) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%6 : !amdaie.async_token)
+        %bd_id_1 = amdaie.bd_id(%tile, %c1)
+        %7 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id_1 channel = %channel start_bd = %bd_id_1) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%7 : !amdaie.async_token)
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Two BD chains are inserted without any interleaving.
+// Same results no matter `enable-interleave` is true or false.
+// CHECK-LABEL: @duplicate_bd_id
+// CHECK-COUNT-2: amdaie.npu.dma_wait
+// CHECK-NOT: amdaie.npu.dma_wait
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @duplicate_bd_id() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    amdaie.workgroup {
+      %tile = amdaie.tile(%c0, %c0)
+      %tile_0 = amdaie.tile(%c0, %c1)
+      %buffer = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_2 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %lock = amdaie.lock(%tile_0(0), 0)
+      %lock_3 = amdaie.lock(%tile_0(1), 0)
+      %channel = amdaie.channel(%tile, 0, port_type = DMA, direction = MM2S)
+      %channel_4 = amdaie.channel(%tile_0, 0, port_type = DMA, direction = S2MM)
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<512x512xbf16>
+      %1 = amdaie.logicalobjectfifo.from_buffers({%buffer, %buffer_2}, {%lock}, {%lock_3}) : memref<1024xbf16, 1 : i32>, memref<1024xbf16, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>
+      %2 = amdaie.logicalobjectfifo.placeholder{%tile} : !amdaie.logicalobjectfifo<memref<512x512xbf16>>
+      %3 = amdaie.flow({%channel} -> {%channel_4}) {is_packet_flow = false}
+      %4 = amdaie.connection(%1 {%channel_4}, %2 {%channel}, flow = %3) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<512x512xbf16>>)
+      amdaie.controlcode {
+        memref.assume_alignment %0, 64 : memref<512x512xbf16>
+        %5 = amdaie.logicalobjectfifo.from_memref %0, {%tile} : memref<512x512xbf16> -> !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %bd_id = amdaie.bd_id(%tile, %c0)
+        %6 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id channel = %channel start_bd = %bd_id) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%6 : !amdaie.async_token)
+        %bd_id_1 = amdaie.bd_id(%tile, %c1)
+        %7 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id_1 channel = %channel start_bd = %bd_id_1) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%7 : !amdaie.async_token)
+        %bd_id_2 = amdaie.bd_id(%tile, %c2)
+        %8 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id_2 channel = %channel start_bd = %bd_id_2) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%8 : !amdaie.async_token)
+        %9 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id_1 channel = %channel start_bd = %bd_id_1) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%9 : !amdaie.async_token)
+        %10 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id_2 channel = %channel start_bd = %bd_id_2) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%10 : !amdaie.async_token)
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// There could be two interleaved BD chains.
+// However, since the `enable-interleave` flag is false, no chain can be finally inserted.
+// CHECK-LABEL: @two_connections
+// CHECK-COUNT-4: amdaie.npu.dma_wait
+// CHECK-NOT: amdaie.npu.dma_wait
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @two_connections() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    amdaie.workgroup {
+      %tile = amdaie.tile(%c0, %c0)
+      %tile_0 = amdaie.tile(%c0, %c1)
+      %buffer = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_4 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_5 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_6 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %lock = amdaie.lock(%tile_0(0), 0)
+      %lock_7 = amdaie.lock(%tile_0(1), 0)
+      %lock_8 = amdaie.lock(%tile_0(2), 0)
+      %lock_9 = amdaie.lock(%tile_0(3), 0)
+      %channel = amdaie.channel(%tile, 0, port_type = DMA, direction = MM2S)
+      %channel_10 = amdaie.channel(%tile_0, 0, port_type = DMA, direction = S2MM)
+      %channel_11 = amdaie.channel(%tile, 1, port_type = DMA, direction = MM2S)
+      %channel_12 = amdaie.channel(%tile_0, 1, port_type = DMA, direction = S2MM)
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<512x512xbf16>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<512x512xbf16>
+      %2 = amdaie.logicalobjectfifo.from_buffers({%buffer, %buffer_4}, {%lock}, {%lock_7}) : memref<1024xbf16, 1 : i32>, memref<1024xbf16, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>
+      %3 = amdaie.logicalobjectfifo.placeholder{%tile} : !amdaie.logicalobjectfifo<memref<512x512xbf16>>
+      %4 = amdaie.flow({%channel} -> {%channel_10}) {is_packet_flow = false}
+      %5 = amdaie.connection(%2 {%channel_10}, %3 {%channel}, flow = %4) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<512x512xbf16>>)
+      %6 = amdaie.logicalobjectfifo.from_buffers({%buffer_5, %buffer_6}, {%lock_8}, {%lock_9}) : memref<1024xbf16, 1 : i32>, memref<1024xbf16, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>
+      %7 = amdaie.logicalobjectfifo.placeholder{%tile} : !amdaie.logicalobjectfifo<memref<512x512xbf16>>
+      %8 = amdaie.flow({%channel_11} -> {%channel_12}) {is_packet_flow = false}
+      %9 = amdaie.connection(%6 {%channel_11}, %7 {%channel_12}, flow = %8) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<512x512xbf16>>)
+      amdaie.controlcode {
+        memref.assume_alignment %0, 64 : memref<512x512xbf16>
+        %10 = amdaie.logicalobjectfifo.from_memref %0, {%tile} : memref<512x512xbf16> -> !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %11 = amdaie.logicalobjectfifo.from_memref %1, {%tile} : memref<512x512xbf16> -> !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %bd_id = amdaie.bd_id(%tile, %c0)
+        %12 = amdaie.npu.half_dma_cpy_nd async %5(%10 [] [] [] bd_id = %bd_id channel = %channel start_bd = %bd_id) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %bd_id_1 = amdaie.bd_id(%tile, %c1)
+        %13 = amdaie.npu.half_dma_cpy_nd async %9(%11 [] [] [] bd_id = %bd_id_1 channel = %channel_11 start_bd = %bd_id_1) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%12 : !amdaie.async_token)
+        amdaie.npu.dma_wait(%13 : !amdaie.async_token)
+        %bd_id_2 = amdaie.bd_id(%tile, %c2)
+        %14 = amdaie.npu.half_dma_cpy_nd async %5(%10 [] [] [] bd_id = %bd_id_2 channel = %channel start_bd = %bd_id_2) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %bd_id_3 = amdaie.bd_id(%tile, %c3)
+        %15 = amdaie.npu.half_dma_cpy_nd async %9(%11 [] [] [] bd_id = %bd_id_3 channel = %channel_11 start_bd = %bd_id_3) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%14 : !amdaie.async_token)
+        amdaie.npu.dma_wait(%15 : !amdaie.async_token)
+        amdaie.end
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
Quote from architecture spec:

In Phoenix, shim can issue only one control-packet per BD transfer to avoid missing TLAST errors, resulting in low configuration throughput due to many short transfers. In Strix, it allows suppressing TLAST errors for write control-packets, enabling multiple control-packets per BD transfer. This improves throughput by using longer linear transfers.