### PR TITLE
[CI] Clean up Windows temp files older than 30 days

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -194,3 +194,10 @@ jobs:
             --target_device "npu1_4col" \
             --device_hal=xrt \
             --skip_tests "Performance"
+
+      - name: Clean up system temp directory
+        run: |
+            Get-ChildItem "$env:TEMP" -Recurse | Where-Object {
+              -not $_.PSIsContainer -and
+              ($_.LastWriteTime -lt (Get-Date).AddDays(-30))
+            } | Remove-Item -ErrorAction SilentlyContinue


### PR DESCRIPTION
During the compilation process, some log files are dumped to the system temp directory by default. 
https://github.com/nod-ai/iree-amd-aie/blob/357698b70dd329239cbf7d2c28e2683560972c2a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp#L564
However, on Windows machines, this directory is not automatically cleaned up, leading to accumulated files that can cause CI failures or significantly slow down runs.