### PR TITLE
[AssignTiles] Update algo to take into account tile memory limitations

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -2338,6 +2338,20 @@ class Tests:
                 "run_on_target": "npu4",
                 "use_chess_for_ukernel": False,
             },
+            {
+                "M": 1024,
+                "N": 4096 * 4,
+                "K": 512,
+                "in_dtype": "i8",
+                "use_ukernel": True,
+                "matmul4d": True,
+                "scale_trunc": True,
+                "tile_pipeline": "pack-peel-4-level-tiling",
+                "run_on_target": "npu4",
+                "use_chess": False,
+                "use_chess_for_ukernel": False,
+                "peano_opt_level": 1,
+            },
         ]
 
         # Some bf16 Performance tests:
@@ -2354,6 +2368,7 @@ class Tests:
             tile_pipeline = test.get("tile_pipeline", "pack-peel")
             matmul4d = test.get("matmul4d", False)
             scale_trunc = test.get("scale_trunc", False)
+            use_chess = test.get("use_chess", False)
             use_chess_for_ukernel = test.get("use_chess_for_ukernel", True)
             run_on_target = test.get("run_on_target", "npu1_4col")
             in_dtype = test.get("in_dtype", "bf16")
@@ -2453,6 +2468,7 @@ class Tests:
                             aie_compilation_flags=aie_compilation_flags,
                             name_suffix=name_suffix,
                             n_repeats=2,
+                            use_chess=use_chess,
                             use_chess_for_ukernel=use_chess_for_ukernel,
                         ),
                         additional_labels=["PerformanceCorrectness"]
@@ -2474,6 +2490,7 @@ class Tests:
                     name_suffix=name_suffix,
                     run_benchmark=True,
                     n_repeats=n_performance_repeats,
+                    use_chess=use_chess,
                     use_chess_for_ukernel=use_chess_for_ukernel,
                 ),
                 additional_labels=["Performance"] + additional_labels,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.td
@@ -23,6 +23,22 @@ def LogicalObjFifoOpInterface : OpInterface<"LogicalObjFifoOpInterface"> {
   let methods = [
     InterfaceMethod<
       /*desc=*/[{
+        A utility to return the allocation size of a logical objFifo in bytes.
+      }],
+      /*retTy=*/"std::optional<int64_t>",
+      /*methodName=*/"getAllocationSizeInBytes",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        MemRefType memrefType = getMemrefType();
+        size_t allocationSizeInBits =
+          memrefType.getNumElements() * memrefType.getElementTypeBitWidth();
+        if (allocationSizeInBits % 8 != 0) return std::nullopt;
+        return allocationSizeInBits / 8 * getDepth();
+      }]
+    >,
+    InterfaceMethod<
+      /*desc=*/[{
         Return the consumer copy-like operations of the logical objFifo.
       }],
       /*retTy=*/"::llvm::SmallVector<::mlir::CopyOpInterface>",

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignTiles.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignTiles.cpp
@@ -151,9 +151,11 @@ class UsageAndColumnBasedTileAllocator final : public TileAllocatorBase {
 
   UsageAndColumnBasedTileAllocator(
       RewriterBase &rewriter, const AMDAIE::AMDAIEDeviceModel &deviceModel,
-      DenseMap<Operation *, DenseSet<Operation *>> uniqueL3L2Pair)
+      DenseMap<Operation *, DenseSet<Operation *>> uniqueL3L2Pair,
+      bool hardwareAware)
       : TileAllocatorBase(rewriter, deviceModel),
-        uniqueL3L2Pair(uniqueL3L2Pair) {}
+        uniqueL3L2Pair(uniqueL3L2Pair),
+        hardwareAware(hardwareAware) {}
 
   LogicalResult assignTiles(
       SmallVector<AMDAIE::LogicalObjFifoOpInterface> &objFifos,
@@ -250,7 +252,26 @@ class UsageAndColumnBasedTileAllocator final : public TileAllocatorBase {
     }
     uint32_t row = memSpaceRows[0];
 
-    for (AMDAIE::LogicalObjFifoOpInterface objFifo : objFifos) {
+    // Sort the logical objectFifos on allocation size so that the largest ones
+    // get assigned first.
+    SmallVector<std::pair<AMDAIE::LogicalObjFifoOpInterface, size_t>>
+        objFifosAndSizes;
+    objFifosAndSizes.reserve(objFifos.size());
+    for (AMDAIE::LogicalObjFifoOpInterface op : objFifos) {
+      std::optional<int64_t> sizeInBytes = op.getAllocationSizeInBytes();
+      if (!sizeInBytes.has_value()) {
+        return op.emitOpError()
+               << "has allocation size that is not a byte-multiple";
+      }
+      objFifosAndSizes.push_back(std::make_pair(op, *sizeInBytes));
+    }
+    llvm::sort(objFifosAndSizes,
+               [&](std::pair<AMDAIE::LogicalObjFifoOpInterface, size_t> a,
+                   std::pair<AMDAIE::LogicalObjFifoOpInterface, size_t> b) {
+                 return a.second > b.second;
+               });
+
+    for (auto [objFifo, allocationSizeInBytes] : objFifosAndSizes) {
       LLVM_DEBUG(llvm::dbgs()
                  << "Assign tile for objFifo: " << objFifo << "\n");
 
@@ -300,9 +321,17 @@ class UsageAndColumnBasedTileAllocator final : public TileAllocatorBase {
               std::min((size_t)uniqueL3L2Pair[defOp].size(), tiles.size()));
       }
 
-      // Assing a tile location.
+      // Prefer the priority column for tile assignment if enough memory
+      // available.
       TileLoc assignedTileLoc;
-      const auto *tileIt = llvm::find_if(tiles, [&](const TileLoc &tileLoc) {
+      const auto *tileIt = llvm::find_if(tiles, [&, allocationSizeInBytes =
+                                                        allocationSizeInBytes](
+                                                    const TileLoc &tileLoc) {
+        if (hardwareAware && (tileLocToUsage[tileLoc] + allocationSizeInBytes) >
+                                 deviceModel.getTileMemorySizeInBytes(
+                                     tileLoc.col, tileLoc.row)) {
+          return false;
+        }
         return tileLoc.col == priorityCol;
       });
       if (tileIt != tiles.end()) {
@@ -314,6 +343,13 @@ class UsageAndColumnBasedTileAllocator final : public TileAllocatorBase {
         assignedTileLoc =
             *std::min_element(tiles.begin(), tiles.end(), tileLocAndUsageCmp);
       }
+      if (hardwareAware &&
+          (tileLocToUsage[assignedTileLoc] + allocationSizeInBytes) >
+              deviceModel.getTileMemorySizeInBytes(assignedTileLoc.col,
+                                                   assignedTileLoc.row)) {
+        return objFifo.emitOpError()
+               << "could not find allocation space for this logical objFifo";
+      }
 
       // Increase usage of the chosen tile as a new logical objectFifo will be
       // assigned to it. This allows distributing the logical objectFifos
@@ -321,7 +357,7 @@ class UsageAndColumnBasedTileAllocator final : public TileAllocatorBase {
       LLVM_DEBUG(llvm::dbgs()
                  << "Assign to tile (col, row): (" << assignedTileLoc.col
                  << ", " << assignedTileLoc.row << ")\n");
-      tileLocToUsage[assignedTileLoc] += 1;
+      tileLocToUsage[assignedTileLoc] += allocationSizeInBytes;
 
       rewriter.setInsertionPoint(objFifo);
       auto getCol = rewriter.create<arith::ConstantIndexOp>(
@@ -384,6 +420,10 @@ class UsageAndColumnBasedTileAllocator final : public TileAllocatorBase {
     }
     return priorityCol;
   }
+
+  /// Whether to make hardware-aware tile assignment decisions, taking into
+  /// account memory limitations for example.
+  bool hardwareAware{true};
 };
 
 /// Assign tile locations to objectFifos based on available resources. Visit
@@ -391,12 +431,13 @@ class UsageAndColumnBasedTileAllocator final : public TileAllocatorBase {
 /// on L1, then L2, etc.
 LogicalResult assignTiles(
     RewriterBase &rewriter, Operation *op, const AMDAIEDeviceModel &deviceModel,
-    DenseMap<Operation *, DenseSet<Operation *>> uniqueL3L2Pair) {
+    DenseMap<Operation *, DenseSet<Operation *>> uniqueL3L2Pair,
+    bool hardwareAware) {
   if (failed(clearNonLocalTiles(rewriter, op)))
     return op->emitOpError() << "failed to clear non-local tile assignments";
 
   UsageAndColumnBasedTileAllocator tileAllocator(rewriter, deviceModel,
-                                                 uniqueL3L2Pair);
+                                                 uniqueL3L2Pair, hardwareAware);
 
   DenseMap<uint8_t, SmallVector<AMDAIE::LogicalObjFifoOpInterface>>
       memSpaceToObjFifos;
@@ -496,7 +537,8 @@ void AMDAIEAssignTilesPass::runOnOperation() {
     return WalkResult::advance();
   });
   // Assign tile locations to logical objectFifos on non-local (not L1) memory.
-  if (failed(assignTiles(rewriter, parentOp, deviceModel, uniqueL3L2Pair))) {
+  if (failed(assignTiles(rewriter, parentOp, deviceModel, uniqueL3L2Pair,
+                         /*hardwareAware*/ true))) {
     parentOp->emitOpError() << "non-local tile assignment failed";
     return signalPassFailure();
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDistributeCoresAndObjectFifos.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDistributeCoresAndObjectFifos.cpp
@@ -512,7 +512,8 @@ void AMDAIEDistributeCoresAndObjectFifosPass::runOnOperation() {
   // TODO(jornt): This is needed inside this pass to make the output stable with
   // respect to cse. When that gets resolved, we can avoid convoluting this
   // pass.
-  if (failed(assignTiles(rewriter, moduleOp, deviceModel, uniqueL3L2Pair))) {
+  if (failed(assignTiles(rewriter, moduleOp, deviceModel, uniqueL3L2Pair,
+                         /*hardwareAware*/ false))) {
     moduleOp.emitOpError() << "local tile assignment failed";
     return signalPassFailure();
   }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Transforms.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Transforms.h
@@ -17,7 +17,8 @@ namespace mlir::iree_compiler::AMDAIE {
 /// Assign tile locations to the logical objectfifos.
 LogicalResult assignTiles(
     RewriterBase &rewriter, Operation *op, const AMDAIEDeviceModel &deviceModel,
-    DenseMap<Operation *, DenseSet<Operation *>> uniqueL3L2Pair);
+    DenseMap<Operation *, DenseSet<Operation *>> uniqueL3L2Pair,
+    bool hardwareAware = true);
 
 /// Unroll the loops within the control code regions.
 LogicalResult controlCodeLoopUnroll(RewriterBase &rewriter,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/distribute_cores_and_objectfifos.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/distribute_cores_and_objectfifos.mlir
@@ -695,9 +695,9 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK-DAG:         %[[FROM_MEMREF_7:.*]] = amdaie.logicalobjectfifo.from_memref %[[ALLOC_0]], {%[[TILE_0_2]], %[[TILE_1_2]]}
 // CHECK-DAG:         %[[FROM_MEMREF_8:.*]] = amdaie.logicalobjectfifo.from_memref %[[ALLOC]], {%[[TILE_1_2]]}
 // CHECK-DAG:         %[[FROM_MEMREF_9:.*]] = amdaie.logicalobjectfifo.from_memref %[[ALLOC]], {%[[TILE_0_2]]}
-// CHECK-DAG:         %[[FROM_MEMREF_10:.*]] = amdaie.logicalobjectfifo.from_memref %[[OUTPUT]], {%[[TILE_0_0]]}
+// CHECK-DAG:         %[[FROM_MEMREF_10:.*]] = amdaie.logicalobjectfifo.from_memref %[[OUTPUT]], {%[[TILE_1_0]]}
 // CHECK-DAG:         %[[FROM_MEMREF_11:.*]] = amdaie.logicalobjectfifo.from_memref %[[IN_A]], {%[[TILE_0_0]]}
-// CHECK-DAG:         %[[FROM_MEMREF_12:.*]] = amdaie.logicalobjectfifo.from_memref %[[IN_B]], {%[[TILE_1_0]]}
+// CHECK-DAG:         %[[FROM_MEMREF_12:.*]] = amdaie.logicalobjectfifo.from_memref %[[IN_B]], {%[[TILE_0_0]]}
 // CHECK-DAG:         %[[DMA_0:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_0]]
 // CHECK-SAME:        %[[FROM_MEMREF_11]]
 // CHECK-DAG:         %[[DMA_1:.*]] = amdaie.dma_cpy_nd(%[[FROM_MEMREF_7]]

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_air.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_air.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(iree-amdaie-lowering-strategy{use-lower-to-aie-pipeline=air use-tile-pipeline=pack-peel})' %s | FileCheck %s --check-prefix=CHECK-PACK-PEEL
 
-// CHECK-PACK-PEEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[512, 256, 0], [0, 0, 1], [1, 1, 0]]>
-// CHECK-PACK-PEEL{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [128, 64, 128], transposePackIndices = [0, 1], unpackEmpty = [false, false], innerPerm = [[0, 1], [1, 0]], outerPerm = [[0, 1], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 8, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+// CHECK-PACK-PEEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[256, 256, 0], [0, 0, 1], [1, 1, 0]]>
+// CHECK-PACK-PEEL{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [64, 64, 128], transposePackIndices = [0, 1], unpackEmpty = [false, false], innerPerm = [[0, 1], [1, 0]], outerPerm = [[0, 1], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 8, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
   <storage_buffer>,
@@ -53,8 +53,8 @@ module {
 
 // -----
 
-// CHECK-PACK-PEEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[256, 128, 0], [0, 0, 1], [1, 1, 0]]>
-// CHECK-PACK-PEEL{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [64, 32, 128], transposePackIndices = [0, 1], unpackEmpty = [false, false], innerPerm = [[0, 1], [0, 1]], outerPerm = [[0, 1], [0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [0, 1], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
+// CHECK-PACK-PEEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 0], [0, 0, 1], [1, 1, 0]]>
+// CHECK-PACK-PEEL{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 128], transposePackIndices = [0, 1], unpackEmpty = [false, false], innerPerm = [[0, 1], [0, 1]], outerPerm = [[0, 1], [0, 1]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [0, 1], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
   <storage_buffer>,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo_npu1.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo_npu1.mlir
@@ -12,7 +12,7 @@
 // CHECK-4x4{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 0], [0, 0, 1], [1, 1, 0]]>
 // CHECK-4x4{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 128], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 
-// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[256, 256, 0], [4, 4, 0], [0, 0, 1], [1, 1, 0]]
+// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 0], [4, 4, 0], [0, 0, 1], [1, 1, 0]]
 // PACK-PEEL-4-LEVEL{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 128], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
@@ -48,7 +48,7 @@ module {
 // CHECK-4x4{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 0], [0, 0, 1], [1, 1, 0]]>
 // CHECK-4x4{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 64], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 
-// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[256, 256, 0], [4, 4, 0], [0, 0, 1], [1, 1, 0]]>
+// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 0], [4, 4, 0], [0, 0, 1], [1, 1, 0]]>
 // PACK-PEEL-4-LEVEL{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 64], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
@@ -84,7 +84,7 @@ module {
 // CHECK-4x4{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 0], [0, 0, 1], [1, 1, 0]]>
 // CHECK-4x4{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 128], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 8, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 
-// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[256, 256, 0], [4, 4, 0], [0, 0, 1], [1, 1, 0]]>
+// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 0], [4, 4, 0], [0, 0, 1], [1, 1, 0]]>
 // PACK-PEEL-4-LEVEL{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 128], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 8, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
@@ -156,7 +156,7 @@ module {
 // CHECK-4x4{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 0], [0, 0, 1], [1, 1, 0]]>
 // CHECK-4x4{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 128], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [0, 1], [0, 1]], outerPerm = [[0, 1], [0, 1], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [0, 1], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 
-// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[256, 256, 0], [4, 4, 0], [0, 0, 1], [1, 1, 0]]>
+// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 0], [4, 4, 0], [0, 0, 1], [1, 1, 0]]>
 // PACK-PEEL-4-LEVEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 128], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [0, 1], [0, 1]], outerPerm = [[0, 1], [0, 1], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [0, 1], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,
@@ -192,7 +192,7 @@ module {
 // CHECK-4x4{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 0], [0, 0, 1], [1, 1, 0]]>
 // CHECK-4x4{LITERAL}: #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 128], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[1, 0], [1, 0], [0, 1]], outerPerm = [[1, 0], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[1, 0], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 
-// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[256, 256, 0], [4, 4, 0], [0, 0, 1], [1, 1, 0]]>
+// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 0], [4, 4, 0], [0, 0, 1], [1, 1, 0]]>
 // PACK-PEEL-4-LEVEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 128], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[1, 0], [1, 0], [0, 1]], outerPerm = [[1, 0], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 4, 4, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[1, 0], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo_npu4.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lowering_strategy_objectfifo_npu4.mlir
@@ -16,7 +16,7 @@
 // CHECK-SAME:                              [0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]
 // CHECK-SAME:                   ]}]>
 
-// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[256, 256, 0], [4, 4, 0], [0, 0, 1], [1, 1, 0]]>
+// PACK-PEEL-4-LEVEL{LITERAL}: #config = #iree_codegen.lowering_config<tile_sizes = [[128, 128, 0], [4, 4, 0], [0, 0, 1], [1, 1, 0]]>
 // PACK-PEEL-4-LEVEL{LITERAL}: #packingConfig = #amdaie.packing_config<packing_config = [{packedSizes = [32, 32, 128], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1], [1, 0], [1, 0]]}, {packedSizes = [0, 0, 0, 8, 8, 8], transposePackIndices = [0, 1, 2], unpackEmpty = [false, false, true], innerPerm = [[0, 1], [1, 0], [0, 1]], outerPerm = [[0, 1, 3, 2], [0, 1, 3, 2], [0, 1, 3, 2]]}]>
 #pipeline_layout = #hal.pipeline.layout<bindings = [
   <storage_buffer>,

--- a/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.cc
+++ b/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.cc
@@ -398,6 +398,22 @@ uint32_t AMDAIEDeviceModel::getCtrlPktMaxOpcode() const {
          1;
 }
 
+uint32_t AMDAIEDeviceModel::getTileMemorySizeInBytes(uint8_t col,
+                                                     uint8_t row) const {
+  AMDAIETileType tileType = getTileType(col, row);
+  switch (tileType) {
+    case AMDAIETileType::AIETILE:
+      return getLocalMemorySize(col, row);
+    case AMDAIETileType::MEMTILE:
+      return getMemTileSize(col, row);
+    case AMDAIETileType::SHIMNOC:
+    case AMDAIETileType::SHIMPL:
+      return std::numeric_limits<uint32_t>::max();
+    default:
+      return 0;
+  }
+}
+
 uint32_t AMDAIEDeviceModel::getMemInternalBaseAddress() const {
   return getMemEastBaseAddress();
 }

--- a/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.h
+++ b/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.h
@@ -461,6 +461,7 @@ struct AMDAIEDeviceModel {
   uint32_t getMemTileSizeInBytes() const;
   uint32_t getMemTileSize(uint8_t col, uint8_t row) const;
   uint32_t getCoreTileLocalMemorySize() const;
+  uint32_t getTileMemorySizeInBytes(uint8_t col, uint8_t row) const;
 
   SmallVector<uint32_t> getMemSpaceRows(uint8_t memSpace) const;
 


### PR DESCRIPTION
This PR increases the usage of L2 memory by increasing the L2 tile sizes within memory bounds and by improving the algorithm to assign logical objectFifos across tiles. This updated algorithm now assigns larger logical objectFifos first and takes into account the actual memory usage on tiles, with leads to better usage of available memory.