### PR TITLE
[CI] Fix operation count logging in test script

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -303,17 +303,6 @@ class BaseMatmul(BaseTest):
     def benchmark(self, config):
         filename = self.get_filename(config)
 
-        # Print some additional information that might have been tagged on earlier.
-        if config.verbose:
-            if hasattr(self, "n_matmul_ops"):
-                print(f"Total ops (2 * M * N * K * repeats) : {self.n_matmul_ops}")
-
-            if hasattr(self, "n_cols"):
-                print(f"Number of columns : {self.n_cols}")
-
-            if hasattr(self, "n_rows"):
-                print(f"Number of rows : {self.n_rows}")
-
         benchmark_aie(
             config=config,
             aie_compilation_flags=self.aie_compilation_flags,
@@ -326,6 +315,17 @@ class BaseMatmul(BaseTest):
             n_kernel_runs=self.n_kernel_runs,
             n_reconfigure_runs=self.n_reconfigure_runs,
         )
+
+        # Print some additional information that might have been tagged on earlier.
+        if config.verbose:
+            if hasattr(self, "n_matmul_ops"):
+                print(f"Total ops (2 * M * N * K * repeats) : {self.n_matmul_ops}")
+
+            if hasattr(self, "n_cols"):
+                print(f"Number of columns : {self.n_cols}")
+
+            if hasattr(self, "n_rows"):
+                print(f"Number of rows : {self.n_rows}")
 
         return True
 


### PR DESCRIPTION
This PR fixes the placement of logging for operation count, number of rows, and number of columns in the test script. According to the parser logic in [performance_summarizer.py](https://github.com/nod-ai/iree-amd-aie/blob/5cfbf5cb0d1593dc3dc1a82d9122c36c9f81d7e1/build_tools/ci/cpu_comparison/performance_summarizer.py#L66-L68), these values should be printed after the `Performance benchmark:` line. Otherwise, it could cause `json_summary["tests"][-1]` to point to the wrong entry.