### PR TITLE
[DmaLoopSubsumption] Account for max repeat count for NpuDmaCpyNd

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaLoopSubsumption.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEDmaLoopSubsumption.cpp
@@ -184,7 +184,7 @@ struct SubsumeLoopIntoDMA
     SmallVector<OpFoldResult> newTargetSizes = op.getTargetMixedSizes();
     SmallVector<OpFoldResult> newTargetStrides = op.getTargetMixedStrides();
 
-    uint64_t maxRepeatCount =
+    uint32_t maxRepeatCount =
         deviceModel.getMaxRepeatCount(AMDAIE::AMDAIETileType::SHIMNOC);
     // Verify number of dimensions needed to subsume this loop into the strided
     // access pattern and fail early if there aren't enough dimensions.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/dma_loop_subsumption.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/dma_loop_subsumption.mlir
@@ -498,7 +498,6 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:         scf.for %{{.+}} = %[[C0]] to %[[C64]] step %[[C1]]
 // CHECK:           amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0] [2, 8, 16] [128, 16, 1])
 // CHECK:         }
-// CHECK:         amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0, 0] [1024, 8, 16] [0, 16, 1])
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @exceed_max_size_source(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32>>) {
@@ -516,9 +515,6 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
         }
         scf.for %arg5 = %c0 to %c64 step %c1 {
           amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0, 0] [2, 8, 16] [128, 16, 1])
-        }
-        scf.for %arg6 = %c0 to %c1024 step %c1 {
-          amdaie.npu.dma_cpy_nd %0([] [] [], [0, 0] [8, 16] [16, 1])
         }
         amdaie.end
       }
@@ -542,7 +538,6 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:         scf.for %{{.+}} = %[[C0]] to %[[C64]] step %[[C1]]
 // CHECK:           amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0] [2, 8, 16] [128, 16, 1], [] [] [])
 // CHECK:         }
-// CHECK:         amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0, 0] [1024, 8, 16] [0, 16, 1], [] [] [])
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @exceed_max_size_target(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
@@ -560,9 +555,6 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
         }
         scf.for %arg5 = %c0 to %c64 step %c1 {
           amdaie.npu.dma_cpy_nd %0([0, 0, 0] [2, 8, 16] [128, 16, 1], [] [] [])
-        }
-        scf.for %arg6 = %c0 to %c1024 step %c1 {
-          amdaie.npu.dma_cpy_nd %0([0, 0] [8, 16] [16, 1], [] [] [])
         }
         amdaie.end
       }
@@ -1515,6 +1507,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 }
 
 // -----
+
+
 
 #map = affine_map<(d0) -> (d0 * 16)>
 module {

--- a/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.h
+++ b/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.h
@@ -557,6 +557,10 @@ struct AMDAIEDeviceModel {
     return deviceConfig.preferredLoadBytes;
   }
 
+  uint64_t getMaxRepeatCount(AMDAIETileType tileType) const {
+    return devInst.DevProp.DevMod[static_cast<uint8_t>(tileType)]
+        .DmaMod->ChProp->MaxRepeatCount;
+  }
   /// Return a map from channels to valid BD ids for the requested tile type.
   /// TODO(jornt): find these ranges in the device model.
   DenseMap<uint32_t, SmallVector<uint32_t>> getChannelToValidBdIds(

--- a/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.h
+++ b/runtime/src/iree-amd-aie/aie_runtime/iree_aie_runtime.h
@@ -557,7 +557,7 @@ struct AMDAIEDeviceModel {
     return deviceConfig.preferredLoadBytes;
   }
 
-  uint64_t getMaxRepeatCount(AMDAIETileType tileType) const {
+  uint32_t getMaxRepeatCount(AMDAIETileType tileType) const {
     return devInst.DevProp.DevMod[static_cast<uint8_t>(tileType)]
         .DmaMod->ChProp->MaxRepeatCount;
   }


### PR DESCRIPTION
-- This commit adds API to fetch max repeat count and uses that to bail
   out on loop subsumption for non-circular DmaCpyNd ops where the total
   loop iteration count is greater than the max repeat count.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>