### PR TITLE
[AssignNpuDmaBdIds] Equally distribute BD IDs amongst DMAs in same scf.for block/tile

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignNpuDmaBdIds.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignNpuDmaBdIds.cpp
@@ -304,6 +304,7 @@ struct BdIdAssignmentUtil {
       std::shared_ptr<DmaBatch> parentDmaBatch) {
     for (std::shared_ptr<DmaBatch> &dmaBatch :
          parentDmaBatch->immediateInnerBatches) {
+      OpBuilder::InsertionGuard guard(rewriter);
       if (failed(processDmaBatch(rewriter, tileOp, dmaBatch))) return failure();
     }
     return success();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignNpuDmaBdIds.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignNpuDmaBdIds.cpp
@@ -191,8 +191,8 @@ struct TileDmaBatchGraph {
     });
   }
 
-  llvm::MapVector<AMDAIE::TileOp, std::shared_ptr<DmaBatch>> *getGraph() {
-    return &tileDmaBatchGraph;
+  llvm::MapVector<AMDAIE::TileOp, std::shared_ptr<DmaBatch>> &getGraph() {
+    return tileDmaBatchGraph;
   }
 
   void addDmaToBatch(AMDAIE::TileOp tile, AMDAIE::NpuDmaCpyNdOp dmaOp) {
@@ -212,7 +212,7 @@ struct TileDmaBatchGraph {
   /// the `immediateInnerBatches` of the corresponding tile's DmaBatch.
   void updateInnerBatchesOfCurrentTileDmaBatchGraph(
       TileDmaBatchGraph &innerTileDmaBatchGraph) {
-    for (auto &[tile, dmaBatch] : *(innerTileDmaBatchGraph.getGraph())) {
+    for (auto &[tile, dmaBatch] : innerTileDmaBatchGraph.getGraph()) {
       if (dmaBatch->isEmpty()) continue;
       currentTileBatch[tile]->immediateInnerBatches.push_back(
           std::move(dmaBatch));
@@ -222,7 +222,7 @@ struct TileDmaBatchGraph {
   /// Traverse each DmaBatch in a given (Tile -> DmaBatch) and infer Bd Ids
   /// required for it.
   void inferBdIdsRequiredInBatches() {
-    for (auto &[tile, dmaBatch] : *getGraph()) {
+    for (auto &[tile, dmaBatch] : getGraph()) {
       std::shared_ptr<DmaBatch> currDmaBatch = dmaBatch;
       do {
         if (currDmaBatch->isEmpty()) break;
@@ -245,7 +245,7 @@ struct TileDmaBatchGraph {
       DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
       DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
           &dmaOpToBdIdMap) {
-    for (auto &[tileOp, dmaBatch] : *getGraph()) {
+    for (auto &[tileOp, dmaBatch] : getGraph()) {
       if (failed(processDmaBatch(rewriter, tileOp, dmaBatch,
                                  shimTileToGeneratorMap, bdIdOpToBdIdsMap,
                                  dmaOpToBdIdMap)))

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignNpuDmaBdIds.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignNpuDmaBdIds.cpp
@@ -75,192 +75,12 @@ std::optional<uint32_t> getNumberIterations(scf::ForOp loop) {
   }
 }
 
-/// A DmaBatch contains the following :-
-///   1. DmaOps within the current batch.
-///   2. Required Bd Ids by the current batch.
-///   3. Nested DmaBatch chain.
-///   4. Pointer to the sibling DmaBatch.
-///   4. A pointer to the parent op if the parent of is a scf.for.
-typedef struct DmaBatchStruct {
-  SmallVector<AMDAIE::NpuDmaCpyNdOp> currentDmaOps = {};
-  int32_t requiredBdIds = 0;
-  SmallVector<DmaBatchStruct *> immediateInnerBatches = {};
-  DmaBatchStruct *nextDmaBatch = nullptr;
-  scf::ForOp forOpParent = nullptr;
-} DmaBatch;
-
-using TileDmaBatchGraph = llvm::MapVector<AMDAIE::TileOp, DmaBatch *>;
-
-/// Create a new TileDmaBatchGraph by traversing over each tiles in a workgroup.
-static TileDmaBatchGraph initTileDmaBatchGraph(
-    AMDAIE::WorkgroupOp workgroupOp) {
-  TileDmaBatchGraph tileDmaBatchGraph;
-  workgroupOp.walk([&](AMDAIE::TileOp tile) {
-    if (tileDmaBatchGraph.contains(tile)) return WalkResult::skip();
-    tileDmaBatchGraph[tile] = new DmaBatch();
-    return WalkResult::advance();
-  });
-  return tileDmaBatchGraph;
-}
-
-/// A DmaBatch with no DmaOps and no nested DmaBatches is an empty DmaBatch.
-static bool isEmptyDmaBatch(DmaBatch *dmaBatch) {
-  return (dmaBatch->currentDmaOps.empty() &&
-          dmaBatch->immediateInnerBatches.empty());
-}
-
-static void updateInnerBatchesOfCurrentTileDmaBatchGraph(
-    DenseMap<AMDAIE::TileOp, DmaBatch *> &currentTileBatch,
-    TileDmaBatchGraph &innerTileDmaBatchGraph) {
-  for (auto [tile, dmaBatch] : innerTileDmaBatchGraph) {
-    if (isEmptyDmaBatch(dmaBatch)) continue;
-    currentTileBatch[tile]->immediateInnerBatches.push_back(dmaBatch);
-  }
-}
-
-static TileDmaBatchGraph formTileDmaBatchGraph(
-    AMDAIE::WorkgroupOp &workgroupOp, Operation *parentOp,
-    DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap) {
-  TileDmaBatchGraph tileDmaBatchGraph = initTileDmaBatchGraph(workgroupOp);
-
-  DenseMap<AMDAIE::TileOp, DmaBatch *> currentTileBatch;
-  for (auto [tile, dmaBatch] : tileDmaBatchGraph) {
-    currentTileBatch[tile] = dmaBatch;
-    currentTileBatch[tile]->forOpParent = dyn_cast<scf::ForOp>(parentOp);
-  }
-  auto addDmaToBatch = [&](AMDAIE::TileOp tile, AMDAIE::NpuDmaCpyNdOp dmaOp) {
-    assert(tileDmaBatchGraph.contains(tile) && "Tile op not found");
-    currentTileBatch[tile]->currentDmaOps.push_back(dmaOp);
-  };
-
-  auto updateCurrentTileBatch = [&](AMDAIE::TileOp tile) {
-    currentTileBatch[tile]->nextDmaBatch = new DmaBatch();
-    currentTileBatch[tile] = currentTileBatch[tile]->nextDmaBatch;
-    currentTileBatch[tile]->forOpParent = dyn_cast<scf::ForOp>(parentOp);
-  };
-
-  auto updateInnerBatchesOfCurrentTileDmaBatchGraph =
-      [&](TileDmaBatchGraph &innerTileDmaBatchGraph) {
-        for (auto [tile, dmaBatch] : innerTileDmaBatchGraph) {
-          if (isEmptyDmaBatch(dmaBatch)) continue;
-          currentTileBatch[tile]->immediateInnerBatches.push_back(dmaBatch);
-        }
-      };
-
-  AMDAIE::NpuDmaCpyNdOp currDmaOp = nullptr;
-  // Traverse the parent operation's immediate child ops and form the
-  // tileParentOpDmaBatchMap.
-  for (Operation &op : parentOp->getRegion(0).getOps()) {
-    if (isa<scf::ForOp, scf::ForallOp>(op)) {
-      TileDmaBatchGraph innerTileDmaBatchGraph =
-          formTileDmaBatchGraph(workgroupOp, &op, shimTileToGeneratorMap);
-      updateInnerBatchesOfCurrentTileDmaBatchGraph(innerTileDmaBatchGraph);
-    } else if (auto dmaOp = dyn_cast<AMDAIE::NpuDmaCpyNdOp>(op)) {
-      if (dmaOp.getSource()) {
-        FailureOr<AMDAIE::TileOp> tile =
-            getGeneratorTileOp<CopyOpOperateOn::Source>(dmaOp,
-                                                        shimTileToGeneratorMap);
-        if (succeeded(tile)) addDmaToBatch(*tile, dmaOp);
-      }
-      if (dmaOp.getTarget()) {
-        FailureOr<AMDAIE::TileOp> tile =
-            getGeneratorTileOp<CopyOpOperateOn::Target>(dmaOp,
-                                                        shimTileToGeneratorMap);
-        if (succeeded(tile)) addDmaToBatch(*tile, dmaOp);
-      }
-      if (!currDmaOp) currDmaOp = dmaOp;
-    } else if (auto npuWaitOp = dyn_cast<AMDAIE::NpuDmaWaitOp>(op)) {
-      for (AMDAIE::NpuDmaCpyNdOp npuDmaOp : npuWaitOp.getDmaOps()) {
-        // Reached the DMA wait operation, reset tracking of current DMA op for
-        // the tile.
-        if (npuDmaOp == currDmaOp) {
-          currDmaOp = nullptr;
-          if (npuDmaOp.getSource()) {
-            FailureOr<AMDAIE::TileOp> tile =
-                getGeneratorTileOp<CopyOpOperateOn::Source>(
-                    npuDmaOp, shimTileToGeneratorMap);
-            if (succeeded(tile)) updateCurrentTileBatch(*tile);
-          }
-          if (npuDmaOp.getTarget()) {
-            FailureOr<AMDAIE::TileOp> tile =
-                getGeneratorTileOp<CopyOpOperateOn::Target>(
-                    npuDmaOp, shimTileToGeneratorMap);
-            if (succeeded(tile)) updateCurrentTileBatch(*tile);
-          }
-        }
-      }
-    }
-  }
-  return tileDmaBatchGraph;
-}
-
-/// Given a non-empty DmaBatch find the immediate surrounding parent op.
-static Operation *findParentOpOfBatch(DmaBatch *dmaBatch) {
-  if (!dmaBatch->currentDmaOps.empty())
-    return dmaBatch->currentDmaOps[0]->getParentOp();
-  assert(!dmaBatch->immediateInnerBatches.empty() &&
-         "DmaBatch found with no DmaOps and no immediate inner batches");
-  Operation *parentOp = findParentOpOfBatch(dmaBatch->immediateInnerBatches[0]);
-  assert(parentOp && "Found inner DmaBatch with no parent");
-  return parentOp->getParentOp();
-}
-
-/// Given a DmaBatch `outerDmaBatch`, traverse each nested DmaBatch in it and
-/// infer the required Bd Ids for them. If the nsted DmaBatch is surrounded with
-/// a scf.for, we account for that while sending the required Bd Ids to the
-/// caller of this API.
-static int32_t getRequiredBdIdsForInnerBatches(DmaBatch *outerDmaBatch) {
-  if (outerDmaBatch->immediateInnerBatches.empty()) return 0;
-  int32_t requiredBdIds = 0;
-  for (DmaBatch *dmaBatch : outerDmaBatch->immediateInnerBatches) {
-    DmaBatch *currDmaBatch = dmaBatch;
-    do {
-      if (isEmptyDmaBatch(currDmaBatch)) break;
-      int32_t totalDmaOpsInCurrentBatch = currDmaBatch->currentDmaOps.size();
-      int32_t requiredBdIdsForInnerBatches =
-          getRequiredBdIdsForInnerBatches(currDmaBatch);
-      currDmaBatch->requiredBdIds =
-          requiredBdIdsForInnerBatches + totalDmaOpsInCurrentBatch;
-      requiredBdIds += totalDmaOpsInCurrentBatch;
-      // Operation *parentOp = findParentOpOfBatch(currDmaBatch);
-      if (currDmaBatch->forOpParent) {
-        std::optional<uint32_t> numIterations =
-            getNumberIterations(currDmaBatch->forOpParent);
-        if (numIterations) {
-          requiredBdIds += requiredBdIdsForInnerBatches * numIterations.value();
-        } else {
-          requiredBdIds += requiredBdIdsForInnerBatches;
-        }
-      }
-      currDmaBatch = currDmaBatch->nextDmaBatch;
-    } while (currDmaBatch != nullptr);
-  }
-  return requiredBdIds;
-}
-
-/// Traverse each DmaBatch in a given (Tile -> DmaBatch) and infer Bd Ids
-/// required for it.
-static void inferBdIdsRequiredInBatches(TileDmaBatchGraph &tileDmaBatchGraph) {
-  for (auto [tile, dmaBatch] : tileDmaBatchGraph) {
-    DmaBatch *currDmaBatch = dmaBatch;
-    do {
-      if (isEmptyDmaBatch(currDmaBatch)) break;
-      int32_t totalDmaOpsInCurrentBatch = currDmaBatch->currentDmaOps.size();
-      int32_t requiredBdIdsForInnerBatches =
-          getRequiredBdIdsForInnerBatches(currDmaBatch);
-      currDmaBatch->requiredBdIds =
-          requiredBdIdsForInnerBatches + totalDmaOpsInCurrentBatch;
-      currDmaBatch = currDmaBatch->nextDmaBatch;
-    } while (currDmaBatch != nullptr);
-  }
-}
-
 /// A struct that maintains the channel and source/target information for a
 /// given DmaOp and TileOp.
-typedef struct DmaTileDataStruct {
+struct DmaTileData {
   uint32_t channel;
   uint32_t bdIdMapIndex;
-} DmaTileData;
+};
 
 /// Given a DmaOp and a TileOp - extract whether the source (or target) operates
 /// on the tile and also extract the corresponding channel.
@@ -294,234 +114,426 @@ static FailureOr<DmaTileData> getDmaTileData(
   return dmaTileData;
 }
 
-/// Assign required Bd Ids to the DmaOps of the current DmaBatch. This
-/// assignment is tracked by maintaining `dmaOpToBdIdMap`, which essentially
-/// maps a DmaOp to its source/target Bd Ids. Also, the API splits the available
-/// BD IDs equally amongst all DmaOps in the DmaBatch when assigning
-static LogicalResult assignRequiredBdIdsInCurrentBatch(
-    IRRewriter &rewriter, AMDAIE::TileOp tileOp, DmaBatch *dmaBatch,
-    DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
-    DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
-    DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
-        &dmaOpToBdIdMap) {
-  // Get the channel.
-  if (dmaBatch->currentDmaOps.empty()) return success();
-  FailureOr<DmaTileData> maybeDmaTileData = getDmaTileData(
-      dmaBatch->currentDmaOps[0], tileOp, shimTileToGeneratorMap);
-  if (failed(maybeDmaTileData)) return failure();
-  DmaTileData dmaTileData = *maybeDmaTileData;
-  ChannelBdIdGenerator &generator = shimTileToGeneratorMap[tileOp.getResult()];
-  uint32_t numAvailableBdIds =
-      generator.getNumAvailableBdIds(dmaTileData.channel);
-  uint32_t size = std::max(numAvailableBdIds / dmaBatch->requiredBdIds, 1u);
-  scf::ForOp loop = nullptr;
-  AffineExpr ivExpr = nullptr;
-  Value iv = nullptr;
-  // In case the parent of the DMA ops is a scf.for we need to keep track of
-  // the loop induction variable in order to create a semi affine expression
-  // later for distributing BD IDs for each iteration.
-  if (loop = dmaBatch->forOpParent; loop && getNumberIterations(loop)) {
-    iv = loop.getInductionVar();
-    bindDims(loop.getContext(), ivExpr);
-  } else {
-    // In case the DMA ops are not surrounded by scf.for, we will assign
-    // only one BD ID.
-    size = 1;
+/// A DmaBatch contains the following :-
+///   1. DmaOps within the current batch.
+///   2. Required Bd Ids by the current batch.
+///   3. Nested DmaBatch chain.
+///   4. Pointer to the sibling DmaBatch.
+///   4. A pointer to the parent op if the parent of is a scf.for.
+struct DmaBatch {
+  SmallVector<AMDAIE::NpuDmaCpyNdOp> currentDmaOps = {};
+  int32_t requiredBdIds = 0;
+  SmallVector<DmaBatch *> immediateInnerBatches = {};
+  DmaBatch *nextDmaBatch = nullptr;
+  scf::ForOp forOpParent = nullptr;
+
+  /// A DmaBatch with no DmaOps and no nested DmaBatches is an empty DmaBatch.
+  bool isEmpty() {
+    return (currentDmaOps.empty() && immediateInnerBatches.empty());
   }
 
-  rewriter.setInsertionPoint(dmaBatch->currentDmaOps[0]);
-  for (AMDAIE::NpuDmaCpyNdOp dmaOp : dmaBatch->currentDmaOps) {
-    maybeDmaTileData = getDmaTileData(dmaOp, tileOp, shimTileToGeneratorMap);
+  /// Given a DmaBatch `outerDmaBatch`, traverse each nested DmaBatch in it and
+  /// infer the required Bd Ids for them. If the nested DmaBatch is surrounded
+  /// with a scf.for, we account for that while sending the required Bd Ids to
+  /// the caller of this API.
+  int32_t getRequiredBdIdsForInnerBatches() {
+    if (immediateInnerBatches.empty()) return 0;
+    int32_t requiredBdIds = 0;
+    for (DmaBatch *dmaBatch : immediateInnerBatches) {
+      DmaBatch *currDmaBatch = dmaBatch;
+      do {
+        if (currDmaBatch->isEmpty()) break;
+        int32_t totalDmaOpsInCurrentBatch = currDmaBatch->currentDmaOps.size();
+        int32_t requiredBdIdsForInnerBatches =
+            currDmaBatch->getRequiredBdIdsForInnerBatches();
+        currDmaBatch->requiredBdIds =
+            requiredBdIdsForInnerBatches + totalDmaOpsInCurrentBatch;
+        requiredBdIds += totalDmaOpsInCurrentBatch;
+        if (currDmaBatch->forOpParent) {
+          std::optional<uint32_t> numIterations =
+              getNumberIterations(currDmaBatch->forOpParent);
+          if (numIterations) {
+            requiredBdIds +=
+                requiredBdIdsForInnerBatches * numIterations.value();
+          } else {
+            requiredBdIds += requiredBdIdsForInnerBatches;
+          }
+        }
+        currDmaBatch = currDmaBatch->nextDmaBatch;
+      } while (currDmaBatch != nullptr);
+    }
+    return requiredBdIds;
+  }
+};
+
+struct TileDmaBatchGraph {
+ private:
+  /// The main tile->DmaBatch graph.
+  llvm::MapVector<AMDAIE::TileOp, DmaBatch *> tileDmaBatchGraph;
+  /// Helps keep track of the current DmaBatch of a tile that's being processed.
+  /// It holds the reference to the last DmaBatch for every tile on the main
+  /// graph.
+  DenseMap<AMDAIE::TileOp, DmaBatch *> currentTileBatch;
+
+ public:
+  /// Create a new TileDmaBatchGraph by traversing over each tiles in a
+  /// workgroup.
+  TileDmaBatchGraph(AMDAIE::WorkgroupOp workgroupOp, Operation *parentOp) {
+    workgroupOp.walk([&](AMDAIE::TileOp tile) {
+      if (tileDmaBatchGraph.contains(tile)) return WalkResult::skip();
+      tileDmaBatchGraph[tile] = new DmaBatch();
+      currentTileBatch[tile] = tileDmaBatchGraph[tile];
+      currentTileBatch[tile]->forOpParent = dyn_cast<scf::ForOp>(parentOp);
+      return WalkResult::advance();
+    });
+  }
+
+  llvm::MapVector<AMDAIE::TileOp, DmaBatch *> getGraph() {
+    return tileDmaBatchGraph;
+  }
+
+  void addDmaToBatch(AMDAIE::TileOp tile, AMDAIE::NpuDmaCpyNdOp dmaOp) {
+    assert(tileDmaBatchGraph.contains(tile) && "Tile op not found");
+    currentTileBatch[tile]->currentDmaOps.push_back(dmaOp);
+  };
+
+  void updateCurrentTileBatch(AMDAIE::TileOp tile) {
+    currentTileBatch[tile]->nextDmaBatch = new DmaBatch();
+    currentTileBatch[tile]->nextDmaBatch->forOpParent =
+        currentTileBatch[tile]->forOpParent;
+    currentTileBatch[tile] = currentTileBatch[tile]->nextDmaBatch;
+  };
+
+  /// Given another `TileDmaBatchGraph` instance, we consider that as the nested
+  /// graph to be added to the current graph instance. We do this by updating
+  /// the `immediateInnerBatches` of the corresponding tile's DmaBatch.
+  void updateInnerBatchesOfCurrentTileDmaBatchGraph(
+      TileDmaBatchGraph &innerTileDmaBatchGraph) {
+    for (auto [tile, dmaBatch] : innerTileDmaBatchGraph.getGraph()) {
+      if (dmaBatch->isEmpty()) continue;
+      currentTileBatch[tile]->immediateInnerBatches.push_back(dmaBatch);
+    }
+  };
+
+  /// Traverse each DmaBatch in a given (Tile -> DmaBatch) and infer Bd Ids
+  /// required for it.
+  void inferBdIdsRequiredInBatches() {
+    for (auto [tile, dmaBatch] : getGraph()) {
+      DmaBatch *currDmaBatch = dmaBatch;
+      do {
+        if (currDmaBatch->isEmpty()) break;
+        int32_t totalDmaOpsInCurrentBatch = currDmaBatch->currentDmaOps.size();
+        int32_t requiredBdIdsForInnerBatches =
+            currDmaBatch->getRequiredBdIdsForInnerBatches();
+        currDmaBatch->requiredBdIds =
+            requiredBdIdsForInnerBatches + totalDmaOpsInCurrentBatch;
+        currDmaBatch = currDmaBatch->nextDmaBatch;
+      } while (currDmaBatch != nullptr);
+    }
+  }
+
+  /// This API will work on assigning Bd Ids to each DmaBatch belonging to a
+  /// particular Tile. And maintain a mapping of DmaOp -> source/target Bd Id
+  /// which would be used later during new DmaOp creation/replacement.
+  LogicalResult assignRequiredBdIdsInBatch(
+      IRRewriter &rewriter,
+      DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
+      DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
+      DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
+          &dmaOpToBdIdMap) {
+    for (auto [tileOp, dmaBatch] : getGraph()) {
+      if (failed(processDmaBatch(rewriter, tileOp, dmaBatch,
+                                 shimTileToGeneratorMap, bdIdOpToBdIdsMap,
+                                 dmaOpToBdIdMap)))
+        return failure();
+    }
+    return success();
+  }
+
+  // ------------------------------------------------------------
+  // ---------------- PRIVATE UTILITY FUNCTIONS -----------------
+  // ------------------------------------------------------------
+ private:
+  /// Since a DmaBatch contains the following :-
+  ///   1. DmaOps within the current batch.
+  ///   2. Nested DmaBatch chain.
+  ///   3. Pointer to the sibling DmaBatch.
+  /// This API processes a given DmaBatch by :-
+  ///   a. Assigning Bd Ids to 1.
+  ///   b. Assigning Bd Ids to 2.
+  ///   c. Releasing Bd Ids assigned to 1.
+  ///   d. Moving on to 3 and repeating steps a-to-d for it.
+  static LogicalResult processDmaBatch(
+      IRRewriter &rewriter, AMDAIE::TileOp tileOp, DmaBatch *currDmaBatch,
+      DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
+      DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
+      DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
+          &dmaOpToBdIdMap) {
+    do {
+      if (currDmaBatch->isEmpty()) break;
+      if (failed(assignRequiredBdIdsInCurrentBatch(
+              rewriter, tileOp, currDmaBatch, shimTileToGeneratorMap,
+              bdIdOpToBdIdsMap, dmaOpToBdIdMap)))
+        return failure();
+
+      if (failed(assignRequiredBdIdsInInnerBatch(
+              rewriter, tileOp, currDmaBatch, shimTileToGeneratorMap,
+              bdIdOpToBdIdsMap, dmaOpToBdIdMap)))
+        return failure();
+
+      if (failed(releaseAssignedBdIdsInCurrentBatch(
+              currDmaBatch->currentDmaOps, shimTileToGeneratorMap,
+              bdIdOpToBdIdsMap, dmaOpToBdIdMap)))
+        return failure();
+
+      currDmaBatch = currDmaBatch->nextDmaBatch;
+    } while (currDmaBatch != nullptr);
+    return success();
+  }
+
+  /// Declaration of an API which will work on assigning Bd Ids to the inner
+  /// DmaBatch of the current DmaBatch `parentDmaBatch`. And maintain a mapping
+  /// of DmaOp -> source/target Bd Id which would be used later during new DmaOp
+  /// creation/replacement.
+  static LogicalResult assignRequiredBdIdsInInnerBatch(
+      IRRewriter &rewriter, AMDAIE::TileOp tileOp, DmaBatch *parentDmaBatch,
+      DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
+      DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
+      DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
+          &dmaOpToBdIdMap) {
+    for (DmaBatch *dmaBatch : parentDmaBatch->immediateInnerBatches) {
+      if (failed(processDmaBatch(rewriter, tileOp, dmaBatch,
+                                 shimTileToGeneratorMap, bdIdOpToBdIdsMap,
+                                 dmaOpToBdIdMap)))
+        return failure();
+    }
+    return success();
+  }
+
+  /// Assign required Bd Ids to the DmaOps of the current DmaBatch. This
+  /// assignment is tracked by maintaining `dmaOpToBdIdMap`, which essentially
+  /// maps a DmaOp to its source/target Bd Ids. Also, the API splits the
+  /// available BD IDs equally amongst all DmaOps in the DmaBatch when assigning
+  static LogicalResult assignRequiredBdIdsInCurrentBatch(
+      IRRewriter &rewriter, AMDAIE::TileOp tileOp, DmaBatch *dmaBatch,
+      DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
+      DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
+      DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
+          &dmaOpToBdIdMap) {
+    // Get the channel.
+    if (dmaBatch->currentDmaOps.empty()) return success();
+    FailureOr<DmaTileData> maybeDmaTileData = getDmaTileData(
+        dmaBatch->currentDmaOps[0], tileOp, shimTileToGeneratorMap);
     if (failed(maybeDmaTileData)) return failure();
-    dmaTileData = *maybeDmaTileData;
-    // Only create expression if more than 1 BD ID is needed and if,
-    // otherwise, fall back to constant BD ID.
-    if (size > 1) {
-      // Assigning BD IDs for all iterations in the loop.
-      SmallVector<uint32_t> bdIds;
-      for (uint32_t i = 0; i < size; i++) {
+    DmaTileData dmaTileData = *maybeDmaTileData;
+    ChannelBdIdGenerator &generator =
+        shimTileToGeneratorMap[tileOp.getResult()];
+    uint32_t numAvailableBdIds =
+        generator.getNumAvailableBdIds(dmaTileData.channel);
+    uint32_t size = std::max(numAvailableBdIds / dmaBatch->requiredBdIds, 1u);
+    scf::ForOp loop = nullptr;
+    AffineExpr ivExpr = nullptr;
+    Value iv = nullptr;
+    // In case the parent of the DMA ops is a scf.for we need to keep track of
+    // the loop induction variable in order to create a semi affine expression
+    // later for distributing BD IDs for each iteration.
+    if (loop = dmaBatch->forOpParent; loop && getNumberIterations(loop)) {
+      iv = loop.getInductionVar();
+      bindDims(loop.getContext(), ivExpr);
+    } else {
+      // In case the DMA ops are not surrounded by scf.for, we will assign
+      // only one BD ID.
+      size = 1;
+    }
+
+    rewriter.setInsertionPoint(dmaBatch->currentDmaOps[0]);
+    for (AMDAIE::NpuDmaCpyNdOp dmaOp : dmaBatch->currentDmaOps) {
+      maybeDmaTileData = getDmaTileData(dmaOp, tileOp, shimTileToGeneratorMap);
+      if (failed(maybeDmaTileData)) return failure();
+      dmaTileData = *maybeDmaTileData;
+      // Only create expression if more than 1 BD ID is needed and if,
+      // otherwise, fall back to constant BD ID.
+      if (size > 1) {
+        // Assigning BD IDs for all iterations in the loop.
+        SmallVector<uint32_t> bdIds;
+        for (uint32_t i = 0; i < size; i++) {
+          std::optional<uint32_t> bdId = generator.getAndAssignBdId(
+              dmaTileData.channel, BdIdAssignmentMode::Incremental);
+          if (!bdId) return failure();
+          bdIds.push_back(bdId.value());
+        }
+        // Get the BD ID for the first iteration as the offset.
+        uint32_t offset = bdIds.front();
+
+        // Create the semi-affine expression.
+        auto affineApply = rewriter.create<affine::AffineApplyOp>(
+            loop.getLoc(), ivExpr % size + offset,
+            ValueRange{
+                iv,
+            });
+        AMDAIE::BdIdOp bdIdOp = rewriter.create<AMDAIE::BdIdOp>(
+            rewriter.getUnknownLoc(), tileOp, affineApply.getResult());
+        bdIdOpToBdIdsMap[bdIdOp] = bdIds;
+        if (!dmaOpToBdIdMap.contains(dmaOp)) {
+          SmallVector<AMDAIE::BdIdOp> bdIdOps = {nullptr, nullptr};
+          dmaOpToBdIdMap[dmaOp] = bdIdOps;
+        }
+
+        dmaOpToBdIdMap[dmaOp][dmaTileData.bdIdMapIndex] = bdIdOp;
+      } else {
+        // Assign a constant BD ID.
         std::optional<uint32_t> bdId = generator.getAndAssignBdId(
             dmaTileData.channel, BdIdAssignmentMode::Incremental);
-        if (!bdId) return failure();
-        bdIds.push_back(bdId.value());
+        if (!bdId) return dmaOp.emitOpError() << "no BD ID available";
+        auto constant = rewriter.create<arith::ConstantOp>(
+            rewriter.getUnknownLoc(), rewriter.getIndexAttr(bdId.value()));
+        AMDAIE::BdIdOp bdIdOp = rewriter.create<AMDAIE::BdIdOp>(
+            rewriter.getUnknownLoc(), tileOp, constant.getResult());
+        if (!dmaOpToBdIdMap.contains(dmaOp)) {
+          SmallVector<AMDAIE::BdIdOp> bdIdOps = {nullptr, nullptr};
+          dmaOpToBdIdMap[dmaOp] = bdIdOps;
+        }
+        dmaOpToBdIdMap[dmaOp][dmaTileData.bdIdMapIndex] = bdIdOp;
       }
-      // Get the BD ID for the first iteration as the offset.
-      uint32_t offset = bdIds.front();
-
-      // Create the semi-affine expression.
-      auto affineApply = rewriter.create<affine::AffineApplyOp>(
-          loop.getLoc(), ivExpr % size + offset,
-          ValueRange{
-              iv,
-          });
-      AMDAIE::BdIdOp bdIdOp = rewriter.create<AMDAIE::BdIdOp>(
-          rewriter.getUnknownLoc(), tileOp, affineApply.getResult());
-      bdIdOpToBdIdsMap[bdIdOp] = bdIds;
-      if (!dmaOpToBdIdMap.contains(dmaOp)) {
-        SmallVector<AMDAIE::BdIdOp> bdIdOps = {nullptr, nullptr};
-        dmaOpToBdIdMap[dmaOp] = bdIdOps;
-      }
-
-      dmaOpToBdIdMap[dmaOp][dmaTileData.bdIdMapIndex] = bdIdOp;
-    } else {
-      // Assign a constant BD ID.
-      std::optional<uint32_t> bdId = generator.getAndAssignBdId(
-          dmaTileData.channel, BdIdAssignmentMode::Incremental);
-      if (!bdId) return dmaOp.emitOpError() << "no BD ID available";
-      auto constant = rewriter.create<arith::ConstantOp>(
-          rewriter.getUnknownLoc(), rewriter.getIndexAttr(bdId.value()));
-      AMDAIE::BdIdOp bdIdOp = rewriter.create<AMDAIE::BdIdOp>(
-          rewriter.getUnknownLoc(), tileOp, constant.getResult());
-      if (!dmaOpToBdIdMap.contains(dmaOp)) {
-        SmallVector<AMDAIE::BdIdOp> bdIdOps = {nullptr, nullptr};
-        dmaOpToBdIdMap[dmaOp] = bdIdOps;
-      }
-      dmaOpToBdIdMap[dmaOp][dmaTileData.bdIdMapIndex] = bdIdOp;
     }
+    return success();
   }
-  return success();
-}
 
-/// Release a given BdId op.
-LogicalResult releaseBdId(
-    AMDAIE::BdIdOp bdIdOp,
-    DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
-    DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap) {
-  auto tileOp =
-      dyn_cast_if_present<AMDAIE::TileOp>(bdIdOp.getTile().getDefiningOp());
-  if (!tileOp)
-    return bdIdOp.emitOpError()
-           << "doesn't operate on a `amdaie.tile` operation";
+  /// Release a given BdId op.
+  static LogicalResult releaseBdId(
+      AMDAIE::BdIdOp bdIdOp,
+      DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
+      DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap) {
+    auto tileOp =
+        dyn_cast_if_present<AMDAIE::TileOp>(bdIdOp.getTile().getDefiningOp());
+    if (!tileOp)
+      return bdIdOp.emitOpError()
+             << "doesn't operate on a `amdaie.tile` operation";
 
-  if (!shimTileToGeneratorMap.contains(tileOp.getResult()))
-    return bdIdOp.emitOpError()
-           << "no BD ID generator found for this BD ID op's tile";
+    if (!shimTileToGeneratorMap.contains(tileOp.getResult()))
+      return bdIdOp.emitOpError()
+             << "no BD ID generator found for this BD ID op's tile";
 
-  ChannelBdIdGenerator &generator = shimTileToGeneratorMap[tileOp.getResult()];
-  Value value = bdIdOp.getValue();
-  if (auto op = value.getDefiningOp<affine::AffineApplyOp>()) {
-    // If the BD ID is a semi-affine expression.
-    if (bdIdOpToBdIdsMap.contains(bdIdOp)) {
-      for (uint32_t bdId : bdIdOpToBdIdsMap[bdIdOp]) {
-        generator.releaseBdId(bdId);
+    ChannelBdIdGenerator &generator =
+        shimTileToGeneratorMap[tileOp.getResult()];
+    Value value = bdIdOp.getValue();
+    if (auto op = value.getDefiningOp<affine::AffineApplyOp>()) {
+      // If the BD ID is a semi-affine expression.
+      if (bdIdOpToBdIdsMap.contains(bdIdOp)) {
+        for (uint32_t bdId : bdIdOpToBdIdsMap[bdIdOp]) {
+          generator.releaseBdId(bdId);
+        }
+      } else {
+        return bdIdOp.emitOpError() << "no BD IDs found for this expression";
       }
     } else {
-      return bdIdOp.emitOpError() << "no BD IDs found for this expression";
+      // Else, must be a constant BD ID.
+      uint32_t bdId = getConstantIndexOrAssert(value);
+      generator.releaseBdId(bdId);
     }
-  } else {
-    // Else, must be a constant BD ID.
-    uint32_t bdId = getConstantIndexOrAssert(value);
-    generator.releaseBdId(bdId);
+    return success();
   }
-  return success();
-}
 
-/// DmaOps are assigned Bd Ids prior to invoking this function and a map
-/// `dmaOpToBdIdMap` is maintained that maps a DmaOp to its source/target Bd
-/// Ids. For each DmaOp in the list `dmaOps`, this API will check the
-/// `dmaOpToBdIdMap` and release Bd Ids if assigned.
-static LogicalResult releaseAssignedBdIdsInCurrentBatch(
-    SmallVector<AMDAIE::NpuDmaCpyNdOp> dmaOps,
-    DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
-    DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
-    DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
-        &dmaOpToBdIdMap) {
-  // Release BD ID used by input DMA op.
-  for (AMDAIE::NpuDmaCpyNdOp npuDmaOp : dmaOps) {
-    if (dmaOpToBdIdMap[npuDmaOp][0]) {
-      if (failed(releaseBdId(dmaOpToBdIdMap[npuDmaOp][0],
-                             shimTileToGeneratorMap, bdIdOpToBdIdsMap)))
-        return failure();
+  /// DmaOps are assigned Bd Ids prior to invoking this function and a map
+  /// `dmaOpToBdIdMap` is maintained that maps a DmaOp to its source/target Bd
+  /// Ids. For each DmaOp in the list `dmaOps`, this API will check the
+  /// `dmaOpToBdIdMap` and release Bd Ids if assigned.
+  static LogicalResult releaseAssignedBdIdsInCurrentBatch(
+      SmallVector<AMDAIE::NpuDmaCpyNdOp> dmaOps,
+      DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
+      DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
+      DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
+          &dmaOpToBdIdMap) {
+    // Release BD ID used by input DMA op.
+    for (AMDAIE::NpuDmaCpyNdOp npuDmaOp : dmaOps) {
+      if (dmaOpToBdIdMap[npuDmaOp][0]) {
+        if (failed(releaseBdId(dmaOpToBdIdMap[npuDmaOp][0],
+                               shimTileToGeneratorMap, bdIdOpToBdIdsMap)))
+          return failure();
+      }
+
+      if (dmaOpToBdIdMap[npuDmaOp][1]) {
+        if (failed(releaseBdId(dmaOpToBdIdMap[npuDmaOp][1],
+                               shimTileToGeneratorMap, bdIdOpToBdIdsMap)))
+          return failure();
+      }
     }
+    return success();
+  }
+};
 
-    if (dmaOpToBdIdMap[npuDmaOp][1]) {
-      if (failed(releaseBdId(dmaOpToBdIdMap[npuDmaOp][1],
-                             shimTileToGeneratorMap, bdIdOpToBdIdsMap)))
-        return failure();
+/// The function `createTileDmaBatchGraph` returns a `TileDmaBatchGraph` to the
+/// caller.
+/// Each invocation of the following function helps create a graph of DmaBatch
+/// as follows :-
+/// 1. Creates a new TileDmaBatchGraph.
+/// 2. For each op in the parent op:
+///     a. If the op is a DMA Op, we get the tiles it operates on and add it to
+///        the current tileDmaBatchGraph formed in step 1 (and updates
+///        `currDmaOp` for tracking the current DmaBatch).
+///     b. If the op is a DMA Wait Op, that means the current DmaBatch can end
+///        and we therefore start a new DmaBatch.
+///     c. If the op is scf.for/forall, we recursively invoke the same function
+///        with this op as the parent op. This basically means we are getting
+///        into a nested structure. And since this API returns a
+///        `TileDmaBatchGraph`, the returned structure is essentially the nested
+///        `TileDmaBatchGraph`. Hence we need to update the current
+///        `TileDmaBatchGraph` formed in step 1 to have this returned structure
+///        as its nested/subgraph.
+static TileDmaBatchGraph createTileDmaBatchGraph(
+    AMDAIE::WorkgroupOp &workgroupOp, Operation *parentOp,
+    DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap) {
+  TileDmaBatchGraph tileDmaBatchGraph =
+      TileDmaBatchGraph(workgroupOp, parentOp);
+
+  AMDAIE::NpuDmaCpyNdOp currDmaOp = nullptr;
+  // Traverse the parent operation's immediate child ops and form the
+  // tileParentOpDmaBatchMap.
+  for (Operation &op : parentOp->getRegion(0).getOps()) {
+    if (isa<scf::ForOp, scf::ForallOp>(op)) {
+      TileDmaBatchGraph innerTileDmaBatchGraph =
+          createTileDmaBatchGraph(workgroupOp, &op, shimTileToGeneratorMap);
+      tileDmaBatchGraph.updateInnerBatchesOfCurrentTileDmaBatchGraph(
+          innerTileDmaBatchGraph);
+    } else if (auto dmaOp = dyn_cast<AMDAIE::NpuDmaCpyNdOp>(op)) {
+      if (dmaOp.getSource()) {
+        FailureOr<AMDAIE::TileOp> tile =
+            getGeneratorTileOp<CopyOpOperateOn::Source>(dmaOp,
+                                                        shimTileToGeneratorMap);
+        if (succeeded(tile)) tileDmaBatchGraph.addDmaToBatch(*tile, dmaOp);
+      }
+      if (dmaOp.getTarget()) {
+        FailureOr<AMDAIE::TileOp> tile =
+            getGeneratorTileOp<CopyOpOperateOn::Target>(dmaOp,
+                                                        shimTileToGeneratorMap);
+        if (succeeded(tile)) tileDmaBatchGraph.addDmaToBatch(*tile, dmaOp);
+      }
+      if (!currDmaOp) currDmaOp = dmaOp;
+    } else if (auto npuWaitOp = dyn_cast<AMDAIE::NpuDmaWaitOp>(op)) {
+      for (AMDAIE::NpuDmaCpyNdOp npuDmaOp : npuWaitOp.getDmaOps()) {
+        // Reached the DMA wait operation, reset tracking of current DMA op for
+        // the tile.
+        if (npuDmaOp == currDmaOp) {
+          currDmaOp = nullptr;
+          if (npuDmaOp.getSource()) {
+            FailureOr<AMDAIE::TileOp> tile =
+                getGeneratorTileOp<CopyOpOperateOn::Source>(
+                    npuDmaOp, shimTileToGeneratorMap);
+            if (succeeded(tile))
+              tileDmaBatchGraph.updateCurrentTileBatch(*tile);
+          }
+          if (npuDmaOp.getTarget()) {
+            FailureOr<AMDAIE::TileOp> tile =
+                getGeneratorTileOp<CopyOpOperateOn::Target>(
+                    npuDmaOp, shimTileToGeneratorMap);
+            if (succeeded(tile))
+              tileDmaBatchGraph.updateCurrentTileBatch(*tile);
+          }
+        }
+      }
     }
   }
-  return success();
-}
-
-/// Declaration of an API which will work on assigning Bd Ids to the inner
-/// DmaBatch of the current DmaBatch `parentDmaBatch`. And maintain a mapping of
-/// DmaOp -> source/target Bd Id which would be used later during new DmaOp
-/// creation/replacement.
-static LogicalResult assignRequiredBdIdsInInnerBatch(
-    IRRewriter &rewriter, AMDAIE::TileOp tileOp, DmaBatch *parentDmaBatch,
-    DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
-    DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
-    DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
-        &dmaOpToBdIdMap);
-
-/// Since a DmaBatch contains the following :-
-///   1. DmaOps within the current batch.
-///   2. Nested DmaBatch chain.
-///   3. Pointer to the sibling DmaBatch.
-/// This API processes a given DmaBatch by :-
-///   a. Assigning Bd Ids to 1.
-///   b. Assigning Bd Ids to 2.
-///   c. Releasing Bd Ids assigned to 1.
-///   d. Moving on to 3 and repeating steps a-to-d for it.
-static LogicalResult processDmaBatch(
-    IRRewriter &rewriter, AMDAIE::TileOp tileOp, DmaBatch *currDmaBatch,
-    DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
-    DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
-    DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
-        &dmaOpToBdIdMap) {
-  do {
-    if (isEmptyDmaBatch(currDmaBatch)) break;
-    if (failed(assignRequiredBdIdsInCurrentBatch(
-            rewriter, tileOp, currDmaBatch, shimTileToGeneratorMap,
-            bdIdOpToBdIdsMap, dmaOpToBdIdMap)))
-      return failure();
-
-    if (failed(assignRequiredBdIdsInInnerBatch(
-            rewriter, tileOp, currDmaBatch, shimTileToGeneratorMap,
-            bdIdOpToBdIdsMap, dmaOpToBdIdMap)))
-      return failure();
-
-    if (failed(releaseAssignedBdIdsInCurrentBatch(
-            currDmaBatch->currentDmaOps, shimTileToGeneratorMap,
-            bdIdOpToBdIdsMap, dmaOpToBdIdMap)))
-      return failure();
-
-    currDmaBatch = currDmaBatch->nextDmaBatch;
-  } while (currDmaBatch != nullptr);
-  return success();
-}
-
-static LogicalResult assignRequiredBdIdsInInnerBatch(
-    IRRewriter &rewriter, AMDAIE::TileOp tileOp, DmaBatch *parentDmaBatch,
-    DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
-    DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
-    DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
-        &dmaOpToBdIdMap) {
-  for (DmaBatch *dmaBatch : parentDmaBatch->immediateInnerBatches) {
-    if (failed(processDmaBatch(rewriter, tileOp, dmaBatch,
-                               shimTileToGeneratorMap, bdIdOpToBdIdsMap,
-                               dmaOpToBdIdMap)))
-      return failure();
-  }
-  return success();
-}
-
-/// This API will work on assigning Bd Ids to each DmaBatch belonging to a
-/// particular Tile. And maintain a mapping of DmaOp -> source/target Bd Id
-/// which would be used later during new DmaOp creation/replacement.
-static LogicalResult assignRequiredBdIdsInBatch(
-    IRRewriter &rewriter, TileDmaBatchGraph &tileDmaBatchGraph,
-    DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
-    DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
-    DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
-        &dmaOpToBdIdMap) {
-  for (auto [tileOp, dmaBatch] : tileDmaBatchGraph) {
-    if (failed(processDmaBatch(rewriter, tileOp, dmaBatch,
-                               shimTileToGeneratorMap, bdIdOpToBdIdsMap,
-                               dmaOpToBdIdMap)))
-      return failure();
-  }
-  return success();
+  return tileDmaBatchGraph;
 }
 
 /// Traverse each DmaOp inside ControlCode and replace it with new new DmaOp
@@ -541,7 +553,7 @@ static LogicalResult createNewDmaOpsAndReplaceOldDmaOps(
       targetBdId = dmaOpToBdIdMap[npuDmaOp][/*targetBdIdIndex=*/1].getResult();
     }
     rewriter.setInsertionPoint(npuDmaOp);
-    (void)rewriter.replaceOpWithNewOp<AMDAIE::NpuDmaCpyNdOp>(
+    rewriter.replaceOpWithNewOp<AMDAIE::NpuDmaCpyNdOp>(
         npuDmaOp, npuDmaOp.getResultTypes(), npuDmaOp.getConnection(),
         npuDmaOp.getTarget(), npuDmaOp.getTargetMixedOffsets(),
         npuDmaOp.getTargetMixedSizes(), npuDmaOp.getTargetMixedStrides(),
@@ -585,12 +597,11 @@ LogicalResult assignNpuDmaBdIds(AMDAIE::WorkgroupOp workgroupOp) {
   // Since a DMA op can have source and target, therefore we can have two BD IDs
   // for any DMA op. Hence we maintain a map from DMA op to a vector of BD IDs.
   DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>> dmaOpToBdIdMap;
-  TileDmaBatchGraph tileDmaBatchGraph =
-      formTileDmaBatchGraph(workgroupOp, controlCodeOp, shimTileToGeneratorMap);
-  inferBdIdsRequiredInBatches(tileDmaBatchGraph);
-  if (failed(assignRequiredBdIdsInBatch(rewriter, tileDmaBatchGraph,
-                                        shimTileToGeneratorMap,
-                                        bdIdOpToBdIdsMap, dmaOpToBdIdMap)))
+  TileDmaBatchGraph tileDmaBatchGraph = createTileDmaBatchGraph(
+      workgroupOp, controlCodeOp, shimTileToGeneratorMap);
+  tileDmaBatchGraph.inferBdIdsRequiredInBatches();
+  if (failed(tileDmaBatchGraph.assignRequiredBdIdsInBatch(
+          rewriter, shimTileToGeneratorMap, bdIdOpToBdIdsMap, dmaOpToBdIdMap)))
     return failure();
   if (failed(createNewDmaOpsAndReplaceOldDmaOps(rewriter, controlCodeOp,
                                                 dmaOpToBdIdMap)))

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignNpuDmaBdIds.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignNpuDmaBdIds.cpp
@@ -75,91 +75,38 @@ std::optional<uint32_t> getNumberIterations(scf::ForOp loop) {
   }
 }
 
-/// Computes the number of BD IDs required between the current
-/// DMA copy operation and its corresponding DMA wait operation; returns the DMA
-/// ops it traverses within same block and on same tile. If a sub-loop is
-/// encountered, it assumes that a BD ID expression will be used within the
-/// sub-loop. This approach ensures that the inner loop has access to a greater
-/// number of BD IDs, which is favorable for enabling efficient BD chaining in
-/// subsequent passes.
-///
-/// Example:
-/// %0 = dma_copy {bd_id = 0}   // Current DMA copy
-/// scf.for %arg0 = %c0 to %c1 step %c2 {
-///   %1 = dma_copy {bd_id = %arg0 + 1}  // DMA copy inside a sub-loop
-///   dma_wait(%1)                       // Wait for the sub-loop DMA copy
-/// }
-/// dma_wait(%0)   // Current DMA wait
-///
-/// In this example:
-/// - The current DMA copy (%0) requires 1 BD ID.
-/// - The sub-loop executes 2 iterations, each requiring 1 BD ID.
-/// - Therefore, the required number of BD IDs is:
-///  3 = 1 (current) + 2 * 1(sub-loop).
-SmallVector<AMDAIE::NpuDmaCpyNdOp> getNumRequiredBdIdsAndDMAOps(
-    Operation *parentOp, AMDAIE::NpuDmaCpyNdOp currDmaOp, AMDAIE::TileOp tileOp,
-    DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
-    uint32_t &numRequiredBdIds) {
-  SmallVector<AMDAIE::NpuDmaCpyNdOp> dmaOps;
-  bool startCounting =
-      (currDmaOp == nullptr);  // Start immediately if no currDmaOp
-
-  parentOp->walk([&](Operation *op) {
-    if (op->getParentOp() != parentOp) return WalkResult::skip();
-    if (auto npuDmaOp = dyn_cast<AMDAIE::NpuDmaCpyNdOp>(op)) {
-      // Skip until currDmaOp is found
-      if (npuDmaOp == currDmaOp) startCounting = true;
-      if (!startCounting) WalkResult::skip();
-      if (npuDmaOp.getSource()) {
-        FailureOr<AMDAIE::TileOp> tile =
-            getGeneratorTileOp<CopyOpOperateOn::Source>(npuDmaOp,
-                                                        shimTileToGeneratorMap);
-        if (succeeded(tile) && *tile == tileOp && !npuDmaOp.getSourceBdIdOp()) {
-          dmaOps.push_back(npuDmaOp);
-          numRequiredBdIds++;
-        }
-      }
-      if (npuDmaOp.getTarget()) {
-        FailureOr<AMDAIE::TileOp> tile =
-            getGeneratorTileOp<CopyOpOperateOn::Target>(npuDmaOp,
-                                                        shimTileToGeneratorMap);
-        if (succeeded(tile) && *tile == tileOp && !npuDmaOp.getTargetBdIdOp()) {
-          dmaOps.push_back(npuDmaOp);
-          numRequiredBdIds++;
-        }
-      }
-    } else if (auto npuWaitOp = dyn_cast<AMDAIE::NpuDmaWaitOp>(op)) {
-      for (AMDAIE::NpuDmaCpyNdOp npuDmaOp : npuWaitOp.getDmaOps()) {
-        // Reached the DMA wait operation, stop counting.
-        if (npuDmaOp == currDmaOp) return WalkResult::interrupt();
-      }
-    } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
-      uint32_t subLoopBdIdCount = 0;
-      (void)getNumRequiredBdIdsAndDMAOps(
-          forOp, nullptr, tileOp, shimTileToGeneratorMap, subLoopBdIdCount);
-      std::optional<uint32_t> subIterations = getNumberIterations(forOp);
-      if (subIterations) {
-        numRequiredBdIds += subLoopBdIdCount * subIterations.value();
-      } else {
-        numRequiredBdIds += subLoopBdIdCount;
-      }
-    }
-    return WalkResult::advance();
-  });
-  return dmaOps;
-}
-
 /// Given a list of DMA Ops and the number of required BD IDs by the first DMA
 /// op in the list, split the available BD IDs equally amongst all and assign it
 /// to the DMA ops.
-LogicalResult assignBdIdsToDMAOps(
+LogicalResult assignBdIdsToDMAOpsBatch(
     IRRewriter &rewriter, SmallVector<AMDAIE::NpuDmaCpyNdOp> &dmaOps,
-    AMDAIE::TileOp tileOp, uint32_t channel,
+    AMDAIE::TileOp tileOp,
     DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
     DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
     DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
         &dmaOpToBdIdMap,
     uint32_t numRequiredBdIds) {
+  llvm::outs() << "assignBdIdsToDMAOpsBatch BEGIN ======\n";
+  llvm::outs() << "DB - 1\n";
+  llvm::outs().flush();
+  // Get the channel.
+  FailureOr<AMDAIE::ChannelOp> maybeChannelOp;
+  if (dmaOps[0].getSource()) {
+    FailureOr<AMDAIE::TileOp> tile =
+        getGeneratorTileOp<CopyOpOperateOn::Source>(dmaOps[0],
+                                                    shimTileToGeneratorMap);
+    if (succeeded(tile)) maybeChannelOp = dmaOps[0].getSourceChannelOp();
+  }
+  if (dmaOps[0].getTarget()) {
+    FailureOr<AMDAIE::TileOp> tile =
+        getGeneratorTileOp<CopyOpOperateOn::Target>(dmaOps[0],
+                                                    shimTileToGeneratorMap);
+    if (succeeded(tile)) maybeChannelOp = dmaOps[0].getTargetChannelOp();
+  }
+  llvm::outs() << "DB - 2\n";
+  llvm::outs().flush();
+  if (failed(maybeChannelOp)) return failure();
+  uint32_t channel = maybeChannelOp.value().getValue();
   // Compute BD ID split amongst all DMA ops.
   ChannelBdIdGenerator &generator = shimTileToGeneratorMap[tileOp.getResult()];
   uint32_t numAvailable = generator.getNumAvailableBdIds(channel);
@@ -180,12 +127,18 @@ LogicalResult assignBdIdsToDMAOps(
     // one BD ID.
     size = 1;
   }
+  llvm::outs() << "DB - 3\n";
+  llvm::outs().flush();
   // In case there are not enough BD ids available, return failure.
   if (size * totalDmaOps > numAvailable) return failure();
 
+  llvm::outs() << "DB - 4\n";
+  llvm::outs().flush();
   // Traverse each DMA op found in step 1, assign BD IDs and keep a track of the
   // first BD ID op assigned.
   rewriter.setInsertionPoint(dmaOps[0]);
+  llvm::outs() << "DMAOps batch size = " << dmaOps.size() << "\n";
+  llvm::outs().flush();
   for (AMDAIE::NpuDmaCpyNdOp dmaOp : dmaOps) {
     uint32_t bdIdMapIndex = 0;
     if (dmaOp.getSource()) {
@@ -209,12 +162,16 @@ LogicalResult assignBdIdsToDMAOps(
     if (size > 1) {
       // Assigning BD IDs for all iterations in the loop.
       SmallVector<uint32_t> bdIds;
+      llvm::outs() << "DB - 1.0\n";
+      llvm::outs().flush();
       for (uint32_t i = 0; i < size; i++) {
         std::optional<uint32_t> bdId = generator.getAndAssignBdId(
             channel, BdIdAssignmentMode::Incremental);
         if (!bdId) return failure();
         bdIds.push_back(bdId.value());
       }
+      llvm::outs() << "DB - 1.1\n";
+      llvm::outs().flush();
       // Get the BD ID for the first iteration as the offset.
       uint32_t offset = bdIds.front();
 
@@ -237,7 +194,11 @@ LogicalResult assignBdIdsToDMAOps(
       // Assign a constant BD ID.
       std::optional<uint32_t> bdId =
           generator.getAndAssignBdId(channel, BdIdAssignmentMode::Incremental);
+      llvm::outs() << "DB - 2.0\n";
+      llvm::outs().flush();
       if (!bdId) return dmaOp.emitOpError() << "no BD ID available";
+      llvm::outs() << "DB - 2.1\n";
+      llvm::outs().flush();
       auto constant = rewriter.create<arith::ConstantOp>(
           rewriter.getUnknownLoc(), rewriter.getIndexAttr(bdId.value()));
       AMDAIE::BdIdOp bdIdOp = rewriter.create<AMDAIE::BdIdOp>(
@@ -249,58 +210,10 @@ LogicalResult assignBdIdsToDMAOps(
       dmaOpToBdIdMap[dmaOp][bdIdMapIndex] = bdIdOp;
     }
   }
+  llvm::outs() << "END =================\n";
+  llvm::outs().flush();
   return success();
 }
-
-/// For a given DMA op operating within a block and a tile, this function first
-/// traverses and collects all DMA ops that lie between the current DMA op and
-/// its corresponding DMA wait operation. During the traversal it also makes a
-/// note of the required BD ID by the current DMA op in order to use it to split
-/// it amongst other DMA ops fetch. It then traverses all those DMA ops fetched
-/// and assigns BD ID to each one of them. If the DMA copy operation is inside a
-/// loop, the BD ID operation will be created with a semi-affine expression to
-/// assign different BD IDs for each iteration. Otherwise, a constant BD ID will
-/// be assigned.
-template <CopyOpOperateOn OperateOn>
-LogicalResult processCurrentDmaOpBlockForAssigningBdId(
-    IRRewriter &rewriter, AMDAIE::NpuDmaCpyNdOp npuDmaOp,
-    DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
-    DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
-    DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
-        &dmaOpToBdIdMap) {
-  // Get the TileOp.
-  FailureOr<AMDAIE::TileOp> maybeTileOp =
-      getGeneratorTileOp<OperateOn>(npuDmaOp, shimTileToGeneratorMap);
-  if (failed(maybeTileOp)) return failure();
-  AMDAIE::TileOp tileOp = maybeTileOp.value();
-
-  // Get the channel.
-  FailureOr<AMDAIE::ChannelOp> maybeChannelOp;
-  if constexpr (OperateOn == CopyOpOperateOn::Source) {
-    maybeChannelOp = npuDmaOp.getSourceChannelOp();
-  } else if constexpr (OperateOn == CopyOpOperateOn::Target) {
-    maybeChannelOp = npuDmaOp.getTargetChannelOp();
-  } else {
-    return npuDmaOp.emitOpError()
-           << "Function can only operate on Source or Target";
-  }
-  if (failed(maybeChannelOp)) return failure();
-  uint32_t channel = maybeChannelOp.value().getValue();
-
-  // Get the number of BD IDs that will be required by the current DMA op.
-  // While fetching the required BD IDs for the current DMA op, keep track
-  // of the DMA ops within the same scf.for block that are operating on the
-  // same tile and lie between the current DMA op and its corresponding DMA
-  // wait op.
-  uint32_t numRequiredBdIds = 0;
-  SmallVector<AMDAIE::NpuDmaCpyNdOp> dmaOps =
-      getNumRequiredBdIdsAndDMAOps(npuDmaOp->getParentOp(), npuDmaOp, tileOp,
-                                   shimTileToGeneratorMap, numRequiredBdIds);
-
-  return assignBdIdsToDMAOps(rewriter, dmaOps, tileOp, channel,
-                             shimTileToGeneratorMap, bdIdOpToBdIdsMap,
-                             dmaOpToBdIdMap, numRequiredBdIds);
-};
 
 LogicalResult releaseBdId(
     AMDAIE::BdIdOp bdIdOp,
@@ -335,6 +248,203 @@ LogicalResult releaseBdId(
   return success();
 }
 
+static LogicalResult releaseAllBdIds(
+    SmallVector<AMDAIE::NpuDmaCpyNdOp> dmaOps,
+    DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
+    DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap) {
+  // Release BD ID used by input DMA op.
+  for (AMDAIE::NpuDmaCpyNdOp npuDmaOp : dmaOps) {
+    AMDAIE::BdIdOp bdIdOp;
+    if (npuDmaOp.getSourceBdId()) {
+      bdIdOp = dyn_cast_if_present<AMDAIE::BdIdOp>(
+          npuDmaOp.getSourceBdId().getDefiningOp());
+      if (!bdIdOp) continue;
+      if (failed(releaseBdId(bdIdOp, shimTileToGeneratorMap, bdIdOpToBdIdsMap)))
+        return failure();
+    }
+
+    if (npuDmaOp.getTargetBdId()) {
+      bdIdOp = dyn_cast_if_present<AMDAIE::BdIdOp>(
+          npuDmaOp.getTargetBdId().getDefiningOp());
+      if (!bdIdOp) continue;
+      if (failed(releaseBdId(bdIdOp, shimTileToGeneratorMap, bdIdOpToBdIdsMap)))
+        return failure();
+    }
+  }
+  return success();
+}
+
+typedef struct ControlCodeGraphStruct {
+  llvm::MapVector<
+      AMDAIE::TileOp,
+      llvm::MapVector<Operation *,
+                      SmallVector<SmallVector<AMDAIE::NpuDmaCpyNdOp>>>>
+      tileParentOpDmaBatchMap;
+  llvm::MapVector<Operation *, SmallVector<Operation *>>
+      parentOpToImmediateInnerParentOps;
+  DenseMap<AMDAIE::NpuDmaCpyNdOp, AMDAIE::NpuDmaWaitOp> dmaOpToWaitOp;
+} ControlCodeGraph;
+
+static void formControlCodeGraph(
+    Operation *parentOp, ControlCodeGraph &controlCodeGraph,
+    DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap) {
+  DenseMap<AMDAIE::TileOp, AMDAIE::NpuDmaCpyNdOp> tileToFirstDmaOpMap;
+  SmallVector<Operation *> immediateInnerParentOps;
+  auto updatetileParentOpDmaBatchMap = [&](AMDAIE::TileOp tile,
+                                           Operation *parentOp,
+                                           AMDAIE::NpuDmaCpyNdOp dmaOp) {
+    if (!controlCodeGraph.tileParentOpDmaBatchMap.contains(tile)) {
+      llvm::MapVector<Operation *,
+                      SmallVector<SmallVector<AMDAIE::NpuDmaCpyNdOp>>>
+          parentOpToBatchMap;
+      parentOpToBatchMap[parentOp] = {};
+      controlCodeGraph.tileParentOpDmaBatchMap[tile] = parentOpToBatchMap;
+    }
+    if (!tileToFirstDmaOpMap.contains(tile) || !tileToFirstDmaOpMap[tile]) {
+      controlCodeGraph.tileParentOpDmaBatchMap[tile][parentOp].push_back(
+          {dmaOp});
+      tileToFirstDmaOpMap[tile] = dmaOp;
+    } else {
+      int32_t totalBatchSoFar =
+          controlCodeGraph.tileParentOpDmaBatchMap[tile][parentOp].size();
+      assert((totalBatchSoFar >= 1) &&
+             "expected at least on DMAOp in the batch");
+      controlCodeGraph
+          .tileParentOpDmaBatchMap[tile][parentOp][totalBatchSoFar - 1]
+          .push_back(dmaOp);
+    }
+  };
+  AMDAIE::NpuDmaCpyNdOp currDmaOp = nullptr;
+  // Traverse the parent operation's immediate child ops and form the
+  // tileParentOpDmaBatchMap.
+  for (Operation &op : parentOp->getRegion(0).getOps()) {
+    if (isa<scf::ForOp, scf::ForallOp>(op))
+      immediateInnerParentOps.push_back(&op);
+    else if (auto dmaOp = dyn_cast<AMDAIE::NpuDmaCpyNdOp>(op)) {
+      if (dmaOp.getSource()) {
+        FailureOr<AMDAIE::TileOp> tile =
+            getGeneratorTileOp<CopyOpOperateOn::Source>(dmaOp,
+                                                        shimTileToGeneratorMap);
+        if (succeeded(tile))
+          updatetileParentOpDmaBatchMap(*tile, parentOp, dmaOp);
+      }
+      if (dmaOp.getTarget()) {
+        FailureOr<AMDAIE::TileOp> tile =
+            getGeneratorTileOp<CopyOpOperateOn::Target>(dmaOp,
+                                                        shimTileToGeneratorMap);
+        if (succeeded(tile))
+          updatetileParentOpDmaBatchMap(*tile, parentOp, dmaOp);
+      }
+      if (!currDmaOp) currDmaOp = dmaOp;
+    } else if (auto npuWaitOp = dyn_cast<AMDAIE::NpuDmaWaitOp>(op)) {
+      for (AMDAIE::NpuDmaCpyNdOp npuDmaOp : npuWaitOp.getDmaOps()) {
+        // Reached the DMA wait operation, reset tracking of current DMA op for
+        // the tile.
+        if (npuDmaOp == currDmaOp) {
+          controlCodeGraph.dmaOpToWaitOp[npuDmaOp] = npuWaitOp;
+          currDmaOp = nullptr;
+          if (npuDmaOp.getSource()) {
+            FailureOr<AMDAIE::TileOp> tile =
+                getGeneratorTileOp<CopyOpOperateOn::Source>(
+                    npuDmaOp, shimTileToGeneratorMap);
+            if (succeeded(tile)) {
+              tileToFirstDmaOpMap[*tile] = nullptr;
+            }
+          }
+          if (npuDmaOp.getTarget()) {
+            FailureOr<AMDAIE::TileOp> tile =
+                getGeneratorTileOp<CopyOpOperateOn::Target>(
+                    npuDmaOp, shimTileToGeneratorMap);
+            if (succeeded(tile)) {
+              tileToFirstDmaOpMap[*tile] = nullptr;
+            }
+          }
+        }
+      }
+    }
+  }
+  controlCodeGraph.parentOpToImmediateInnerParentOps[parentOp] =
+      immediateInnerParentOps;
+  // Traverse the immediate inner child operations of the parent op which can in
+  // turn have DMA ops.
+  for (Operation *op : immediateInnerParentOps)
+    formControlCodeGraph(op, controlCodeGraph, shimTileToGeneratorMap);
+}
+
+static uint32_t traverseInnerParentOpChain(AMDAIE::TileOp tile,
+                                           Operation *parentOp,
+                                           ControlCodeGraph &controlCodeGraph) {
+  uint32_t requiredBdIds = 0;
+  if (isa<scf::ForallOp>(parentOp)) return 0;
+  if (!controlCodeGraph.tileParentOpDmaBatchMap[tile].contains(parentOp)) {
+    requiredBdIds = 0;
+  } else {
+    SmallVector<SmallVector<AMDAIE::NpuDmaCpyNdOp>> batches =
+        controlCodeGraph.tileParentOpDmaBatchMap[tile][parentOp];
+    uint32_t totalDmaOpsInParentOpOperatingOnTile = 0;
+    for (SmallVector<AMDAIE::NpuDmaCpyNdOp> batch : batches) {
+      totalDmaOpsInParentOpOperatingOnTile += batch.size();
+    }
+    requiredBdIds = totalDmaOpsInParentOpOperatingOnTile;
+  }
+  for (Operation *immediateInnerParentOp :
+       controlCodeGraph.parentOpToImmediateInnerParentOps[parentOp]) {
+    uint32_t requiredBdIdsByInnerParentOp = traverseInnerParentOpChain(
+        tile, immediateInnerParentOp, controlCodeGraph);
+    std::optional<uint32_t> loopIterations =
+        getNumberIterations(cast<scf::ForOp>(immediateInnerParentOp));
+    if (loopIterations) {
+      requiredBdIds += requiredBdIdsByInnerParentOp * loopIterations.value();
+    } else {
+      requiredBdIds += requiredBdIdsByInnerParentOp;
+    }
+  }
+  return requiredBdIds;
+}
+
+/// Computes the number of BD IDs required between the current
+/// DMA copy operation and its corresponding DMA wait operation; returns the DMA
+/// ops it traverses within same block and on same tile. If a sub-loop is
+/// encountered, it takes into account any DMA ops being used on the same tile.
+/// This approach ensures that the inner loop has access to a greater
+/// number of BD IDs, which is favorable for enabling efficient BD chaining in
+/// subsequent passes.
+///
+/// Example:
+/// %0 = dma_copy {bd_id = 0}   // Current DMA copy
+/// scf.for %arg0 = %c0 to %c1 step %c2 {
+///   %1 = dma_copy {bd_id = %arg0 + 1}  // DMA copy inside a sub-loop
+///   dma_wait(%1)                       // Wait for the sub-loop DMA copy
+/// }
+/// dma_wait(%0)   // Current DMA wait
+///
+/// In this example:
+/// - The current DMA copy (%0) requires 1 BD ID.
+/// - The sub-loop executes 2 iterations, each requiring 1 BD ID.
+/// - Therefore, the required number of BD IDs is:
+///  3 = 1 (current) + 2 * 1(sub-loop).
+static uint32_t traverseParentOpChainToGetBdIds(
+    AMDAIE::TileOp tile, Operation *parentOp,
+    ControlCodeGraph &controlCodeGraph, AMDAIE::NpuDmaCpyNdOp npuDmaOp) {
+  uint32_t requiredBdIds = 0;
+  AMDAIE::NpuDmaWaitOp npuWaitOp = controlCodeGraph.dmaOpToWaitOp[npuDmaOp];
+  for (Operation *immediateInnerParentOp :
+       controlCodeGraph.parentOpToImmediateInnerParentOps[parentOp]) {
+    if (!immediateInnerParentOp->isBeforeInBlock(npuWaitOp)) break;
+    if (auto forOp = dyn_cast<scf::ForOp>(immediateInnerParentOp)) {
+      uint32_t requiredBdIdsByInnerParentOp = traverseInnerParentOpChain(
+          tile, immediateInnerParentOp, controlCodeGraph);
+      std::optional<uint32_t> loopIterations = getNumberIterations(forOp);
+      if (loopIterations) {
+        requiredBdIds += requiredBdIdsByInnerParentOp * loopIterations.value();
+      } else {
+        requiredBdIds += requiredBdIdsByInnerParentOp;
+      }
+    }
+  }
+  return requiredBdIds;
+}
+
 /// Assign BD ids to NPU dma operations using the BD generator.
 LogicalResult assignNpuDmaBdIds(AMDAIE::WorkgroupOp workgroupOp) {
   IRRewriter rewriter(workgroupOp->getContext());
@@ -366,20 +476,38 @@ LogicalResult assignNpuDmaBdIds(AMDAIE::WorkgroupOp workgroupOp) {
   // Since a DMA op can have source and target, therefore we can have two BD IDs
   // for any DMA op. Hence we maintain a map from DMA op to a vector of BD IDs.
   DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>> dmaOpToBdIdMap;
+  ControlCodeGraph controlCodeGraph;
+  formControlCodeGraph(controlCodeOp, controlCodeGraph, shimTileToGeneratorMap);
+  // For each (tile, parentOp) pair assign BD Ids to DMA Ops batch by updating
+  // `dmaOpToBdIdMap`.
+  for (auto tileParentOpDmaBatch : controlCodeGraph.tileParentOpDmaBatchMap) {
+    AMDAIE::TileOp tile = tileParentOpDmaBatch.first;
+    llvm::outs() << "Tile = " << tile << "\n";
+    llvm::outs().flush();
+    for (auto parentOpDmaBatch : tileParentOpDmaBatch.second) {
+      Operation *parentOp = parentOpDmaBatch.first;
+      llvm::outs() << "ParentOp = " << (*parentOp) << "\n";
+      llvm::outs().flush();
+      for (SmallVector<AMDAIE::NpuDmaCpyNdOp> batch : parentOpDmaBatch.second) {
+        uint32_t requiredBdIdsByInnerOpChain = traverseParentOpChainToGetBdIds(
+            tile, parentOp, controlCodeGraph, batch[0]);
+        uint32_t totalBdIdsRequiredPerIteration =
+            requiredBdIdsByInnerOpChain + batch.size();
+        if (failed(assignBdIdsToDMAOpsBatch(
+                rewriter, batch, tile, shimTileToGeneratorMap, bdIdOpToBdIdsMap,
+                dmaOpToBdIdMap, totalBdIdsRequiredPerIteration)))
+          return failure();
+        if (failed(releaseAllBdIds(batch, shimTileToGeneratorMap,
+                                   bdIdOpToBdIdsMap)))
+          return failure();
+      }
+    }
+  }
+  // At this step we have all the information to traverse and perform the
+  // replacements of the DMA Ops.
   WalkResult res = controlCodeOp->walk([&](Operation *op) {
     if (auto npuDmaOp = dyn_cast<AMDAIE::NpuDmaCpyNdOp>(op)) {
       if (npuDmaOp.getSource()) {
-        // In case a BD ID candidate has not been assigned to the current DMA
-        // op's source, we go ahead to process the block that contains this DMA
-        // op.
-        if (!dmaOpToBdIdMap.contains(npuDmaOp) ||
-            !dmaOpToBdIdMap[npuDmaOp][/*sourceBdIdIndex=*/0]) {
-          if (failed(processCurrentDmaOpBlockForAssigningBdId<
-                     CopyOpOperateOn::Source>(
-                  rewriter, npuDmaOp, shimTileToGeneratorMap, bdIdOpToBdIdsMap,
-                  dmaOpToBdIdMap)))
-            return WalkResult::interrupt();
-        }
         assert(dmaOpToBdIdMap.contains(npuDmaOp) && "No BD ID mapping found");
         assert((dmaOpToBdIdMap[npuDmaOp][/*sourceBdIdIndex=*/0] != nullptr) &&
                "No source BD ID mapping found");
@@ -399,17 +527,6 @@ LogicalResult assignNpuDmaBdIds(AMDAIE::WorkgroupOp workgroupOp) {
         dmaOpToBdIdMap[npuDmaOp] = dmaOpToBdIdMap[oldNpuDmaOp];
       }
       if (npuDmaOp.getTarget()) {
-        // In case a BD ID candidate has not been assigned to the current DMA
-        // op's target, we go ahead to process the block that contains this DMA
-        // op.
-        if (!dmaOpToBdIdMap.contains(npuDmaOp) ||
-            !dmaOpToBdIdMap[npuDmaOp][/*targetBdIdIndex=*/1]) {
-          if (failed(processCurrentDmaOpBlockForAssigningBdId<
-                     CopyOpOperateOn::Target>(
-                  rewriter, npuDmaOp, shimTileToGeneratorMap, bdIdOpToBdIdsMap,
-                  dmaOpToBdIdMap)))
-            return WalkResult::interrupt();
-        }
         assert(dmaOpToBdIdMap.contains(npuDmaOp) && "No BD ID mapping found");
         assert((dmaOpToBdIdMap[npuDmaOp][/*targetBdIdIndex=*/1] != nullptr) &&
                "No target BD ID mapping found");
@@ -425,28 +542,28 @@ LogicalResult assignNpuDmaBdIds(AMDAIE::WorkgroupOp workgroupOp) {
       }
       return WalkResult::advance();
     } else if (auto npuWaitOp = dyn_cast<AMDAIE::NpuDmaWaitOp>(op)) {
-      // Release BD ID used by input DMA op.
-      for (AMDAIE::NpuDmaCpyNdOp npuDmaOp : npuWaitOp.getDmaOps()) {
-        AMDAIE::BdIdOp bdIdOp;
-        if (npuDmaOp.getSourceBdId()) {
-          bdIdOp = dyn_cast_if_present<AMDAIE::BdIdOp>(
-              npuDmaOp.getSourceBdId().getDefiningOp());
-          if (!bdIdOp) return WalkResult::advance();
-          if (failed(releaseBdId(bdIdOp, shimTileToGeneratorMap,
-                                 bdIdOpToBdIdsMap)))
-            return WalkResult::interrupt();
-        }
+      // // Release BD ID used by input DMA op.
+      // for (AMDAIE::NpuDmaCpyNdOp npuDmaOp : npuWaitOp.getDmaOps()) {
+      //   AMDAIE::BdIdOp bdIdOp;
+      //   if (npuDmaOp.getSourceBdId()) {
+      //     bdIdOp = dyn_cast_if_present<AMDAIE::BdIdOp>(
+      //         npuDmaOp.getSourceBdId().getDefiningOp());
+      //     if (!bdIdOp) return WalkResult::advance();
+      //     if (failed(releaseBdId(bdIdOp, shimTileToGeneratorMap,
+      //                            bdIdOpToBdIdsMap)))
+      //       return WalkResult::interrupt();
+      //   }
 
-        if (npuDmaOp.getTargetBdId()) {
-          bdIdOp = dyn_cast_if_present<AMDAIE::BdIdOp>(
-              npuDmaOp.getTargetBdId().getDefiningOp());
-          if (!bdIdOp) return WalkResult::advance();
-          if (failed(releaseBdId(bdIdOp, shimTileToGeneratorMap,
-                                 bdIdOpToBdIdsMap)))
-            return WalkResult::interrupt();
-        }
-      }
-      return WalkResult::advance();
+      //   if (npuDmaOp.getTargetBdId()) {
+      //     bdIdOp = dyn_cast_if_present<AMDAIE::BdIdOp>(
+      //         npuDmaOp.getTargetBdId().getDefiningOp());
+      //     if (!bdIdOp) return WalkResult::advance();
+      //     if (failed(releaseBdId(bdIdOp, shimTileToGeneratorMap,
+      //                            bdIdOpToBdIdsMap)))
+      //       return WalkResult::interrupt();
+      //   }
+      // }
+      // return WalkResult::advance();
     }
     return WalkResult::advance();
   });

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignNpuDmaBdIds.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignNpuDmaBdIds.cpp
@@ -97,40 +97,41 @@ std::optional<uint32_t> getNumberIterations(scf::ForOp loop) {
 /// - Therefore, the required number of BD IDs is:
 ///  3 = 1 (current) + 2 * 1(sub-loop).
 SmallVector<AMDAIE::NpuDmaCpyNdOp> getNumRequiredBdIdsAndDMAOps(
-    scf::ForOp loop, AMDAIE::NpuDmaCpyNdOp currDmaOp, AMDAIE::TileOp tileOp,
+    Operation *parentOp, AMDAIE::NpuDmaCpyNdOp currDmaOp, AMDAIE::TileOp tileOp,
     DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
-    uint32_t &bdIdCount) {
+    uint32_t &numRequiredBdIds) {
   SmallVector<AMDAIE::NpuDmaCpyNdOp> dmaOps;
   bool startCounting =
       (currDmaOp == nullptr);  // Start immediately if no currDmaOp
 
-  for (auto &op : loop.getOps()) {
+  parentOp->walk([&](Operation *op) {
+    if (op->getParentOp() != parentOp) return WalkResult::skip();
     if (auto npuDmaOp = dyn_cast<AMDAIE::NpuDmaCpyNdOp>(op)) {
       // Skip until currDmaOp is found
       if (npuDmaOp == currDmaOp) startCounting = true;
-      if (!startCounting) continue;
+      if (!startCounting) WalkResult::skip();
       if (npuDmaOp.getSource()) {
         FailureOr<AMDAIE::TileOp> tile =
             getGeneratorTileOp<CopyOpOperateOn::Source>(npuDmaOp,
                                                         shimTileToGeneratorMap);
-        if (succeeded(tile) && *tile == tileOp) {
+        if (succeeded(tile) && *tile == tileOp && !npuDmaOp.getSourceBdIdOp()) {
           dmaOps.push_back(npuDmaOp);
-          bdIdCount++;
+          numRequiredBdIds++;
         }
       }
       if (npuDmaOp.getTarget()) {
         FailureOr<AMDAIE::TileOp> tile =
             getGeneratorTileOp<CopyOpOperateOn::Target>(npuDmaOp,
                                                         shimTileToGeneratorMap);
-        if (succeeded(tile) && *tile == tileOp) {
+        if (succeeded(tile) && *tile == tileOp && !npuDmaOp.getTargetBdIdOp()) {
           dmaOps.push_back(npuDmaOp);
-          bdIdCount++;
+          numRequiredBdIds++;
         }
       }
     } else if (auto npuWaitOp = dyn_cast<AMDAIE::NpuDmaWaitOp>(op)) {
       for (AMDAIE::NpuDmaCpyNdOp npuDmaOp : npuWaitOp.getDmaOps()) {
         // Reached the DMA wait operation, stop counting.
-        if (npuDmaOp == currDmaOp) return dmaOps;
+        if (npuDmaOp == currDmaOp) return WalkResult::interrupt();
       }
     } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
       uint32_t subLoopBdIdCount = 0;
@@ -138,26 +139,135 @@ SmallVector<AMDAIE::NpuDmaCpyNdOp> getNumRequiredBdIdsAndDMAOps(
           forOp, nullptr, tileOp, shimTileToGeneratorMap, subLoopBdIdCount);
       std::optional<uint32_t> subIterations = getNumberIterations(forOp);
       if (subIterations) {
-        bdIdCount += subLoopBdIdCount * subIterations.value();
+        numRequiredBdIds += subLoopBdIdCount * subIterations.value();
       } else {
-        bdIdCount += subLoopBdIdCount;
+        numRequiredBdIds += subLoopBdIdCount;
       }
     }
-  }
+    return WalkResult::advance();
+  });
   return dmaOps;
 }
 
-/// Creates a BD ID operation for the given DMA copy operation.
-/// If the DMA copy operation is inside a loop, the BD ID operation will be
-/// created with a semi-affine expression to assign different BD IDs for each
-/// iteration. Otherwise, a constant BD ID will be assigned.
+/// Given a list of DMA Ops and the number of required BD IDs by the first DMA
+/// op in the list, split the available BD IDs equally amongst all and assign it
+/// to the DMA ops.
+LogicalResult assignBdIdsToDMAOps(
+    IRRewriter &rewriter, SmallVector<AMDAIE::NpuDmaCpyNdOp> &dmaOps,
+    AMDAIE::TileOp tileOp, uint32_t channel,
+    DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
+    DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
+    DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
+        &dmaOpToBdIdMap,
+    uint32_t numRequiredBdIds) {
+  // Compute BD ID split amongst all DMA ops.
+  ChannelBdIdGenerator &generator = shimTileToGeneratorMap[tileOp.getResult()];
+  uint32_t numAvailable = generator.getNumAvailableBdIds(channel);
+  uint32_t totalDmaOps = dmaOps.size();
+  uint32_t size = std::max(numAvailable / numRequiredBdIds, 1u);
+  scf::ForOp loop = nullptr;
+  AffineExpr ivExpr = nullptr;
+  Value iv = nullptr;
+  // In case the parent of the DMA ops is a scf.for we need to keep track of the
+  // loop induction variable in order to create a semi affine expression later
+  // for distributing BD IDs for each iteration.
+  if (loop = dmaOps[0]->getParentOfType<scf::ForOp>();
+      loop && getNumberIterations(loop)) {
+    iv = loop.getInductionVar();
+    bindDims(loop.getContext(), ivExpr);
+  } else {
+    // In case the DMA ops are not surrounded by scf.for, we will assign only
+    // one BD ID.
+    size = 1;
+  }
+  // In case there are not enough BD ids available, return failure.
+  if (size * totalDmaOps > numAvailable) return failure();
+
+  // Traverse each DMA op found in step 1, assign BD IDs and keep a track of the
+  // first BD ID op assigned.
+  rewriter.setInsertionPoint(dmaOps[0]);
+  for (AMDAIE::NpuDmaCpyNdOp dmaOp : dmaOps) {
+    uint32_t bdIdMapIndex = 0;
+    if (dmaOp.getSource()) {
+      FailureOr<AMDAIE::TileOp> tile =
+          getGeneratorTileOp<CopyOpOperateOn::Source>(dmaOp,
+                                                      shimTileToGeneratorMap);
+      if (succeeded(tile) && *tile == tileOp) {
+        bdIdMapIndex = 0;
+      }
+    }
+    if (dmaOp.getTarget()) {
+      FailureOr<AMDAIE::TileOp> tile =
+          getGeneratorTileOp<CopyOpOperateOn::Target>(dmaOp,
+                                                      shimTileToGeneratorMap);
+      if (succeeded(tile) && *tile == tileOp) {
+        bdIdMapIndex = 1;
+      }
+    }
+    // Only create expression if more than 1 BD ID is needed and if,
+    // otherwise, fall back to constant BD ID.
+    if (size > 1) {
+      // Assigning BD IDs for all iterations in the loop.
+      SmallVector<uint32_t> bdIds;
+      for (uint32_t i = 0; i < size; i++) {
+        std::optional<uint32_t> bdId = generator.getAndAssignBdId(
+            channel, BdIdAssignmentMode::Incremental);
+        if (!bdId) return failure();
+        bdIds.push_back(bdId.value());
+      }
+      // Get the BD ID for the first iteration as the offset.
+      uint32_t offset = bdIds.front();
+
+      // Create the semi-affine expression.
+      auto affineApply = rewriter.create<affine::AffineApplyOp>(
+          loop.getLoc(), ivExpr % size + offset,
+          ValueRange{
+              iv,
+          });
+      AMDAIE::BdIdOp bdIdOp = rewriter.create<AMDAIE::BdIdOp>(
+          rewriter.getUnknownLoc(), tileOp, affineApply.getResult());
+      bdIdOpToBdIdsMap[bdIdOp] = bdIds;
+      if (!dmaOpToBdIdMap.contains(dmaOp)) {
+        SmallVector<AMDAIE::BdIdOp> bdIdOps = {nullptr, nullptr};
+        dmaOpToBdIdMap[dmaOp] = bdIdOps;
+      }
+
+      dmaOpToBdIdMap[dmaOp][bdIdMapIndex] = bdIdOp;
+    } else {
+      // Assign a constant BD ID.
+      std::optional<uint32_t> bdId =
+          generator.getAndAssignBdId(channel, BdIdAssignmentMode::Incremental);
+      if (!bdId) return dmaOp.emitOpError() << "no BD ID available";
+      auto constant = rewriter.create<arith::ConstantOp>(
+          rewriter.getUnknownLoc(), rewriter.getIndexAttr(bdId.value()));
+      AMDAIE::BdIdOp bdIdOp = rewriter.create<AMDAIE::BdIdOp>(
+          rewriter.getUnknownLoc(), tileOp, constant.getResult());
+      if (!dmaOpToBdIdMap.contains(dmaOp)) {
+        SmallVector<AMDAIE::BdIdOp> bdIdOps = {nullptr, nullptr};
+        dmaOpToBdIdMap[dmaOp] = bdIdOps;
+      }
+      dmaOpToBdIdMap[dmaOp][bdIdMapIndex] = bdIdOp;
+    }
+  }
+  return success();
+}
+
+/// For a given DMA op operating within a block and a tile, this function first
+/// traverses and collects all DMA ops that lie between the current DMA op and
+/// its corresponding DMA wait operation. During the traversal it also makes a
+/// note of the required BD ID by the current DMA op in order to use it to split
+/// it amongst other DMA ops fetch. It then traverses all those DMA ops fetched
+/// and assigns BD ID to each one of them. If the DMA copy operation is inside a
+/// loop, the BD ID operation will be created with a semi-affine expression to
+/// assign different BD IDs for each iteration. Otherwise, a constant BD ID will
+/// be assigned.
 template <CopyOpOperateOn OperateOn>
-FailureOr<AMDAIE::BdIdOp> getBdIdOp(
+LogicalResult processCurrentDmaOpBlockForAssigningBdId(
     IRRewriter &rewriter, AMDAIE::NpuDmaCpyNdOp &npuDmaOp,
     DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
     DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
-    DenseMap<AMDAIE::NpuDmaCpyNdOp, AMDAIE::BdIdOp> &dmaOpToBdIdMap) {
-  if (dmaOpToBdIdMap.contains(npuDmaOp)) return dmaOpToBdIdMap[npuDmaOp];
+    DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
+        &dmaOpToBdIdMap) {
   // Get the TileOp.
   FailureOr<AMDAIE::TileOp> maybeTileOp =
       getGeneratorTileOp<OperateOn>(npuDmaOp, shimTileToGeneratorMap);
@@ -177,87 +287,19 @@ FailureOr<AMDAIE::BdIdOp> getBdIdOp(
   if (failed(maybeChannelOp)) return failure();
   uint32_t channel = maybeChannelOp.value().getValue();
 
-  ChannelBdIdGenerator &generator = shimTileToGeneratorMap[tileOp.getResult()];
-  rewriter.setInsertionPoint(npuDmaOp);
-  if (scf::ForOp loop = npuDmaOp->getParentOfType<scf::ForOp>();
-      loop && getNumberIterations(loop)) {
-    // In a loop, using the semi-affine expression:
-    // `iv % size + offset`,
-    // `iv` is the loop induction variable,
-    // `size` is the number of BD IDs assigned to each DMA op,
-    // `offset` is the BD ID assigned to current DMA op at first iteration.
-    Value iv = loop.getInductionVar();
+  // Get the number of BD IDs that will be required by the current DMA op.
+  // While fetching the required BD IDs for the current DMA op, keep a track
+  // of the DMA ops within the same scf.for block that are operating on the
+  // same tile and lies between the current DMA op and its corresponding DMA
+  // wait op.
+  uint32_t numRequiredBdIds = 0;
+  SmallVector<AMDAIE::NpuDmaCpyNdOp> dmaOps =
+      getNumRequiredBdIdsAndDMAOps(npuDmaOp->getParentOp(), npuDmaOp, tileOp,
+                                   shimTileToGeneratorMap, numRequiredBdIds);
 
-    // Step 1: Get the number of BD IDs will be required by the current DMA op.
-    // While fetching the required BD IDs for the current DMA op, keep a track
-    // of the DMA ops within the same scf.for block that are operating on the
-    // same tile and lies between the current DMA op and its corresponding DMA
-    // wait op.
-    uint32_t numRequired = 0;
-    SmallVector<AMDAIE::NpuDmaCpyNdOp> dmaOps = getNumRequiredBdIdsAndDMAOps(
-        loop, npuDmaOp, tileOp, shimTileToGeneratorMap, numRequired);
-
-    // Step 2: Compute BD ID split amongst all DMA ops.
-    uint32_t numAvailable = generator.getNumAvailableBdIds(channel);
-    uint32_t totalDmaOps = dmaOps.size();
-    uint32_t size = std::max(numAvailable / numRequired, 1u);
-    // In case there are not enough BD ids available, return failure.
-    if (size * totalDmaOps > numAvailable) return failure();
-
-    // Step 3: Traverse each DMA op found in step 1, assign BD IDs and keep a
-    // track of the first BD ID op assigned.
-    for (AMDAIE::NpuDmaCpyNdOp dmaOp : dmaOps) {
-      // Only create expression if more than 1 BD ID is needed,
-      // otherwise, fall back to constant BD ID.
-      if (size > 1) {
-        // Assigning BD IDs for all iterations in the loop.
-        SmallVector<uint32_t> bdIds;
-        for (uint32_t i = 0; i < size; i++) {
-          std::optional<uint32_t> bdId = generator.getAndAssignBdId(
-              channel, BdIdAssignmentMode::Incremental);
-          if (!bdId) return failure();
-          bdIds.push_back(bdId.value());
-        }
-        // Get the BD ID for the first iteration as the offset.
-        uint32_t offset = bdIds.front();
-
-        // Create the semi-affine expression.
-        AffineExpr ivExpr;
-        bindDims(loop.getContext(), ivExpr);
-        auto affineApply = rewriter.create<affine::AffineApplyOp>(
-            loop.getLoc(), ivExpr % size + offset,
-            ValueRange{
-                iv,
-            });
-        AMDAIE::BdIdOp bdIdOp = rewriter.create<AMDAIE::BdIdOp>(
-            rewriter.getUnknownLoc(), tileOp, affineApply.getResult());
-        bdIdOpToBdIdsMap[bdIdOp] = bdIds;
-        dmaOpToBdIdMap[dmaOp] = bdIdOp;
-      } else {
-        // Assign a constant BD ID.
-        std::optional<uint32_t> bdId = generator.getAndAssignBdId(
-            channel, BdIdAssignmentMode::Incremental);
-        if (!bdId) return npuDmaOp.emitOpError() << "no BD ID available";
-        auto constant = rewriter.create<arith::ConstantOp>(
-            rewriter.getUnknownLoc(), rewriter.getIndexAttr(bdId.value()));
-        AMDAIE::BdIdOp bdIdOp = rewriter.create<AMDAIE::BdIdOp>(
-            rewriter.getUnknownLoc(), tileOp, constant.getResult());
-        dmaOpToBdIdMap[dmaOp] = bdIdOp;
-      }
-    }
-    // Step 4: Return BD ID for the current DMA op.
-    return dmaOpToBdIdMap[npuDmaOp];
-  }
-
-  // Assign a constant BD ID.
-  std::optional<uint32_t> bdId =
-      generator.getAndAssignBdId(channel, BdIdAssignmentMode::Incremental);
-  if (!bdId) return npuDmaOp.emitOpError() << "no BD ID available";
-  auto constant = rewriter.create<arith::ConstantOp>(
-      rewriter.getUnknownLoc(), rewriter.getIndexAttr(bdId.value()));
-  AMDAIE::BdIdOp bdIdOp = rewriter.create<AMDAIE::BdIdOp>(
-      rewriter.getUnknownLoc(), tileOp, constant.getResult());
-  return bdIdOp;
+  return assignBdIdsToDMAOps(rewriter, dmaOps, tileOp, channel,
+                             shimTileToGeneratorMap, bdIdOpToBdIdsMap,
+                             dmaOpToBdIdMap, numRequiredBdIds);
 };
 
 LogicalResult releaseBdId(
@@ -321,34 +363,63 @@ LogicalResult assignNpuDmaBdIds(AMDAIE::WorkgroupOp workgroupOp) {
   // and release BD IDs when encountering the respective operations using the
   // tile BD ID generators initialized earlier.
   AMDAIE::ControlCodeOp controlCodeOp = workgroupOp.getControlCode();
-  DenseMap<AMDAIE::NpuDmaCpyNdOp, AMDAIE::BdIdOp> dmaOpToBdIdMap;
+  // Since a DMA op can have source and target, therefore we can have two BD IDs
+  // for any DMA op. Hence we maintain a map from DMA op to a vector of BD IDs.
+  DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>> dmaOpToBdIdMap;
   WalkResult res = controlCodeOp->walk([&](Operation *op) {
     if (auto npuDmaOp = dyn_cast<AMDAIE::NpuDmaCpyNdOp>(op)) {
       if (npuDmaOp.getSource()) {
-        FailureOr<AMDAIE::BdIdOp> bdIdOp = getBdIdOp<CopyOpOperateOn::Source>(
-            rewriter, npuDmaOp, shimTileToGeneratorMap, bdIdOpToBdIdsMap,
-            dmaOpToBdIdMap);
-        if (failed(bdIdOp)) return WalkResult::interrupt();
+        // In case a BD ID candidate has not been assigned to the current DMA
+        // op's source, we go ahead to process the block that contains this DMA
+        // op.
+        if (!dmaOpToBdIdMap.contains(npuDmaOp) ||
+            !dmaOpToBdIdMap[npuDmaOp][/*sourceBdIdIndex=*/0]) {
+          if (failed(processCurrentDmaOpBlockForAssigningBdId<
+                     CopyOpOperateOn::Source>(
+                  rewriter, npuDmaOp, shimTileToGeneratorMap, bdIdOpToBdIdsMap,
+                  dmaOpToBdIdMap)))
+            return WalkResult::interrupt();
+        }
+        assert(dmaOpToBdIdMap.contains(npuDmaOp) && "No BD ID mapping found");
+        assert((dmaOpToBdIdMap[npuDmaOp][/*sourceBdIdIndex=*/0] != nullptr) &&
+               "No source BD ID mapping found");
+        AMDAIE::BdIdOp bdIdOp = dmaOpToBdIdMap[npuDmaOp][/*sourceBdIdIndex=*/0];
         rewriter.setInsertionPoint(npuDmaOp);
+        AMDAIE::NpuDmaCpyNdOp oldNpuDmaOp = npuDmaOp;
         npuDmaOp = rewriter.replaceOpWithNewOp<AMDAIE::NpuDmaCpyNdOp>(
             npuDmaOp, npuDmaOp.getResultTypes(), npuDmaOp.getConnection(),
             npuDmaOp.getTarget(), npuDmaOp.getTargetMixedOffsets(),
             npuDmaOp.getTargetMixedSizes(), npuDmaOp.getTargetMixedStrides(),
             npuDmaOp.getTargetBdId(), npuDmaOp.getSource(),
             npuDmaOp.getSourceMixedOffsets(), npuDmaOp.getSourceMixedSizes(),
-            npuDmaOp.getSourceMixedStrides(), *bdIdOp);
+            npuDmaOp.getSourceMixedStrides(), bdIdOp);
+        // Since we have created a new NPU DMA op by assigning BD ID to the
+        // source, we need to copy the BD ID assignment to this new NPU DMA op
+        // in order to preserve the information about target BD ID candidate.
+        dmaOpToBdIdMap[npuDmaOp] = dmaOpToBdIdMap[oldNpuDmaOp];
       }
       if (npuDmaOp.getTarget()) {
-        FailureOr<AMDAIE::BdIdOp> bdIdOp = getBdIdOp<CopyOpOperateOn::Target>(
-            rewriter, npuDmaOp, shimTileToGeneratorMap, bdIdOpToBdIdsMap,
-            dmaOpToBdIdMap);
-        if (failed(bdIdOp)) return WalkResult::interrupt();
+        // In case a BD ID candidate has not been assigned to the current DMA
+        // op's target, we go ahead to process the block that contains this DMA
+        // op.
+        if (!dmaOpToBdIdMap.contains(npuDmaOp) ||
+            !dmaOpToBdIdMap[npuDmaOp][/*targetBdIdIndex=*/1]) {
+          if (failed(processCurrentDmaOpBlockForAssigningBdId<
+                     CopyOpOperateOn::Target>(
+                  rewriter, npuDmaOp, shimTileToGeneratorMap, bdIdOpToBdIdsMap,
+                  dmaOpToBdIdMap)))
+            return WalkResult::interrupt();
+        }
+        assert(dmaOpToBdIdMap.contains(npuDmaOp) && "No BD ID mapping found");
+        assert((dmaOpToBdIdMap[npuDmaOp][/*targetBdIdIndex=*/1] != nullptr) &&
+               "No target BD ID mapping found");
+        AMDAIE::BdIdOp bdIdOp = dmaOpToBdIdMap[npuDmaOp][/*targetBdIdIndex=*/1];
         rewriter.setInsertionPoint(npuDmaOp);
         (void)rewriter.replaceOpWithNewOp<AMDAIE::NpuDmaCpyNdOp>(
             npuDmaOp, npuDmaOp.getResultTypes(), npuDmaOp.getConnection(),
             npuDmaOp.getTarget(), npuDmaOp.getTargetMixedOffsets(),
             npuDmaOp.getTargetMixedSizes(), npuDmaOp.getTargetMixedStrides(),
-            *bdIdOp, npuDmaOp.getSource(), npuDmaOp.getSourceMixedOffsets(),
+            bdIdOp, npuDmaOp.getSource(), npuDmaOp.getSourceMixedOffsets(),
             npuDmaOp.getSourceMixedSizes(), npuDmaOp.getSourceMixedStrides(),
             npuDmaOp.getSourceBdId());
       }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignNpuDmaBdIds.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignNpuDmaBdIds.cpp
@@ -23,7 +23,7 @@ namespace {
 /// appropriate verifications.
 template <CopyOpOperateOn OperateOn>
 FailureOr<AMDAIE::TileOp> getGeneratorTileOp(
-    AMDAIE::NpuDmaCpyNdOp &npuDmaOp,
+    AMDAIE::NpuDmaCpyNdOp npuDmaOp,
     DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap) {
   SmallVector<Value> tiles;
   if constexpr (OperateOn == CopyOpOperateOn::Source) {
@@ -263,7 +263,7 @@ LogicalResult assignBdIdsToDMAOps(
 /// be assigned.
 template <CopyOpOperateOn OperateOn>
 LogicalResult processCurrentDmaOpBlockForAssigningBdId(
-    IRRewriter &rewriter, AMDAIE::NpuDmaCpyNdOp &npuDmaOp,
+    IRRewriter &rewriter, AMDAIE::NpuDmaCpyNdOp npuDmaOp,
     DenseMap<Value, ChannelBdIdGenerator> &shimTileToGeneratorMap,
     DenseMap<AMDAIE::BdIdOp, SmallVector<uint32_t>> &bdIdOpToBdIdsMap,
     DenseMap<AMDAIE::NpuDmaCpyNdOp, SmallVector<AMDAIE::BdIdOp>>
@@ -288,9 +288,9 @@ LogicalResult processCurrentDmaOpBlockForAssigningBdId(
   uint32_t channel = maybeChannelOp.value().getValue();
 
   // Get the number of BD IDs that will be required by the current DMA op.
-  // While fetching the required BD IDs for the current DMA op, keep a track
+  // While fetching the required BD IDs for the current DMA op, keep track
   // of the DMA ops within the same scf.for block that are operating on the
-  // same tile and lies between the current DMA op and its corresponding DMA
+  // same tile and lie between the current DMA op and its corresponding DMA
   // wait op.
   uint32_t numRequiredBdIds = 0;
   SmallVector<AMDAIE::NpuDmaCpyNdOp> dmaOps =

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
@@ -403,7 +403,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 
 // -----
 
-// Expect all three DMA copy operations have BD IDs as expressions. #map0: 0~1, #map1: 2~8, #map2: 9~15.
+// Expect all three DMA copy operations have BD IDs as expressions. #map0: 0~4, #map1: 5~9, #map2: 10~14.
 // BD IDs used by #map0 are released after the innermost loop, so that they cannot be reused by #map1 and #map2.
 
 // CHECK: #map = affine_map<(d0) -> (d0 mod 5)>

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
@@ -637,6 +637,12 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 
 // -----
 
+// Here we have three scf.for ops where the last two scf.for ops are nested with no dma ops in between.
+// So we'd expect the dma op before the second last scf.for to have the following total no. of required Bd Ids :-
+//    1 (Bd Id reqired by itself) + 2 * 2 * 1
+// i.e. 5 Bd Ids, where 2 * 2 is the loop iteration count of the two nested scf.for ops which is multiplied
+//      by the no. of Bd Ids required by DmaOps inside the innermost scf.for (1).
+
 // CHECK: #map = affine_map<(d0) -> (d0 mod 4)>
 // CHECK: #map1 = affine_map<(d0) -> (d0 mod 12 + 4)>
 // CHECK-LABEL: @nested_loops_with_no_dma_ops_in_between

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
@@ -406,9 +406,9 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // Expect all three DMA copy operations have BD IDs as expressions. #map0: 0~1, #map1: 2~8, #map2: 9~15.
 // BD IDs used by #map0 are released after the innermost loop, so that they cannot be reused by #map1 and #map2.
 
-// CHECK: #map = affine_map<(d0) -> (d0 mod 2)>
-// CHECK: #map1 = affine_map<(d0) -> (d0 mod 7 + 2)>
-// CHECK: #map2 = affine_map<(d0) -> (d0 mod 7 + 9)>
+// CHECK: #map = affine_map<(d0) -> (d0 mod 5)>
+// CHECK: #map1 = affine_map<(d0) -> (d0 mod 5 + 5)>
+// CHECK: #map2 = affine_map<(d0) -> (d0 mod 5 + 10)>
 // CHECK-LABEL: @nested_loops_wait_after_innerloop
 // CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
@@ -552,10 +552,10 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // corresponding source/target. This test demonstrates how even with different tile distribution
 // amongst the DMA ops a well distributed BD ID assignment split is ensured.
 //
-//       CHECK: #map1 = affine_map<(d0) -> (d0 mod 16)>
-//       CHECK: #map2 = affine_map<(d0) -> (d0 mod 5)>
-//       CHECK: #map3 = affine_map<(d0) -> (d0 mod 5 + 5)>
-//       CHECK: #map4 = affine_map<(d0) -> (d0 mod 5 + 10)>
+//       CHECK: #map1 = affine_map<(d0) -> (d0 mod 5)>
+//       CHECK: #map2 = affine_map<(d0) -> (d0 mod 5 + 5)>
+//       CHECK: #map3 = affine_map<(d0) -> (d0 mod 5 + 10)>
+//       CHECK: #map4 = affine_map<(d0) -> (d0 mod 16)>
 //       CHECK: #map5 = affine_map<(d0) -> (d0 mod 8)>
 //       CHECK: #map6 = affine_map<(d0) -> (d0 mod 8 + 8)>
 // CHECK-LABEL: @multi_dma_users_within_same_block_and_different_source_target_tile
@@ -570,20 +570,20 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 //       CHECK:         amdaie.controlcode
 //       CHECK:             scf.for %[[LOOP_VAR_0:.+]] = %[[C0]] to %[[C4]] step %[[C1]]
 //       CHECK:               %[[VAR_1:.+]] = affine.apply #map1(%[[LOOP_VAR_0]])
-//       CHECK:               %[[BD_ID_1:.+]] = amdaie.bd_id(%[[TILE_1_0]], %[[VAR_1]])
+//       CHECK:               %[[BD_ID_1:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[VAR_1]])
 //       CHECK:               %[[VAR_2:.+]] = affine.apply #map2(%[[LOOP_VAR_0]])
 //       CHECK:               %[[BD_ID_2:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[VAR_2]])
 //       CHECK:               %[[VAR_3:.+]] = affine.apply #map3(%[[LOOP_VAR_0]])
 //       CHECK:               %[[BD_ID_3:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[VAR_3]])
 //       CHECK:               %[[VAR_4:.+]] = affine.apply #map4(%[[LOOP_VAR_0]])
-//       CHECK:               %[[BD_ID_4:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[VAR_4]])
-//       CHECK:               %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_target %{{.+}}(%{{.+}} bd_id = %[[BD_ID_2]], %{{.+}} bd_id = %[[BD_ID_1]])
+//       CHECK:               %[[BD_ID_4:.+]] = amdaie.bd_id(%[[TILE_1_0]], %[[VAR_4]])
+//       CHECK:               %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_target %{{.+}}(%{{.+}} bd_id = %[[BD_ID_1]], %{{.+}} bd_id = %[[BD_ID_4]])
 //       CHECK:               %[[VAR_5:.+]] = affine.apply #map5(%[[LOOP_VAR_0]])
 //       CHECK:               %[[BD_ID_5:.+]] = amdaie.bd_id(%[[TILE_2_0]], %[[VAR_5]])
 //       CHECK:               %[[VAR_6:.+]] = affine.apply #map6(%[[LOOP_VAR_0]])
 //       CHECK:               %[[BD_ID_6:.+]] = amdaie.bd_id(%[[TILE_2_0]], %[[VAR_6]])
-//       CHECK:               %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd async_source %{{.+}}(%{{.+}} bd_id = %[[BD_ID_5]], %{{.+}} bd_id = %[[BD_ID_3]])
-//       CHECK:               %[[NPU_DMA_3:.+]] = amdaie.npu.dma_cpy_nd async_source %{{.+}}(%{{.+}} bd_id = %[[BD_ID_6]], %{{.+}} bd_id = %[[BD_ID_4]])
+//       CHECK:               %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd async_source %{{.+}}(%{{.+}} bd_id = %[[BD_ID_5]], %{{.+}} bd_id = %[[BD_ID_2]])
+//       CHECK:               %[[NPU_DMA_3:.+]] = amdaie.npu.dma_cpy_nd async_source %{{.+}}(%{{.+}} bd_id = %[[BD_ID_6]], %{{.+}} bd_id = %[[BD_ID_3]])
 //       CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_1]] : !amdaie.async_target_token)
 //       CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_2]] : !amdaie.async_source_token)
 //       CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_3]] : !amdaie.async_source_token)
@@ -627,6 +627,74 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
           amdaie.npu.dma_wait(%0 : !amdaie.async_target_token)
           amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
           amdaie.npu.dma_wait(%2 : !amdaie.async_source_token)
+        }
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// CHECK: #map = affine_map<(d0) -> (d0 mod 4)>
+// CHECK: #map1 = affine_map<(d0) -> (d0 mod 12 + 4)>
+// CHECK-LABEL: @nested_loops_with_no_dma_ops_in_between
+// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG:   %[[C4:.+]] = arith.constant 4 : index
+// CHECK:       amdaie.workgroup
+// CHECK:         %[[TILE_0_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
+// CHECK:         amdaie.controlcode
+// CHECK:           scf.for %[[LOOP_VAR_0:.+]] = %[[C0]] to %[[C4]] step %[[C1]]
+// CHECK:             %[[VAR_0:.+]] = affine.apply #map(%[[LOOP_VAR_0]])
+// CHECK:             %[[BD_ID_0:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[VAR_0]])
+// CHECK:             %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd async_source %{{.+}}([] [] [], %{{.+}}[] [] [] bd_id = %[[BD_ID_0]])
+// CHECK:             scf.for %[[LOOP_VAR_1:.+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// CHECK:               scf.for %[[LOOP_VAR_2:.+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// CHECK:                 %[[VAR_1:.+]] = affine.apply #map1(%[[LOOP_VAR_2]])
+// CHECK:                 %[[BD_ID_1:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[VAR_1]])
+// CHECK:                 %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_target %{{.+}}(%{{.+}}[] [] [] bd_id = %[[BD_ID_1]], [] [] [])
+// CHECK:                 amdaie.npu.dma_wait(%[[NPU_DMA_1]] : !amdaie.async_target_token)
+// CHECK:               }
+// CHECK:             }
+// CHECK:             amdaie.npu.dma_wait(%[[NPU_DMA_0]] : !amdaie.async_source_token)
+// CHECK:           }
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @nested_loops_with_no_dma_ops_in_between(%arg0: memref<8x16xi32>, %arg1: memref<8x16xi32>, %arg2: memref<8x16xi32>, %arg3: memref<1x1x8x16xi32, 1>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c4 = arith.constant 4 : index
+    amdaie.workgroup {
+      %tile_0_0 = amdaie.tile(%c0, %c0)
+      %tile_0_1 = amdaie.tile(%c0, %c1)
+      %channel_0 = amdaie.channel(%tile_0_0, 0, port_type = DMA, direction = MM2S)
+      %channel_1 = amdaie.channel(%tile_0_0, 0, port_type = DMA, direction = S2MM)
+      %channel_2 = amdaie.channel(%tile_0_0, 1, port_type = DMA, direction = MM2S)
+      %channel_3 = amdaie.channel(%tile_0_1, 0, port_type = DMA, direction = S2MM)
+      %channel_4 = amdaie.channel(%tile_0_1, 0, port_type = DMA, direction = MM2S)
+      %channel_5 = amdaie.channel(%tile_0_1, 1, port_type = DMA, direction = S2MM)
+      %from_memref_0 = amdaie.logicalobjectfifo.from_memref %arg3, {%tile_0_1} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<128xi32, 1>, 2>
+      %placeholder = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<8x16xi32>>
+      %connection_0 = amdaie.connection(%from_memref_0 {%channel_3}, %placeholder {%channel_0}) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<128xi32, 1>, 2>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      %connection_1 = amdaie.connection(%placeholder {%channel_1}, %from_memref_0 {%channel_4}) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<8x16xi32>>, !amdaie.logicalobjectfifo<memref<128xi32, 1>, 2>)
+      %connection_2 = amdaie.connection(%from_memref_0 {%channel_5}, %placeholder {%channel_2}) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<128xi32, 1>, 2>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      amdaie.controlcode {
+        %from_memref_1 = amdaie.logicalobjectfifo.from_memref %arg0, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %from_memref_2 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %from_memref_3 = amdaie.logicalobjectfifo.from_memref %arg2, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        scf.for %arg4 = %c0 to %c4 step %c1 {
+          %0 = amdaie.npu.dma_cpy_nd async_source %connection_0([] [] [], %from_memref_1[] [] []) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+          scf.for %arg5 = %c0 to %c2 step %c1 {
+            scf.for %arg6 = %c0 to %c2 step %c1 {
+              %1 = amdaie.npu.dma_cpy_nd async_target %connection_1(%from_memref_2[] [] [], [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+              amdaie.npu.dma_wait(%1 : !amdaie.async_target_token)
+            }
+          }
+          amdaie.npu.dma_wait(%0 : !amdaie.async_source_token)
         }
         amdaie.end
       }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
@@ -550,7 +550,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // Expect all DMA ops, between the first DMA op and its corresponding DMA wait op, operating
 // within same scf.for's block and on same tile to have equal BD ID distribution for the
 // corresponding source/target. This test demonstrates how even with different tile distribution
-// amongst the DMA ops a well distributed BD ID assignment split is ensured.
+// amongs the DMA ops a well distributed BD ID assignment split is ensured.
 //
 //       CHECK: #map1 = affine_map<(d0) -> (d0 mod 5)>
 //       CHECK: #map2 = affine_map<(d0) -> (d0 mod 5 + 5)>

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
@@ -351,9 +351,9 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:             scf.for %[[LOOP_VAR_1:.+]] = %[[C0]] to %[[C2]] step %[[C1]]
 // CHECK:               %[[VAR_1:.+]] = affine.apply #map1(%[[LOOP_VAR_1]])
 // CHECK:               %[[BD_ID_1:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[VAR_1]])
-// CHECK:               %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_target %{{.+}}(%{{.+}}[] [] [] bd_id = %[[BD_ID_1]], [] [] [])
 // CHECK:               %[[VAR_2:.+]] = affine.apply #map2(%[[LOOP_VAR_1]])
 // CHECK:               %[[BD_ID_2:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[VAR_2]])
+// CHECK:               %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_target %{{.+}}(%{{.+}}[] [] [] bd_id = %[[BD_ID_1]], [] [] [])
 // CHECK:               %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd async_source %{{.+}}([] [] [], %{{.+}}[] [] [] bd_id = %[[BD_ID_2]])
 // CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_1]] : !amdaie.async_target_token)
 // CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_2]] : !amdaie.async_source_token)
@@ -424,9 +424,9 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:             scf.for %[[LOOP_VAR_1:.+]] = %[[C0]] to %[[C2]] step %[[C1]]
 // CHECK:               %[[VAR_1:.+]] = affine.apply #map1(%[[LOOP_VAR_1]])
 // CHECK:               %[[BD_ID_1:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[VAR_1]])
-// CHECK:               %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_target %{{.+}}(%{{.+}}[] [] [] bd_id = %[[BD_ID_1]], [] [] [])
 // CHECK:               %[[VAR_2:.+]] = affine.apply #map2(%[[LOOP_VAR_1]])
 // CHECK:               %[[BD_ID_2:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[VAR_2]])
+// CHECK:               %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_target %{{.+}}(%{{.+}}[] [] [] bd_id = %[[BD_ID_1]], [] [] [])
 // CHECK:               %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd async_source %{{.+}}([] [] [], %{{.+}}[] [] [] bd_id = %[[BD_ID_2]])
 // CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_1]] : !amdaie.async_target_token)
 // CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_2]] : !amdaie.async_source_token)
@@ -467,6 +467,75 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
             amdaie.npu.dma_wait(%2 : !amdaie.async_source_token)
           }
           amdaie.npu.dma_wait(%0 : !amdaie.async_source_token)
+        }
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Expect all DMA ops operating within same scf.for's block and on same tile to have equal BD ID distribution.
+
+//       CHECK: #map1 = affine_map<(d0) -> (d0 mod 5)>
+//       CHECK: #map2 = affine_map<(d0) -> (d0 mod 5 + 5)>
+//       CHECK: #map3 = affine_map<(d0) -> (d0 mod 5 + 10)>
+// CHECK-LABEL: @multi_dma_users_within_same_block_and_tile
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C4:.+]] = arith.constant 4 : index
+//       CHECK:       amdaie.workgroup
+//       CHECK:         %[[TILE_0_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
+//       CHECK:         amdaie.controlcode
+//       CHECK:             scf.for %[[LOOP_VAR_0:.+]] = %[[C0]] to %[[C4]] step %[[C1]]
+//       CHECK:               %[[VAR_1:.+]] = affine.apply #map1(%[[LOOP_VAR_0]])
+//       CHECK:               %[[BD_ID_1:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[VAR_1]])
+//       CHECK:               %[[VAR_2:.+]] = affine.apply #map2(%[[LOOP_VAR_0]])
+//       CHECK:               %[[BD_ID_2:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[VAR_2]])
+//       CHECK:               %[[VAR_3:.+]] = affine.apply #map3(%[[LOOP_VAR_0]])
+//       CHECK:               %[[BD_ID_3:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[VAR_3]])
+//       CHECK:               %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_target %{{.+}}(%{{.+}} bd_id = %[[BD_ID_1]], [] [] [])
+//       CHECK:               %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd async_source %{{.+}}([] [] [], %{{.+}} bd_id = %[[BD_ID_2]])
+//       CHECK:               %[[NPU_DMA_3:.+]] = amdaie.npu.dma_cpy_nd async_source %{{.+}}([] [] [], %{{.+}} bd_id = %[[BD_ID_3]])
+//       CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_1]] : !amdaie.async_target_token)
+//       CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_2]] : !amdaie.async_source_token)
+//       CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_3]] : !amdaie.async_source_token)
+//       CHECK:             }
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu4", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @multi_dma_users_within_same_block_and_tile(%arg0: memref<8x16xi32>, %arg1: memref<8x16xi32>, %arg2: memref<8x16xi32>, %arg3: memref<1x1x8x16xi32, 1>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c4 = arith.constant 4 : index
+    amdaie.workgroup {
+      %tile_0_0 = amdaie.tile(%c0, %c0)
+      %tile_0_1 = amdaie.tile(%c0, %c1)
+      %channel_0 = amdaie.channel(%tile_0_0, 0, port_type = DMA, direction = MM2S)
+      %channel_1 = amdaie.channel(%tile_0_0, 0, port_type = DMA, direction = S2MM)
+      %channel_2 = amdaie.channel(%tile_0_0, 1, port_type = DMA, direction = MM2S)
+      %channel_3 = amdaie.channel(%tile_0_1, 0, port_type = DMA, direction = S2MM)
+      %channel_4 = amdaie.channel(%tile_0_1, 0, port_type = DMA, direction = MM2S)
+      %channel_5 = amdaie.channel(%tile_0_1, 1, port_type = DMA, direction = S2MM)
+      %from_memref_0 = amdaie.logicalobjectfifo.from_memref %arg3, {%tile_0_1} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<128xi32, 1>, 2>
+      %placeholder = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<8x16xi32>>
+      %connection_0 = amdaie.connection(%from_memref_0 {%channel_3}, %placeholder {%channel_0}) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<128xi32, 1>, 2>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      %connection_1 = amdaie.connection(%placeholder {%channel_1}, %from_memref_0 {%channel_4}) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<8x16xi32>>, !amdaie.logicalobjectfifo<memref<128xi32, 1>, 2>)
+      %connection_2 = amdaie.connection(%from_memref_0 {%channel_5}, %placeholder {%channel_2}) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<128xi32, 1>, 2>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      amdaie.controlcode {
+        %from_memref_1 = amdaie.logicalobjectfifo.from_memref %arg0, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %from_memref_2 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %from_memref_3 = amdaie.logicalobjectfifo.from_memref %arg2, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        scf.for %arg4 = %c0 to %c4 step %c1 {
+          %iv_map = affine.apply affine_map<(d0) -> (d0 * 4)>(%arg4)
+          %0 = amdaie.npu.dma_cpy_nd async_target %connection_1(%from_memref_2[%iv_map, 0] [4, 16] [16, 1], [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+          %1 = amdaie.npu.dma_cpy_nd async_source %connection_0([] [] [], %from_memref_1[0,0] [8, 16] [16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+          %2 = amdaie.npu.dma_cpy_nd async_source %connection_2([] [] [], %from_memref_3[%iv_map, 0] [8, 16] [16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+          amdaie.npu.dma_wait(%0 : !amdaie.async_target_token)
+          amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
+          amdaie.npu.dma_wait(%2 : !amdaie.async_source_token)
         }
         amdaie.end
       }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
@@ -477,8 +477,9 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 
 // -----
 
-// Expect all DMA ops operating within same scf.for's block and on same tile to have equal BD ID distribution.
-
+// Expect all DMA ops, between the first DMA op and its corresponding DMA wait op, operating
+// within same scf.for's block and on same tile to have equal BD ID distribution.
+//
 //       CHECK: #map1 = affine_map<(d0) -> (d0 mod 5)>
 //       CHECK: #map2 = affine_map<(d0) -> (d0 mod 5 + 5)>
 //       CHECK: #map3 = affine_map<(d0) -> (d0 mod 5 + 10)>

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_npu_dma_bd_ids.mlir
@@ -204,10 +204,10 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:         %[[TILE_0_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
 // CHECK:         amdaie.controlcode
 // CHECK:           %[[BD_ID_0:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[C0]])
-// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd async_source %{{.+}}([] [] [], %{{.+}}[0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
 // CHECK:           %[[BD_ID_1:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[C1]])
-// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_source %{{.+}}([] [] [], %{{.+}}[0, 0] [8, 16] [16, 1] bd_id = %[[BD_ID_1]])
 // CHECK:           %[[BD_ID_2:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[C2]])
+// CHECK:           %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd async_source %{{.+}}([] [] [], %{{.+}}[0, 0, 0] [1, 8, 16] [128, 16, 1] bd_id = %[[BD_ID_0]])
+// CHECK:           %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_source %{{.+}}([] [] [], %{{.+}}[0, 0] [8, 16] [16, 1] bd_id = %[[BD_ID_1]])
 // CHECK:           %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd async_source %{{.+}}([] [] [], %{{.+}}[0] [128] [1] bd_id = %[[BD_ID_2]])
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_0]] : !amdaie.async_source_token)
 // CHECK:           amdaie.npu.dma_wait(%[[NPU_DMA_1]] : !amdaie.async_source_token)
@@ -534,6 +534,96 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
           %0 = amdaie.npu.dma_cpy_nd async_target %connection_1(%from_memref_2[%iv_map, 0] [4, 16] [16, 1], [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
           %1 = amdaie.npu.dma_cpy_nd async_source %connection_0([] [] [], %from_memref_1[0,0] [8, 16] [16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
           %2 = amdaie.npu.dma_cpy_nd async_source %connection_2([] [] [], %from_memref_3[%iv_map, 0] [8, 16] [16, 1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+          amdaie.npu.dma_wait(%0 : !amdaie.async_target_token)
+          amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
+          amdaie.npu.dma_wait(%2 : !amdaie.async_source_token)
+        }
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Expect all DMA ops, between the first DMA op and its corresponding DMA wait op, operating
+// within same scf.for's block and on same tile to have equal BD ID distribution for the
+// corresponding source/target. This test demonstrates how even with different tile distribution
+// amongst the DMA ops a well distributed BD ID assignment split is ensured.
+//
+//       CHECK: #map1 = affine_map<(d0) -> (d0 mod 16)>
+//       CHECK: #map2 = affine_map<(d0) -> (d0 mod 5)>
+//       CHECK: #map3 = affine_map<(d0) -> (d0 mod 5 + 5)>
+//       CHECK: #map4 = affine_map<(d0) -> (d0 mod 5 + 10)>
+//       CHECK: #map5 = affine_map<(d0) -> (d0 mod 8)>
+//       CHECK: #map6 = affine_map<(d0) -> (d0 mod 8 + 8)>
+// CHECK-LABEL: @multi_dma_users_within_same_block_and_different_source_target_tile
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+//   CHECK-DAG:   %[[C4:.+]] = arith.constant 4 : index
+//       CHECK:       amdaie.workgroup
+//       CHECK:         %[[TILE_0_0:.+]] = amdaie.tile(%[[C0]], %[[C0]])
+//       CHECK:         %[[TILE_1_0:.+]] = amdaie.tile(%[[C1]], %[[C0]])
+//       CHECK:         %[[TILE_2_0:.+]] = amdaie.tile(%[[C2]], %[[C0]])
+//       CHECK:         amdaie.controlcode
+//       CHECK:             scf.for %[[LOOP_VAR_0:.+]] = %[[C0]] to %[[C4]] step %[[C1]]
+//       CHECK:               %[[VAR_1:.+]] = affine.apply #map1(%[[LOOP_VAR_0]])
+//       CHECK:               %[[BD_ID_1:.+]] = amdaie.bd_id(%[[TILE_1_0]], %[[VAR_1]])
+//       CHECK:               %[[VAR_2:.+]] = affine.apply #map2(%[[LOOP_VAR_0]])
+//       CHECK:               %[[BD_ID_2:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[VAR_2]])
+//       CHECK:               %[[VAR_3:.+]] = affine.apply #map3(%[[LOOP_VAR_0]])
+//       CHECK:               %[[BD_ID_3:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[VAR_3]])
+//       CHECK:               %[[VAR_4:.+]] = affine.apply #map4(%[[LOOP_VAR_0]])
+//       CHECK:               %[[BD_ID_4:.+]] = amdaie.bd_id(%[[TILE_0_0]], %[[VAR_4]])
+//       CHECK:               %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_target %{{.+}}(%{{.+}} bd_id = %[[BD_ID_2]], %{{.+}} bd_id = %[[BD_ID_1]])
+//       CHECK:               %[[VAR_5:.+]] = affine.apply #map5(%[[LOOP_VAR_0]])
+//       CHECK:               %[[BD_ID_5:.+]] = amdaie.bd_id(%[[TILE_2_0]], %[[VAR_5]])
+//       CHECK:               %[[VAR_6:.+]] = affine.apply #map6(%[[LOOP_VAR_0]])
+//       CHECK:               %[[BD_ID_6:.+]] = amdaie.bd_id(%[[TILE_2_0]], %[[VAR_6]])
+//       CHECK:               %[[NPU_DMA_2:.+]] = amdaie.npu.dma_cpy_nd async_source %{{.+}}(%{{.+}} bd_id = %[[BD_ID_5]], %{{.+}} bd_id = %[[BD_ID_3]])
+//       CHECK:               %[[NPU_DMA_3:.+]] = amdaie.npu.dma_cpy_nd async_source %{{.+}}(%{{.+}} bd_id = %[[BD_ID_6]], %{{.+}} bd_id = %[[BD_ID_4]])
+//       CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_1]] : !amdaie.async_target_token)
+//       CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_2]] : !amdaie.async_source_token)
+//       CHECK:               amdaie.npu.dma_wait(%[[NPU_DMA_3]] : !amdaie.async_source_token)
+//       CHECK:             }
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu4", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @multi_dma_users_within_same_block_and_different_source_target_tile(
+    %arg0: memref<8x16xi32>, %arg1: memref<8x16xi32>, %arg2: memref<8x16xi32>, %arg3: memref<1x1x8x16xi32, 1>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c4 = arith.constant 4 : index
+    amdaie.workgroup {
+      %tile_0_0 = amdaie.tile(%c0, %c0)
+      %tile_1_0 = amdaie.tile(%c1, %c0)
+      %tile_2_0 = amdaie.tile(%c2, %c0)
+      %tile_0_1 = amdaie.tile(%c0, %c1)
+      %channel_0 = amdaie.channel(%tile_0_0, 0, port_type = DMA, direction = MM2S)
+      %channel_1 = amdaie.channel(%tile_0_0, 0, port_type = DMA, direction = S2MM)
+      %channel_2 = amdaie.channel(%tile_0_0, 1, port_type = DMA, direction = MM2S)
+      %channel_3 = amdaie.channel(%tile_0_1, 0, port_type = DMA, direction = S2MM)
+      %channel_4 = amdaie.channel(%tile_0_1, 0, port_type = DMA, direction = MM2S)
+      %channel_5 = amdaie.channel(%tile_0_1, 1, port_type = DMA, direction = S2MM)
+      %from_memref_0 = amdaie.logicalobjectfifo.from_memref %arg3, {%tile_0_1} : memref<1x1x8x16xi32, 1> -> !amdaie.logicalobjectfifo<memref<128xi32, 1>, 2>
+      %placeholder = amdaie.logicalobjectfifo.placeholder{%tile_0_0} : !amdaie.logicalobjectfifo<memref<8x16xi32>>
+      %connection_0 = amdaie.connection(%from_memref_0 {%channel_3}, %placeholder {%channel_0}) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<128xi32, 1>, 2>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      %connection_1 = amdaie.connection(%placeholder {%channel_1}, %from_memref_0 {%channel_4}) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<8x16xi32>>, !amdaie.logicalobjectfifo<memref<128xi32, 1>, 2>)
+      %connection_2 = amdaie.connection(%from_memref_0 {%channel_5}, %placeholder {%channel_2}) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<128xi32, 1>, 2>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      amdaie.controlcode {
+        %from_memref_1 = amdaie.logicalobjectfifo.from_memref %arg0, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %from_memref_2 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %from_memref_3 = amdaie.logicalobjectfifo.from_memref %arg2, {%tile_0_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %from_memref_11 = amdaie.logicalobjectfifo.from_memref %arg0, {%tile_1_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %from_memref_22 = amdaie.logicalobjectfifo.from_memref %arg1, {%tile_2_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        %from_memref_33 = amdaie.logicalobjectfifo.from_memref %arg2, {%tile_2_0} : memref<8x16xi32> -> !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        scf.for %arg4 = %c0 to %c4 step %c1 {
+          %iv_map = affine.apply affine_map<(d0) -> (d0 * 4)>(%arg4)
+          %0 = amdaie.npu.dma_cpy_nd async_target %connection_1(%from_memref_2[%iv_map, 0] [4, 16] [16, 1], %from_memref_11[] [] []) : target_type = !amdaie.logicalobjectfifo<memref<8x16xi32>> source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+          %1 = amdaie.npu.dma_cpy_nd async_source %connection_0(%from_memref_22[] [] [], %from_memref_1[0,0] [8, 16] [16, 1]) : target_type = !amdaie.logicalobjectfifo<memref<8x16xi32>> source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+          %2 = amdaie.npu.dma_cpy_nd async_source %connection_2(%from_memref_33[] [] [], %from_memref_3[%iv_map, 0] [8, 16] [16, 1]) : target_type = !amdaie.logicalobjectfifo<memref<8x16xi32>> source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
           amdaie.npu.dma_wait(%0 : !amdaie.async_target_token)
           amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
           amdaie.npu.dma_wait(%2 : !amdaie.async_source_token)


### PR DESCRIPTION

-- This commit updates `iree-amdaie-npu-dma-bd-ids` pass to ensure
   equal distribution of BD IDs amongst DMAs within same scf.for block and
   operating on same tile.
-- This fixes the issue of misalignment of DMA ops which causes issues
    further down the stack in `insert-dma-chain` optimization pass.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>