### PR TITLE
[CI] Disable `three_matmuls` test

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -2458,7 +2458,8 @@ class Tests:
                 ["two_matmul_switching", "matmul_small"],
                 ["matmul_f32_8_8_4", "matmul_8_8_4"],
                 ["matmul_f32_8_4_8", "matmul_8_4_8"],
-                ["three_matmuls", "three_$mm$"],
+                # TODO (zhewen): investigate why the following test randomly fails when control packet is enabled.
+                # ["three_matmuls", "three_$mm$"],
             ]:
                 self.register(
                     MultipleDispatches(


### PR DESCRIPTION
The test is randomly failing on both main and PRs.