### PR TITLE
Add 1024x16384x512 matmul bench with peano ukernel

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -2185,6 +2185,20 @@ class Tests:
                 "use_chess_for_ukernel": True,
                 "peano_opt_level": 1,
             },
+            {
+                "M": 1024,
+                "N": 4096 * 4,
+                "K": 512,
+                "in_dtype": "i8",
+                "use_ukernel": True,
+                "matmul4d": True,
+                "scale_trunc": True,
+                "tile_pipeline": "pack-peel-4-level-tiling",
+                "run_on_target": "npu4",
+                "use_chess": False,
+                "use_chess_for_ukernel": False,
+                "peano_opt_level": 1,
+            },
         ]
 
         # Some bf16 Performance tests:


### PR DESCRIPTION
Adds back the 1024x16384x512 matmul benchmark through peano to compare with chess to check whether it passes CI. Will follow up with another PR to improve the ukernel performance.