### PR TITLE
[CtrlPkt] Fix `three_matmuls` test

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -260,6 +260,7 @@ class MultipleDispatches(BaseTest):
             self.aie_compilation_flags,
             self.filename,
             function_name=self.function_name,
+            n_repeats=self.n_repeats,
         )
         return True
 
@@ -2419,7 +2420,10 @@ class Tests:
                     in_type,
                     out_type,
                     test_params=TestParams(
-                        run_on_target=target, enable_ctrlpkt=True, name_suffix=target
+                        run_on_target=target,
+                        enable_ctrlpkt=True,
+                        name_suffix=target,
+                        n_repeats=10,
                     ),
                 )
             )
@@ -2472,8 +2476,7 @@ class Tests:
                 ["two_matmul_switching", "matmul_small"],
                 ["matmul_f32_8_8_4", "matmul_8_8_4"],
                 ["matmul_f32_8_4_8", "matmul_8_4_8"],
-                # TODO (zhewen): investigate why the following test randomly fails when control packet is enabled.
-                # ["three_matmuls", "three_$mm$"],
+                ["three_matmuls", "three_$mm$"],
             ]:
                 self.register(
                     MultipleDispatches(
@@ -2487,6 +2490,7 @@ class Tests:
                             run_on_target=target,
                             name_suffix="OneCore_" + target,
                             enable_ctrlpkt=enable_ctrlpkt,
+                            n_repeats=50 if enable_ctrlpkt else 2,
                         ),
                     )
                 )

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -967,6 +967,11 @@ def AMDAIE_NpuDmaWaitOp: AMDAIE_Op<"npu.dma_wait", []> {
   }];
 }
 
+def AMDAIE_NpuBarrierOp: AMDAIE_Op<"npu.barrier"> {
+  let summary = "Boundaries to stop wait/sync optimizations in NPU controller";
+  let assemblyFormat = [{ attr-dict }];
+}
+
 def AMDAIE_NpuPushToQueueOp: AMDAIE_Op<"npu.push_to_queue">,
   Results<(outs Optional<AMDAIE_AsyncTokenType>:$async_token)> {
   let summary = "Push the provided BD to the specified channel's queue.";

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/roundtrip.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/roundtrip.mlir
@@ -434,6 +434,25 @@ func.func @npu_patch_address() {
 
 // -----
 
+// CHECK-LABEL: func.func @npu_dma_wait
+// CHECK:       amdaie.npu.dma_wait(%arg0 : !amdaie.async_source_token)
+// CHECK:       amdaie.npu.dma_wait(%arg1 : !amdaie.async_target_token)
+func.func @npu_dma_wait(%arg0: !amdaie.async_source_token, %arg1: !amdaie.async_target_token) {
+  amdaie.npu.dma_wait(%arg0 : !amdaie.async_source_token)
+  amdaie.npu.dma_wait(%arg1 : !amdaie.async_target_token)
+  return
+}
+
+// -----
+// CHECK-LABEL: func.func @npu_barrier
+// CHECK:       amdaie.npu.barrier
+func.func @npu_barrier() {
+  amdaie.npu.barrier
+  return
+}
+
+// -----
+
 // CHECK-LABEL: func.func @npu_push_to_queue
 // CHECK:       amdaie.npu.push_to_queue {bd_id = 0 : ui32, channel = 0 : ui32, col = 0 : ui32, direction = 1 : i32, repeat_count = 1 : ui32, row = 0 : ui32}
 // CHECK:       %{{.+}} = amdaie.npu.push_to_queue async {bd_id = 15 : ui32, channel = 0 : ui32, col = 2 : ui32, direction = 1 : i32, repeat_count = 256 : ui32, row = 0 : ui32}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
@@ -1483,14 +1483,7 @@ LogicalResult generateControlPackets(
   pm.addPass(createCanonicalizerPass());
   // Optimize the controlcode size.
   pm.addPass(createAMDAIENpuDmaToHalfDmaCpyNdPass());
-  {
-    // Building multple BD chains in an interleaved way can disrupt the ordering
-    // of the reconfiguration data. Disabled for now.
-    // TODO (zhewen): check if possible to (partially) enable this.
-    AMDAIEInsertDmaBdChainOptions options;
-    options.enableInterleave = false;
-    pm.addPass(createAMDAIEInsertDmaBdChainPass(options));
-  }
+  pm.addPass(createAMDAIEInsertDmaBdChainPass());
   pm.addPass(createAMDAIEFoldDmaWaitsPass());
   // Lower the DMA instructions for sending control packets.
   pm.addPass(createAMDAIEControlCodeLoweringPass());

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEFoldDmaWaits.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEFoldDmaWaits.cpp
@@ -198,7 +198,7 @@ LogicalResult foldDmaWaitsByQueue(const AMDAIE::AMDAIEDeviceModel &deviceModel,
           }
         } else if (auto npuBarrierOp = dyn_cast<AMDAIE::NpuBarrierOp>(op)) {
           // Clear all queues if a sync barrier is encountered.
-          for (auto &entry : dmaBdIdsMap) entry.second.clear();
+          for (auto &[_, bdIds] : dmaBdIdsMap) bdIds.clear();
         }
         return WalkResult::advance();
       });
@@ -353,7 +353,7 @@ LogicalResult foldDmaWaitsByBatch(AMDAIE::ControlCodeOp controlCodeOp) {
         } else if (auto npuBarrierOp = dyn_cast<AMDAIE::NpuBarrierOp>(op)) {
           // Clear all batches if a sync barrier is encountered.
           connectionOps.clear();
-          for (auto &entry : dmaBdIdsMap) entry.second.clear();
+          for (auto &[_, bdIds] : dmaBdIdsMap) bdIds.clear();
         }
         return WalkResult::advance();
       });

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEFoldDmaWaits.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEFoldDmaWaits.cpp
@@ -163,37 +163,42 @@ LogicalResult foldDmaWaitsByQueue(const AMDAIE::AMDAIEDeviceModel &deviceModel,
 
   // Traverse the control code in reverse.
   WalkResult res = controlCodeOp->walk<WalkOrder::PostOrder, ReverseIterator>(
-      [&](AMDAIE::NpuDmaWaitOp waitOp) {
-        bool toQueue = true;
-        Operation *queueParentOp =
-            waitOpQueues.empty() ? waitOp->getParentOp()
-                                 : waitOpQueues.back().front()->getParentOp();
-        for (Value token : waitOp.getAsyncTokens()) {
-          if (auto npuHalfDmaCpyNdOp =
-                  dyn_cast_if_present<AMDAIE::NpuHalfDmaCpyNdOp>(
-                      token.getDefiningOp())) {
-            // Retrieve the TileOp, ConnectionOp, and BD ID.
-            FailureOr<DmaBdIdPair> currBdIdPair =
-                retrieveDmaBdIdPair(npuHalfDmaCpyNdOp);
-            if (failed(currBdIdPair)) return WalkResult::interrupt();
-            // Check if the current DMA wait op can be folded into the queue.
-            FailureOr<bool> canFold =
-                canFoldByQueue(deviceModel, queueParentOp, dmaBdIdsMap,
-                               npuHalfDmaCpyNdOp, *currBdIdPair);
-            if (failed(canFold)) return WalkResult::interrupt();
-            // Update the `dmaBdIdsMap`.
-            updateWithCurrBdId(*canFold, *currBdIdPair, dmaBdIdsMap);
-            toQueue &= *canFold;
+      [&](Operation *op) {
+        if (auto waitOp = dyn_cast<AMDAIE::NpuDmaWaitOp>(op)) {
+          bool toQueue = true;
+          Operation *queueParentOp =
+              waitOpQueues.empty() ? waitOp->getParentOp()
+                                   : waitOpQueues.back().front()->getParentOp();
+          for (Value token : waitOp.getAsyncTokens()) {
+            if (auto npuHalfDmaCpyNdOp =
+                    dyn_cast_if_present<AMDAIE::NpuHalfDmaCpyNdOp>(
+                        token.getDefiningOp())) {
+              // Retrieve the TileOp, ConnectionOp, and BD ID.
+              FailureOr<DmaBdIdPair> currBdIdPair =
+                  retrieveDmaBdIdPair(npuHalfDmaCpyNdOp);
+              if (failed(currBdIdPair)) return WalkResult::interrupt();
+              // Check if the current DMA wait op can be folded into the queue.
+              FailureOr<bool> canFold =
+                  canFoldByQueue(deviceModel, queueParentOp, dmaBdIdsMap,
+                                 npuHalfDmaCpyNdOp, *currBdIdPair);
+              if (failed(canFold)) return WalkResult::interrupt();
+              // Update the `dmaBdIdsMap`.
+              updateWithCurrBdId(*canFold, *currBdIdPair, dmaBdIdsMap);
+              toQueue &= *canFold;
+            }
           }
-        }
-        // Store all the queues, and modify later to avoid invalidating the
-        // iterator.
-        if (toQueue) {
-          // Append the wait op to the last queue if it can be folded.
-          waitOpQueues.back().push_back(waitOp);
-        } else {
-          // Create a new queue if the wait op cannot be folded.
-          waitOpQueues.push_back({waitOp});
+          // Store all the queues, and modify later to avoid invalidating the
+          // iterator.
+          if (toQueue) {
+            // Append the wait op to the last queue if it can be folded.
+            waitOpQueues.back().push_back(waitOp);
+          } else {
+            // Create a new queue if the wait op cannot be folded.
+            waitOpQueues.push_back({waitOp});
+          }
+        } else if (auto npuBarrierOp = dyn_cast<AMDAIE::NpuBarrierOp>(op)) {
+          // Clear all queues if a sync barrier is encountered.
+          for (auto &entry : dmaBdIdsMap) entry.second.clear();
         }
         return WalkResult::advance();
       });
@@ -310,39 +315,46 @@ LogicalResult foldDmaWaitsByBatch(AMDAIE::ControlCodeOp controlCodeOp) {
 
   // Traverse the control code in reverse.
   WalkResult res = controlCodeOp->walk<WalkOrder::PostOrder, ReverseIterator>(
-      [&](AMDAIE::NpuDmaWaitOp waitOp) {
-        bool toBatch = true;
-        Operation *batchParentOp =
-            waitOps.empty() ? waitOp->getParentOp() : waitOps[0]->getParentOp();
-        for (Value token : waitOp.getAsyncTokens()) {
-          if (auto npuHalfDmaCpyNdOp =
-                  dyn_cast_if_present<AMDAIE::NpuHalfDmaCpyNdOp>(
-                      token.getDefiningOp())) {
-            // Retrieve the TileOp, ConnectionOp, and BD ID.
-            FailureOr<DmaBdIdPair> currBdIdPair =
-                retrieveDmaBdIdPair(npuHalfDmaCpyNdOp);
-            if (failed(currBdIdPair)) return WalkResult::interrupt();
-            // Check if the current DMA wait op can be folded into the batch.
-            FailureOr<bool> canFold =
-                canFoldByBatch(batchParentOp, connectionOps, dmaBdIdsMap,
-                               npuHalfDmaCpyNdOp, *currBdIdPair);
-            if (failed(canFold)) return WalkResult::interrupt();
-            // Update the `connectionOps` and `dmaBdIdsMap`.
-            updateWithCurrBdId(*canFold, *currBdIdPair, connectionOps,
-                               dmaBdIdsMap);
-            toBatch &= *canFold;
+      [&](Operation *op) {
+        if (auto waitOp = dyn_cast<AMDAIE::NpuDmaWaitOp>(op)) {
+          bool toBatch = true;
+          Operation *batchParentOp = waitOps.empty()
+                                         ? waitOp->getParentOp()
+                                         : waitOps[0]->getParentOp();
+          for (Value token : waitOp.getAsyncTokens()) {
+            if (auto npuHalfDmaCpyNdOp =
+                    dyn_cast_if_present<AMDAIE::NpuHalfDmaCpyNdOp>(
+                        token.getDefiningOp())) {
+              // Retrieve the TileOp, ConnectionOp, and BD ID.
+              FailureOr<DmaBdIdPair> currBdIdPair =
+                  retrieveDmaBdIdPair(npuHalfDmaCpyNdOp);
+              if (failed(currBdIdPair)) return WalkResult::interrupt();
+              // Check if the current DMA wait op can be folded into the batch.
+              FailureOr<bool> canFold =
+                  canFoldByBatch(batchParentOp, connectionOps, dmaBdIdsMap,
+                                 npuHalfDmaCpyNdOp, *currBdIdPair);
+              if (failed(canFold)) return WalkResult::interrupt();
+              // Update the `connectionOps` and `dmaBdIdsMap`.
+              updateWithCurrBdId(*canFold, *currBdIdPair, connectionOps,
+                                 dmaBdIdsMap);
+              toBatch &= *canFold;
+            }
           }
+          // Process the previous batch of wait ops, and start a new batch.
+          if (!toBatch) {
+            // Since the controlcode is traversed in reverse order, we need to
+            // restore the original order of the DMA operations.
+            std::reverse(waitOps.begin(), waitOps.end());
+            if (failed(eraseBatchOperations(rewriter, waitOps)))
+              return WalkResult::interrupt();
+            waitOps.clear();
+          }
+          waitOps.push_back(waitOp);
+        } else if (auto npuBarrierOp = dyn_cast<AMDAIE::NpuBarrierOp>(op)) {
+          // Clear all batches if a sync barrier is encountered.
+          connectionOps.clear();
+          for (auto &entry : dmaBdIdsMap) entry.second.clear();
         }
-        // Process the previous batch of wait ops, and start a new batch.
-        if (!toBatch) {
-          // Since the controlcode is traversed in reverse order, we need to
-          // restore the original order of the DMA operations.
-          std::reverse(waitOps.begin(), waitOps.end());
-          if (failed(eraseBatchOperations(rewriter, waitOps)))
-            return WalkResult::interrupt();
-          waitOps.clear();
-        }
-        waitOps.push_back(waitOp);
         return WalkResult::advance();
       });
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertDmaBdChain.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertDmaBdChain.cpp
@@ -101,8 +101,7 @@ void checkForChainsWithDuplicateBdId(
 /// traversal simplifies handling duplicate BD IDs, preventing the need to
 /// revisit and modify earlier operations after processing later ones.
 LogicalResult insertDmaBdChain(const AMDAIE::AMDAIEDeviceModel &deviceModel,
-                               AMDAIE::ControlCodeOp controlCodeOp,
-                               bool enableInterleave) {
+                               AMDAIE::ControlCodeOp controlCodeOp) {
   IRRewriter rewriter(controlCodeOp->getContext());
 
   // Move all BdIdOps to the beginning of the control code.
@@ -123,6 +122,7 @@ LogicalResult insertDmaBdChain(const AMDAIE::AMDAIEDeviceModel &deviceModel,
   // Buffers the DMA ops that will be chained.
   DenseMap<DmaChain, SmallVector<AMDAIE::NpuHalfDmaCpyNdOp>> dmaChainToDmaOps;
 
+  llvm::SmallSetVector<DmaChain, 4> chainsToBreak;
   res = controlCodeOp->walk<WalkOrder::PostOrder,
                             ReverseIterator>([&](Operation *op) {
     if (auto npuHalfDmaCpyNdOp = dyn_cast<AMDAIE::NpuHalfDmaCpyNdOp>(op)) {
@@ -183,14 +183,7 @@ LogicalResult insertDmaBdChain(const AMDAIE::AMDAIEDeviceModel &deviceModel,
         return WalkResult::interrupt();
       }
 
-      llvm::SmallSetVector<DmaChain, 4> chainsToBreak;
       DmaChain currDmaChain = {tileOp, connectionOp};
-      // Check if there are other chains being built in an interleaved way.
-      if (!enableInterleave) {
-        for (auto &entry : dmaChainToBdIds) {
-          if (entry.first != currDmaChain) chainsToBreak.insert(entry.first);
-        }
-      }
       // Any duplicate BD ID from the same tile indicates that the chain
       // cannot grow further and requires breaking to release the
       // conflicting BD ID.
@@ -210,9 +203,13 @@ LogicalResult insertDmaBdChain(const AMDAIE::AMDAIEDeviceModel &deviceModel,
           dmaChainToBdIds.erase(entry);
           dmaChainToDmaOps.erase(entry);
         }
+        chainsToBreak.clear();
       }
       dmaChainToBdIds[currDmaChain].insert(bdId);
       dmaChainToDmaOps[currDmaChain].push_back(npuHalfDmaCpyNdOp);
+    } else if (auto npuBarrierOp = dyn_cast<AMDAIE::NpuBarrierOp>(op)) {
+      // Clear all chains if a sync barrier is encountered.
+      for (auto &entry : dmaChainToBdIds) chainsToBreak.insert(entry.first);
     }
     return WalkResult::advance();
   });
@@ -240,8 +237,6 @@ class AMDAIEInsertDmaBdChainPass
 
   AMDAIEInsertDmaBdChainPass() = default;
   AMDAIEInsertDmaBdChainPass(const AMDAIEInsertDmaBdChainPass &pass){};
-  AMDAIEInsertDmaBdChainPass(const AMDAIEInsertDmaBdChainOptions &options)
-      : AMDAIEInsertDmaBdChainBase(options) {}
   void runOnOperation() override;
 };
 
@@ -262,8 +257,7 @@ void AMDAIEInsertDmaBdChainPass::runOnOperation() {
 
   WalkResult res = parentOp->walk([&](AMDAIE::WorkgroupOp workgroupOp) {
     AMDAIE::ControlCodeOp controlCodeOp = workgroupOp.getControlCode();
-    if (failed(
-            insertDmaBdChain(deviceModel, controlCodeOp, enableInterleave))) {
+    if (failed(insertDmaBdChain(deviceModel, controlCodeOp))) {
       return WalkResult::interrupt();
     }
     return WalkResult::advance();
@@ -273,9 +267,8 @@ void AMDAIEInsertDmaBdChainPass::runOnOperation() {
 
 }  // namespace
 
-std::unique_ptr<Pass> createAMDAIEInsertDmaBdChainPass(
-    AMDAIEInsertDmaBdChainOptions options) {
-  return std::make_unique<AMDAIEInsertDmaBdChainPass>(options);
+std::unique_ptr<Pass> createAMDAIEInsertDmaBdChainPass() {
+  return std::make_unique<AMDAIEInsertDmaBdChainPass>();
 }
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -218,8 +218,7 @@ std::unique_ptr<Pass> createAMDAIEHoistForLoopAffineApplyPass();
 std::unique_ptr<Pass> createAMDAIEHoistLogicalObjFifoPass();
 
 /// Create pass to chain DMA BD IDs by updating next_bd operands.
-std::unique_ptr<Pass> createAMDAIEInsertDmaBdChainPass(
-    AMDAIEInsertDmaBdChainOptions options = {});
+std::unique_ptr<Pass> createAMDAIEInsertDmaBdChainPass();
 
 /// Create a pass to transform linalg.generics into a form which benefits later
 /// vectorization passes (to vector and aievec dialects).

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -406,10 +406,6 @@ def AMDAIEInsertDmaBdChain :
     Pass<"iree-amdaie-insert-dma-bd-chain"> {
   let summary = "Chain DMA BD IDs by updating next_bd operands.";
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIEInsertDmaBdChainPass()";
-  let options = [
-    Option<"enableInterleave", "enable-interleave", "bool", /*default=*/"true",
-      "Enable multiple BD chains to be built in an interleaved way.">,
-  ];
 }
 
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/fold_dma_waits.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/fold_dma_waits.mlir
@@ -471,6 +471,91 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
   }
 }
 
+
+// -----
+
+// Four DMA operations interleaved on two connections.
+// When `barrier = true` is encountered, any cross-barrier folding is disallowed.
+// CHECK-LABEL: @sync_barrier
+// CHECK:       %[[OBJECT_FIFO_0:.+]] = amdaie.logicalobjectfifo.from_buffers
+// CHECK:       %[[OBJECT_FIFO_1:.+]] = amdaie.logicalobjectfifo.from_buffers
+// CHECK:       %[[CHANNEL_0:.+]] = amdaie.channel
+// CHECK:       %[[CHANNEL_1:.+]] = amdaie.channel
+// CHECK:       %[[CHANNEL_2:.+]] = amdaie.channel
+// CHECK:       %[[CHANNEL_3:.+]] = amdaie.channel
+// CHECK:       %[[CONNECTION_0:.+]] = amdaie.connection
+// CHECK:       %[[CONNECTION_1:.+]] = amdaie.connection
+// CHECK:         %[[OBJECT_FIFO_2:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK:         %[[OBJECT_FIFO_3:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK:         %[[BD_ID_0:.+]] = amdaie.bd_id
+// CHECK:         %[[TOKEN_0:.+]] = amdaie.npu.half_dma_cpy_nd async %[[CONNECTION_0]](%[[OBJECT_FIFO_2]] [] [] [] bd_id = %[[BD_ID_0]] channel = %[[CHANNEL_0]]) : !amdaie.logicalobjectfifo<memref<2048xi32>>
+// CHECK:         %[[BD_ID_1:.+]] = amdaie.bd_id
+// CHECK:         %[[TOKEN_1:.+]] = amdaie.npu.half_dma_cpy_nd async %[[CONNECTION_1]](%[[OBJECT_FIFO_3]] [] [] [] bd_id = %[[BD_ID_1]] channel = %[[CHANNEL_2]]) : !amdaie.logicalobjectfifo<memref<2048xi32>>
+// CHECK:         amdaie.npu.dma_wait(%[[TOKEN_0]], %[[TOKEN_1]] : !amdaie.async_token, !amdaie.async_token)
+// CHECK:         amdaie.npu.barrier
+// CHECK:         %[[BD_ID_2:.+]] = amdaie.bd_id
+// CHECK:         %[[TOKEN_2:.+]] = amdaie.npu.half_dma_cpy_nd async %[[CONNECTION_0]](%[[OBJECT_FIFO_2]] [] [] [] bd_id = %[[BD_ID_2]] channel = %[[CHANNEL_0]]) : !amdaie.logicalobjectfifo<memref<2048xi32>>
+// CHECK:         %[[BD_ID_3:.+]] = amdaie.bd_id
+// CHECK:         %[[TOKEN_3:.+]] = amdaie.npu.half_dma_cpy_nd async %[[CONNECTION_1]](%[[OBJECT_FIFO_3]] [] [] [] bd_id = %[[BD_ID_3]] channel = %[[CHANNEL_2]]) : !amdaie.logicalobjectfifo<memref<2048xi32>>
+// CHECK:         amdaie.npu.dma_wait(%[[TOKEN_2]], %[[TOKEN_3]] : !amdaie.async_token, !amdaie.async_token)
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @sync_barrier() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    amdaie.workgroup {
+      %tile = amdaie.tile(%c0, %c1)
+      %tile_0 = amdaie.tile(%c0, %c0)
+      %buffer = amdaie.buffer(%tile) : memref<2048xi32, 1 : i32>
+      %buffer_1 = amdaie.buffer(%tile) : memref<2048xi32, 1 : i32>
+      %buffer_2 = amdaie.buffer(%tile) : memref<2048xi32, 1 : i32>
+      %buffer_3 = amdaie.buffer(%tile) : memref<2048xi32, 1 : i32>
+      %lock = amdaie.lock(%tile(4), 4)
+      %lock_4 = amdaie.lock(%tile(5), 0)
+      %lock_5 = amdaie.lock(%tile(6), 4)
+      %lock_6 = amdaie.lock(%tile(7), 0)
+      %0 = amdaie.logicalobjectfifo.from_buffers({%buffer, %buffer_1}, {%lock}, {%lock_4}) : memref<2048xi32, 1 : i32>, memref<2048xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2048xi32, 1 : i32>, 2>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<64x32xi32>
+      %2 = amdaie.logicalobjectfifo.placeholder{%tile_0} : !amdaie.logicalobjectfifo<memref<64x32xi32>>
+      %3 = amdaie.logicalobjectfifo.from_buffers({%buffer_2, %buffer_3}, {%lock_5}, {%lock_6}) : memref<2048xi32, 1 : i32>, memref<2048xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2048xi32, 1 : i32>, 2>
+      %4 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<64x32xi32>
+      %5 = amdaie.logicalobjectfifo.placeholder{%tile_0} : !amdaie.logicalobjectfifo<memref<64x32xi32>>
+      %channel = amdaie.channel(%tile_0, 0, port_type = DMA, direction = MM2S)
+      %channel_7 = amdaie.channel(%tile_0, 1, port_type = DMA, direction = MM2S)
+      %channel_8 = amdaie.channel(%tile, 0, port_type = DMA, direction = S2MM)
+      %channel_9 = amdaie.channel(%tile, 1, port_type = DMA, direction = S2MM)
+      %6 = amdaie.flow({%channel} -> {%channel_7}) {is_packet_flow = false}
+      %7 = amdaie.flow({%channel_8} -> {%channel_9}) {is_packet_flow = false}
+      %8 = amdaie.connection(%0 {%channel_7}, %2 {%channel}, flow = %6) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<2048xi32, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<64x32xi32>>)
+      %9 = amdaie.connection(%3 {%channel_9}, %5 {%channel_8}, flow = %7) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<2048xi32, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<64x32xi32>>)
+      amdaie.controlcode {
+        %10 = amdaie.logicalobjectfifo.from_memref %1, {%tile_0} : memref<64x32xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
+        memref.assume_alignment %1, 64 : memref<64x32xi32>
+        %11 = amdaie.logicalobjectfifo.from_memref %4, {%tile_0} : memref<64x32xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
+        memref.assume_alignment %4, 64 : memref<64x32xi32>
+        %bd_id = amdaie.bd_id(%tile_0, %c0)
+        %12 = amdaie.npu.half_dma_cpy_nd async %8(%10 [] [] [] bd_id = %bd_id channel = %channel) : !amdaie.logicalobjectfifo<memref<2048xi32>>
+        amdaie.npu.dma_wait(%12 : !amdaie.async_token)
+        %bd_id_1 = amdaie.bd_id(%tile_0, %c1)
+        %13 = amdaie.npu.half_dma_cpy_nd async %9(%11 [] [] [] bd_id = %bd_id_1 channel = %channel_8) : !amdaie.logicalobjectfifo<memref<2048xi32>>
+        amdaie.npu.dma_wait(%13 : !amdaie.async_token)
+        amdaie.npu.barrier
+        %bd_id_2 = amdaie.bd_id(%tile_0, %c2)
+        %14 = amdaie.npu.half_dma_cpy_nd async %8(%10 [] [] [] bd_id = %bd_id_2 channel = %channel) : !amdaie.logicalobjectfifo<memref<2048xi32>>
+        amdaie.npu.dma_wait(%14 : !amdaie.async_token)
+        %bd_id_3 = amdaie.bd_id(%tile_0, %c3)
+        %15 = amdaie.npu.half_dma_cpy_nd async %9(%11 [] [] [] bd_id = %bd_id_3 channel = %channel_8) : !amdaie.logicalobjectfifo<memref<2048xi32>>
+        amdaie.npu.dma_wait(%15 : !amdaie.async_token)
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
 // -----
 
 // Four DMA operations interleaved on two connections (in packet mode).

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_dma_bd_chain.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_dma_bd_chain.mlir
@@ -1,5 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-insert-dma-bd-chain{enable-interleave=true})" --split-input-file --verify-diagnostics %s | FileCheck %s
-// RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-insert-dma-bd-chain{enable-interleave=false})" --split-input-file --verify-diagnostics %s | FileCheck %s --check-prefix=DISABLE-INTERLEAVE
+// RUN: iree-opt --pass-pipeline="builtin.module(iree-amdaie-insert-dma-bd-chain)" --split-input-file --verify-diagnostics %s | FileCheck %s
 
 // Expect a single DMA BD chain, containing the IDs: [0, 1].
 // CHECK-LABEL: @single_bd_chain
@@ -12,12 +11,6 @@
 // CHECK:         amdaie.npu.half_dma_cpy_nd  %[[CONNECTION]](%[[OBJECT_FIFO]] [] [] [] bd_id = %[[BD_ID_0]] channel = %[[CHANNEL]] next_bd = %[[BD_ID_1]] start_bd = %[[BD_ID_0]])
 // CHECK:         %[[TOKEN_0:.+]] = amdaie.npu.half_dma_cpy_nd async %[[CONNECTION]](%[[OBJECT_FIFO]] [] [] [] bd_id = %[[BD_ID_1]] channel = %[[CHANNEL]] start_bd = %[[BD_ID_0]])
 // CHECK:         amdaie.npu.dma_wait(%[[TOKEN_0]] : !amdaie.async_token)
-
-// There is only a single BD chain anyway.
-// Same results no matter `enable-interleave` is true or false.
-// DISABLE-INTERLEAVE-LABEL:   @single_bd_chain
-// DISABLE-INTERLEAVE-COUNT-1: amdaie.npu.dma_wait
-// DISABLE-INTERLEAVE-NOT:     amdaie.npu.dma_wait
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -67,12 +60,6 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:         amdaie.npu.half_dma_cpy_nd  %[[CONNECTION]](%[[OBJECT_FIFO]] [] [] [] bd_id = %[[BD_ID_0]] channel = %[[CHANNEL]] next_bd = %[[BD_ID_1]] start_bd = %[[BD_ID_0]])
 // CHECK:         %[[TOKEN_0:.+]] = amdaie.npu.half_dma_cpy_nd async %[[CONNECTION]](%[[OBJECT_FIFO]] [] [] [] bd_id = %[[BD_ID_1]] channel = %[[CHANNEL]] start_bd = %[[BD_ID_0]])
 // CHECK:         amdaie.npu.dma_wait(%[[TOKEN_0]] : !amdaie.async_token)
-
-// There is only a single BD chain anyway.
-// Same results no matter `enable-interleave` is true or false.
-// DISABLE-INTERLEAVE-LABEL:   @single_bd_chain_pktflow
-// DISABLE-INTERLEAVE-COUNT-1: amdaie.npu.dma_wait
-// DISABLE-INTERLEAVE-NOT:     amdaie.npu.dma_wait
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -123,12 +110,6 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:         amdaie.npu.dma_wait(%[[TOKEN_0]] : !amdaie.async_token)
 // CHECK:         %[[TOKEN_1:.+]] = amdaie.npu.half_dma_cpy_nd async %[[CONNECTION]](%[[OBJECT_FIFO]] [0, 0] [2, 1] [0, 1] bd_id = %[[BD_ID_1]] channel = %[[CHANNEL]] start_bd = %[[BD_ID_1]])
 // CHECK:         amdaie.npu.dma_wait(%[[TOKEN_1]] : !amdaie.async_token)
-
-// There is no BD chain inserted.
-// Same results no matter `enable-interleave` is true or false.
-// DISABLE-INTERLEAVE-LABEL:   @no_bd_chain_repeat_count
-// DISABLE-INTERLEAVE-COUNT-2: amdaie.npu.dma_wait
-// DISABLE-INTERLEAVE-NOT:     amdaie.npu.dma_wait
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -227,12 +208,6 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:         amdaie.npu.half_dma_cpy_nd  %[[CONNECTION]](%[[OBJECT_FIFO]] [] [] [] bd_id = %[[BD_ID_1]] channel = %[[CHANNEL]]  next_bd = %[[BD_ID_2]] start_bd = %[[BD_ID_1]])
 // CHECK:         %[[TOKEN_1:.+]] = amdaie.npu.half_dma_cpy_nd async %[[CONNECTION]](%[[OBJECT_FIFO]] [] [] [] bd_id = %[[BD_ID_2]] channel = %[[CHANNEL]] start_bd = %[[BD_ID_1]])
 // CHECK:         amdaie.npu.dma_wait(%[[TOKEN_1]] : !amdaie.async_token)
-
-// Two BD chains are inserted without any interleaving.
-// Same results no matter `enable-interleave` is true or false.
-// DISABLE-INTERLEAVE-LABEL:   @duplicate_bd_id
-// DISABLE-INTERLEAVE-COUNT-2: amdaie.npu.dma_wait
-// DISABLE-INTERLEAVE-NOT:     amdaie.npu.dma_wait
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -279,6 +254,77 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 
 // -----
 
+// Expect two BD ID chains, as the chain breaks when `barrier=true` is encountered.
+// The first chain: [0, 1, 2]. The second chain: [3, 4].
+// CHECK-LABEL: @sync_barrier
+// CHECK:       %[[CHANNEL:.+]] = amdaie.channel
+// CHECK:       %[[CONNECTION:.+]] = amdaie.connection
+// CHECK:       amdaie.controlcode
+// CHECK:         %[[BD_ID_0:.+]] = amdaie.bd_id
+// CHECK:         %[[BD_ID_1:.+]] = amdaie.bd_id
+// CHECK:         %[[BD_ID_2:.+]] = amdaie.bd_id
+// CHECK:         %[[BD_ID_3:.+]] = amdaie.bd_id
+// CHECK:         %[[BD_ID_4:.+]] = amdaie.bd_id
+// CHECK:         %[[OBJECT_FIFO:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK:         amdaie.npu.half_dma_cpy_nd  %[[CONNECTION]](%[[OBJECT_FIFO]] [] [] [] bd_id = %[[BD_ID_0]] channel = %[[CHANNEL]]  next_bd = %[[BD_ID_1]] start_bd = %[[BD_ID_0]])
+// CHECK:         amdaie.npu.half_dma_cpy_nd  %[[CONNECTION]](%[[OBJECT_FIFO]] [] [] [] bd_id = %[[BD_ID_1]] channel = %[[CHANNEL]]  next_bd = %[[BD_ID_2]] start_bd = %[[BD_ID_0]])
+// CHECK:         %[[TOKEN_0:.+]] = amdaie.npu.half_dma_cpy_nd async %[[CONNECTION]](%[[OBJECT_FIFO]] [] [] [] bd_id = %[[BD_ID_2]] channel = %[[CHANNEL]] start_bd = %[[BD_ID_0]])
+// CHECK:         amdaie.npu.dma_wait(%[[TOKEN_0]] : !amdaie.async_token)
+// CHECK:         amdaie.npu.barrier
+// CHECK:         amdaie.npu.half_dma_cpy_nd  %[[CONNECTION]](%[[OBJECT_FIFO]] [] [] [] bd_id = %[[BD_ID_3]] channel = %[[CHANNEL]]  next_bd = %[[BD_ID_4]] start_bd = %[[BD_ID_3]])
+// CHECK:         %[[TOKEN_1:.+]] = amdaie.npu.half_dma_cpy_nd async %[[CONNECTION]](%[[OBJECT_FIFO]] [] [] [] bd_id = %[[BD_ID_4]] channel = %[[CHANNEL]] start_bd = %[[BD_ID_3]])
+// CHECK:         amdaie.npu.dma_wait(%[[TOKEN_1]] : !amdaie.async_token)
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @sync_barrier() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    amdaie.workgroup {
+      %tile = amdaie.tile(%c0, %c0)
+      %tile_0 = amdaie.tile(%c0, %c1)
+      %buffer = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_2 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %lock = amdaie.lock(%tile_0(0), 0)
+      %lock_3 = amdaie.lock(%tile_0(1), 0)
+      %channel = amdaie.channel(%tile, 0, port_type = DMA, direction = MM2S)
+      %channel_4 = amdaie.channel(%tile_0, 0, port_type = DMA, direction = S2MM)
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<512x512xbf16>
+      %1 = amdaie.logicalobjectfifo.from_buffers({%buffer, %buffer_2}, {%lock}, {%lock_3}) : memref<1024xbf16, 1 : i32>, memref<1024xbf16, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>
+      %2 = amdaie.logicalobjectfifo.placeholder{%tile} : !amdaie.logicalobjectfifo<memref<512x512xbf16>>
+      %3 = amdaie.flow({%channel} -> {%channel_4}) {is_packet_flow = false}
+      %4 = amdaie.connection(%1 {%channel_4}, %2 {%channel}, flow = %3) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<512x512xbf16>>)
+      amdaie.controlcode {
+        memref.assume_alignment %0, 64 : memref<512x512xbf16>
+        %5 = amdaie.logicalobjectfifo.from_memref %0, {%tile} : memref<512x512xbf16> -> !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %bd_id = amdaie.bd_id(%tile, %c0)
+        %6 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id channel = %channel start_bd = %bd_id) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%6 : !amdaie.async_token)
+        %bd_id_1 = amdaie.bd_id(%tile, %c1)
+        %7 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id_1 channel = %channel start_bd = %bd_id_1) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%7 : !amdaie.async_token)
+        %bd_id_2 = amdaie.bd_id(%tile, %c2)
+        %8 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id_2 channel = %channel start_bd = %bd_id_2) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%8 : !amdaie.async_token)
+        amdaie.npu.barrier
+        %bd_id_3 = amdaie.bd_id(%tile, %c3)
+        %9 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id_3 channel = %channel start_bd = %bd_id_3) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%9 : !amdaie.async_token)
+        %bd_id_4 = amdaie.bd_id(%tile, %c4)
+        %10 = amdaie.npu.half_dma_cpy_nd async %4(%5 [] [] [] bd_id = %bd_id_4 channel = %channel start_bd = %bd_id_4) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%10 : !amdaie.async_token)
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
 // Expect two DMA BD chains interleaved, as they belong to different connections.
 // One chain contains the IDs: [0, 2], the other chain contains: [1, 3].
 // CHECK-LABEL: @two_connections
@@ -301,12 +347,6 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:         %[[TOKEN_1:.+]] = amdaie.npu.half_dma_cpy_nd async %[[CONNECTION_1]](%[[OBJECT_FIFO_1]] [] [] [] bd_id = %[[BD_ID_3]] channel = %[[CHANNEL_2]] start_bd = %[[BD_ID_1]])
 // CHECK:         amdaie.npu.dma_wait(%[[TOKEN_0]] : !amdaie.async_token)
 // CHECK:         amdaie.npu.dma_wait(%[[TOKEN_1]] : !amdaie.async_token)
-
-// There could be two interleaved BD chains.
-// However, when the `enable-interleave` flag is false, no chain can be finally inserted.
-// DISABLE-INTERLEAVE-LABEL:   @two_connections
-// DISABLE-INTERLEAVE-COUNT-4: amdaie.npu.dma_wait
-// DISABLE-INTERLEAVE-NOT:     amdaie.npu.dma_wait
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {


### PR DESCRIPTION
Follow-up to #1210 and #1243.

This PR introduces a new  `barrier` op to provide finer-grained control over the ordering of control packets.

It serves as an optimization boundary, preventing any DMA wait/sync optimizations (such as folding or chaining) from crossing it. 

Currently, the barrier is heuristically set when control packets switch between destination tile types.