### PR TITLE
[DmaLoopSubsumption][CI] Allow any size if corresponding stride is zero + add 32x32192x32 in e2e CI

### DIFF
--- a/build_tools/ci/cpu_comparison/matmul_test_config.py
+++ b/build_tools/ci/cpu_comparison/matmul_test_config.py
@@ -113,6 +113,20 @@ npu4_matmul_tests = [
             "--iree-amdaie-num-cols=1",
         ],
     },
+    {
+        "M": 32,
+        "N": 32192,
+        "K": 32,
+        "input_type": "i32",
+        "acc_type": "i32",
+        "tile_pipeline": "pack-peel-4-level-tiling",
+        "name_suffix": "OneCore_npu4",
+        "additional_labels": ["OneCore"],
+        "aie_compilation_flags": [
+            "--iree-amdaie-num-rows=1",
+            "--iree-amdaie-num-cols=1",
+        ],
+    },
     # 4x2 core tests.
     {
         "M": 32,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.cpp
@@ -662,13 +662,13 @@ bool DmaDimConfig::isValidAccessPattern(ArrayRef<int64_t> sizes,
                                         ArrayRef<int64_t> strides) const {
   assert(sizes.size() == strides.size() &&
          "`sizes` and `strides` should have the same size");
-  // No need to check the unit dimensions.
+  // No need to check the unit dimensions and those with zero strides.
   SmallVector<int64_t> nonUnitSizes;
-  SmallVector<int64_t> nonUnitStrides;
+  SmallVector<int64_t> nonZeroStrides;
   for (size_t i = 0; i < sizes.size(); ++i) {
-    if (sizes[i] != 1) {
+    if (sizes[i] != 1 && strides[i] != 0) {
       nonUnitSizes.push_back(sizes[i]);
-      nonUnitStrides.push_back(strides[i]);
+      nonZeroStrides.push_back(strides[i]);
     }
   }
   SmallVector<int64_t> maxSizes = getMaxSizes(nonUnitSizes.size());
@@ -677,7 +677,7 @@ bool DmaDimConfig::isValidAccessPattern(ArrayRef<int64_t> sizes,
   size_t frontToDrop = maxSizes.size() - nonUnitSizes.size();
   if (anyOutOfRange(nonUnitSizes, maxSizes, frontToDrop)) return false;
   SmallVector<int64_t> maxStrides = getMaxStrides(nonUnitSizes.size());
-  if (anyOutOfRange(nonUnitStrides, maxStrides, frontToDrop)) return false;
+  if (anyOutOfRange(nonZeroStrides, maxStrides, frontToDrop)) return false;
   return true;
 }
 


### PR DESCRIPTION
-- This commit updates DMAUtils to allow any size if the corresponding stride is zero.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>