### PR TITLE
[AssignBufferAddresses] Improve bank-aware scheme to support large  buffer across multiple contiguous banks

### DIFF
--- a/compiler/plugins/target/AMD-AIE/aie/test/bank_aware_buffer_alloc.mlir
+++ b/compiler/plugins/target/AMD-AIE/aie/test/bank_aware_buffer_alloc.mlir
@@ -1,7 +1,8 @@
 
 // RUN: iree-opt --amdaie-assign-buffer-addresses="alloc-scheme=bank-aware" --verify-diagnostics --split-input-file %s | FileCheck %s
 
-// CHECK-LABEL:   aie.device(xcvc1902) {
+// CHECK-LABEL: @tile_test
+// CHECK:         aie.device(xcvc1902) {
 // CHECK:           %[[TILE_3_3:.*]] = aie.tile(3, 3)
 // CHECK:           aie.buffer(%[[TILE_3_3]]) {address = 16384 : i32, mem_bank = 2 : i32, sym_name = "a"} : memref<16xi8>
 // CHECK:           aie.buffer(%[[TILE_3_3]]) {address = 1024 : i32, mem_bank = 0 : i32, sym_name = "b"} : memref<512xi32>
@@ -35,7 +36,8 @@ module @tile_test {
 
 // -----
 
-// CHECK-LABEL:   aie.device(xcve2302) {
+// CHECK-LABEL: @memtile_test
+// CHECK:         aie.device(xcve2302) {
 // CHECK:           %[[TILE_3_1:.*]] = aie.tile(3, 1)
 // CHECK:           aie.buffer(%[[TILE_3_1]]) {address = 0 : i32, mem_bank = 0 : i32, sym_name = "a"} : memref<16384xi32>
 // CHECK:           aie.memtile_dma(%[[TILE_3_1]]) {
@@ -55,7 +57,8 @@ module @memtile_test {
 
 // -----
 
-// CHECK-LABEL:   aie.device(npu1) {
+// CHECK-LABEL: @prealloc_conflict
+// CHECK:         aie.device(npu1) {
 // CHECK:           %[[TILE:.*]] = aie.tile(4, 4)
 // CHECK:           aie.buffer(%[[TILE]]) {address = 0 : i32, mem_bank = 0 : i32, sym_name = "a"} : memref<1024xi32>
 // CHECK:           aie.buffer(%[[TILE]]) {address = 4096 : i32, mem_bank = 0 : i32, sym_name = "b"} : memref<1024xi32>
@@ -70,7 +73,8 @@ module @prealloc_conflict {
 
 // -----
 
-// CHECK-LABEL:   aie.device(npu1) {
+// CHECK-LABEL: @mix_prealloc
+// CHECK:         aie.device(npu1) {
 // CHECK:           %[[TILE:.*]] = aie.tile(4, 4)
 // CHECK:           aie.buffer(%[[TILE]]) {address = 32768 : i32, mem_bank = 2 : i32, sym_name = "_anonymous0"} : memref<200xi32>
 // CHECK:           aie.buffer(%[[TILE]]) {address = 49152 : i32, mem_bank = 3 : i32, sym_name = "_anonymous1"} : memref<100xi32>
@@ -96,10 +100,59 @@ module @mix_prealloc {
 
 // -----
 
+// CHECK-LABEL: @single_buffer_multiple_banks
+// CHECK:         aie.device(npu4) {
+// CHECK:           %[[TILE:.*]] = aie.tile(0, 1)
+// CHECK:           aie.buffer(%[[TILE]]) {address = 0 : i32, mem_bank = 0 : i32, sym_name = "buff_0"} : memref<131072xi8>
+// CHECK:           aie.buffer(%[[TILE]]) {address = 131072 : i32, mem_bank = 2 : i32, sym_name = "buff_1"} : memref<131072xi8>
+// CHECK:           aie.buffer(%[[TILE]]) {address = 262144 : i32, mem_bank = 4 : i32, sym_name = "buff_2"} : memref<131072xi8>
+// CHECK:         }
+
+module @single_buffer_multiple_banks {
+  aie.device(npu4) {
+    %tile_0_1 = aie.tile(0, 1)
+    %buf0 = aie.buffer(%tile_0_1) {sym_name = "buff_0"} : memref<131072xi8>
+    %buf1 = aie.buffer(%tile_0_1) {sym_name = "buff_1"} : memref<131072xi8>
+    %buf2 = aie.buffer(%tile_0_1) {sym_name = "buff_2"} : memref<131072xi8>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @multiple_buffers_round_robin
+// CHECK:         aie.device(npu4) {
+// CHECK:           %[[TILE:.*]] = aie.tile(1, 5)
+// CHECK:           aie.buffer(%[[TILE]]) {address = 16384 : i32, mem_bank = 1 : i32, sym_name = "buff_40"} : memref<4096xi32>
+// CHECK:           aie.buffer(%[[TILE]]) {address = 57344 : i32, mem_bank = 3 : i32, sym_name = "buff_41"} : memref<4096xi8>
+// CHECK:           aie.buffer(%[[TILE]]) {address = 9216 : i32, mem_bank = 0 : i32, sym_name = "buff_42"} : memref<4096xi8>
+// CHECK:           aie.buffer(%[[TILE]]) {address = 32768 : i32, mem_bank = 2 : i32, sym_name = "buff_43"} : memref<8192xi8>
+// CHECK:           aie.buffer(%[[TILE]]) {address = 49152 : i32, mem_bank = 3 : i32, sym_name = "buff_44"} : memref<8192xi8>
+// CHECK:           aie.buffer(%[[TILE]]) {address = 1024 : i32, mem_bank = 0 : i32, sym_name = "buff_45"} : memref<8192xi8>
+// CHECK:           aie.buffer(%[[TILE]]) {address = 40960 : i32, mem_bank = 2 : i32, sym_name = "buff_46"} : memref<8192xi8>
+// CHECK:         }
+
+module @multiple_buffers_round_robin {
+  aie.device(npu4) {
+    %tile_1_5 = aie.tile(1, 5)
+    %buf0 = aie.buffer(%tile_1_5) {sym_name = "buff_40"} : memref<4096xi32>
+    %buf1 = aie.buffer(%tile_1_5) {sym_name = "buff_41"} : memref<4096xi8>
+    %buf2 = aie.buffer(%tile_1_5) {sym_name = "buff_42"} : memref<4096xi8>
+    %buf3 = aie.buffer(%tile_1_5) {sym_name = "buff_43"} : memref<8192xi8>
+    %buf4 = aie.buffer(%tile_1_5) {sym_name = "buff_44"} : memref<8192xi8>
+    %buf5 = aie.buffer(%tile_1_5) {sym_name = "buff_45"} : memref<8192xi8>
+    %buf6 = aie.buffer(%tile_1_5) {sym_name = "buff_46"} : memref<8192xi8>
+    aie.core(%tile_1_5) {
+      aie.end
+    }
+  }
+}
+
+// -----
+
 module @no_available_bank {
-  aie.device(xcve2302) {
+  aie.device(npu1) {
     %0 = aie.tile(3, 1)
-    // expected-error @+1 {{Failed to allocate buffer: "a" with size: 528000 bytes on any of the bank.}}
+    // expected-error @+1 {{Buffer size exceeds total available memory across all banks (528000 > 524288)}}
     %b1 = aie.buffer(%0) { sym_name = "a" } : memref<132000xi32>
     aie.memtile_dma(%0) {
       aie.end


### PR DESCRIPTION
This PR mainly contains two improvements:
1. Switch different schemes per tile, so if a particular tile failed on `bank-aware` scheme, it will fall back to the `sequential` scheme but not affect any buffer in other tiles.
2. For large buffers that cannot fit in a single bank, it will try to allocate a group of contiguous banks and avoid bank conflicts.