### PR TITLE
[CI] Fix control packet tests

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -154,6 +154,7 @@ class BaseTest(ABC):
             self.labels.append("CtrlPkt")
             self.add_aie_compilation_flags(
                 [
+                    "--iree-amdaie-enable-control-packet=true",
                     "--iree-amdaie-enable-input-packet-flow=true",
                 ]
             )


### PR DESCRIPTION
The `--iree-amdaie-enable-control-packet=true` flag was accidentally removed as part of #1251.