### PR TITLE
Add flag to specify stack size to be allocated in AIE cores

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -2254,6 +2254,7 @@ class Tests:
             run_on_target = test.get("run_on_target", "npu1_4col")
             in_dtype = test.get("in_dtype", "bf16")
             out_dtype = test.get("out_dtype", "f32")
+            stack_size = test.get("stack_size", "1024")
             use_packet_flow = test.get("use_packet_flow", False)
 
             # Default of 1 means that outlined functions are called once at each
@@ -2279,6 +2280,7 @@ class Tests:
             aie_compilation_flags += [
                 outlining_string,
                 f"--iree-amd-aie-additional-peano-opt-flags={peano_opt_level_string}",
+                f"--iree-amdaie-stack-size={stack_size}",
             ]
 
             if call_replication != 1:

--- a/compiler/plugins/target/AMD-AIE/aie/AIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/aie/AIEOps.td
@@ -136,6 +136,10 @@ def AIE_CoreOp: AIE_Op<"core", [
   let builders = [
     OpBuilder<(ins "mlir::Value":$tile), [{
       build($_builder, $_state, $_builder.getIndexType(), tile);
+    }]>,
+    OpBuilder<(ins "mlir::Value":$tile, "mlir::IntegerAttr":$stack_size), [{
+      build($_builder, $_state, $_builder.getIndexType(), tile, stack_size,
+            nullptr, nullptr);
     }]>
   ];
   // mlir-air legacy

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.cpp
@@ -105,21 +105,22 @@ LogicalResult ControlCodeOp::verify() {
 // AMDAIE_CoreOp
 //===----------------------------------------------------------------------===//
 
-void CoreOp::build(OpBuilder &b, OperationState &result, AMDAIE::TileOp tileOp,
-                   ValueRange inputDmas, ValueRange outputDmas) {
-  build(b, result, b.getIndexType(), tileOp, inputDmas, outputDmas, nullptr);
-}
-
 /// Hardcoded row_offset == 2 -> AIE core rows start from 2
 /// TODO(jornt): avoid hardcoding here. Add a device model/identifier to loop up
 /// core offset. This will be handled in a follow-up.
 void CoreOp::build(OpBuilder &b, OperationState &result, Value coreCol,
-                   Value coreRow, ValueRange inputDmas, ValueRange outputDmas) {
+                   Value coreRow, ValueRange inputDmas, ValueRange outputDmas,
+                   IntegerAttr stackSize) {
   auto rowOffset = b.create<arith::ConstantIndexOp>(b.getUnknownLoc(), 2);
   auto row =
       b.createOrFold<arith::AddIOp>(b.getUnknownLoc(), rowOffset, coreRow);
   auto tileOp = b.create<AMDAIE::TileOp>(b.getUnknownLoc(), coreCol, row);
-  build(b, result, tileOp, inputDmas, outputDmas, nullptr);
+  build(b, result, tileOp, inputDmas, outputDmas, stackSize, nullptr);
+}
+
+void CoreOp::build(OpBuilder &b, OperationState &result, Value coreCol,
+                   Value coreRow, ValueRange inputDmas, ValueRange outputDmas) {
+  build(b, result, coreCol, coreRow, inputDmas, outputDmas, nullptr);
 }
 
 void CoreOp::build(OpBuilder &b, OperationState &result, Value coreCol,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -62,7 +62,7 @@ def AMDAIE_CoreOp: AMDAIE_Op<"core", [SingleBlock, AttrSizedOperandSegments]>, R
     relay to AIE core op for linking with Ukernel.
 
     It has a `stack_size` attribute with default value to specify the size of stack
-    buffer that has to be allocated on the cores' local memory.
+    buffer that has to be allocated on the core's local memory.
   }];
 
   let arguments = (

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -60,12 +60,16 @@ def AMDAIE_CoreOp: AMDAIE_Op<"core", [SingleBlock, AttrSizedOperandSegments]>, R
 
     It has an optional attribute `link_with` which will carry the information to
     relay to AIE core op for linking with Ukernel.
+
+    It has a `stack_size` attribute with default value to specify the size of stack
+    buffer that has to be allocated on the cores' local memory.
   }];
 
   let arguments = (
     ins Index:$tile,
         Variadic<Index>:$input_dmas,
         Variadic<Index>:$output_dmas,
+        DefaultValuedAttr<I32Attr, "1024">:$stack_size,
         OptionalAttr<StrAttr>:$link_with
   );
 
@@ -77,7 +81,22 @@ def AMDAIE_CoreOp: AMDAIE_Op<"core", [SingleBlock, AttrSizedOperandSegments]>, R
     OpBuilder<(ins "mlir::Value":$coreCol, "mlir::Value":$coreRow)>,
     OpBuilder<(ins "mlir::Value":$coreCol, "mlir::Value":$coreRow,
       "ValueRange":$input_dmas, "ValueRange":$output_dmas)>,
-    OpBuilder<(ins "TileOp":$tile, "ValueRange":$input_dmas, "ValueRange":$output_dmas)>
+    OpBuilder<(ins "mlir::Value":$coreCol, "mlir::Value":$coreRow, "ValueRange":$input_dmas,
+                   "ValueRange":$output_dmas, "mlir::IntegerAttr":$stack_size)>,
+    OpBuilder<(ins "mlir::Value":$coreCol, "mlir::Value":$coreRow, "ValueRange":$input_dmas,
+                   "ValueRange":$output_dmas, "uint32_t":$stack_size), [{
+      build($_builder, $_state, coreCol, coreRow, input_dmas, output_dmas,
+            $_builder.getIntegerAttr($_builder.getIntegerType(32), stack_size));
+    }]>,
+    OpBuilder<(ins "TileOp":$tile, "ValueRange":$input_dmas, "ValueRange":$output_dmas), [{
+      build($_builder, $_state, $_builder.getIndexType(), tile, input_dmas, output_dmas,
+            nullptr, nullptr);
+    }]>,
+    OpBuilder<(ins "TileOp":$tile, "ValueRange":$input_dmas, "ValueRange":$output_dmas,
+                    "uint32_t":$stack_size), [{
+      build($_builder, $_state, $_builder.getIndexType(), tile, input_dmas, output_dmas,
+            stack_size, nullptr);
+    }]>
   ];
 
   let extraClassDeclaration = [{

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/roundtrip.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/roundtrip.mlir
@@ -37,12 +37,13 @@ func.func @buffer() {
 // CHECK: %[[TILE_0:.*]] = amdaie.tile(%[[C0]], %[[C0]])
 // CHECK: %[[CORE_0:.*]] = amdaie.core(%[[TILE_0]], in : [], out : [])
 // CHECK: amdaie.end
+// CHECK: link_with = "/path/to/ukernel/mm.o", stack_size = 2048 : i32
 func.func @core() {
   %c0 = arith.constant 0 : index
   %tile = amdaie.tile(%c0, %c0)
   %core = amdaie.core(%tile, in : [], out : []) {
     amdaie.end
-  }
+  } {link_with = "/path/to/ukernel/mm.o", stack_size = 2048 : i32}
   return
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -241,7 +241,8 @@ class AIETargetBackend final : public IREE::HAL::TargetBackend {
         options.enableInputPacketFlow, options.enableOutputPacketFlow,
         options.enableCoalescingLoops, options.enableCollapsingUnitDims,
         options.enableFunctionOutlining, options.callReplication,
-        options.insertLoopAroundCoreBlock, options.enableCtrlPkt);
+        options.insertLoopAroundCoreBlock, options.enableCtrlPkt,
+        options.coreStackSize);
   }
 
   void buildLinkingPassPipeline(OpPassManager &passManager) override {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
@@ -91,6 +91,9 @@ struct AMDAIEOptions {
   enum class DeviceHAL { XRT, XRT_LITE };
   DeviceHAL deviceHal{DeviceHAL::XRT_LITE};
 
+  // The default stack size for all cores is 1024.
+  uint32_t coreStackSize{1024};
+
   void bindOptions(OptionsBinder &binder) {
     static llvm::cl::OptionCategory category("AMD AIE Options");
 
@@ -322,6 +325,10 @@ struct AMDAIEOptions {
         llvm::cl::desc(
             "Enable conversion of `aie.device` "
             "operations into control packets for fast reconfiguration."));
+
+    binder.opt<unsigned>(
+        "iree-amdaie-stack-size", coreStackSize, llvm::cl::cat(category),
+        llvm::cl::desc("The stack size to be used for the AIE cores."));
   }
 };
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.h
@@ -91,7 +91,7 @@ struct AMDAIEOptions {
   enum class DeviceHAL { XRT, XRT_LITE };
   DeviceHAL deviceHal{DeviceHAL::XRT_LITE};
 
-  // The default stack size for all cores is 1024.
+  // The default stack size for all cores is 1024 bytes.
   uint32_t coreStackSize{1024};
 
   void bindOptions(OptionsBinder &binder) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.cpp
@@ -35,9 +35,11 @@ AMDAIE::CoreOp CoreContext::mergeCoreOps(AMDAIE::CoreOp source,
                                             destOutputDmas.end());
   outputDmas.insert(sourceOutputDmas.begin(), sourceOutputDmas.end());
   rewriter.setInsertionPoint(source);
-  auto newCoreOp = rewriter.create<AMDAIE::CoreOp>(rewriter.getUnknownLoc(),
-                                                   tile, inputDmas.takeVector(),
-                                                   outputDmas.takeVector());
+  // Use the max stack size for the combined core.
+  uint32_t maxStackSize = std::max(source.getStackSize(), dest.getStackSize());
+  auto newCoreOp = rewriter.create<AMDAIE::CoreOp>(
+      rewriter.getUnknownLoc(), tile, inputDmas.takeVector(),
+      outputDmas.takeVector(), maxStackSize);
   Region &region = newCoreOp.getRegion();
   Block *newBlock = rewriter.createBlock(&region);
   rewriter.setInsertionPointToStart(newBlock);

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertCores.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertCores.cpp
@@ -58,7 +58,7 @@ void getAttributeMapping(SmallVector<scf::ForallOp> forallOps,
 /// Insert core ops inside innermost forall ops around computational ops and
 /// add synchronization ops along the way to synchronize with surrounding
 /// dma ops.
-LogicalResult insertCoreOps(mlir::ModuleOp moduleOp) {
+static LogicalResult insertCoreOps(mlir::ModuleOp moduleOp, int64_t stackSize) {
   IRRewriter rewriter(moduleOp.getContext());
   WalkResult res = moduleOp->walk([&](scf::ForallOp forallOp) {
     // Currently, innermost `scf.forall` operations are expected to have thread
@@ -120,8 +120,9 @@ LogicalResult insertCoreOps(mlir::ModuleOp moduleOp) {
 
     // Create CoreOp at the end of the innermost forall
     rewriter.setInsertionPoint(forallOp.getBody()->getTerminator());
-    auto coreOp = rewriter.create<AMDAIE::CoreOp>(
-        rewriter.getUnknownLoc(), threadX, threadY, inputDmas, outputDmas);
+    auto coreOp = rewriter.create<AMDAIE::CoreOp>(rewriter.getUnknownLoc(),
+                                                  threadX, threadY, inputDmas,
+                                                  outputDmas, stackSize);
     Region &region = coreOp.getRegion();
     Block *newBlock = rewriter.createBlock(&region);
     rewriter.setInsertionPointToStart(newBlock);
@@ -183,19 +184,23 @@ class AMDAIEInsertCoresPass
 
   AMDAIEInsertCoresPass() = default;
   AMDAIEInsertCoresPass(const AMDAIEInsertCoresPass &pass){};
+  AMDAIEInsertCoresPass(const AMDAIEInsertCoresOptions &options)
+      : AMDAIEInsertCoresBase(options) {}
+
   void runOnOperation() override;
 };
 
 void AMDAIEInsertCoresPass::runOnOperation() {
-  if (failed(insertCoreOps(getOperation()))) {
+  if (failed(insertCoreOps(getOperation(), stackSize))) {
     return signalPassFailure();
   }
 }
 
 }  // namespace
 
-std::unique_ptr<Pass> createAMDAIEInsertCoresPass() {
-  return std::make_unique<AMDAIEInsertCoresPass>();
+std::unique_ptr<Pass> createAMDAIEInsertCoresPass(
+    AMDAIEInsertCoresOptions options) {
+  return std::make_unique<AMDAIEInsertCoresPass>(options);
 }
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
@@ -494,8 +494,8 @@ LogicalResult AIEDeviceBuilder::coreToAIE(AMDAIE::CoreOp coreOp,
     return coreOp.emitError()
            << "couldn't look up input `aie.tile` operation in IR map";
   }
-  auto aieCoreOp =
-      rewriter.create<AIE::CoreOp>(rewriter.getUnknownLoc(), tileOp);
+  auto aieCoreOp = rewriter.create<AIE::CoreOp>(
+      rewriter.getUnknownLoc(), tileOp, coreOp.getStackSizeAttr());
   Region &aieCoreRegion = aieCoreOp.getBody();
   Block *aieCoreBlock = rewriter.createBlock(&aieCoreRegion);
   auto insertIt = aieCoreBlock->begin();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -604,7 +604,8 @@ void buildAMDAIETransformPassPipeline(
     const std::string &pathToUkernels, bool enableInputPacketFlow,
     bool enableOutputPacketFlow, bool enableCoalescingLoops,
     bool enableCollapsingUnitDims, OutliningStrategy enableFunctionOutlining,
-    int callReplication, bool insertLoopAroundCoreBlock, bool enableCtrlPkt) {
+    int callReplication, bool insertLoopAroundCoreBlock, bool enableCtrlPkt,
+    uint32_t coreStackSize) {
   OpPassManager &modulePassManager = variantPassManager.nest<ModuleOp>();
   {
     FunctionLikeNest funcPassManager(modulePassManager);
@@ -637,7 +638,7 @@ void buildAMDAIETransformPassPipeline(
         modulePassManager, enableInputPacketFlow, enableOutputPacketFlow,
         useTilePipeline, enableVectorizationPasses, enableCoalescingLoops,
         enableCollapsingUnitDims, enableFunctionOutlining, callReplication,
-        insertLoopAroundCoreBlock, numCols, enableCtrlPkt);
+        insertLoopAroundCoreBlock, numCols, enableCtrlPkt, coreStackSize);
   } else if (useLowerToAIEPipeline == LowerToAIEPassPipeline::AIR) {
     addMLIRAIRLoweringPasses(modulePassManager, device, useTilePipeline,
                              matmulElementwiseFusion,
@@ -663,7 +664,7 @@ void addAMDAIEObjectFifoLoweringPasses(
     bool enableVectorizationPasses, bool enableCoalescingLoops,
     bool enableCollapsingUnitDims, OutliningStrategy enableFunctionOutlining,
     int callReplication, bool insertLoopAroundCoreBlock, uint32_t numCols,
-    bool enableCtrlPkt) {
+    bool enableCtrlPkt, uint32_t coreStackSize) {
   passManager.addPass(createEraseHALDescriptorTypeFromMemRefPass());
   passManager.addPass(memref::createFoldMemRefAliasOpsPass());
 
@@ -687,7 +688,7 @@ void addAMDAIEObjectFifoLoweringPasses(
   }
 
   passManager.addPass(createAMDAIENormalizeLoopBoundsPass());
-  passManager.addPass(createAMDAIEInsertCoresPass());
+  passManager.addPass(createAMDAIEInsertCoresPass({coreStackSize}));
 
   // Create function outlining options object, etc.
   {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -20,7 +20,7 @@ void addAMDAIEObjectFifoLoweringPasses(
     bool enableVectorizationPasses, bool enableCoalescingLoops,
     bool enableCollapsingUnitDims, OutliningStrategy enableFunctionOutlining,
     int outliningLoopInCallCount, bool insertLoopAroundCoreBlock,
-    uint32_t numCols, bool emitCtrlPkt);
+    uint32_t numCols, bool emitCtrlPkt, uint32_t coreStackSize);
 
 /// Add passes to lower from MLIR-AIR through AIE. This is
 /// currently the default passes used for lowering after IREEs tiling.
@@ -46,7 +46,7 @@ void buildAMDAIETransformPassPipeline(
     bool enableOutputPacketFlow, bool enableCoalescingLoops,
     bool enableCollapsingUnitDims, OutliningStrategy enableFunctionOutlining,
     int outliningLoopInCallCount, bool insertLoopAroundCoreBlock,
-    bool emitCtrlPkt);
+    bool emitCtrlPkt, uint32_t coreStackSize);
 
 /// Populates passes needed to lower the IR via a Pack-Peel based approach.
 void addPackPeelBasedPassPipeline(OpPassManager &passManager,
@@ -234,7 +234,8 @@ std::unique_ptr<Pass> createAMDAIEFuseProducerIntoLoopPass(
 
 /// Create pass to insert `amdaie.core` operations inside the innermost
 /// `scf.forall` operations selected for parallel execution.
-std::unique_ptr<Pass> createAMDAIEInsertCoresPass();
+std::unique_ptr<Pass> createAMDAIEInsertCoresPass(
+    AMDAIEInsertCoresOptions = {});
 
 /// Links AMDAIE HAL executables within the top-level program module.
 std::unique_ptr<OperationPass<mlir::ModuleOp>>

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -400,6 +400,10 @@ def AMDAIEInsertCores :
   let summary = "Insert `amdaie.core` operations inside the innermost "
                 "`scf.forall` operations selected for parallel execution.";
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIEInsertCoresPass()";
+  let options = [
+    Option<"stackSize", "stack-size", "int64_t", /*default=*/"1024",
+      "Set the stack size to be used in the cores.">
+  ];
 }
 
 def AMDAIEInsertDmaBdChain :

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/create_aie_workgroup.mlir
@@ -341,10 +341,11 @@ func.func @forall_dmas(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 1>) 
 // CHECK:         %[[CONNECTION:.+]] = amdaie.connection(%[[FROMMEMREF0]], %[[PLACEHOLDER]]) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>)
 // CHECK-DAG:     %[[PLACEHOLDER2:.+]] = amdaie.logicalobjectfifo.placeholder{} : !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
 // CHECK:         %[[CONNECTION2:.+]] = amdaie.connection(%[[FROMMEMREF0]], %[[PLACEHOLDER2]]) : (!amdaie.logicalobjectfifo<memref<8x16xi32, 2>>, !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>)
-// CHECK:         %{{.+}} = amdaie.core(%[[TILE_0]], in : [%[[CONNECTION]], %[[CONNECTION2]]], out : [])
+// CHECK:         %{{.+}} = amdaie.core(%[[TILE_0]], in : [%[[CONNECTION]], %[[CONNECTION2]]], out : []) {
 // CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF0]], Read)
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
 // CHECK:             amdaie.logicalobjectfifo.access(%[[FROMMEMREF0]], Read)
+// CHECK:         } {stack_size = 2048 : i32}
 // CHECK:         %{{.+}} = amdaie.core(%[[TILE_1]], in : [%[[CONNECTION]], %[[CONNECTION2]]], out : [])
 // CHECK:           amdaie.logicalobjectfifo.access(%[[FROMMEMREF0]], Read)
 // CHECK:           scf.for %{{.*}} = %[[C0]] to %[[C8]] step %[[C1]]
@@ -374,7 +375,7 @@ func.func @merge_cores(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 2>) 
   %core_0_0_0 = amdaie.core(%tile_0_0, in : [%2], out : []) {
     amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<8x16xi32, 2>> -> memref<8x16xi32, 2>
     amdaie.end
-  }
+  } {stack_size = 2048 : i32}
   %core_0_1_0 = amdaie.core(%tile_0_1, in : [%2], out : []) {
     amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<8x16xi32, 2>> -> memref<8x16xi32, 2>
     amdaie.end
@@ -384,7 +385,7 @@ func.func @merge_cores(%arg0: memref<1x1x8x16xi32>, %arg1: memref<8x16xi32, 2>) 
     %core_0_0_1 = amdaie.core(%tile_0_0, in : [%3], out : []) {
       amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<8x16xi32, 2>> -> memref<8x16xi32, 2>
       amdaie.end
-    }
+    } {stack_size = 512 : i32}
     %core_0_1_1 = amdaie.core(%tile_0_1, in : [%3], out : []) {
       amdaie.logicalobjectfifo.access(%1, Read) : !amdaie.logicalobjectfifo<memref<8x16xi32, 2>> -> memref<8x16xi32, 2>
       amdaie.end

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
@@ -834,7 +834,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // CHECK:     %[[TILE_0_2:.+]] = aie.tile(0, 2)
 // CHECK:     aie.core(%[[TILE_0_2]]) {
 // CHECK:       aie.end
-// CHECK:     }
+// CHECK:     } {stack_size = 2048 : i32}
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
   func.func @core() {
@@ -844,7 +844,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %tile_0_2 = amdaie.tile(%c0, %c2)
       %core_0_0 = amdaie.core(%tile_0_2, in : [], out : []) {
         amdaie.end
-      }
+      } {stack_size = 2048 : i32}
       amdaie.controlcode {
         amdaie.end
       }


### PR DESCRIPTION
This is needed to start enabling O2 in the peano ukernel compilation as the stack size needs increase. This doesn't enable O2 yet by default as that results in out-of-program memory issues in other tests, so leaving that to a follow up.