### PR TITLE
[CI] Do not run benchmark tests twice on strix

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -313,6 +313,7 @@ jobs:
             --reset_npu_between_runs \
             --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS \
             --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS \
+            --skip_tests=Performance \
             -v
 
       # Run the 'Performance' tests. These do not check numerical correctness,


### PR DESCRIPTION
This PR updates the CI workflow to skip the Performance (benchmark) tests during the `E2E comparison of AIE to llvm-cpu` step on Strix. The corresponding numerical correctness tests will still run as expected.

No changes are needed for Phoenix tests, as the `--skip_tests` flag is already set correctly for them.