### PR TITLE
Enable O2 by default for Peano ukernels

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -54,6 +54,7 @@ class TestParams(ABC):
         run_benchmark=False,
         n_repeats=1,
         enable_ctrlpkt=True,
+        stack_size=1024,
     ):
         self.run_on_target = run_on_target
         self.aie_compilation_flags = (
@@ -68,6 +69,7 @@ class TestParams(ABC):
         self.run_benchmark = run_benchmark
         self.n_repeats = n_repeats
         self.enable_ctrlpkt = enable_ctrlpkt
+        self.stack_size = stack_size
 
 
 class BaseTest(ABC):
@@ -126,16 +128,19 @@ class BaseTest(ABC):
         self.run_benchmark = run_benchmark
         self.n_repeats = n_repeats
         self.enable_ctrlpkt = enable_ctrlpkt
+        self.stack_size = test_params.stack_size
 
         if tile_pipeline == "pack-peel-4-level-tiling":
             self.name += "_4_level_tiling"
 
-        if use_chess:
-            self.name += f"_chess"
+        if use_chess or use_chess_for_ukernel:
             self.labels.append("Chess")
-            self.add_aie_compilation_flags([f"--iree-amd-aie-enable-chess=1"])
         else:
             self.labels.append("Peano")
+
+        if use_chess:
+            self.name += f"_chess"
+            self.add_aie_compilation_flags([f"--iree-amd-aie-enable-chess=1"])
 
         if use_ukernel:
             self.labels.append("UKernel")
@@ -165,6 +170,8 @@ class BaseTest(ABC):
 
         if run_benchmark:
             self.name += "_benchmark"
+
+        self.add_aie_compilation_flags([f"--iree-amdaie-stack-size={self.stack_size}"])
 
     def add_aie_compilation_flags(self, flags):
         if flags:
@@ -1766,6 +1773,7 @@ class Tests:
             test_params = TestParams(
                 tile_pipeline="pack-peel-4-level-tiling",
                 run_on_target=test["run_on_target"],
+                stack_size=3072,
             )
             if "use_ukernel" in test:
                 test_params.use_ukernel = test["use_ukernel"]
@@ -1921,7 +1929,7 @@ class Tests:
 
         for device in matmul_tests_for_each_device:
             for test in matmul_tests_for_each_device[device]:
-                test_params = TestParams(run_on_target=[device])
+                test_params = TestParams(run_on_target=[device], stack_size=3072)
                 if "use_ukernel" in test:
                     test_params.use_ukernel = test["use_ukernel"]
                 if "use_chess" in test:
@@ -2139,6 +2147,7 @@ class Tests:
                 "use_ukernel": True,
                 "outline": "all",
                 "run_on_target": "npu4",
+                "stack_size": 3072,
             },
             {
                 "M": 512,
@@ -2149,6 +2158,7 @@ class Tests:
                 "outline": "all",
                 "run_on_target": "npu4",
                 "use_packet_flow": True,
+                "stack_size": 3072,
             },
             {
                 "M": 512,
@@ -2170,6 +2180,7 @@ class Tests:
                 "tile_pipeline": "pack-peel-4-level-tiling",
                 "run_on_target": "npu4",
                 "use_chess_for_ukernel": False,
+                "stack_size": 3072,
             },
             {
                 "M": 512,
@@ -2180,6 +2191,7 @@ class Tests:
                 "outline": "all",
                 "tile_pipeline": "pack-peel-4-level-tiling",
                 "run_on_target": "npu4",
+                "stack_size": 3072,
             },
             {
                 "M": 1024,
@@ -2208,6 +2220,7 @@ class Tests:
                 "use_chess": False,
                 "use_chess_for_ukernel": False,
                 "peano_opt_level": 1,
+                "stack_size": 3072,
             },
         ]
 
@@ -2256,7 +2269,6 @@ class Tests:
             aie_compilation_flags += [
                 outlining_string,
                 f"--iree-amd-aie-additional-peano-opt-flags={peano_opt_level_string}",
-                f"--iree-amdaie-stack-size={stack_size}",
             ]
 
             if call_replication != 1:
@@ -2330,6 +2342,7 @@ class Tests:
                             n_repeats=2,
                             use_chess=use_chess,
                             use_chess_for_ukernel=use_chess_for_ukernel,
+                            stack_size=stack_size,
                         ),
                         additional_labels=["PerformanceCorrectness"]
                         + additional_labels,
@@ -2352,6 +2365,7 @@ class Tests:
                     n_repeats=n_performance_repeats,
                     use_chess=use_chess,
                     use_chess_for_ukernel=use_chess_for_ukernel,
+                    stack_size=stack_size,
                 ),
                 additional_labels=["Performance"] + additional_labels,
                 n_kernel_runs=n_performance_kernel_runs,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/XCLBinGen.cpp
@@ -647,11 +647,16 @@ static LogicalResult assembleFileUsingPeano(
   std::vector<std::string> args;
   args.reserve(args.size() + std::distance(extraArgs.begin(), extraArgs.end()));
   args.insert(args.end(), extraArgs.begin(), extraArgs.end());
-  // TODO(jornt): O0 fails with peano, so we use O1 for now.
-  args.emplace_back("-O1");
+  // Use O2 by default as this is recommended by peano folks.
+  args.emplace_back("-O2");
   // The following flag is needed to prevent peano from inlining memset, which
   // results in slow scalar code for the vectorized zeroization ukernel.
   args.emplace_back("-fno-builtin-memset");
+  // The `-ffunction-sections` and `-fdata-sections` flags are needed to put
+  // each function and data item into their own section so any unused sections
+  // can be discarded later during linking with `-Wl,--gc-sections`.
+  args.emplace_back("-ffunction-sections");
+  args.emplace_back("-fdata-sections");
   args.emplace_back("-c");
   args.emplace_back(inputFile);
   args.emplace_back("-o");


### PR DESCRIPTION
Enabling O2 by default for compiling peano ukernels on all tests in CI needs following changes:
- Avoid out-of-memory errors (program memory)  by adding `-ffunction-sections` and `-fdata-sections` flags to put each function and data item into its own section to enable them to be discarded later during linking with `-Wl,--gc-sections`.
- Avoid numerical issues due to not enough stack size being allocated in matmul tests, leading to override of data buffers on L1. This is solved for now by passing large enough stack sizes for those tests. The exact stack sizes being passed are found as experimentally as the smallest multiple of 1024 that is large enough.