### PR TITLE
[CI] Disable NPU reset between runs in Strix tests

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -310,7 +310,8 @@ jobs:
             --peano_dir=$PWD/llvm-aie \
             --vitis_dir=/opt/xilinx/Vitis/2024.2 \
             --target_device="npu4" \
-            --reset_npu_between_runs \
+            # Disabled reset npu due to instability issues in CI.
+            # --reset_npu_between_runs
             --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS \
             --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS \
             --skip_tests=Performance \
@@ -327,10 +328,11 @@ jobs:
             --peano_dir=$PWD/llvm-aie \
             --vitis_dir=/opt/xilinx/Vitis/2024.2 \
             --target_device="npu4" \
-            --reset_npu_between_runs -v \
+            # Disabled reset npu due to instability issues in CI.
+            # --reset_npu_between_runs
             --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS \
             --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS \
-            --tests=Performance > performance_npu4.log
+            --tests=Performance -v > performance_npu4.log
 
           # Print a summary of the findings.
           python build_tools/ci/cpu_comparison/performance_summarizer.py \

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -310,8 +310,6 @@ jobs:
             --peano_dir=$PWD/llvm-aie \
             --vitis_dir=/opt/xilinx/Vitis/2024.2 \
             --target_device="npu4" \
-            # Disabled reset npu due to instability issues in CI.
-            # --reset_npu_between_runs
             --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS \
             --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS \
             --skip_tests=Performance \
@@ -328,8 +326,6 @@ jobs:
             --peano_dir=$PWD/llvm-aie \
             --vitis_dir=/opt/xilinx/Vitis/2024.2 \
             --target_device="npu4" \
-            # Disabled reset npu due to instability issues in CI.
-            # --reset_npu_between_runs
             --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS \
             --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS \
             --tests=Performance -v > performance_npu4.log


### PR DESCRIPTION
Note: NPU reset was already disabled previously in Phoenix tests.