### PR TITLE
[Softmax] Add fix to copy to destination

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_copy_ops.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_copy_ops.mlir
@@ -1,12 +1,14 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-amdaie-insert-copy-ops),canonicalize,cse)" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-amdaie-insert-copy-ops))" %s | FileCheck %s
 
 // CHECK: func.func @softmax_insert_copy_ops
 // CHECK:   %[[CST:.*]] = arith.constant 0 : i32
+// CHECK:   %[[EMPTY0:.*]] = tensor.empty() : tensor<1x32xbf16>
+// CHECK:   %[[FILL:.*]] = linalg.fill ins(%[[CST]] : i32) outs(%[[EMPTY0]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
 // CHECK:   %[[ALLOC0:.*]] = bufferization.alloc_tensor() : tensor<1x32xbf16>
 // CHECK:   %[[COPYIN:.*]] = linalg.copy ins(%arg0 : tensor<1x32xbf16>) outs(%[[ALLOC0]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
 // CHECK:   %[[ALLOC1:.*]] = bufferization.alloc_tensor() : tensor<1x32xbf16>
-// CHECK:   %[[FILL:.*]] = linalg.fill ins(%[[CST]] : i32) outs(%[[ALLOC1]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
-// CHECK:   %[[SOFTMAX:.*]] = linalg.softmax dimension(1) ins(%[[COPYIN]] : tensor<1x32xbf16>) outs(%[[FILL]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
+// CHECK:   %[[COPYINIT:.*]] = linalg.copy ins(%[[FILL]] : tensor<1x32xbf16>) outs(%[[ALLOC1]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
+// CHECK:   %[[SOFTMAX:.*]] = linalg.softmax dimension(1) ins(%[[COPYIN]] : tensor<1x32xbf16>) outs(%[[COPYINIT]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
 // CHECK:   %[[ALLOC2:.*]] = bufferization.alloc_tensor() : tensor<1x32xbf16>
 // CHECK:   %[[COPYOUT:.*]] = linalg.copy ins(%[[SOFTMAX]] : tensor<1x32xbf16>) outs(%[[ALLOC2]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
 // CHECK:   return %[[COPYOUT]] : tensor<1x32xbf16>
@@ -24,12 +26,14 @@ func.func @softmax_insert_copy_ops(%in0: tensor<1x32xbf16>) -> tensor<1x32xbf16>
 // CHECK:   %[[CST:.*]] = arith.constant 0 : i32
 // CHECK:   %[[EMPTY:.*]] = tensor.empty() : tensor<1x32xbf16>
 // CHECK:   %[[FORALL:.*]] = scf.forall (%[[ARG1:.*]]) in (1) shared_outs(%[[ARG2:.*]] = %[[EMPTY]]) -> (tensor<1x32xbf16>) {
+// CHECK:     %[[FILL:.*]] = linalg.fill ins(%[[CST]] : i32) outs(%[[ARG2]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
 // CHECK:     %[[ALLOC0:.*]] = bufferization.alloc_tensor() : tensor<1x32xbf16>
 // CHECK:     %[[COPYIN:.*]] = linalg.copy ins(%arg0 : tensor<1x32xbf16>) outs(%[[ALLOC0]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
 // CHECK:     %[[ALLOC1:.*]] = bufferization.alloc_tensor() : tensor<1x32xbf16>
-// CHECK:     %[[FILL:.*]] = linalg.fill ins(%[[CST]] : i32) outs(%[[ALLOC1]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
-// CHECK:     %[[SOFTMAX:.*]] = linalg.softmax dimension(1) ins(%[[COPYIN]] : tensor<1x32xbf16>) outs(%[[FILL]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
-// CHECK:     %[[COPYOUT:.*]] = linalg.copy ins(%[[SOFTMAX]] : tensor<1x32xbf16>) outs(%[[ARG2]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
+// CHECK:     %[[COPYINIT:.*]] = linalg.copy ins(%[[FILL]] : tensor<1x32xbf16>) outs(%[[ALLOC1]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
+// CHECK:     %[[EXTRACT:.*]] = tensor.extract_slice %[[ARG2]][%[[ARG1]], 0] [1, 32] [1, 1] : tensor<1x32xbf16> to tensor<1x32xbf16>
+// CHECK:     %[[SOFTMAX:.*]] = linalg.softmax dimension(1) ins(%[[COPYIN]] : tensor<1x32xbf16>) outs(%[[COPYINIT]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
+// CHECK:     %[[COPYOUT:.*]] = linalg.copy ins(%[[SOFTMAX]] : tensor<1x32xbf16>) outs(%[[EXTRACT]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
 // CHECK:   } {mapping = [#gpu.block<y>]}
 // CHECK:   return %[[FORALL]] : tensor<1x32xbf16>
 func.func @softmax_forall(%arg0: tensor<1x32xbf16>) -> tensor<1x32xbf16> {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_copy_ops.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_copy_ops.mlir
@@ -1,14 +1,14 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-amdaie-insert-copy-ops))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-amdaie-insert-copy-ops),canonicalize,cse)" %s | FileCheck %s
 
 // CHECK: func.func @softmax_insert_copy_ops
 // CHECK:   %[[CST:.*]] = arith.constant 0 : i32
-// CHECK:   %[[EMPTY0:.*]] = tensor.empty() : tensor<1x32xbf16>
-// CHECK:   %[[FILL:.*]] = linalg.fill ins(%[[CST]] : i32) outs(%[[EMPTY0]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
-// CHECK:   %[[EMPTY1:.*]] = tensor.empty() : tensor<1x32xbf16>
-// CHECK:   %[[COPYIN:.*]] = linalg.copy ins(%arg0 : tensor<1x32xbf16>) outs(%[[EMPTY1]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
+// CHECK:   %[[ALLOC0:.*]] = bufferization.alloc_tensor() : tensor<1x32xbf16>
+// CHECK:   %[[COPYIN:.*]] = linalg.copy ins(%arg0 : tensor<1x32xbf16>) outs(%[[ALLOC0]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
+// CHECK:   %[[ALLOC1:.*]] = bufferization.alloc_tensor() : tensor<1x32xbf16>
+// CHECK:   %[[FILL:.*]] = linalg.fill ins(%[[CST]] : i32) outs(%[[ALLOC1]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
 // CHECK:   %[[SOFTMAX:.*]] = linalg.softmax dimension(1) ins(%[[COPYIN]] : tensor<1x32xbf16>) outs(%[[FILL]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
-// CHECK:   %[[EMPTY2:.*]] = tensor.empty() : tensor<1x32xbf16>
-// CHECK:   %[[COPYOUT:.*]] = linalg.copy ins(%[[SOFTMAX]] : tensor<1x32xbf16>) outs(%[[EMPTY2]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
+// CHECK:   %[[ALLOC2:.*]] = bufferization.alloc_tensor() : tensor<1x32xbf16>
+// CHECK:   %[[COPYOUT:.*]] = linalg.copy ins(%[[SOFTMAX]] : tensor<1x32xbf16>) outs(%[[ALLOC2]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
 // CHECK:   return %[[COPYOUT]] : tensor<1x32xbf16>
 func.func @softmax_insert_copy_ops(%in0: tensor<1x32xbf16>) -> tensor<1x32xbf16> {
   %cst = arith.constant 0 : i32
@@ -16,4 +16,31 @@ func.func @softmax_insert_copy_ops(%in0: tensor<1x32xbf16>) -> tensor<1x32xbf16>
   %1 = linalg.fill ins(%cst : i32) outs(%0 :tensor<1x32xbf16>) -> tensor<1x32xbf16>
   %2 = linalg.softmax dimension(1) ins(%in0 : tensor<1x32xbf16>) outs(%1 : tensor<1x32xbf16>) -> tensor<1x32xbf16>
   return %2 : tensor<1x32xbf16>
+}
+
+// -----
+
+// CHECK: func.func @softmax_forall
+// CHECK:   %[[CST:.*]] = arith.constant 0 : i32
+// CHECK:   %[[EMPTY:.*]] = tensor.empty() : tensor<1x32xbf16>
+// CHECK:   %[[FORALL:.*]] = scf.forall (%[[ARG1:.*]]) in (1) shared_outs(%[[ARG2:.*]] = %[[EMPTY]]) -> (tensor<1x32xbf16>) {
+// CHECK:     %[[ALLOC0:.*]] = bufferization.alloc_tensor() : tensor<1x32xbf16>
+// CHECK:     %[[COPYIN:.*]] = linalg.copy ins(%arg0 : tensor<1x32xbf16>) outs(%[[ALLOC0]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
+// CHECK:     %[[ALLOC1:.*]] = bufferization.alloc_tensor() : tensor<1x32xbf16>
+// CHECK:     %[[FILL:.*]] = linalg.fill ins(%[[CST]] : i32) outs(%[[ALLOC1]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
+// CHECK:     %[[SOFTMAX:.*]] = linalg.softmax dimension(1) ins(%[[COPYIN]] : tensor<1x32xbf16>) outs(%[[FILL]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
+// CHECK:     %[[COPYOUT:.*]] = linalg.copy ins(%[[SOFTMAX]] : tensor<1x32xbf16>) outs(%[[ARG2]] : tensor<1x32xbf16>) -> tensor<1x32xbf16>
+// CHECK:   } {mapping = [#gpu.block<y>]}
+// CHECK:   return %[[FORALL]] : tensor<1x32xbf16>
+func.func @softmax_forall(%arg0: tensor<1x32xbf16>) -> tensor<1x32xbf16> {
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tensor.empty() : tensor<1x32xbf16>
+  %1 = scf.forall (%arg1) in (1) shared_outs(%arg2 = %0) -> (tensor<1x32xbf16>) {
+    %2 = linalg.fill ins(%c0_i32 : i32) outs(%arg2 : tensor<1x32xbf16>) -> tensor<1x32xbf16>
+    %3 = linalg.softmax dimension(1) ins(%arg0 : tensor<1x32xbf16>) outs(%2 : tensor<1x32xbf16>) -> tensor<1x32xbf16>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %3 into %arg2[0, 0] [1, 32] [1, 1] : tensor<1x32xbf16> into tensor<1x32xbf16>
+    }
+  } {mapping = [#gpu.block<y>]}
+  return %1 : tensor<1x32xbf16>
 }


### PR DESCRIPTION
The previous codes of `InsertCopyOpsPass` generated redundant `linalg.generic copies` as
```
scf.forall (%arg0) in (1) {
    linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%1 : memref<1x32xbf16>) outs(%alloc_2 : memref<1x32xbf16, 1 : i32>) {
    ^bb0(%in: bf16, %out: bf16):
      linalg.yield %in : bf16
    }
    linalg.copy ins(%0 : memref<1x32xbf16>) outs(%alloc_1 : memref<1x32xbf16, 1 : i32>)
    scf.forall (%arg1) in (1) {
      linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%alloc_2 : memref<1x32xbf16, 1 : i32>) outs(%alloc_0 : memref<1x32xbf16, 2 : i32>) {
      ^bb0(%in: bf16, %out: bf16):
        linalg.yield %in : bf16
      }
      %base_buffer, %offset, %sizes:2, %strides:2 = memref.extract_strided_metadata %alloc_0 : memref<1x32xbf16, 2 : i32> -> memref<bf16, 2 : i32>, index, index, index, index, index
      func.call @zero_bf16_1x32(%base_buffer, %c0) : (memref<bf16, 2 : i32>, index) -> ()
      linalg.copy ins(%alloc_1 : memref<1x32xbf16, 1 : i32>) outs(%alloc : memref<1x32xbf16, 2 : i32>)
      %base_buffer_3, %offset_4, %sizes_5:2, %strides_6:2 = memref.extract_strided_metadata %alloc : memref<1x32xbf16, 2 : i32> -> memref<bf16, 2 : i32>, index, index, index, index, index
      %base_buffer_7, %offset_8, %sizes_9:2, %strides_10:2 = memref.extract_strided_metadata %alloc_0 : memref<1x32xbf16, 2 : i32> -> memref<bf16, 2 : i32>, index, index, index, index, index
      func.call @softmax_bf16_1x32(%base_buffer_3, %c0, %base_buffer_7, %c0) : (memref<bf16, 2 : i32>, index, memref<bf16, 2 : i32>, index) -> ()
      linalg.copy ins(%alloc_0 : memref<1x32xbf16, 2 : i32>) outs(%alloc_2 : memref<1x32xbf16, 1 : i32>)
    } {mapping = [#gpu.thread<y>]}
    linalg.copy ins(%alloc_2 : memref<1x32xbf16, 1 : i32>) outs(%1 : memref<1x32xbf16>)
  } {mapping = [#gpu.block<y>]}
```
This happened because the result is copied to an empty tensor instead of the block argument of forall ops. Unlike lowering using the `tensor.pad` operation, the copy ops are inserted without using the destination passing style. This PR fixes the issue by inserting copies to destinations exactly following the codes generated by `AMDAIEPadPass`.