### PR TITLE
[UKernel] Add pragmas to guide loop pipelining

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/uKernels/npu4/peano/matmul.cc
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/uKernels/npu4/peano/matmul.cc
@@ -35,10 +35,14 @@ void matmul_vectorized_i8_i32(const int8 *__restrict pA, unsigned offsetA,
   v64acc32 acc_C10;
   v64acc32 acc_C11;
 
+#pragma clang loop min_iteration_count(rowA / 2)
+#pragma clang loop max_iteration_count(rowA / 2)
   for (unsigned z = 0; z < rowA; z += 2) {
     v64acc32 *__restrict pC0 = (v64acc32 *)(pC + offsetC + (z)*size_C);
     v64acc32 *__restrict pC1 = (v64acc32 *)(pC + offsetC + ((z + 1)) * size_C);
 
+#pragma clang loop min_iteration_count(colB / 2)
+#pragma clang loop max_iteration_count(colB / 2)
     for (unsigned j = 0; j < colB; j += 2) {
       const v64int8 *__restrict pA0 = (v64int8 *)(pA + offsetA + (z)*size_A);
       const v64int8 *__restrict pA1 =
@@ -75,6 +79,8 @@ void matmul_vectorized_i8_i32(const int8 *__restrict pA, unsigned offsetA,
       acc_C10 = mac_8x8_8x8(A1, B0, acc_C10);
       acc_C11 = mac_8x8_8x8(A1, B1, acc_C11);
 
+#pragma clang loop min_iteration_count((colA - 2) / 2)
+#pragma clang loop max_iteration_count((colA - 2) / 2)
       for (unsigned i = 1; i < colA - 1; i += 2) {
         A0 = *pA0;
         pA0 += rowA;


### PR DESCRIPTION
This should help Peano with pipelining the matmul loops. Will report numbers based on CI run.

Latest benchmark numbers with this PR:
```
matmul4d_scale_trunci_1024_16384_512_i8_i32_O1_npu4_outline_4_level_tiling_ukernel_peano_ctrlpkt_benchmark
-----------------------------------------------------------------------------------------------------------
Benchmark                                                 Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------------------
BM_matmul4d_trunci/process_time/real_time_mean          974 us         40.4 us            5 items_per_second=1.02679k/s
BM_matmul4d_trunci/process_time/real_time_median        974 us         40.0 us            5 items_per_second=1.02638k/s
BM_matmul4d_trunci/process_time/real_time_stddev       4.12 us         2.26 us            5 items_per_second=4.34723/s
-----------------------------------------------------------------------------------------------------------
The largest program memory size (read from byte 72 of elf files) is 2320 bytes
```
Compared with main:
```
matmul4d_scale_trunci_1024_16384_512_i8_i32_O1_npu4_outline_4_level_tiling_ukernel_peano_ctrlpkt_benchmark
-----------------------------------------------------------------------------------------------------------
Benchmark                                                 Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------------------
BM_matmul4d_trunci/process_time/real_time_mean         1240 us         53.3 us            5 items_per_second=815.268/s
BM_matmul4d_trunci/process_time/real_time_median       1159 us         52.6 us            5 items_per_second=862.837/s
BM_matmul4d_trunci/process_time/real_time_stddev        147 us         1.65 us            5 items_per_second=93.072/s
-----------------------------------------------------------------------------------------------------------
The largest program memory size (read from byte 72 of elf files) is 2240 bytes.
```