### PR TITLE
[Softmax] Support run on a column of cores

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -2576,7 +2576,7 @@ class Tests:
                 test_params=TestParams(
                     name_suffix="chess",
                     aie_compilation_flags=[
-                        "--iree-amdaie-num-rows=1",
+                        "--iree-amdaie-num-rows=4",
                         "--iree-amdaie-num-cols=1",
                     ],
                     use_chess=True,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -815,8 +815,11 @@ static LogicalResult setRootConfigForSoftmaxCopyPipeline(
     mlir::FunctionOpInterface entryPointFn, linalg::SoftmaxOp softmaxOp,
     AMDAIEDevice targetDevice, uint32_t numRows, uint32_t numCols,
     std::string enableAMDAIEUkernels) {
+  // For now, we are targeting a single column of cores, and the tile sizes are
+  // hardcoded. We don't tile the reduction dim as the softmax op is not a pure
+  // reduction op.
   if (failed(setOpConfigAndEntryPointFnTranslation(
-          entryPointFn, softmaxOp, TileSizesListType{{64, 0}, {32, 0}, {0, 0}},
+          entryPointFn, softmaxOp, TileSizesListType{{128, 0}, {32, 0}, {0, 0}},
           IREE::Codegen::DispatchLoweringPassPipeline::Custom))) {
     return failure();
   }


### PR DESCRIPTION
Currently, the softmax ukernel can run on a single column of 4 cores. Since there is only one parallel dimension, we'll have to modify the logic of `AssignTiles` to utilize more AIE columns.