### PR TITLE
Update windows-2019 to windows-2022

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   build_and_ctest:
     name: Build and Test (windows, ASSERTIONS)
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       fail-fast: true
     env:


### PR DESCRIPTION
Windows-2019 is being deprecated: https://github.com/actions/runner-images/issues/12045