### PR TITLE
Use pip install in peano download script

### DIFF
--- a/build_tools/download_peano.ps1
+++ b/build_tools/download_peano.ps1
@@ -8,8 +8,4 @@ $ErrorActionPreference = 'Stop'
 
 $this_dir = Split-Path -Path $MyInvocation.MyCommand.Path -Parent
 $RELEASE = (Get-Content -Path "$this_dir/peano_commit_windows.txt")
-pip download llvm_aie==$RELEASE -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
-$peano = (Get-ChildItem -Filter llvm*.whl)
-$new_name = ($peano.Basename + ".zip")
-Rename-Item -Path $peano.Name -NewName $new_name
-Expand-Archive $new_name -DestinationPath $PWD.Path -Force
+pip install llvm_aie==$RELEASE --upgrade --target $PWD.Path -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly

--- a/build_tools/download_peano.sh
+++ b/build_tools/download_peano.sh
@@ -8,5 +8,4 @@
 
 this_dir="$(cd $(dirname $0) && pwd)"
 RELEASE=$(cat $this_dir/peano_commit_linux.txt)
-pip download llvm_aie==$RELEASE -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
-unzip llvm_aie*whl
+pip install llvm_aie==$RELEASE --upgrade --target $PWD -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly


### PR DESCRIPTION
Previously, we used `pip download` and then extracted the .whl manually. However, this approach fails when there are multiple versions of llvm_aie wheels present in the same directory, as the script cannot reliably identify the correct .whl to unzip, and will raise an error.

To make the process more simple and robust, we now use `pip install` directly with the `--target` option to install/overwrite llvm_aie to a specified directory. 

However, a drawback of using `--target` is that it disables pip's cache mechanism, causing the .whl file (~140MB) to be downloaded every time the script runs, even if the version hasn't changed.