### PR TITLE
[SplitLogicalObjFifo] Avoid over-splitting if the op shape is small 

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -2674,10 +2674,6 @@ class Tests:
                 function_name="reduction_sum",
                 test_params=TestParams(
                     name_suffix="sum",
-                    aie_compilation_flags=[
-                        "--iree-amdaie-num-rows=4",
-                        "--iree-amdaie-num-cols=1",
-                    ],
                 ),
             )
         )

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIESplitLogicalObjFifos.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIESplitLogicalObjFifos.cpp
@@ -390,12 +390,37 @@ void AMDAIESplitLogicalObjFifosPass::runOnOperation() {
                               "correctly split logical objectFifos.";
     return signalPassFailure();
   }
+  // Use the maximum number of columns available on the device for the default
+  // split factor.
   int64_t numColumns = maybeNumColumns.value();
+
+  // Check if any CoreOp is present, and if so, get the number of columns
+  // actually in use.
+  std::optional<int64_t> mayNumColumnsInUse;
+  WalkResult res = moduleOp->walk([&](AMDAIE::CoreOp coreOp) {
+    AMDAIE::TileOp tileOp = coreOp.getTileOp();
+    std::optional<int64_t> maybeColumn = getConstantIntValue(tileOp.getCol());
+    std::optional<int64_t> maybeRow = getConstantIntValue(tileOp.getRow());
+    if (!maybeColumn || !maybeRow) {
+      coreOp.emitOpError() << "has non-constant tile location";
+      return WalkResult::interrupt();
+    }
+    // +1 for 0-based indexing.
+    int64_t column = maybeColumn.value() + 1;
+    mayNumColumnsInUse = mayNumColumnsInUse.has_value()
+                             ? std::max(mayNumColumnsInUse.value(), column)
+                             : column;
+    return WalkResult::advance();
+  });
+  if (res.wasInterrupted()) return signalPassFailure();
+  // If the column usage info is available, use it for determining the split
+  // factor instead.
+  if (mayNumColumnsInUse.has_value()) numColumns = mayNumColumnsInUse.value();
 
   // Walk and collect all dma ops between L3 and L2.
   SmallVector<AMDAIE::DmaCpyNdOp> l3L2DmaOps;
   SmallVector<DmaObjFifoPairT> dmaObjFifoPairs;
-  WalkResult res = moduleOp->walk([&](AMDAIE::DmaCpyNdOp op) {
+  res = moduleOp->walk([&](AMDAIE::DmaCpyNdOp op) {
     std::optional<uint8_t> sourceMemSpace = op.getSourceMemorySpaceAsUInt();
     std::optional<uint8_t> targetMemSpace = op.getTargetMemorySpaceAsUInt();
     if (!sourceMemSpace || !targetMemSpace) {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/KernelDispatch.cpp
@@ -852,7 +852,7 @@ static LogicalResult setRootConfigForReductionCopyPipeline(
           .getShape();
   assert(inputShape.size() == 2 && "expected the input as 2D");
   int64_t m1Tile = std::min<int64_t>(inputShape[0], 32);
-  int64_t m0Tile = std::min<int64_t>(inputShape[0], numRows * m1Tile);
+  int64_t m0Tile = std::min<int64_t>(inputShape[0], numRows * numCols * m1Tile);
 
   SmallVector<int64_t> tileSizeLevel0 = {m0Tile, 0};
   SmallVector<int64_t> tileSizeLevel1 = {m1Tile, 0};

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIELogicalObjFifoSplittingUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIELogicalObjFifoSplittingUtils.cpp
@@ -700,9 +700,9 @@ LogicalResult splitLogicalObjectFifo(IRRewriter &rewriter,
       llvm::to_vector(op.getMemrefType().getShape());
   int64_t splitFactor = maybeSplitFactor.has_value() ? maybeSplitFactor.value()
                                                      : memrefShape[splitDim];
-  if (memrefShape[splitDim] < splitFactor) {
-    splitFactor = memrefShape[splitDim];
-  }
+  if (memrefShape[splitDim] < splitFactor) splitFactor = memrefShape[splitDim];
+  // If the split factor is 1, we don't need to do anything.
+  if (splitFactor == 1) return success();
   assert(
       memrefShape[splitDim] % splitFactor == 0 &&
       "the target size for splitting is not divisible by the splitting factor");


### PR DESCRIPTION
The split factor was previously determined based on the number of columns available on the target device. However, when the operation shape is too small to utilize all available columns, this led to over-splitting.

This PR refines the logic by also inspecting the CoreOps present in the module. If cores are already assigned and occupy only a subset of the columns, the split factor is adjusted accordingly based on the actual number of columns in use.