### PR TITLE
[CI] Fix performance webpage publishing

### DIFF
--- a/build_tools/ci/cpu_comparison/performance_publish.py
+++ b/build_tools/ci/cpu_comparison/performance_publish.py
@@ -15,14 +15,15 @@ def append_history(results_json_path: str, results_history_path: str):
     # Append the results to the history.
     results_history = []
     max_history = 100
-    with open(results_history_path, "r+") as f:
+    with open(results_history_path, "r") as f:
         results_history = json.load(f)
         results_history.append(results)
         # Keep only the most recent results.
         if len(results_history) > max_history:
             results_history = results_history[-max_history:]
-        f.seek(0)
-        # Write the updated history back to the file.
+
+    # Write the updated history back to the file.
+    with open(results_history_path, "w") as f:
         json.dump(results_history, f, indent=2)
 
 

--- a/build_tools/ci/cpu_comparison/performance_summarizer.py
+++ b/build_tools/ci/cpu_comparison/performance_summarizer.py
@@ -58,8 +58,9 @@ def get_json_summary(lines):
             test_name = Path(path_str).stem
             json_summary["tests"].append({"name": test_name})
         if "real_time_mean" in line:
-            # Extract the first number and unit.
-            match = re.search(r"(\d+)\s+([a-zA-Z]+)", line)
+            # Extract the first number (may contain a decimal point) and unit.
+            match = re.search(r"(\d+(?:\.\d+)?)\s+([a-zA-Z]+)", line)
+            print(line.strip())
             json_summary["tests"][-1]["time_mean"] = match.group(1)
             json_summary["tests"][-1]["time_mean_unit"] = match.group(2)
 


### PR DESCRIPTION
The PR fixes two bugs:

1. For any test whose latency is less than 100 µs, the benchmark result contains a decimal point (e.g., "80.4 us"). This was not previously handled by the script, causing the result to be incorrectly captured as "4 us" instead.
2. The previous implementation used "r+" mode to read and write the result history file. This approach did not truncate the file if the updated content was shorter, potentially leaving trailing content and corrupting the JSON. The script now uses a safer two-step method: reading the file in "r" mode and writing back using "w" mode to ensure clean overwriting.
