### PR TITLE
[UKernel] Add loop unrolling to peano zeroization and truncation

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/uKernels/npu4/peano/trunci.cc
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/uKernels/npu4/peano/trunci.cc
@@ -4,9 +4,11 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-template <int M, int N, int r>
+template <int M, int N, int r, int u>
 void trunci_vectorized(v32int32 *__restrict in, int64_t offsetIn, int64_t shift,
                        v32int8 *__restrict out, int64_t offsetOut) {
+  static_assert(M * N / r / u > 0);
+#pragma clang loop unroll_count(M *N / r / u)
   for (unsigned i = 0; i < M * N / r; i++) {
     out[offsetOut + i] = ssrs((v32acc32)in[offsetIn + i], shift, 0);
   }
@@ -16,12 +18,14 @@ void trunci_vectorized(v32int32 *__restrict in, int64_t offsetIn, int64_t shift,
 extern "C" {
 
 #define trunci_combos_i32_i8(X, M, N)  \
-  X(v32int32, i32, v32int8, i8, M, N, 32)
+  X(v32int32, i32, v32int8, i8, M, N, 32, 8)
 
-#define trunci_c_func(ctype_in, mlir_type_in, ctype_out, mlir_type_out, M, N, r)                  \
+// A vectorized truncation function on a buffer of size M * N with vectorization size
+// 'r' and unrolling factor 'u'. The unrolling factor is typically found experimentally.
+#define trunci_c_func(ctype_in, mlir_type_in, ctype_out, mlir_type_out, M, N, r, u)                  \
   void trunci_##mlir_type_in##_##mlir_type_out##_##M##x##N(                                       \
       ctype_in *in, int64_t offsetIn, int64_t shift, ctype_out *out, int64_t offsetOut) {         \
-    trunci_vectorized<M, N, r>(in, offsetIn, shift, out, offsetOut);                              \
+    trunci_vectorized<M, N, r, u>(in, offsetIn, shift, out, offsetOut);                              \
   }
 
 trunci_combos_i32_i8(trunci_c_func, 32, 32)

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/uKernels/npu4/peano/zero_fill.cc
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/uKernels/npu4/peano/zero_fill.cc
@@ -4,17 +4,21 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-template <int M, int N, int r>
+template <int M, int N, int r, int u>
 void zero_fill_vectorized(v16int32 *__restrict pC, unsigned offsetC) {
+  static_assert(M * N / r / u > 0);
   v16int32 zeros = broadcast_zero_to_v16int32();
+#pragma clang loop unroll_count(M *N / r / u)
   for (unsigned i = offsetC / r; i < offsetC / r + M * N / r; i++) {
     pC[i] = zeros;
   }
 }
 
-template <int M, int N, int r>
+template <int M, int N, int r, int u>
 void zero_fill_vectorized(v16float *__restrict pC, unsigned offsetC) {
+  static_assert(M * N / r / u > 0);
   v16float zeros = broadcast_zero_to_v16float();
+#pragma clang loop unroll_count(M *N / r / u)
   for (unsigned i = offsetC / r; i < offsetC / r + M * N / r; i++) {
     pC[i] = zeros;
   }
@@ -24,14 +28,16 @@ void zero_fill_vectorized(v16float *__restrict pC, unsigned offsetC) {
 extern "C" {
 
 #define zero_fill_combos_i32(X, M, N)  \
-  X(v16int32, i32, M, N, 16)
+  X(v16int32, i32, M, N, 16, 8)
 
 #define zero_fill_combos_f32(X, M, N)  \
-  X(v16float, f32, M, N, 16)
+  X(v16float, f32, M, N, 16, 8)
 
-#define zero_fill_vectorized_c_func(ctype_out, mlir_type_out, M, N, r)             \
+// A vectorized zeroization function on a buffer of size M * N with vectorization size
+// 'r' and unrolling factor 'u'. The unrolling factor is typically found experimentally.
+#define zero_fill_vectorized_c_func(ctype_out, mlir_type_out, M, N, r, u)             \
   void zero_fill_##mlir_type_out##_##M##x##N(ctype_out *c_out, unsigned offsetC) { \
-    zero_fill_vectorized<M, N, r>(c_out, offsetC);                      \
+    zero_fill_vectorized<M, N, r, u>(c_out, offsetC);                      \
   }
 
 zero_fill_combos_i32(zero_fill_vectorized_c_func, 32, 32)


### PR DESCRIPTION
I think this should improve performance on the i8->i32 matmuls.