### PR TITLE
[Reprogramming][IR] Add dma_start + dma_bd + next_bd ops in AMDAIE dialect

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEAttrs.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEAttrs.td
@@ -162,4 +162,21 @@ def AMDAIE_PackingConfigAttr :
   }];
 }
 
+def BDDimLayoutAttr : AttrDef<AMDAIE_Dialect, "BDDimLayout", []> {
+  let mnemonic = "bd_dim_layout";
+  let parameters = (ins
+    "uint16_t" : $size,
+    "uint32_t" : $stride
+  );
+
+  let assemblyFormat = "`<` struct(params) `>`";
+}
+
+def BDDimLayoutArrayAttr : ArrayOfAttr<
+    /*dialect*/AMDAIE_Dialect,
+    /*attrName*/"BDDimLayoutArray",
+    /*attrMnemonic*/"bd_dim_layout_array",
+    /*eltName*/BDDimLayoutAttr.cppClassName
+>;
+
 #endif // IREE_COMPILER_AMDAIE_DIALECT_IREEAMDAIEATTRS

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -1733,4 +1733,85 @@ def AMDAIE_ReferenceToOp: AMDAIE_Op<"reference_to", [SameOperandsAndResultType]>
   let assemblyFormat = "$memref attr-dict `:` type($memref)";
 }
 
+def AMDAIE_DMAStartOp: AMDAIE_Op<"dma_start", [
+    DeclareOpInterfaceMethods<InferTypeOpInterface>
+  ]>, Results<(outs I1:$valid)> {
+
+  let summary = "An op to start DMA";
+  let arguments = (
+    ins Index:$tile,
+        DMAChannelDir:$channel_dir,
+        ConfinedAttr<I8Attr, [IntMinValue<0>]>:$channel_index,
+        // `repeat_count==1` means "do it once".
+        DefaultValuedAttr<I8Attr, "1">:$repeat_count
+  );
+  let regions = (region AnyRegion:$body);
+  let assemblyFormat = [{
+    `(` $tile `,` $channel_dir `,` $channel_index (`,` `repeat_count` `=` $repeat_count^)? `)` regions attr-dict
+  }];
+}
+
+def AMDAIE_DMABDOp: AMDAIE_Op<"dma_bd", [
+    DeclareOpInterfaceMethods<OpAsmOpInterface>
+  ]> {
+  let summary = "Declare a dma buffer descriptor op";
+  let arguments = (
+    ins AnyMemRef:$buffer,
+        // in multiples of element width (not bytes)
+        DefaultValuedOptionalAttr<I32Attr, "0">:$offset,
+        // in multiples of element width (not bytes)
+        OptionalAttr<I32Attr>:$len,
+        OptionalAttr<BDDimLayoutArrayAttr>:$dimensions,
+        DefaultValuedOptionalAttr<I32Attr, "0">:$pad_value,
+        OptionalAttr<I32Attr>:$bd_id,
+        // should never be assigned by user...
+        OptionalAttr<I32Attr>:$next_bd_id
+  );
+
+  let assemblyFormat = [{
+    `(` $buffer `:` type($buffer) `)` attr-dict
+  }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::Value":$buffer, "int":$offset, "int":$len), [{
+      $_state.addOperands(buffer);
+      $_state.addAttribute("offset", $_builder.getI32IntegerAttr(offset));
+      $_state.addAttribute("len", $_builder.getI32IntegerAttr(len));
+    }]>,
+    OpBuilder<(ins "mlir::Value":$buffer, "int":$offset, "int":$len, "BDDimLayoutArrayAttr":$dims), [{
+      $_state.addOperands(buffer);
+      $_state.addAttribute("offset", $_builder.getI32IntegerAttr(offset));
+      $_state.addAttribute("len", $_builder.getI32IntegerAttr(len));
+      $_state.addAttribute("dimensions", dims);
+    }]>,
+  ];
+
+  let extraClassDeclaration = [{
+    int32_t getBufferElementTypeWidthInBytes() {
+      return getBuffer().getType().getElementTypeBitWidth() / 8;
+    }
+
+    int32_t getLenInBytes() {
+      if (std::optional<int32_t> len = getLen(); len.has_value())
+        return len.value() * getBufferElementTypeWidthInBytes();
+      else
+        return getBuffer().getType().getNumElements() *
+              getBufferElementTypeWidthInBytes();
+    }
+
+    int32_t getOffsetInBytes() {
+      return getOffset() * getBufferElementTypeWidthInBytes();
+    }
+  }];
+}
+
+def AMDAIE_NextBDOp: AMDAIE_Op<"next_bd", [Terminator]> {
+  let summary = "The next buffer descriptor";
+  let successors = (successor AnySuccessor:$dest);
+
+  let assemblyFormat = [{
+    $dest attr-dict
+  }];
+}
+
 #endif // IREE_AMDAIE_DIALECT_IREEAMDAIE_OPS


### PR DESCRIPTION
-- This commit adds the following ops in AMDAIE dialect :-
1. amdaie.dma_start
2. amdaie.dma_bd
3. amdaie.next_bd

-- These ops are similar to what's already there in AIE dialect.
-- They are being added to AMDAIE dialect to make [DMA reprogramming](https://github.com/nod-ai/iree-amd-aie/issues/1287) work.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>