### PR TITLE
[Reprogram][CreateAieWorkgroup] Modify create-aie-workgroup for reprogramming Dmas

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.h
@@ -197,14 +197,13 @@ class CoreContext {
 class WorkgroupBuilder {
  public:
   WorkgroupBuilder(IRRewriterAndMapper &rewriter,
-                   IRRewriterAndMapper &controlCodeRewriter,
-                   bool &reprogramDmas)
+                   IRRewriterAndMapper &controlCodeRewriter, bool reprogramDmas)
       : rewriter(rewriter),
         controlCodeRewriter(controlCodeRewriter),
         reprogramDmas(reprogramDmas) {}
   WorkgroupBuilder(IRRewriterAndMapper &&rewriter,
                    IRRewriterAndMapper &controlCodeRewriter,
-                   bool &reprogramDmas) = delete;
+                   bool reprogramDmas) = delete;
 
   /// Recursive workgroup build function for an operation.
   LogicalResult build(Operation *op, Block *target, Block *controlCode,
@@ -264,7 +263,7 @@ class WorkgroupBuilder {
   IRRewriterAndMapper &controlCodeRewriter;
 
   // Flag to enable/disable reprogramming of DMAs.
-  bool &reprogramDmas;
+  bool reprogramDmas;
 };
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECreateAIEWorkgroup.h
@@ -197,10 +197,14 @@ class CoreContext {
 class WorkgroupBuilder {
  public:
   WorkgroupBuilder(IRRewriterAndMapper &rewriter,
-                   IRRewriterAndMapper &controlCodeRewriter)
-      : rewriter(rewriter), controlCodeRewriter(controlCodeRewriter) {}
+                   IRRewriterAndMapper &controlCodeRewriter,
+                   bool &reprogramDmas)
+      : rewriter(rewriter),
+        controlCodeRewriter(controlCodeRewriter),
+        reprogramDmas(reprogramDmas) {}
   WorkgroupBuilder(IRRewriterAndMapper &&rewriter,
-                   IRRewriterAndMapper &controlCodeRewriter) = delete;
+                   IRRewriterAndMapper &controlCodeRewriter,
+                   bool &reprogramDmas) = delete;
 
   /// Recursive workgroup build function for an operation.
   LogicalResult build(Operation *op, Block *target, Block *controlCode,
@@ -258,6 +262,9 @@ class WorkgroupBuilder {
 
   /// Rewriter and mapper for the control code context.
   IRRewriterAndMapper &controlCodeRewriter;
+
+  // Flag to enable/disable reprogramming of DMAs.
+  bool &reprogramDmas;
 };
 
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.cpp
@@ -797,7 +797,14 @@ void addAMDAIEObjectFifoLoweringPasses(
   passManager.addPass(createCanonicalizerPass());
 
   passManager.addPass(createAMDAIEDmaToCircularDmaPass());
-  passManager.addNestedPass<func::FuncOp>(createAMDAIECreateAIEWorkgroupPass());
+  {
+    AMDAIECreateAIEWorkgroupOptions options;
+    // TODO(avarma): In follow-up PRs this will be replaced by a global flag.
+    // Currently setting as `false`.
+    options.reprogramDmas = /*reprogramDmas=*/false;
+    passManager.addNestedPass<func::FuncOp>(
+        createAMDAIECreateAIEWorkgroupPass(options));
+  }
   passManager.addPass(createCSEPass());
   passManager.addPass(createAMDAIEDmaCSEPass());
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.h
@@ -149,7 +149,8 @@ std::unique_ptr<Pass> createAMDAIEConvertDeviceToControlPacketsPass(
 std::unique_ptr<Pass> createAMDAIEInsertInfiniteLoopAroundCoreBlockPass();
 
 /// Pass to create a single AIE workgroup.
-std::unique_ptr<Pass> createAMDAIECreateAIEWorkgroupPass();
+std::unique_ptr<Pass> createAMDAIECreateAIEWorkgroupPass(
+    AMDAIECreateAIEWorkgroupOptions options = {});
 
 /// Pass to create references to allocations in L1 memory space.
 std::unique_ptr<Pass> createAMDAIECreateReferenceToAllocationPass();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Passes.td
@@ -234,6 +234,10 @@ def AMDAIECreateAIEWorkgroup :
   Pass<"iree-amdaie-create-aie-workgroup", "func::FuncOp"> {
   let summary = "Creates a single AIE workgroup.";
   let constructor = "mlir::iree_compiler::AMDAIE::createAMDAIECreateAIEWorkgroupPass()";
+  let options = [
+    Option<"reprogramDmas", "reprogram-dmas", "bool", /*default=*/"false",
+           "Flag to reprogram DMAs. When enabled, no circular DMAs will be produced">,
+  ];
 }
 
 def AMDAIECreateReferenceToAllocation :


### PR DESCRIPTION
-- This commit adds a pass flag `reprogram-dmas` (`false` by default). When `false`,
   we get a mix of npu.circular_dma_cpy_nd + npu.dma_cpy_nd ops, but when enabled/`true`,
   we get only npu.dma_cpy_nd ops.
-- This is being added to AMDAIE dialect to make [DMA reprogramming](https://github.com/nod-ai/iree-amd-aie/issues/1287) work.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>