### PR TITLE
[Reprogram][NpuDmaToHalfDmaCpyNd] Modify npu-dma-to-half-dma-cpy-nd

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIENpuDmaToHalfDmaCpyNd.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIENpuDmaToHalfDmaCpyNd.cpp
@@ -32,6 +32,8 @@ struct NpuDmaToHalfDmaCpyNdConverter final
              << "should operate on an `amdaie.connection` op";
     }
     AMDAIE::NpuHalfDmaCpyNdOp sourceDma, targetDma;
+    SmallVector<Type> resultTypes = {
+        rewriter.getType<AMDAIE::AsyncTokenType>()};
     // Convert source half.
     if (dmaOp.hasSourceAddressing()) {
       Value source =
@@ -44,8 +46,6 @@ struct NpuDmaToHalfDmaCpyNdConverter final
           llvm::any_of(dmaOp.getAsyncTokens(), [](Value token) {
             return isa<AMDAIE::AsyncSourceTokenType>(token.getType());
           });
-      SmallVector<Type> resultTypes = {
-          rewriter.getType<AMDAIE::AsyncTokenType>()};
       TypeRange sourceResultTypes =
           hasAsyncSourceToken ? TypeRange{resultTypes} : TypeRange{};
       rewriter.setInsertionPoint(dmaOp);
@@ -74,6 +74,7 @@ struct NpuDmaToHalfDmaCpyNdConverter final
           });
       TypeRange targetResultTypes =
           hasAsyncTargetToken ? TypeRange{resultTypes} : TypeRange{};
+      rewriter.setInsertionPoint(dmaOp);
       targetDma = rewriter.create<AMDAIE::NpuHalfDmaCpyNdOp>(
           dmaOp.getLoc(), targetResultTypes, connectionOp, target,
           dmaOp.getTargetMixedOffsets(), dmaOp.getTargetMixedSizes(),

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIENpuDmaToHalfDmaCpyNd.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIENpuDmaToHalfDmaCpyNd.cpp
@@ -31,59 +31,67 @@ struct NpuDmaToHalfDmaCpyNdConverter final
       return dmaOp.emitOpError()
              << "should operate on an `amdaie.connection` op";
     }
+    AMDAIE::NpuHalfDmaCpyNdOp sourceDma, targetDma;
     // Convert source half.
-    Value source =
-        dmaOp.getSource() ? dmaOp.getSource() : connectionOp.getSource();
-    if (connectionOp.getSourceChannels().size() != 1)
-      return connectionOp.emitOpError() << "expected a single source channel";
-    auto sourceChannelOp = dyn_cast<AMDAIE::ChannelOp>(
-        connectionOp.getSourceChannels()[0].getDefiningOp());
-    bool hasAsyncSourceToken =
-        llvm::any_of(dmaOp.getAsyncTokens(), [](Value token) {
-          return isa<AMDAIE::AsyncSourceTokenType>(token.getType());
-        });
-    SmallVector<Type> resultTypes = {
-        rewriter.getType<AMDAIE::AsyncTokenType>()};
-    TypeRange sourceResultTypes =
-        hasAsyncSourceToken ? TypeRange{resultTypes} : TypeRange{};
-    rewriter.setInsertionPoint(dmaOp);
-    auto sourceDma = rewriter.create<AMDAIE::NpuHalfDmaCpyNdOp>(
-        dmaOp.getLoc(), sourceResultTypes, connectionOp, source,
-        dmaOp.getSourceMixedOffsets(), dmaOp.getSourceMixedSizes(),
-        dmaOp.getSourceMixedStrides(), dmaOp.getSourceBdId(), sourceChannelOp);
+    if (dmaOp.hasSourceAddressing()) {
+      Value source =
+          dmaOp.getSource() ? dmaOp.getSource() : connectionOp.getSource();
+      if (connectionOp.getSourceChannels().size() != 1)
+        return connectionOp.emitOpError() << "expected a single source channel";
+      auto sourceChannelOp = dyn_cast<AMDAIE::ChannelOp>(
+          connectionOp.getSourceChannels()[0].getDefiningOp());
+      bool hasAsyncSourceToken =
+          llvm::any_of(dmaOp.getAsyncTokens(), [](Value token) {
+            return isa<AMDAIE::AsyncSourceTokenType>(token.getType());
+          });
+      SmallVector<Type> resultTypes = {
+          rewriter.getType<AMDAIE::AsyncTokenType>()};
+      TypeRange sourceResultTypes =
+          hasAsyncSourceToken ? TypeRange{resultTypes} : TypeRange{};
+      rewriter.setInsertionPoint(dmaOp);
+      sourceDma = rewriter.create<AMDAIE::NpuHalfDmaCpyNdOp>(
+          dmaOp.getLoc(), sourceResultTypes, connectionOp, source,
+          dmaOp.getSourceMixedOffsets(), dmaOp.getSourceMixedSizes(),
+          dmaOp.getSourceMixedStrides(), dmaOp.getSourceBdId(),
+          sourceChannelOp);
+    }
 
     // Convert target half.
-    Value target =
-        dmaOp.getTarget() ? dmaOp.getTarget() : connectionOp.getTarget();
-    // Broadcasting is allowed only when the NPU DMA operation does not specify
-    // a target LogicalObjectFifo, meaning the data flow is directed into the
-    // AIE array. Otherwise, if a target is specified, ensure there is exactly
-    // one target channel.
-    if (dmaOp.getTarget() && connectionOp.getTargetChannels().size() != 1)
-      return connectionOp.emitOpError() << "expected a single target channel";
-    auto targetChannelOp = dyn_cast<AMDAIE::ChannelOp>(
-        connectionOp.getTargetChannels()[0].getDefiningOp());
-    bool hasAsyncTargetToken =
-        llvm::any_of(dmaOp.getAsyncTokens(), [](Value token) {
-          return isa<AMDAIE::AsyncTargetTokenType>(token.getType());
-        });
-    TypeRange targetResultTypes =
-        hasAsyncTargetToken ? TypeRange{resultTypes} : TypeRange{};
-    auto targetDma = rewriter.create<AMDAIE::NpuHalfDmaCpyNdOp>(
-        dmaOp.getLoc(), targetResultTypes, connectionOp, target,
-        dmaOp.getTargetMixedOffsets(), dmaOp.getTargetMixedSizes(),
-        dmaOp.getTargetMixedStrides(), dmaOp.getTargetBdId(), targetChannelOp);
-    if (dmaOp.getNumResults() == 1) {
-      if (sourceDma.getNumResults() == 1) {
+    if (dmaOp.hasTargetAddressing()) {
+      Value target =
+          dmaOp.getTarget() ? dmaOp.getTarget() : connectionOp.getTarget();
+      // Broadcasting is allowed only when the NPU DMA operation does not
+      // specify a target LogicalObjectFifo, meaning the data flow is directed
+      // into the AIE array. Otherwise, if a target is specified, ensure there
+      // is exactly one target channel.
+      if (dmaOp.getTarget() && connectionOp.getTargetChannels().size() != 1)
+        return connectionOp.emitOpError() << "expected a single target channel";
+      auto targetChannelOp = dyn_cast<AMDAIE::ChannelOp>(
+          connectionOp.getTargetChannels()[0].getDefiningOp());
+      bool hasAsyncTargetToken =
+          llvm::any_of(dmaOp.getAsyncTokens(), [](Value token) {
+            return isa<AMDAIE::AsyncTargetTokenType>(token.getType());
+          });
+      TypeRange targetResultTypes =
+          hasAsyncTargetToken ? TypeRange{resultTypes} : TypeRange{};
+      targetDma = rewriter.create<AMDAIE::NpuHalfDmaCpyNdOp>(
+          dmaOp.getLoc(), targetResultTypes, connectionOp, target,
+          dmaOp.getTargetMixedOffsets(), dmaOp.getTargetMixedSizes(),
+          dmaOp.getTargetMixedStrides(), dmaOp.getTargetBdId(),
+          targetChannelOp);
+    }
+    if (dmaOp.getNumResults() >= 1) {
+      if (sourceDma && sourceDma.getNumResults() == 1) {
         rewriter.replaceUsesWithIf(
             dmaOp.getResult(0), sourceDma.getResult(0), [&](OpOperand &use) {
               return isa<AMDAIE::AsyncSourceTokenType>(use.get().getType()) &&
                      isa<AMDAIE::NpuDmaWaitOp>(use.getOwner());
             });
       }
-      if (targetDma.getNumResults() == 1) {
+      if (targetDma && targetDma.getNumResults() == 1) {
         rewriter.replaceUsesWithIf(
-            dmaOp.getResult(0), targetDma.getResult(0), [&](OpOperand &use) {
+            dmaOp.getResult(dmaOp.getNumResults() - 1), targetDma.getResult(0),
+            [&](OpOperand &use) {
               return isa<AMDAIE::AsyncTargetTokenType>(use.get().getType()) &&
                      isa<AMDAIE::NpuDmaWaitOp>(use.getOwner());
             });


### PR DESCRIPTION
-- This commit modifies `npu-dma-to-half-dma-cpy-nd` pass to go ahead
   with the conversion only when the corresponding addressing data is
   present.
-- This is useful for the L2/L1 DMA->HalfDma conversion.
-- This is being added to AMDAIE dialect to make [DMA reprogramming](https://github.com/nod-ai/iree-amd-aie/issues/1287) work.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>