### PR TITLE
[Reprogram][ControlCodeToTransactionBinary] Add support for DMA Start Op

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlCodeToTransaction.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEControlCodeToTransaction.cpp
@@ -63,20 +63,37 @@ LogicalResult convertOp(AMDAIE::NpuWriteBdOp op, TransactionBuilder &builder) {
   return success();
 }
 
+LogicalResult convertOp(AMDAIE::DMAStartOp op, TransactionBuilder &builder) {
+  if (failed(builder.appendDmaStartOp(op))) {
+    return failure();
+  }
+  return success();
+}
+
 LogicalResult controlCodeToTransaction(IRRewriter &rewriter,
                                        AMDAIE::ControlCodeOp controlCodeOp,
                                        TransactionBuilder &builder) {
   SmallVector<Operation *> toBeErased;
-  WalkResult res = controlCodeOp->walk([&](Operation *op) {
+  DenseSet<AMDAIE::LockOp> lockOps;
+  WalkResult res = controlCodeOp->walk([&](AMDAIE::UseLockOp op) {
+    auto lockOp = op.getLock().getDefiningOp<AMDAIE::LockOp>();
+    if (lockOps.count(lockOp) == 0) {
+      if (failed(builder.appendLockOp(lockOp))) return WalkResult::interrupt();
+      lockOps.insert(lockOp);
+    }
+    return WalkResult::advance();
+  });
+  if (res.wasInterrupted()) return failure();
+  res = controlCodeOp->walk([&](Operation *op) {
     LogicalResult switchResult =
         TypeSwitch<Operation *, LogicalResult>(op)
             .Case<AMDAIE::NpuAddressPatchOp, AMDAIE::NpuTctSyncOp,
-                  AMDAIE::NpuPushToQueueOp, AMDAIE::NpuWriteBdOp>(
-                [&](auto npuOp) {
-                  if (failed(convertOp(npuOp, builder))) return failure();
-                  toBeErased.push_back(npuOp);
-                  return success();
-                })
+                  AMDAIE::NpuPushToQueueOp, AMDAIE::NpuWriteBdOp,
+                  AMDAIE::DMAStartOp>([&](auto npuOp) {
+              if (failed(convertOp(npuOp, builder))) return failure();
+              toBeErased.push_back(npuOp);
+              return success();
+            })
             .Default([&](Operation *) { return success(); });
     if (failed(switchResult)) return WalkResult::interrupt();
     return WalkResult::advance();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIETransactionBuilder.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIETransactionBuilder.h
@@ -7,6 +7,7 @@
 #ifndef IREE_AMD_AIE_TRANSFORMS_AMDAIETRANSACTIONBUILDER_H_
 #define IREE_AMD_AIE_TRANSFORMS_AMDAIETRANSACTIONBUILDER_H_
 
+#include "iree-amd-aie/IR/AMDAIEOps.h"
 #include "iree-amd-aie/aie_runtime/AMDAIEEnums.h"
 #include "iree-amd-aie/aie_runtime/iree_aie_configure.h"
 #include "iree-amd-aie/aie_runtime/iree_aie_runtime.h"
@@ -27,6 +28,9 @@ class TransactionBuilder {
 
   LogicalResult appendAddressPatch(uint32_t addr, uint32_t argIdx,
                                    uint32_t offset);
+
+  LogicalResult appendLockOp(AMDAIE::LockOp lockOp);
+  LogicalResult appendDmaStartOp(AMDAIE::DMAStartOp dmaStartOp);
 
   LogicalResult appendTCTSync(uint32_t col, uint32_t row, uint32_t direction,
                               uint32_t rowNum, uint32_t colNum,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/controlcode_to_transaction.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/controlcode_to_transaction.mlir
@@ -271,3 +271,105 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     return
   }
 }
+
+// -----
+
+// CHECK:       0x06030100
+// CHECK:       0x00000104
+// CHECK:       0x00000008
+// CHECK:       0x00000100
+// CHECK:       0x00200100
+// CHECK:       0x00000000
+// CHECK:       0x001C0020
+// CHECK:       0x00000000
+// CHECK:       0x00000001
+// CHECK:       0x00000018
+// CHECK:       0x00300100
+// CHECK:       0x00000000
+// CHECK:       0x001C0030
+// CHECK:       0x00000000
+// CHECK:       0x00000000
+// CHECK:       0x00000018
+// CHECK:       0x00000101
+// CHECK:       0x00000000
+// CHECK:       0x001A0000
+// CHECK:       0x00000030
+// CHECK:       0x00000400
+// CHECK:       0x00024000
+// CHECK:       0x00400000
+// CHECK:       0x0040001F
+// CHECK:       0x00000000
+// CHECK:       0x00000000
+// CHECK:       0x00000000
+// CHECK:       0x8143FF42
+// CHECK:       0x00140100
+// CHECK:       0x00000000
+// CHECK:       0x001A0614
+// CHECK:       0x00000000
+// CHECK:       0x00000000
+// CHECK:       0x00000018
+// CHECK:       0x00100100
+// CHECK:       0x00000000
+// CHECK:       0x001A0610
+// CHECK:       0x00000000
+// CHECK:       0x00000001
+// CHECK:       0x00000018
+// CHECK:       0x00000101
+// CHECK:       0x00000000
+// CHECK:       0x001A0000
+// CHECK:       0x00000030
+// CHECK:       0x00000400
+// CHECK:       0x00024000
+// CHECK:       0x00400000
+// CHECK:       0x0040001F
+// CHECK:       0x00000000
+// CHECK:       0x00000000
+// CHECK:       0x00000000
+// CHECK:       0x8142FF43
+// CHECK:       0x00340100
+// CHECK:       0x00000000
+// CHECK:       0x001A0634
+// CHECK:       0x00000000
+// CHECK:       0x00000000
+// CHECK:       0x00000018
+// CHECK:       0x00300100
+// CHECK:       0x00000000
+// CHECK:       0x001A0630
+// CHECK:       0x00000000
+// CHECK:       0x00000001
+// CHECK:       0x00000018
+// CHECK-LABE:  @dma_start
+// CHECK:       npu_instructions = dense_resource<npu_instructions> : tensor<64xui32>
+#executable_target_amdaie_pdi_fb = #hal.executable.target<"amd-aie", "amdaie-pdi-fb", {num_cols = 1 : i32, num_rows = 1 : i32, target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_pdi_fb} {
+  func.func @dma_start() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    amdaie.workgroup {
+      %tile_0_1 = amdaie.tile(%c0, %c1)
+      %buffer = amdaie.buffer(%tile_0_1) {address = 65536 : ui32, mem_bank = 1 : ui32, sym_name = "_anonymous1"} : memref<1024xi32, 1 : i32>
+      %lock = amdaie.lock(%tile_0_1(2), 1)
+      %lock_0 = amdaie.lock(%tile_0_1(3), 0)
+      amdaie.controlcode {
+        %0 = amdaie.dma_start(%tile_0_1, S2MM, 2) {
+          amdaie.use_lock(%lock, AcquireGreaterOrEqual(1))
+          amdaie.dma_bd(%buffer : memref<1024xi32, 1 : i32>) {bd_id = 0 : i32, dimensions = #amdaie<bd_dim_layout_array[<size = 32, stride = 32>, <size = 32, stride = 1>]>, len = 1024 : i32}
+          amdaie.use_lock(%lock_0, Release(1))
+          amdaie.next_bd ^bb1
+        ^bb1:  // pred: ^bb0
+          amdaie.end
+        }
+        %1 = amdaie.dma_start(%tile_0_1, MM2S, 0) {
+          amdaie.use_lock(%lock_0, AcquireGreaterOrEqual(1))
+          amdaie.dma_bd(%buffer : memref<1024xi32, 1 : i32>) {bd_id = 0 : i32, dimensions = #amdaie<bd_dim_layout_array[<size = 32, stride = 32>, <size = 32, stride = 1>]>, len = 1024 : i32}
+          amdaie.use_lock(%lock, Release(1))
+          amdaie.next_bd ^bb1
+        ^bb1:  // pred: ^bb0
+          amdaie.end
+        }
+        amdaie.end
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
-- This commit adds support for converting DMA start to transaction
   binary.
-- Also involves initializing locks before processing any other ops. -- This is being added to AMDAIE dialect to make
   [DMA reprogramming](https://github.com/nod-ai/iree-amd-aie/issues/1287) work.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>