### PR TITLE
[IR] Add connection field to write_bd and dma_start ops for pairing

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -1041,7 +1041,7 @@ def AMDAIE_NpuWriteBdOp: AMDAIE_Op<"npu.write_bd"> {
     Example:
 
     ```mlir
-    amdaie.npu.write_bd {bd_id = 0 : ui32, buffer_length = 0 : ui32,
+    amdaie.npu.write_bd(%0) {bd_id = 0 : ui32, buffer_length = 0 : ui32,
       buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = false,
       iteration_current = 0 : ui32, iteration_size = 0 : ui32,
       iteration_stride = 0 : ui32, lock_acq_enable = false,
@@ -1053,7 +1053,8 @@ def AMDAIE_NpuWriteBdOp: AMDAIE_Op<"npu.write_bd"> {
     ```
   }];
   let arguments = (
-    ins UI32Attr:$col,
+    ins Optional<Index>:$connection,
+        UI32Attr:$col,
         UI32Attr:$row,
         UI32Attr:$bd_id,
         UI32Attr:$buffer_length,
@@ -1078,7 +1079,7 @@ def AMDAIE_NpuWriteBdOp: AMDAIE_Op<"npu.write_bd"> {
         I32Attr:$lock_acq_val,
         UI32Attr:$lock_acq_id
   );
-  let assemblyFormat = [{ attr-dict }];
+  let assemblyFormat = [{ ( `(` $connection^ `)` ) ? attr-dict }];
 }
 
 def AMDAIE_NpuTctSyncOp: AMDAIE_Op<"npu.tct_sync"> {
@@ -1749,15 +1750,18 @@ def AMDAIE_DMAStartOp: AMDAIE_Op<"dma_start", [
 
   let summary = "An op to start DMA";
   let arguments = (
-    ins Index:$tile,
-        DMAChannelDir:$channel_dir,
-        ConfinedAttr<I8Attr, [IntMinValue<0>]>:$channel_index,
+    ins Index:$channel,
+        Variadic<Index>:$connections,
         // `repeat_count==1` means "do it once".
         DefaultValuedAttr<I8Attr, "1">:$repeat_count
   );
   let regions = (region AnyRegion:$body);
   let assemblyFormat = [{
-    `(` $tile `,` $channel_dir `,` $channel_index (`,` `repeat_count` `=` $repeat_count^)? `)` regions attr-dict
+    `(`
+    $channel
+    ( `,` `{` $connections^ `}` )?
+    `)`
+    regions attr-dict
   }];
 }
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -1037,7 +1037,9 @@ def AMDAIE_NpuWriteBdOp: AMDAIE_Op<"npu.write_bd"> {
   let summary = "Initialize the buffer descriptor with specified ID";
   let description = [{
     This NPU controller operation to initialize the `bd_id` buffer descriptor on
-    the (`col`, `row`) tile with the provided configurations.
+    the (`col`, `row`) tile with the provided configurations. The connection field
+    is required for the out-of-order DMA mode, to pass to the corresponding BD IDs
+    between paired write_bd/dma_start ops.
 
     Example:
 
@@ -1750,6 +1752,12 @@ def AMDAIE_DMAStartOp: AMDAIE_Op<"dma_start", [
   ]>, Results<(outs I1:$valid)> {
 
   let summary = "An op to start DMA";
+  let description = [{
+    This opertion specifies a list of DMA tasks (BDs) to be exectuted on the given channel.
+    The connection field is required for the out-of-order DMA mode, to pass to the corresponding
+    BD IDs between paired write_bd/dma_start ops.
+  }];
+
   let arguments = (
     ins Index:$channel,
         Variadic<Index>:$connections,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/roundtrip.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/test/roundtrip.mlir
@@ -466,9 +466,11 @@ func.func @npu_push_to_queue() {
 // -----
 
 // CHECK-LABEL: func.func @npu_write_bd
-// CHECK:       amdaie.npu.write_bd {bd_id = 2 : ui32, buffer_length = 1024 : ui32, buffer_offset = 32 : ui32, col = 1 : ui32, enable_packet = true, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 1 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 4, 16, 16>, strides = array<i32: 64, 8, 1>, use_next_bd = false, valid_bd = true}
-func.func @npu_write_bd() {
-  amdaie.npu.write_bd {bd_id = 2 : ui32, buffer_length = 1024 : ui32, buffer_offset = 32 : ui32, col = 1 : ui32, enable_packet = true, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 1 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 4, 16, 16>, strides = array<i32: 64, 8, 1>, use_next_bd = false, valid_bd = true}
+// CHECK:         %[[CONNECTION_0:.+]] = amdaie.connection
+// CHECK:         amdaie.npu.write_bd(%[[CONNECTION_0]]) {bd_id = 2 : ui32, buffer_length = 1024 : ui32, buffer_offset = 32 : ui32, col = 1 : ui32, enable_packet = true, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 1 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 4, 16, 16>, strides = array<i32: 64, 8, 1>, use_next_bd = false, valid_bd = true}
+func.func @npu_write_bd(%arg0: !amdaie.logicalobjectfifo<memref<32xi32>>, %arg1: !amdaie.logicalobjectfifo<memref<32xi32, 1 : i32>>) {
+  %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<32xi32>>, !amdaie.logicalobjectfifo<memref<32xi32, 1 : i32>>)
+  amdaie.npu.write_bd(%0) {bd_id = 2 : ui32, buffer_length = 1024 : ui32, buffer_offset = 32 : ui32, col = 1 : ui32, enable_packet = true, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 1 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 4, 16, 16>, strides = array<i32: 64, 8, 1>, use_next_bd = false, valid_bd = true}
   return
 }
 
@@ -676,7 +678,9 @@ func.func @from_memref_unknown_row_column(%arg0 : memref<8xi32>, %t0 : index) {
 //       CHECK: %[[LOCK_0:.*]] = amdaie.lock
 //       CHECK: %[[LOCK_1:.*]] = amdaie.lock
 //       CHECK: %[[BUFFER:.*]] = amdaie.buffer
-//       CHECK: amdaie.dma_start(%[[TILE]], S2MM, 1) {
+//       CHECK: %[[CHANNEL:.*]] = amdaie.channel
+//       CHECK: %[[CONNECTION:.*]] = amdaie.connection
+//       CHECK: amdaie.dma_start(%[[CHANNEL]], {%[[CONNECTION]]}) {
 //       CHECK:   amdaie.use_lock(%[[LOCK_0]], AcquireGreaterOrEqual(1))
 //       CHECK:   amdaie.dma_bd(%[[BUFFER]] : memref<1024xi32, 2 : i32>)
 //  CHECK-SAME:     {dimensions = #amdaie<bd_dim_layout_array[<size = 32, stride = 8>, <size = 4, stride = 256>, <size = 8, stride = 1>]>, len = 1024 : i32}
@@ -685,14 +689,16 @@ func.func @from_memref_unknown_row_column(%arg0 : memref<8xi32>, %t0 : index) {
 //       CHECK:  ^bb1:
 //       CHECK:   amdaie.end
 //       CHECK: }
-func.func @dma_start_block_ops() {
+func.func @dma_start_block_ops(%arg0: !amdaie.logicalobjectfifo<memref<1024xi32, 1 : i32>>, %arg1: !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>>) {
   %c0 = arith.constant 0 : index
   %c2 = arith.constant 2 : index
   %tile_0_2 = amdaie.tile(%c0, %c2)
   %lock = amdaie.lock(%tile_0_2(0), 1)
   %lock_0 = amdaie.lock(%tile_0_2(1), 0)
   %buffer = amdaie.buffer(%tile_0_2) : memref<1024xi32, 2 : i32>
-  %0 = amdaie.dma_start(%tile_0_2, S2MM, 1) {
+  %channel = amdaie.channel(%tile_0_2, 0, port_type = DMA, direction = MM2S)
+  %connection = amdaie.connection(%arg0, %arg1 {%channel}) : (!amdaie.logicalobjectfifo<memref<1024xi32, 1 : i32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>>)
+  amdaie.dma_start(%channel, {%connection}) {
     amdaie.use_lock(%lock, AcquireGreaterOrEqual(1))
     amdaie.dma_bd(%buffer : memref<1024xi32, 2 : i32>) {dimensions = #amdaie<bd_dim_layout_array[<size = 32, stride = 8>, <size = 4, stride = 256>, <size = 8, stride = 1>]>, len = 1024 : i32}
     amdaie.use_lock(%lock_0, Release(1))

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignBDIDs.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignBDIDs.cpp
@@ -52,7 +52,8 @@ LogicalResult assignBdIds(Operation *deviceOp) {
   deviceOp->walk(
       [&](AMDAIE::DMAStartOp dmaStartOp) { memOps.push_back(dmaStartOp); });
   for (AMDAIE::DMAStartOp dmaStartOp : memOps) {
-    auto tile = dmaStartOp.getTile().getDefiningOp<AMDAIE::TileOp>();
+    auto channelOp = dmaStartOp.getChannel().getDefiningOp<AMDAIE::ChannelOp>();
+    AMDAIE::TileOp tile = channelOp.getTileOp();
     std::optional<int64_t> col = getConstantIntValue(tile.getCol());
     std::optional<int64_t> row = getConstantIntValue(tile.getRow());
     if (!col || !row) {
@@ -69,8 +70,8 @@ LogicalResult assignBdIds(Operation *deviceOp) {
 
     DenseMap<Block *, int> blockChannelMap;
     // Associate with each block the channel index specified by the
-    // dma_start
-    int chNum = dmaStartOp.getChannelIndex();
+    // dma_start.
+    int chNum = channelOp.getValue();
     dmaStartOp->walk<WalkOrder::PreOrder>([&](AMDAIE::DMABDOp bd) {
       if (bd.getBdId().has_value()) {
         assert(gen.isBdIdAssigned(bd.getBdId().value()) &&

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_bd_ids.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/assign_bd_ids.mlir
@@ -6,7 +6,8 @@
 // CHECK:           %[[IN:.*]] = amdaie.buffer(%[[TILE_2_1]])
 // CHECK:           %[[LOCK_2_1:.*]] = amdaie.lock(%[[TILE_2_1]](1), 0)
 // CHECK:           %[[LOCK_2_1_0:.*]] = amdaie.lock(%[[TILE_2_1]](0), 1)
-// CHECK:           amdaie.dma_start(%[[TILE_2_1]], MM2S, 0) {
+// CHECK:           %[[CHANNEL:.*]] = amdaie.channel(%[[TILE_2_1]], 0, port_type = DMA, direction = MM2S)
+// CHECK:           amdaie.dma_start(%[[CHANNEL]]) {
 // CHECK:             amdaie.use_lock(%[[LOCK_2_1]], AcquireGreaterOrEqual
 // CHECK:             amdaie.dma_bd(%[[IN]] : memref<16xi32>) {bd_id = 0 : i32
 // CHECK:             amdaie.next_bd ^bb1
@@ -34,7 +35,8 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     %buf01_0 = amdaie.buffer(%t01) { address = 8192 : i32, sym_name = "in" } : memref<16xi32>
     %l01_0 = amdaie.lock(%t01(1), 0)
     %l01_1 = amdaie.lock(%t01(0), 1)
-    %dstDma = amdaie.dma_start(%t01, MM2S, 0) {
+    %channel = amdaie.channel(%t01, 0, port_type = DMA, direction = MM2S)
+    %dstDma = amdaie.dma_start(%channel) {
         amdaie.use_lock(%l01_0, AcquireGreaterOrEqual(1))
         amdaie.dma_bd(%buf01_0 : memref<16xi32>) {len = 16 : i32, dimensions = #amdaie<bd_dim_layout_array[<size = 2, stride = 1>, <size = 3, stride = 2>, <size = 2, stride = 4>, <size = 1, stride = 1>]>}
         amdaie.next_bd ^bb1

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/controlcode_lowering.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/controlcode_lowering.mlir
@@ -46,38 +46,45 @@ module attributes {hal.executable.target = #executable_target_amdaie_pdi_fb} {
     %c2 = arith.constant 2 : index
     %c1 = arith.constant 1 : index
     amdaie.workgroup {
+      // REPROGRAM: %[[TILE_0:.*]] = amdaie.tile(%[[C0]], %[[C0]])
       %tile_0_0 = amdaie.tile(%c0, %c0)
       %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<32x32xi32>
-      // REPROGRAM: %[[TILE:.*]] = amdaie.tile(%[[C0]], %[[C1]])
-      // REPROGRAM: %[[BUFFER_L2:.*]] = amdaie.buffer(%[[TILE]]) : memref<1024xi32, 1 : i32>
-      // REPROGRAM: %[[TILE_1:.*]] = amdaie.tile(%[[C0]], %[[C2]])
-      // REPROGRAM: %[[BUFFER_L1:.*]] = amdaie.buffer(%[[TILE_1]]) : memref<1024xi32, 2 : i32>
+      // REPROGRAM: %[[TILE_1:.*]] = amdaie.tile(%[[C0]], %[[C1]])
       %tile_0_1 = amdaie.tile(%c0, %c1)
+      // REPROGRAM: %[[BUFFER_L2:.*]] = amdaie.buffer(%[[TILE_1]]) : memref<1024xi32, 1 : i32>
       %buffer = amdaie.buffer(%tile_0_1) : memref<1024xi32, 1 : i32>
       %lock = amdaie.lock(%tile_0_1(2), 1)
       %lock_0 = amdaie.lock(%tile_0_1(3), 0)
       %1 = amdaie.logicalobjectfifo.from_buffers({%buffer}, {%lock}, {%lock_0}) : memref<1024xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1024xi32, 1 : i32>>
       %lof_0_0 = amdaie.logicalobjectfifo.from_memref %0, {%tile_0_0} : memref<32x32xi32> -> !amdaie.logicalobjectfifo<memref<1024xi32>>
+      // REPROGRAM: %[[CHANNEL_0:.+]] = amdaie.channel(%[[TILE_0]], 0, port_type = DMA, direction = MM2S)
       %channel = amdaie.channel(%tile_0_0, 0, port_type = DMA, direction = MM2S)
+      // REPROGRAM: %[[CHANNEL_1:.+]] = amdaie.channel(%[[TILE_1]], 2, port_type = DMA, direction = S2MM)
       %channel_1 = amdaie.channel(%tile_0_1, 2, port_type = DMA, direction = S2MM)
       %2 = amdaie.flow({%channel} -> {%channel_1}) {is_packet_flow = true, packet_id = 2 : ui8}
+      // REPROGRAM: %[[CONNECTION_0:.+]] = amdaie.connection
       %3 = amdaie.connection(%1 {%channel_1}, %lof_0_0 {%channel}, flow = %2) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<1024xi32, 1 : i32>>, !amdaie.logicalobjectfifo<memref<1024xi32>>)
+      // REPROGRAM: %[[TILE_2:.*]] = amdaie.tile(%[[C0]], %[[C2]])
       %tile_0_2 = amdaie.tile(%c0, %c2)
+      // REPROGRAM: %[[BUFFER_L1:.*]] = amdaie.buffer(%[[TILE_2]]) : memref<1024xi32, 2 : i32>
       %buffer_2 = amdaie.buffer(%tile_0_2) : memref<1024xi32, 2 : i32>
       %lock_3 = amdaie.lock(%tile_0_2(2), 1)
       %lock_4 = amdaie.lock(%tile_0_2(3), 0)
       %4 = amdaie.logicalobjectfifo.from_buffers({%buffer_2}, {%lock_3}, {%lock_4}) : memref<1024xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>>
+      // REPROGRAM: %[[CHANNEL_2:.+]] = amdaie.channel(%[[TILE_1]], 0, port_type = DMA, direction = MM2S)
       %channel_5 = amdaie.channel(%tile_0_1, 0, port_type = DMA, direction = MM2S)
+      // REPROGRAM: %[[CHANNEL_3:.+]] = amdaie.channel(%[[TILE_2]], 0, port_type = DMA, direction = S2MM)
       %channel_6 = amdaie.channel(%tile_0_2, 0, port_type = DMA, direction = S2MM)
       %5 = amdaie.flow({%channel_5} -> {%channel_6}) {is_packet_flow = false}
+      // REPROGRAM: %[[CONNECTION_1:.+]] = amdaie.connection
       %6 = amdaie.connection(%4 {%channel_6}, %1 {%channel_5}, flow = %5) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<1024xi32, 2 : i32>>, !amdaie.logicalobjectfifo<memref<1024xi32, 1 : i32>>)
       amdaie.controlcode {
         %bd_id = amdaie.bd_id(%tile_0_0, %c0)
         %bd_id_7 = amdaie.bd_id(%tile_0_0, %c1)
         %bd_id_8 = amdaie.bd_id(%tile_0_0, %c2)
-        // REPROGRAM: amdaie.npu.write_bd {bd_id = 1 : ui32
+        // REPROGRAM: amdaie.npu.write_bd(%[[CONNECTION_0]]) {bd_id = 1 : ui32
         %7 = amdaie.npu.half_dma_cpy_nd async %3(%lof_0_0 [0, 0] [32, 32] [32, 1] bd_id = %bd_id_7 channel = %channel) : !amdaie.logicalobjectfifo<memref<1024xi32>>
-        // REPROGRAM: amdaie.dma_start(%[[TILE]], S2MM, 2) {
+        // REPROGRAM: amdaie.dma_start(%[[CHANNEL_1]], {%[[CONNECTION_0]]}) {
         // REPROGRAM:    amdaie.use_lock
         // REPROGRAM:    amdaie.dma_bd(%[[BUFFER_L2]] : memref<1024xi32, 1 : i32>) {dimensions = #amdaie<bd_dim_layout_array[<size = 32, stride = 32>, <size = 32, stride = 1>]>, len = 1024 : i32}
         // REPROGRAM:    amdaie.use_lock
@@ -88,7 +95,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_pdi_fb} {
         amdaie.npu.half_dma_cpy_nd  %3(%1 [0, 0] [32, 32] [32, 1] channel = %channel_1) : !amdaie.logicalobjectfifo<memref<1024xi32, 1 : i32>>
         // REPROGRAM: amdaie.npu.tct_sync
         amdaie.npu.dma_wait(%7 : !amdaie.async_token)
-        // REPROGRAM: amdaie.dma_start(%[[TILE]], MM2S, 0) {
+        // REPROGRAM: amdaie.dma_start(%[[CHANNEL_2]], {%[[CONNECTION_1]]}) {
         // REPROGRAM:   amdaie.use_lock
         // REPROGRAM:   amdaie.dma_bd(%[[BUFFER_L2]] : memref<1024xi32, 1 : i32>) {dimensions = #amdaie<bd_dim_layout_array[<size = 32, stride = 32>, <size = 32, stride = 1>]>, len = 1024 : i32}
         // REPROGRAM:   amdaie.use_lock
@@ -96,7 +103,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_pdi_fb} {
         // REPROGRAM: ^bb1:  // pred: ^bb0
         // REPROGRAM:   amdaie.end
         // REPROGRAM: }
-        // REPROGRAM: amdaie.dma_start(%[[TILE_1]], S2MM, 0) {
+        // REPROGRAM: amdaie.dma_start(%[[CHANNEL_3]], {%[[CONNECTION_1]]}) {
         // REPROGRAM:   amdaie.use_lock
         // REPROGRAM:   amdaie.dma_bd(%[[BUFFER_L1]] : memref<1024xi32, 2 : i32>) {dimensions = #amdaie<bd_dim_layout_array[<size = 32, stride = 4>, <size = 8, stride = 128>, <size = 4, stride = 1>]>, len = 1024 : i32}
         // REPROGRAM:   amdaie.use_lock
@@ -116,7 +123,6 @@ module attributes {hal.executable.target = #executable_target_amdaie_pdi_fb} {
 // -----
 
 // CHECK-LABEL: @half_npu_dma_cpy_nd
-// CHECK:       amdaie.controlcode
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -136,22 +142,23 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %channel = amdaie.channel(%tile_0, 0, port_type = DMA, direction = MM2S)
       %channel_3 = amdaie.channel(%tile, 0, port_type = DMA, direction = S2MM)
       %3 = amdaie.flow({%channel} -> {%channel_3}) {is_packet_flow = true, packet_id = 0 : ui8}
+// CHECK: %[[CONNECTION:.+]] = amdaie.connection
       %4 = amdaie.connection(%0 {%channel_3}, %2 {%channel}, flow = %3) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<2048xi32, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<64x32xi32>>)
       amdaie.controlcode {
         %5 = amdaie.logicalobjectfifo.from_memref %1, {%tile_0} : memref<64x32xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
         memref.assume_alignment %1, 64 : memref<64x32xi32>
         %bd_id = amdaie.bd_id(%tile_0, %c0)
-// CHECK: amdaie.npu.write_bd {bd_id = 0 : ui32, buffer_length = 0 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = true, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 0, 0, 0>, strides = array<i32: 0, 0, 0>, use_next_bd = false, valid_bd = true}
+// CHECK: amdaie.npu.write_bd(%[[CONNECTION]]) {bd_id = 0 : ui32, buffer_length = 0 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = true, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 0, 0, 0>, strides = array<i32: 0, 0, 0>, use_next_bd = false, valid_bd = true}
 // CHECK: amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 0 : ui32, col = 0 : ui32, offset = 0 : ui32}
 // CHECK: amdaie.npu.push_to_queue {bd_id = 0 : ui32, channel = 0 : ui32, col = 0 : ui32, direction = 1 : i32, repeat_count = 1 : ui32, row = 0 : ui32}
         amdaie.npu.half_dma_cpy_nd %4(%5[] [] [] bd_id = %bd_id channel = %channel) : !amdaie.logicalobjectfifo<memref<2048xi32>>
-// CHECK: amdaie.npu.write_bd {bd_id = 0 : ui32, buffer_length = 2048 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = true, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 0, 0, 2048>, strides = array<i32: 0, 0, 1>, use_next_bd = false, valid_bd = true}
+// CHECK: amdaie.npu.write_bd(%[[CONNECTION]]) {bd_id = 0 : ui32, buffer_length = 2048 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = true, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 0, 0, 2048>, strides = array<i32: 0, 0, 1>, use_next_bd = false, valid_bd = true}
 // CHECK: amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 0 : ui32, col = 0 : ui32, offset = 0 : ui32}
 // CHECK: %[[TOKEN_0:.+]] = amdaie.npu.push_to_queue async {bd_id = 0 : ui32, channel = 0 : ui32, col = 0 : ui32, direction = 1 : i32, repeat_count = 1 : ui32, row = 0 : ui32}
 // CHECK: amdaie.npu.tct_sync {channel = 0 : ui32, col = 0 : ui32, col_num = 1 : ui32, direction = 1 : i32, row = 0 : ui32, row_num = 1 : ui32}
         %6 = amdaie.npu.half_dma_cpy_nd async %4(%5[0] [2048] [1] bd_id = %bd_id channel = %channel) : !amdaie.logicalobjectfifo<memref<2048xi32>>
         amdaie.npu.dma_wait(%6 : !amdaie.async_token)
-// CHECK: amdaie.npu.write_bd {bd_id = 0 : ui32, buffer_length = 1024 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = true, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 4, 16, 16>, strides = array<i32: 64, 8, 1>, use_next_bd = false, valid_bd = true}
+// CHECK: amdaie.npu.write_bd(%[[CONNECTION]]) {bd_id = 0 : ui32, buffer_length = 1024 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = true, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 4, 16, 16>, strides = array<i32: 64, 8, 1>, use_next_bd = false, valid_bd = true}
 // CHECK: amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 0 : ui32, col = 0 : ui32, offset = 0 : ui32}
 // CHECK: %[[TOKEN_1:.+]] = amdaie.npu.push_to_queue async {bd_id = 0 : ui32, channel = 0 : ui32, col = 0 : ui32, direction = 1 : i32, repeat_count = 2 : ui32, row = 0 : ui32}
 // CHECK: amdaie.npu.tct_sync {channel = 0 : ui32, col = 0 : ui32, col_num = 1 : ui32, direction = 1 : i32, row = 0 : ui32, row_num = 1 : ui32}
@@ -174,7 +181,6 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // -----
 
 // CHECK-LABEL: @half_npu_dma_cpy_nd_bf16
-// CHECK:       amdaie.controlcode
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -194,22 +200,23 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %channel = amdaie.channel(%tile_0, 0, port_type = DMA, direction = MM2S)
       %channel_3 = amdaie.channel(%tile, 0, port_type = DMA, direction = S2MM)
       %3 = amdaie.flow({%channel} -> {%channel_3}) {is_packet_flow = true, packet_id = 0 : ui8}
+// CHECK: %[[CONNECTION:.+]] = amdaie.connection
       %4 = amdaie.connection(%0 {%channel_3}, %2 {%channel}, flow = %3) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<2048xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<64x32xi32>>)
       amdaie.controlcode {
         %5 = amdaie.logicalobjectfifo.from_memref %1, {%tile_0} : memref<64x32xi32> -> !amdaie.logicalobjectfifo<memref<2048xbf16>>
         memref.assume_alignment %1, 64 : memref<64x32xi32>
         %bd_id = amdaie.bd_id(%tile_0, %c0)
-// CHECK: amdaie.npu.write_bd {bd_id = 0 : ui32, buffer_length = 0 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = true, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 0, 0, 0>, strides = array<i32: 0, 0, 0>, use_next_bd = false, valid_bd = true}
+// CHECK: amdaie.npu.write_bd(%[[CONNECTION]]) {bd_id = 0 : ui32, buffer_length = 0 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = true, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 0, 0, 0>, strides = array<i32: 0, 0, 0>, use_next_bd = false, valid_bd = true}
 // CHECK: amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 0 : ui32, col = 0 : ui32, offset = 0 : ui32}
 // CHECK: amdaie.npu.push_to_queue {bd_id = 0 : ui32, channel = 0 : ui32, col = 0 : ui32, direction = 1 : i32, repeat_count = 1 : ui32, row = 0 : ui32}
         amdaie.npu.half_dma_cpy_nd %4(%5[] [] [] bd_id = %bd_id channel = %channel) : !amdaie.logicalobjectfifo<memref<2048xbf16>>
-// CHECK: amdaie.npu.write_bd {bd_id = 0 : ui32, buffer_length = 1024 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = true, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 0, 0, 1024>, strides = array<i32: 0, 0, 1>, use_next_bd = false, valid_bd = true}
+// CHECK: amdaie.npu.write_bd(%[[CONNECTION]]) {bd_id = 0 : ui32, buffer_length = 1024 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = true, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 0, 0, 1024>, strides = array<i32: 0, 0, 1>, use_next_bd = false, valid_bd = true}
 // CHECK: amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 0 : ui32, col = 0 : ui32, offset = 0 : ui32}
 // CHECK: %[[TOKEN_0:.+]] = amdaie.npu.push_to_queue async {bd_id = 0 : ui32, channel = 0 : ui32, col = 0 : ui32, direction = 1 : i32, repeat_count = 1 : ui32, row = 0 : ui32}
 // CHECK: amdaie.npu.tct_sync {channel = 0 : ui32, col = 0 : ui32, col_num = 1 : ui32, direction = 1 : i32, row = 0 : ui32, row_num = 1 : ui32}
         %6 = amdaie.npu.half_dma_cpy_nd async %4(%5[0] [2048] [1] bd_id = %bd_id channel = %channel) : !amdaie.logicalobjectfifo<memref<2048xbf16>>
         amdaie.npu.dma_wait(%6 : !amdaie.async_token)
-// CHECK: amdaie.npu.write_bd {bd_id = 0 : ui32, buffer_length = 512 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = true, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 4, 16, 8>, strides = array<i32: 32, 4, 1>, use_next_bd = false, valid_bd = true}
+// CHECK: amdaie.npu.write_bd(%[[CONNECTION]]) {bd_id = 0 : ui32, buffer_length = 512 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = true, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 4, 16, 8>, strides = array<i32: 32, 4, 1>, use_next_bd = false, valid_bd = true}
 // CHECK: amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 0 : ui32, col = 0 : ui32, offset = 64 : ui32}
 // CHECK: %[[TOKEN_1:.+]] = amdaie.npu.push_to_queue async {bd_id = 0 : ui32, channel = 0 : ui32, col = 0 : ui32, direction = 1 : i32, repeat_count = 2 : ui32, row = 0 : ui32}
 // CHECK: amdaie.npu.tct_sync {channel = 0 : ui32, col = 0 : ui32, col_num = 1 : ui32, direction = 1 : i32, row = 0 : ui32, row_num = 1 : ui32}
@@ -232,7 +239,6 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // -----
 
 // CHECK-LABEL: @half_npu_dma_cpy_nd_chain
-// CHECK:       amdaie.controlcode
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 #pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
@@ -253,6 +259,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
       %channel = amdaie.channel(%tile_0, 0, port_type = DMA, direction = MM2S)
       %channel_3 = amdaie.channel(%tile, 0, port_type = DMA, direction = S2MM)
       %3 = amdaie.flow({%channel} -> {%channel_3}) {is_packet_flow = false}
+// CHECK: %[[CONNECTION:.+]] = amdaie.connection
       %4 = amdaie.connection(%0 {%channel_3}, %2 {%channel}, flow = %3) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<2048xi32, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<64x32xi32>>)
       amdaie.controlcode {
         %5 = amdaie.logicalobjectfifo.from_memref %1, {%tile_0} : memref<64x32xi32> -> !amdaie.logicalobjectfifo<memref<2048xi32>>
@@ -260,13 +267,13 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
         %bd_id = amdaie.bd_id(%tile_0, %c0)
         %bd_id_1 = amdaie.bd_id(%tile_0, %c1)
         %bd_id_2 = amdaie.bd_id(%tile_0, %c2)
-// CHECK: amdaie.npu.write_bd {bd_id = 0 : ui32, buffer_length = 0 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = false, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 1 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 0, 0, 0>, strides = array<i32: 0, 0, 0>, use_next_bd = true, valid_bd = true}
+// CHECK: amdaie.npu.write_bd(%[[CONNECTION]]) {bd_id = 0 : ui32, buffer_length = 0 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = false, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 1 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 0, 0, 0>, strides = array<i32: 0, 0, 0>, use_next_bd = true, valid_bd = true}
 // CHECK: amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 0 : ui32, col = 0 : ui32, offset = 0 : ui32}
         amdaie.npu.half_dma_cpy_nd %4(%5[] [] [] bd_id = %bd_id channel = %channel next_bd = %bd_id_1 start_bd = %bd_id) : !amdaie.logicalobjectfifo<memref<2048xi32>>
-// CHECK: amdaie.npu.write_bd {bd_id = 1 : ui32, buffer_length = 2048 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = false, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 2 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 0, 0, 2048>, strides = array<i32: 0, 0, 1>, use_next_bd = true, valid_bd = true}
+// CHECK: amdaie.npu.write_bd(%[[CONNECTION]]) {bd_id = 1 : ui32, buffer_length = 2048 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = false, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 2 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 0, 0, 2048>, strides = array<i32: 0, 0, 1>, use_next_bd = true, valid_bd = true}
 // CHECK: amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 1 : ui32, col = 0 : ui32, offset = 0 : ui32}
         amdaie.npu.half_dma_cpy_nd async %4(%5[0] [2048] [1] bd_id = %bd_id_1 channel = %channel next_bd = %bd_id_2 start_bd = %bd_id) : !amdaie.logicalobjectfifo<memref<2048xi32>>
-// CHECK: amdaie.npu.write_bd {bd_id = 2 : ui32, buffer_length = 1024 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = false, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 4, 16, 16>, strides = array<i32: 64, 8, 1>, use_next_bd = false, valid_bd = true}
+// CHECK: amdaie.npu.write_bd(%[[CONNECTION]]) {bd_id = 2 : ui32, buffer_length = 1024 : ui32, buffer_offset = 0 : ui32, col = 0 : ui32, enable_packet = false, iteration_current = 0 : ui32, iteration_size = 0 : ui32, iteration_stride = 0 : ui32, lock_acq_enable = false, lock_acq_id = 0 : ui32, lock_acq_val = 0 : i32, lock_rel_id = 0 : ui32, lock_rel_val = 0 : i32, next_bd = 0 : ui32, out_of_order_id = 0 : ui32, packet_id = 0 : ui32, packet_type = 0 : ui32, paddings_after = array<i32>, paddings_before = array<i32>, row = 0 : ui32, sizes = array<i32: 4, 16, 16>, strides = array<i32: 64, 8, 1>, use_next_bd = false, valid_bd = true}
 // CHECK: amdaie.npu.address_patch {arg_idx = 0 : ui32, bd_id = 2 : ui32, col = 0 : ui32, offset = 0 : ui32}
 // CHECK: %[[TOKEN_0:.+]] = amdaie.npu.push_to_queue async {bd_id = 0 : ui32, channel = 0 : ui32, col = 0 : ui32, direction = 1 : i32, repeat_count = 2 : ui32, row = 0 : ui32}
 // CHECK: amdaie.npu.tct_sync {channel = 0 : ui32, col = 0 : ui32, col_num = 1 : ui32, direction = 1 : i32, row = 0 : ui32, row_num = 1 : ui32}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/controlcode_to_transaction.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/controlcode_to_transaction.mlir
@@ -350,8 +350,10 @@ module attributes {hal.executable.target = #executable_target_amdaie_pdi_fb} {
       %buffer = amdaie.buffer(%tile_0_1) {address = 65536 : i32, mem_bank = 1 : ui32, sym_name = "_anonymous1"} : memref<1024xi32, 1 : i32>
       %lock = amdaie.lock(%tile_0_1(2), 1)
       %lock_0 = amdaie.lock(%tile_0_1(3), 0)
+      %channel_1 = amdaie.channel(%tile_0_1, 2, port_type = DMA, direction = S2MM)
+      %channel_2 = amdaie.channel(%tile_0_1, 0, port_type = DMA, direction = MM2S)
       amdaie.controlcode {
-        %0 = amdaie.dma_start(%tile_0_1, S2MM, 2) {
+        %0 = amdaie.dma_start(%channel_1) {
           amdaie.use_lock(%lock, AcquireGreaterOrEqual(1))
           amdaie.dma_bd(%buffer : memref<1024xi32, 1 : i32>) {bd_id = 0 : i32, dimensions = #amdaie<bd_dim_layout_array[<size = 32, stride = 32>, <size = 32, stride = 1>]>, len = 1024 : i32}
           amdaie.use_lock(%lock_0, Release(1))
@@ -359,7 +361,7 @@ module attributes {hal.executable.target = #executable_target_amdaie_pdi_fb} {
         ^bb1:  // pred: ^bb0
           amdaie.end
         }
-        %1 = amdaie.dma_start(%tile_0_1, MM2S, 0) {
+        %1 = amdaie.dma_start(%channel_2) {
           amdaie.use_lock(%lock_0, AcquireGreaterOrEqual(1))
           amdaie.dma_bd(%buffer : memref<1024xi32, 1 : i32>) {bd_id = 0 : i32, dimensions = #amdaie<bd_dim_layout_array[<size = 32, stride = 32>, <size = 32, stride = 1>]>, len = 1024 : i32}
           amdaie.use_lock(%lock, Release(1))


### PR DESCRIPTION
 This enables passing the corresponding BD IDs between paired ops, which is required for out-of-order DMA mode.