### PR TITLE
Bump IREE to iree-org/iree@77daeb0

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDmaOpInterface.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDmaOpInterface.h
@@ -12,7 +12,6 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Interfaces/CopyOpInterface.h"
 
 namespace mlir::iree_compiler::AMDAIE {
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDmaOpInterface.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEDmaOpInterface.td
@@ -8,11 +8,30 @@
 #define IREE_AMDAIE_DIALECT_DMAOPINTERFACE
 
 include "mlir/IR/OpBase.td"
-include "mlir/Interfaces/CopyOpInterface.td"
 
 //===----------------------------------------------------------------------===//
 // Defines the interface for dma-like operations.
 //===----------------------------------------------------------------------===//
+
+def CopyOpInterface : OpInterface<"CopyOpInterface"> {
+  let description = [{
+    A copy-like operation is one that copies from source value to target value.
+  }];
+  let cppNamespace = "mlir::iree_compiler::AMDAIE";
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/"Returns the source value for this copy operation",
+      /*retTy=*/"::mlir::Value",
+      /*methodName=*/"getSource"
+    >,
+    InterfaceMethod<
+      /*desc=*/"Returns the target value for this copy operation",
+      /*retTy=*/"::mlir::Value",
+      /*methodName=*/"getTarget"
+    >
+  ];
+}
 
 def DoublyStridedOpInterface : OpInterface<"DoublyStridedOpInterface"> {
   let description = [{

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.cpp
@@ -13,9 +13,9 @@ namespace mlir::iree_compiler::AMDAIE {
 
 namespace detail {
 
-SmallVector<mlir::CopyOpInterface> getCopyLikeConsumers(
+SmallVector<CopyOpInterface> getCopyLikeConsumers(
     LogicalObjFifoOpInterface op) {
-  SmallVector<mlir::CopyOpInterface> copyLikOps;
+  SmallVector<CopyOpInterface> copyLikOps;
   for (Operation *userOp : op->getUsers()) {
     if (auto copyOp = dyn_cast<CopyOpInterface>(userOp);
         copyOp && dyn_cast_if_present<LogicalObjFifoOpInterface>(
@@ -26,9 +26,9 @@ SmallVector<mlir::CopyOpInterface> getCopyLikeConsumers(
   return copyLikOps;
 }
 
-SmallVector<mlir::CopyOpInterface> getCopyLikeProducers(
+SmallVector<CopyOpInterface> getCopyLikeProducers(
     LogicalObjFifoOpInterface op) {
-  SmallVector<mlir::CopyOpInterface> copyLikOps;
+  SmallVector<CopyOpInterface> copyLikOps;
   for (Operation *userOp : op->getUsers()) {
     if (auto copyOp = dyn_cast<CopyOpInterface>(userOp);
         copyOp && dyn_cast_if_present<LogicalObjFifoOpInterface>(

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.h
@@ -7,9 +7,9 @@
 #ifndef IREE_COMPILER_AMDAIE_LOGICALOBJFIFOOPINTERFACE_H_
 #define IREE_COMPILER_AMDAIE_LOGICALOBJFIFOOPINTERFACE_H_
 
+#include "iree-amd-aie/IR/AMDAIEDmaOpInterface.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Interfaces/CopyOpInterface.h"
 
 namespace mlir::iree_compiler::AMDAIE {
 
@@ -18,12 +18,10 @@ class LogicalObjFifoOpInterface;
 namespace detail {
 
 /// Return the consumer copy-like operations of the logical objFifo.
-SmallVector<mlir::CopyOpInterface> getCopyLikeConsumers(
-    LogicalObjFifoOpInterface op);
+SmallVector<CopyOpInterface> getCopyLikeConsumers(LogicalObjFifoOpInterface op);
 
 /// Return the producer copy-like operations of the logical objFifo.
-SmallVector<mlir::CopyOpInterface> getCopyLikeProducers(
-    LogicalObjFifoOpInterface op);
+SmallVector<CopyOpInterface> getCopyLikeProducers(LogicalObjFifoOpInterface op);
 
 }  // namespace detail
 

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIELogicalObjFifoOpInterface.td
@@ -8,7 +8,7 @@
 #define IREE_AMDAIE_DIALECT_LOGICALOBJFIFOOPINTERFACE
 
 include "mlir/IR/OpBase.td"
-include "mlir/Interfaces/CopyOpInterface.td"
+include "iree-amd-aie/IR/AMDAIEDmaOpInterface.td"
 
 //===----------------------------------------------------------------------===//
 // Defines the interface for logical objectFifo operations.
@@ -41,7 +41,7 @@ def LogicalObjFifoOpInterface : OpInterface<"LogicalObjFifoOpInterface"> {
       /*desc=*/[{
         Return the consumer copy-like operations of the logical objFifo.
       }],
-      /*retTy=*/"::llvm::SmallVector<::mlir::CopyOpInterface>",
+      /*retTy=*/"::llvm::SmallVector<::mlir::iree_compiler::AMDAIE::CopyOpInterface>",
       /*methodName=*/"getCopyLikeConsumers",
       /*args=*/(ins),
       /*methodBody=*/"",
@@ -54,7 +54,7 @@ def LogicalObjFifoOpInterface : OpInterface<"LogicalObjFifoOpInterface"> {
       /*desc=*/[{
         Return the producer copy-like operations of the logical objFifo.
       }],
-      /*retTy=*/"::llvm::SmallVector<::mlir::CopyOpInterface>",
+      /*retTy=*/"::llvm::SmallVector<::mlir::iree_compiler::AMDAIE::CopyOpInterface>",
       /*methodName=*/"getCopyLikeProducers",
       /*args=*/(ins),
       /*methodBody=*/"",

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.h
@@ -16,7 +16,6 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
-#include "mlir/Interfaces/CopyOpInterface.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
 
 // clang-format off

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -7,7 +7,6 @@
 #ifndef IREE_AMDAIE_DIALECT_IREEAMDAIE_OPS
 #define IREE_AMDAIE_DIALECT_IREEAMDAIE_OPS
 
-include "mlir/Interfaces/CopyOpInterface.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/ViewLikeInterface.td"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/CMakeLists.txt
@@ -50,7 +50,6 @@ iree_cc_library(
     iree-amd-aie::aie_runtime::AMDAIEEnums
     LLVMSupport
     MLIRArithUtils
-    MLIRCopyOpInterface
     MLIRDialectUtils
     MLIRIR
     MLIRParser


### PR DESCRIPTION
`CopyOpInterface` is dropped in upstream (https://github.com/llvm/llvm-project/pull/157711). Move this interface to our codebase.