### PR TITLE
[CI] Unlimit mmap for strix tests

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -304,6 +304,7 @@ jobs:
 
       - name : E2E comparison of AIE to llvm-cpu
         run: |
+          sudo prlimit -lunlimited --pid $$
           source .venv/bin/activate
           python build_tools/ci/cpu_comparison/run.py \
             test_aie_vs_cpu \
@@ -320,6 +321,7 @@ jobs:
       # just measure the time to run some workloads.
       - name : Performance benchmarks
         run: |
+          sudo prlimit -lunlimited --pid $$
           source .venv/bin/activate
           python build_tools/ci/cpu_comparison/run.py \
             test_aie_vs_cpu \


### PR DESCRIPTION
These commands were previously used in [Phoenix tests](https://github.com/nod-ai/iree-amd-aie/blob/fc045456ada597a404370d1ba1ab0b53598c248c/.github/workflows/ci-linux.yml#L188-L191) only, now apply them to strix as well.

This change is required for the newly added Strix CI runner ([Shark-Strix-3](https://github.com/nod-ai/iree-amd-aie/settings/actions/runners/58)).
