### PR TITLE
[CI] Handle RyzenAI vbnv format in util script

### DIFF
--- a/build_tools/ci/amdxdna_driver_utils/amdxdna_ioctl.py
+++ b/build_tools/ci/amdxdna_driver_utils/amdxdna_ioctl.py
@@ -167,9 +167,24 @@ def find_npu_device():
 
 def read_vbnv(npu_device_path):
     f = open(npu_device_path / "vbnv")
-    vbnv = f.read()
-    assert vbnv.startswith("NPU ")
-    return vbnv.split(" ")[-1].strip()
+    vbnv = f.read().strip().lower()
+
+    # Accept multiple formats:
+    # - "NPU Phoenix", "NPU Strix"
+    # - "RyzenAI-npu5", "RyzenAI-npu6", etc.
+    if vbnv.startswith("npu "):
+        tokens = vbnv.split()
+        assert len(tokens) == 2
+        return tokens[1]
+
+    # RyzenAI formats like "RyzenAI-npu5"
+    if vbnv.startswith("ryzenai-npu"):
+        # Map known RyzenAI-npu generations to canonical names
+        # Adjust mapping as needed for new generations.
+        if vbnv == "ryzenai-npu5":
+            return "Strix"
+
+    assert False, f"unrecognized vbnv format: {vbnv}"
 
 
 def get_core_n_cols(drv_fd, npu_device):


### PR DESCRIPTION
Was following the CI scripts for my local setup on a fresh Framework desktop 
and noticed that we need a patch in this utility script.

<img width="1058" height="542" alt="Screenshot 2025-09-27 at 22 48 56" src="https://github.com/user-attachments/assets/8c9af861-783e-4215-8f1f-e7c1933f23cf" />
