### PR TITLE
Bump IREE to iree-org/iree@26083307b

### DIFF
--- a/runtime/src/iree-amd-aie/driver/xrt-lite/cts/backends.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/cts/backends.cc
@@ -7,15 +7,14 @@
 // CTS backend registration for the xrt-lite HAL driver.
 
 #include "iree-amd-aie/driver/xrt-lite/registration/driver_module.h"
-#include "iree/async/util/proactor_pool.h"
-#include "iree/base/threading/numa.h"
 #include "iree/hal/api.h"
 #include "iree/hal/cts/util/registry.h"
 
 namespace iree::hal::cts {
 
-static iree_status_t CreateXrtLiteDevice(iree_hal_driver_t** out_driver,
-                                         iree_hal_device_t** out_device) {
+static iree_status_t CreateXrtLiteDevice(
+    const iree_hal_device_create_params_t* create_params,
+    iree_hal_driver_t** out_driver, iree_hal_device_t** out_device) {
   iree_status_t status = iree_hal_xrt_lite_driver_module_register(
       iree_hal_driver_registry_default());
   if (iree_status_is_already_exists(status)) {
@@ -30,24 +29,11 @@ static iree_status_t CreateXrtLiteDevice(iree_hal_driver_t** out_driver,
         iree_allocator_system(), &driver);
   }
 
-  iree_async_proactor_pool_t* proactor_pool = nullptr;
-  if (iree_status_is_ok(status)) {
-    status = iree_async_proactor_pool_create(
-        iree_numa_node_count(), /*node_ids=*/NULL,
-        iree_async_proactor_pool_options_default(), iree_allocator_system(),
-        &proactor_pool);
-  }
-
   iree_hal_device_t* device = nullptr;
   if (iree_status_is_ok(status)) {
-    iree_hal_device_create_params_t create_params =
-        iree_hal_device_create_params_default();
-    create_params.proactor_pool = proactor_pool;
     status = iree_hal_driver_create_default_device(
-        driver, &create_params, iree_allocator_system(), &device);
+        driver, create_params, iree_allocator_system(), &device);
   }
-
-  iree_async_proactor_pool_release(proactor_pool);
 
   if (iree_status_is_ok(status)) {
     *out_driver = driver;

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/device.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/device.cc
@@ -309,7 +309,7 @@ static iree_status_t iree_hal_xrt_lite_device_queue_alloca(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     const iree_hal_semaphore_list_t wait_semaphore_list,
     const iree_hal_semaphore_list_t signal_semaphore_list,
-    iree_hal_allocator_pool_t pool, iree_hal_buffer_params_t params,
+    iree_hal_pool_t* pool, iree_hal_buffer_params_t params,
     iree_device_size_t allocation_size, iree_hal_alloca_flags_t flags,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   IREE_TRACE_ZONE_BEGIN(z0);

--- a/runtime/src/iree-amd-aie/driver/xrt/xrt_device.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt/xrt_device.cc
@@ -352,7 +352,7 @@ static iree_status_t iree_hal_xrt_device_queue_alloca(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     const iree_hal_semaphore_list_t wait_semaphore_list,
     const iree_hal_semaphore_list_t signal_semaphore_list,
-    iree_hal_allocator_pool_t pool, iree_hal_buffer_params_t params,
+    iree_hal_pool_t* pool, iree_hal_buffer_params_t params,
     iree_device_size_t allocation_size, iree_hal_alloca_flags_t flags,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   (void)queue_affinity;


### PR DESCRIPTION
Bump IREE to iree-org/iree@26083307b

Updates made to iree-amd-aie runtime :-
1. `driver/xrt-lite/device.cc`, `driver/xrt/xrt_device.cc`: `queue_alloca` pool parameter changed from `iree_hal_allocator_pool_t` -> `iree_hal_pool_t*`
2. `driver/xrt-lite/cts/backends.cc`: `DeviceFactory` now uses `const iree_hal_device_create_params_t* create_params` argument; therefore the framework now owns the proactor pool necessitating the removal of local pool plumbing.