### PR TITLE
[xrt-lite] Fill virtual-memory vtable slots with not-supported stubs

### DIFF
--- a/runtime/src/iree-amd-aie/driver/xrt-lite/allocator.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/allocator.cc
@@ -177,6 +177,14 @@ static void iree_hal_xrt_lite_allocator_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+static bool iree_hal_xrt_lite_allocator_supports_virtual_memory(
+    iree_hal_allocator_t* base_allocator) {
+  // XDNA exposes BOs via DRM ioctl, not a virtual-address-reservation API. A
+  // real implementation would need kernel support for partial-population /
+  // page-level mapping that the amdxdna driver does not provide today.
+  return false;
+}
+
 static iree_allocator_t iree_hal_xrt_lite_allocator_host_allocator(
     const iree_hal_allocator_t* base_allocator) {
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -214,5 +222,21 @@ const iree_hal_allocator_vtable_t iree_hal_xrt_lite_allocator_vtable = {
     // of one copy), or add a kernel userptr path (zero-copy, kernel work).
     .import_buffer = unimplemented,
     .export_buffer = unimplemented,
+    // Virtual memory is not supported on XDNA. supports_virtual_memory
+    // returns false so callers short-circuit before reaching the rest of
+    // the VM vtable; the remaining slots are filled with UNIMPLEMENTED
+    // stubs to keep the vtable complete (NULL fn pointers would SEGV any
+    // caller that bypasses the supports check).
+    .supports_virtual_memory =
+        iree_hal_xrt_lite_allocator_supports_virtual_memory,
+    .virtual_memory_query_granularity = unimplemented,
+    .virtual_memory_reserve = unimplemented,
+    .virtual_memory_release = unimplemented,
+    .physical_memory_allocate = unimplemented,
+    .physical_memory_free = unimplemented,
+    .virtual_memory_map = unimplemented,
+    .virtual_memory_unmap = unimplemented,
+    .virtual_memory_protect = unimplemented,
+    .virtual_memory_advise = unimplemented,
 };
 }


### PR DESCRIPTION
xrt-lite's allocator vtable did not provide entries for the virtual-memory operations added by recent IREE HAL changes. Callers that invoke iree_hal_allocator_supports_virtual_memory (or any of the other VM ops) before checking support would dereference a NULL function pointer and SEGV.

The XDNA kernel UABI does not expose a virtual-address-reservation / mapping API equivalent to cuMemReserve/cuMemMap. A real implementation would need kernel-side support that does not exist today, so the correct fix is to declare the capability as unsupported rather than to leave the slots NULL.

Add iree_hal_xrt_lite_allocator_supports_virtual_memory returning false. Wire the remaining virtual_memory_* / physical_memory_* vtable slots to the existing unimplemented template. Callers that respect the supports == false short-circuit (e.g. iree/hal/allocator_heap.c pattern) never reach these; they exist purely so a spec-violating caller fails cleanly rather than SEGVs.

Discovered by running HRX (ROCm/hrx) CTS against an xrt-lite-backed device; hrx_cts_virtual_memory crashed when calling supports_virtual_memory on the xrt-lite allocator. iree-amd-aie's own CTS does not exercise virtual_memory operations.