### PR TITLE
[xrt-lite] Batch dispatches via ERT_CMD_CHAIN (PARTIAL_ELF + compiler patch table)

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -236,6 +236,11 @@ jobs:
         run: |
           DEVICE_TEST_DIR="$PWD/iree-install/device_tests"
           for t in $(ls $DEVICE_TEST_DIR); do
+            # xexec_chain_test embeds an npu4-compiled control-packet matmul
+            # (cmd_chain is firmware-gated to npu4); skip on phoenix.
+            case "$t" in
+              xexec_chain_test) continue ;;
+            esac
             $DEVICE_TEST_DIR/$t --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS
           done
 

--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -49,6 +49,9 @@ class TestParams(ABC):
     n_reconfigure_runs: int = 1
     n_pdi_loads: int = 1
     enable_ctrlpkt: bool = True
+    # Submit each dispatch's commands as a single ERT_CMD_CHAIN (xrt-lite HAL,
+    # via --xrt_lite_cmd_chain=1) instead of per-command issue/wait.
+    use_cmd_chain: bool = False
     stack_size: int = 1024
     rtol: float = 1e-6
     atol: float = 1e-6
@@ -212,6 +215,7 @@ class BaseTest(ABC):
             atol=self.atol,
             preset_inputs=self.preset_inputs,
             preset_output=self.preset_output,
+            use_cmd_chain=self.use_cmd_chain,
         )
         return True
 
@@ -993,7 +997,9 @@ def generate_aie_vmfb(
     return aie_vmfb
 
 
-def generate_aie_output(config, aie_vmfb, input_args, function_name, name, output_type):
+def generate_aie_output(
+    config, aie_vmfb, input_args, function_name, name, output_type, use_cmd_chain=False
+):
     """
     Run a compiled AIE module (aie_vmfb), returning a numpy array of the output.
     """
@@ -1013,6 +1019,9 @@ def generate_aie_output(config, aie_vmfb, input_args, function_name, name, outpu
         run_args += [f"--xrt_lite_n_core_rows={config.xrt_lite_n_core_rows}"]
     if config.xrt_lite_n_core_cols is not None:
         run_args += [f"--xrt_lite_n_core_cols={config.xrt_lite_n_core_cols}"]
+    if use_cmd_chain:
+        # Batch the dispatch's commands into a single ERT_CMD_CHAIN (xrt-lite).
+        run_args += ["--xrt_lite_cmd_chain=1"]
 
     if config.reset_npu_between_runs:
         shell_out(config.reset_npu_script, verbose=config.verbose)
@@ -1390,6 +1399,7 @@ def aie_vs_baseline(
     atol,
     n_repeats,
     output_type,
+    use_cmd_chain=False,
 ):
     """
     Arguments to the function are:
@@ -1453,6 +1463,7 @@ def aie_vs_baseline(
             function_name,
             name,
             output_type,
+            use_cmd_chain=use_cmd_chain,
         )
 
         summary_string = compare(baseline_value, aie_output, rtol, atol)
@@ -1582,6 +1593,7 @@ def aie_vs_llvm_cpu(
     n_repeats=1,
     preset_inputs={},
     preset_output=None,
+    use_cmd_chain=False,
 ):
     """
     Compare the output obtained when compiling and running on IREE's
@@ -1628,6 +1640,7 @@ def aie_vs_llvm_cpu(
         atol,
         n_repeats,
         output_type,
+        use_cmd_chain=use_cmd_chain,
     )
 
 
@@ -2450,6 +2463,33 @@ class Tests:
                         ),
                     )
                 )
+
+        # ERT_CMD_CHAIN coverage (xrt-lite): the same multi-kernel + control-packet
+        # designs, submitted as one ERT_CMD_CHAIN per dispatch (reconfig + exec
+        # batched) instead of per-command issue/wait. Verifies chaining produces
+        # results identical to the default path (compared against llvm-cpu). npu4
+        # only, where the ERT_CMD_CHAIN path is supported.
+        for file_base_name, func_name in [
+            ["two_matmul_switching", "matmul_small"],
+            ["three_matmuls", "three_$mm$"],
+        ]:
+            self.register(
+                MultipleDispatches(
+                    file_base_name,
+                    func_name,
+                    test_params=TestParams(
+                        aie_compilation_flags=[
+                            "--iree-amdaie-num-rows=1",
+                            "--iree-amdaie-num-cols=1",
+                        ],
+                        run_on_target=["npu4"],
+                        name_suffix="OneCore_npu4_cmd_chain",
+                        enable_ctrlpkt=True,
+                        use_cmd_chain=True,
+                        n_repeats=2,
+                    ),
+                )
+            )
 
         # Convolution 2D tests:
         conv_2d_map = {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/AIETarget.cpp
@@ -19,6 +19,7 @@
 #include "air/Dialect/AIRRt/AIRRtDialect.h"
 #include "iree-amd-aie/IR/AMDAIEDialect.h"
 #include "iree-amd-aie/Transforms/Passes.h"
+#include "iree-amd-aie/Transforms/Utils/AMDAIETransactionBuilder.h"
 #include "iree-amd-aie/schemas/pdi_executable_def_builder.h"
 #include "iree-amd-aie/schemas/xrt_executable_def_builder.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenDialect.h"
@@ -305,7 +306,8 @@ void serializePDIToFb(FlatbufferBuilder &builder,
                       SmallVector<int32_t> &reconfDataIndices,
                       SmallVector<flatbuffers_ref_t> pdiRefs,
                       SmallVector<flatbuffers_ref_t> asmInstrRefs,
-                      SmallVector<flatbuffers_ref_t> reconfDataRefs) {
+                      SmallVector<flatbuffers_ref_t> reconfDataRefs,
+                      SmallVector<flatbuffers_ref_t> patchRefs) {
   // Add the entry points to the flatbuffer.
   iree_amd_aie_hal_xrt_lite_ExecutableDef_entry_points_add(builder,
                                                            entryPointsRef);
@@ -335,6 +337,10 @@ void serializePDIToFb(FlatbufferBuilder &builder,
       builder.createOffsetVecDestructive(reconfDataRefs);
   iree_amd_aie_hal_xrt_lite_ExecutableDef_reconf_data_runlists_add(
       builder, reconfDataRef);
+  // Add the host patch table (parallel to asm_instr_runlists).
+  flatbuffers_vec_ref_t patchRef =
+      builder.createOffsetVecDestructive(patchRefs);
+  iree_amd_aie_hal_xrt_lite_ExecutableDef_patch_runlists_add(builder, patchRef);
   iree_amd_aie_hal_xrt_lite_ExecutableDef_end_as_root(builder);
 }
 
@@ -532,6 +538,9 @@ LogicalResult AIETargetBackend::serializeExecutable(
   Flatbuffer1dStringArrayConverter entryPointNameConvertor(ordinalCount);
   Flatbuffer1dStringArrayConverter artifactConvertor(ordinalCount);
   Flatbuffer3dUInt32ArrayConverter asmInstrConverter(ordinalCount);
+  // Host patch table, parallel to `asmInstrConverter` (xrt-lite cmd-chain
+  // path).
+  Flatbuffer3dUInt32ArrayConverter patchConverter(ordinalCount);
   Flatbuffer3dUInt32ArrayConverter reconfDataConverter(ordinalCount);
 
   for (size_t i = 0; i < entryPointNames.size(); i++) {
@@ -670,6 +679,14 @@ LogicalResult AIETargetBackend::serializeExecutable(
     // Add the 2D array entry to the converter.
     asmInstrConverter.addEntry(ordinal, asmInstrs2d);
     reconfDataConverter.addEntry(ordinal, reconfData2d);
+    // Derive the host patch table for each run, parallel to `asmInstrs2d`.
+    // Parsing of the serialized transaction format lives entirely in the
+    // transaction-builder layer (the component that produces it); the HAL only
+    // applies the resulting (offset, arg_idx, arg_plus) triples.
+    SmallVector<std::vector<uint32_t>> patch2d;
+    for (const std::vector<uint32_t> &txn : asmInstrs2d)
+      patch2d.push_back(deriveHostPatchTableFromTransaction(txn));
+    patchConverter.addEntry(ordinal, patch2d);
 
     // Get the artifact (XCLBIN or PDI) only if control packet reconfiguration
     // is disabled or this is the first entry point. Otherwise, leave it as an
@@ -724,7 +741,8 @@ LogicalResult AIETargetBackend::serializeExecutable(
                        artifactConvertor.getFlatbufferRefs(
                            builder, iree_amd_aie_hal_xrt_lite_PdiDef_create),
                        get3dUInt32ArrayRefs(asmInstrConverter),
-                       get3dUInt32ArrayRefs(reconfDataConverter));
+                       get3dUInt32ArrayRefs(reconfDataConverter),
+                       get3dUInt32ArrayRefs(patchConverter));
       break;
     }
     default:

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIETransactionBuilder.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIETransactionBuilder.cpp
@@ -6,11 +6,96 @@
 
 #include "AMDAIETransactionBuilder.h"
 
+#include <cstring>
+
 #include "AMDAIEUtils.h"
+#include "llvm/Support/ErrorHandling.h"
 
 #define DEBUG_TYPE "iree-amdaie-transaction-builder"
 
 namespace mlir::iree_compiler::AMDAIE {
+
+std::vector<uint32_t> deriveHostPatchTableFromTransaction(
+    ArrayRef<uint32_t> txn) {
+  // Transaction opcodes (XAie_TxnOpcode) and the field layouts below follow
+  // aie-rt's serialized header structs (XAie_TxnHeader, XAie_Write32Hdr,
+  // XAie_BlockWrite32Hdr, XAie_MaskWrite32Hdr, XAie_MaskPoll32Hdr,
+  // XAie_CustomOpHdr) and XRT's patch_op_t, matching what this file's
+  // `appendAddressPatch` / aie-rt emit.
+  enum : uint8_t {
+    kWrite32 = 0,
+    kBlockWrite = 1,
+    kMaskWrite = 3,
+    kMaskPoll = 4,
+    kCustomOpBase = 128,
+    kDdrPatch =
+        static_cast<uint8_t>(XAie_TxnOpcode::XAIE_IO_CUSTOM_OP_DDR_PATCH),
+  };
+  std::vector<uint32_t> table;
+  const uint8_t *b = reinterpret_cast<const uint8_t *>(txn.data());
+  size_t total = txn.size() * sizeof(uint32_t);
+  if (total < 16) return table;
+  auto rd = [&](size_t off) -> uint32_t {
+    uint32_t v;
+    std::memcpy(&v, b + off, sizeof(v));
+    return v;
+  };
+  uint32_t numOps = rd(8);  // XAie_TxnHeader.NumOps
+  size_t p = 16;            // past the 16-byte header
+  struct BlockWrite {
+    uint32_t reg;
+    uint32_t bytes;
+    size_t payloadOff;
+  };
+  SmallVector<BlockWrite> bws;
+  for (uint32_t i = 0; i < numOps && p + 8 <= total; i++) {
+    uint8_t op = b[p];
+    uint32_t sz;
+    if (op == kWrite32) {
+      sz = rd(p + 20);
+    } else if (op == kBlockWrite) {
+      sz = rd(p + 12);
+    } else if (op == kMaskWrite || op == kMaskPoll) {
+      sz = rd(p + 24);
+    } else if (op >= kCustomOpBase) {
+      sz = rd(p + 4);  // custom op (TCT, DDR_PATCH, ...)
+    } else {
+      sz = 4;
+    }
+    if (sz < 4 || p + sz > total) break;
+    if (op == kBlockWrite && sz >= 16) {
+      bws.push_back({rd(p + 8), sz - 16, p + 16});
+    } else if (op == kDdrPatch && sz >= 44) {
+      uint32_t regAddr = rd(p + 24), argIdx = rd(p + 32), argPlus = rd(p + 40);
+      uint32_t bdBase = regAddr & ~0xFu;
+      bool matched = false;
+      for (const BlockWrite &bw : bws) {
+        if (bdBase >= bw.reg && bdBase < bw.reg + bw.bytes) {
+          table.push_back(
+              static_cast<uint32_t>(bw.payloadOff + (bdBase - bw.reg)));
+          table.push_back(argIdx);
+          table.push_back(argPlus);
+          matched = true;
+          break;
+        }
+      }
+      if (!matched) {
+        // A DDR_PATCH with no covering BLOCKWRITE means the transaction builder
+        // emitted an address patch for a BD that nothing programs — silently
+        // dropping it produces a runtime where that BD's shim-DMA address stays
+        // zero (output buffer reads as zeros). That's a compiler bug; fail
+        // loudly here rather than burying it in inscrutable runtime behavior.
+        llvm::report_fatal_error(
+            "DDR_PATCH op has no covering BLOCKWRITE in the transaction "
+            "stream; the transaction builder emitted an address patch for a "
+            "BD that no BLOCKWRITE programs (this would silently produce a "
+            "zero shim-DMA address at runtime)");
+      }
+    }
+    p += sz;
+  }
+  return table;
+}
 
 void TransactionBuilder::clearAndInitialize() {
   instructions.clear();

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIETransactionBuilder.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIETransactionBuilder.h
@@ -54,6 +54,25 @@ class TransactionBuilder {
   std::vector<uint32_t> instructions;
 };
 
+/// Derive the host-side address-patch table for a serialized uController
+/// transaction (the binary produced by `TransactionBuilder`, i.e. the same
+/// format `appendAddressPatch` emits into).
+///
+/// Returns a flat list of (byteOffset, argIdx, argPlus) triples. For each
+/// `XAIE_IO_CUSTOM_OP_DDR_PATCH` op, `byteOffset` is the offset (in bytes, from
+/// the start of `txn`) of the BD-address word that must be patched at dispatch
+/// time with `args[argIdx] + argPlus`. A single BLOCKWRITE may program several
+/// consecutive BDs, so each DDR_PATCH is matched to the BLOCKWRITE whose
+/// register span [reg, reg + payload_bytes) contains its BD base
+/// (`regaddr & ~0xF`), and `byteOffset` points into that BLOCKWRITE's payload.
+///
+/// This is the single place that parses the serialized transaction binary: the
+/// xrt-lite HAL's ERT_CMD_CHAIN path cannot rely on firmware-side address
+/// patching, so it host-patches BD addresses using this table without itself
+/// understanding the transaction format.
+std::vector<uint32_t> deriveHostPatchTableFromTransaction(
+    ArrayRef<uint32_t> txn);
+
 }  // namespace mlir::iree_compiler::AMDAIE
 
 #endif

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIETransactionBuilderTest.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIETransactionBuilderTest.cpp
@@ -1,0 +1,187 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Unit tests for deriveHostPatchTableFromTransaction — the parser that walks a
+// serialized XAie transaction binary, correlates each DDR_PATCH custom op to
+// the BLOCKWRITE whose register span contains its BD base, and emits the flat
+// (offset, arg_idx, arg_plus) triples the HAL uses to host-patch shim-DMA
+// buffer addresses on the ERT_CMD_CHAIN path. This is the single place that
+// understands the TXN binary layout (op headers, custom-op size fields, the
+// BLOCKWRITE-payload-span trick); a bug here either silently drops patches
+// (output buffers stay zero) or scribbles outside the control code.
+
+#include <cstdint>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "iree-amd-aie/Transforms/Utils/AMDAIETransactionBuilder.h"
+
+namespace {
+
+using namespace mlir::iree_compiler::AMDAIE;
+
+// Little-endian byte writers — the XAie TXN binary is built as bytes and we
+// then reinterpret it as u32. Construction in bytes is what the parser reads.
+struct Bytes {
+  std::vector<uint8_t> data;
+  size_t size() const { return data.size(); }
+  void u8(uint8_t v) { data.push_back(v); }
+  void u32_at(size_t off, uint32_t v) {
+    if (data.size() < off + 4) data.resize(off + 4, 0);
+    for (int i = 0; i < 4; ++i) data[off + i] = (v >> (8 * i)) & 0xff;
+  }
+  void pad_to(size_t off) {
+    if (data.size() < off) data.resize(off, 0);
+  }
+  std::vector<uint32_t> as_u32() const {
+    std::vector<uint32_t> out(data.size() / 4);
+    std::memcpy(out.data(), data.data(), out.size() * 4);
+    return out;
+  }
+};
+
+// Sets up a 16-byte XAie_TxnHeader; NumOps and TxnSize get filled in once the
+// ops are appended.
+static void WriteTxnHeader(Bytes &b) {
+  b.pad_to(16);  // Major/Minor/DevGen/etc. stay 0 — the parser ignores them.
+}
+
+// Appends a BLOCKWRITE op (opcode 1) programming `payload_bytes` bytes of data
+// starting at register `reg`. Header layout: byte0=opcode, reg at p+8, size at
+// p+12 (total bytes = 16 + payload_bytes). The payload itself is zero-filled —
+// the parser only cares about its span [reg, reg+payload_bytes), not contents.
+static size_t AppendBlockWrite(Bytes &b, uint32_t reg, uint32_t payload_bytes) {
+  size_t op_off = b.size();
+  size_t total = 16 + payload_bytes;
+  b.pad_to(op_off + total);
+  b.data[op_off] = /*opcode=*/1;
+  b.u32_at(op_off + 8, reg);
+  b.u32_at(op_off + 12, static_cast<uint32_t>(total));
+  return op_off;
+}
+
+// Appends a DDR_PATCH op (opcode 129, size 44). Field offsets follow XRT's
+// patch_op_t / XAie_CustomOpHdr: size@p+4, regaddr@p+24, argidx@p+32,
+// argplus@p+40.
+static void AppendDdrPatch(Bytes &b, uint32_t regaddr, uint32_t argidx,
+                           uint32_t argplus) {
+  size_t op_off = b.size();
+  size_t total = 44;
+  b.pad_to(op_off + total);
+  b.data[op_off] = /*opcode=*/129;
+  b.u32_at(op_off + 4, static_cast<uint32_t>(total));
+  b.u32_at(op_off + 24, regaddr);
+  b.u32_at(op_off + 32, argidx);
+  b.u32_at(op_off + 40, argplus);
+}
+
+// Sets NumOps@byte8 and TxnSize@byte12 once all ops are appended.
+static std::vector<uint32_t> FinalizeTxn(Bytes &b, uint32_t num_ops) {
+  b.u32_at(8, num_ops);
+  b.u32_at(12, static_cast<uint32_t>(b.size()));
+  return b.as_u32();
+}
+
+TEST(DeriveHostPatchTableTest, EmptyTxnReturnsEmptyTable) {
+  // Header-only TXN with NumOps=0 → no DDR_PATCH ops → no triples.
+  Bytes b;
+  WriteTxnHeader(b);
+  auto txn = FinalizeTxn(b, /*num_ops=*/0);
+  auto table = deriveHostPatchTableFromTransaction(txn);
+  EXPECT_TRUE(table.empty());
+}
+
+TEST(DeriveHostPatchTableTest, SingleBdProducesOneTriple) {
+  // One BLOCKWRITE at reg 0x1D000 with payload 16 bytes (one BD), followed by
+  // a DDR_PATCH that targets bd[1] (BD base = regaddr & ~0xF = 0x1D000).
+  // Expected: offset = blockwrite_payload_start + (0x1D000 - 0x1D000) = the
+  // first payload word of the BLOCKWRITE.
+  Bytes b;
+  WriteTxnHeader(b);
+  size_t bw_off = AppendBlockWrite(b, /*reg=*/0x1D000, /*payload_bytes=*/16);
+  AppendDdrPatch(b, /*regaddr=*/0x1D004, /*argidx=*/0, /*argplus=*/0);
+  auto txn = FinalizeTxn(b, /*num_ops=*/2);
+  auto table = deriveHostPatchTableFromTransaction(txn);
+  ASSERT_EQ(table.size(), 3u);
+  // payload_off = bw_off + 16 (BLOCKWRITE header). The bd base 0x1D000 is at
+  // bw.reg exactly, so the offset into the patch table is payload_off + 0.
+  EXPECT_EQ(table[0], static_cast<uint32_t>(bw_off + 16));
+  EXPECT_EQ(table[1], 0u);  // arg_idx
+  EXPECT_EQ(table[2], 0u);  // arg_plus
+}
+
+TEST(DeriveHostPatchTableTest, WideBlockWriteSpansMultipleBdsAndPatchesMiddle) {
+  // The bug-prone case: a single BLOCKWRITE of 3 BDs (payload 0x60 = 96 bytes,
+  // i.e. 3 × 0x20-stride BDs) at reg 0x1D000. A DDR_PATCH targets the MIDDLE
+  // BD (regaddr 0x1D024 → bd base 0x1D020). The parser must match the
+  // covering BLOCKWRITE by SPAN (reg ≤ bd_base < reg + payload_bytes) and
+  // index into the payload by (bd_base - reg) = 0x20, NOT match the
+  // BLOCKWRITE's exact starting register.
+  Bytes b;
+  WriteTxnHeader(b);
+  size_t bw_off = AppendBlockWrite(b, /*reg=*/0x1D000, /*payload_bytes=*/0x60);
+  AppendDdrPatch(b, /*regaddr=*/0x1D024, /*argidx=*/2, /*argplus=*/0x100);
+  auto txn = FinalizeTxn(b, /*num_ops=*/2);
+  auto table = deriveHostPatchTableFromTransaction(txn);
+  ASSERT_EQ(table.size(), 3u);
+  // Expected offset = payload_off + (bd_base - reg) = (bw_off + 16) + 0x20.
+  EXPECT_EQ(table[0], static_cast<uint32_t>(bw_off + 16 + 0x20));
+  EXPECT_EQ(table[1], 2u);      // arg_idx
+  EXPECT_EQ(table[2], 0x100u);  // arg_plus (cumulative byte offset)
+}
+
+TEST(DeriveHostPatchTableDeathTest, DdrPatchWithNoCoveringBlockWriteIsFatal) {
+  // A DDR_PATCH whose BD base falls outside any BLOCKWRITE's span is a
+  // compiler bug — silently dropping it would leave the BD's shim-DMA address
+  // at zero at runtime (output buffer reads as zeros). The parser must abort
+  // loudly via llvm::report_fatal_error so the bug surfaces at compile time.
+  Bytes b;
+  WriteTxnHeader(b);
+  AppendBlockWrite(b, /*reg=*/0x1D000, /*payload_bytes=*/16);
+  AppendDdrPatch(b, /*regaddr=*/0x1E004, /*argidx=*/0,
+                 /*argplus=*/0);  // 0x1E000 is outside [0x1D000, 0x1D010).
+  auto txn = FinalizeTxn(b, /*num_ops=*/2);
+  EXPECT_DEATH(
+      { (void)deriveHostPatchTableFromTransaction(txn); },
+      "DDR_PATCH op has no covering BLOCKWRITE");
+}
+
+TEST(DeriveHostPatchTableTest,
+     MultipleBlockWritesAndDdrPatchesProduceOrderedTable) {
+  // Two BLOCKWRITEs at distinct register ranges plus three DDR_PATCHes that
+  // target one BD in the first BLOCKWRITE, one in the second, and one in the
+  // first again. The output triples must appear in the order the DDR_PATCH
+  // ops appear in the TXN stream (parser walks ops linearly).
+  Bytes b;
+  WriteTxnHeader(b);
+  size_t bw1 = AppendBlockWrite(b, /*reg=*/0x1D000, /*payload_bytes=*/0x40);
+  size_t bw2 = AppendBlockWrite(b, /*reg=*/0x1D100, /*payload_bytes=*/0x40);
+  AppendDdrPatch(b, /*regaddr=*/0x1D004, /*argidx=*/0, /*argplus=*/0x0);
+  AppendDdrPatch(b, /*regaddr=*/0x1D124, /*argidx=*/1, /*argplus=*/0x20);
+  AppendDdrPatch(b, /*regaddr=*/0x1D024, /*argidx=*/0, /*argplus=*/0x40);
+  auto txn = FinalizeTxn(b, /*num_ops=*/5);
+  auto table = deriveHostPatchTableFromTransaction(txn);
+  ASSERT_EQ(table.size(), 9u);  // three triples
+  // Triple 0: BD 0x1D000 in BLOCKWRITE-1 → bw1 payload + 0x00.
+  EXPECT_EQ(table[0], static_cast<uint32_t>(bw1 + 16));
+  EXPECT_EQ(table[1], 0u);
+  EXPECT_EQ(table[2], 0x0u);
+  // Triple 1: BD 0x1D120 in BLOCKWRITE-2 → bw2 payload + 0x20.
+  EXPECT_EQ(table[3], static_cast<uint32_t>(bw2 + 16 + 0x20));
+  EXPECT_EQ(table[4], 1u);
+  EXPECT_EQ(table[5], 0x20u);
+  // Triple 2: BD 0x1D020 in BLOCKWRITE-1 → bw1 payload + 0x20.
+  EXPECT_EQ(table[6], static_cast<uint32_t>(bw1 + 16 + 0x20));
+  EXPECT_EQ(table[7], 0u);
+  EXPECT_EQ(table[8], 0x40u);
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/CMakeLists.txt
@@ -140,3 +140,13 @@ iree_cc_test(
     gtest
     iree::target::amd-aie::Transforms
 )
+
+iree_cc_test(
+  NAME
+    AMDAIETransactionBuilderTest
+  SRCS
+    "AMDAIETransactionBuilderTest.cpp"
+  DEPS
+    gtest
+    iree::target::amd-aie::Transforms
+)

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/api.h
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/api.h
@@ -15,6 +15,11 @@ struct iree_hal_xrt_lite_device_params {
   int32_t n_core_rows;
   int32_t n_core_cols;
   iree_string_view_t power_mode;
+  // When non-zero, batch each dispatch's commands (control-packet reconfig +
+  // kernel exec) into a single ERT_CMD_CHAIN submitted with one issue/wait,
+  // removing the per-command host round-trip. Default 0 = the proven
+  // per-command ERT_START_CU path.
+  int32_t cmd_chain;
 };
 
 IREE_API_EXPORT void iree_hal_xrt_lite_device_options_initialize(

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/cts/CMakeLists.txt
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/cts/CMakeLists.txt
@@ -117,3 +117,69 @@ iree_cc_test(
 
 target_include_directories(iree-amd-aie_driver_xrt-lite_cts_xrt_lite_executable_cache_test PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 target_include_directories(iree-amd-aie_driver_xrt-lite_cts_xrt_lite_dispatch_test PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
+
+# Cross-executable ERT_CMD_CHAIN test. Compiles a small control-packet matmul at
+# build time (npu4-only, since ERT_CMD_CHAIN is firmware-gated to npu4) and
+# embeds the resulting amdaie-pdi-fb so the test can load it twice as two
+# distinct hal.executable objects.
+iree_bytecode_module(
+  NAME
+    xexec_chain_test_module
+  MODULE_FILE_NAME
+    xexec_chain_test.bin
+  SRC
+    "${CMAKE_CURRENT_LIST_DIR}/xexec_chain_test.mlir"
+  FLAGS
+    --compile-mode=hal-executable
+    --iree-hal-target-backends=amd-aie
+    --iree-amdaie-lower-to-aie-pipeline=objectFifo
+    --iree-amdaie-target-device=npu4
+    --iree-amd-aie-peano-install-dir=${PEANO_INSTALL_DIR}
+    --iree-amd-aie-vitis-install-dir=${VITIS_DIR}
+    --iree-amdaie-device-hal=xrt-lite
+    --iree-amdaie-enable-control-packet=true
+    --iree-amdaie-packet-flow-strategy=auto
+    --iree-amdaie-num-rows=1
+    --iree-amdaie-num-cols=1
+    --iree-amdaie-stack-size=1024
+    --iree-hal-memoization=false
+    --iree-hal-indirect-command-buffers=false
+  PUBLIC
+  TESTONLY
+)
+
+iree_c_embed_data(
+  NAME
+    xexec_chain_executables_c
+  SRCS
+    xexec_chain_test.bin
+  C_FILE_OUTPUT
+    xexec_chain_executables_c.c
+  H_FILE_OUTPUT
+    xexec_chain_executables_c.h
+  IDENTIFIER
+    iree_cts_testdata_executables_xexec_chain
+  STRIP_PREFIX
+    xexec_chain_
+  DEPENDS
+    ::xexec_chain_test_module
+  FLATTEN
+  PUBLIC
+  TESTONLY
+)
+
+iree_cc_test(
+  NAME
+    xexec_chain_test
+  SRCS
+    xexec_chain_test.cc
+  DEPS
+    ::xexec_chain_executables_c
+    iree-amd-aie::driver::xrt-lite::xrt-lite
+    iree::async::util::proactor_pool
+    iree::base
+    iree::base::tooling::flags
+    iree::hal
+    iree::testing::gtest_main
+)
+target_include_directories(iree-amd-aie_driver_xrt-lite_cts_xexec_chain_test PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/cts/xexec_chain_test.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/cts/xexec_chain_test.cc
@@ -1,0 +1,237 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Cross-executable ERT_CMD_CHAIN tests (NPU).
+//
+// Proves that TWO DISTINCT hal.executable objects shipping a byte-identical
+// control-packet bootstrap PDI are (a) resolved to ONE shared hw context by
+// the device PDI cache and (b) batched into ERT_CMD_CHAIN(s) on that shared
+// queue when recorded into a single command buffer with cmd_chain enabled.
+//
+// This case can't be produced from MLIR via the full iree-compile pipeline
+// (the AIE backend co-locates a function's dispatches into one executable with
+// N entry points, only entry 0 carrying the PDI), so the test loads the same
+// control-packet matmul PDI twice as two distinct hal.executable structs.
+// The PDI is compiled at build time from xexec_chain_test.mlir and embedded.
+//
+// The fixture runs the same 2-dispatch scenario; individual tests vary
+// `forced_max_slots` to exercise the default (one fused chain) and chunking
+// (the same dispatches split across multiple chains) paths.
+
+#include <vector>
+
+#include "iree-amd-aie/driver/xrt-lite/api.h"
+#include "iree-amd-aie/driver/xrt-lite/device.h"
+#include "iree-amd-aie/driver/xrt-lite/executable.h"
+#include "iree-amd-aie/driver/xrt-lite/shim/linux/kmq/hwq.h"
+#include "iree/async/util/proactor_pool.h"
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+#include "xexec_chain_executables_c.h"
+
+namespace {
+
+static iree_const_byte_span_t GetTestExecutableData() {
+  const struct iree_file_toc_t* toc =
+      iree_cts_testdata_executables_xexec_chain_create();
+  return iree_make_const_byte_span(toc[0].data, toc[0].size);
+}
+
+static iree_hal_buffer_ref_t BufferRefOf(iree_hal_buffer_t* b, size_t size) {
+  iree_hal_buffer_ref_t r = {};
+  r.buffer = b;
+  r.offset = 0;
+  r.length = size;
+  return r;
+}
+
+// Runs the 2-distinct-executable + 2-dispatch + 1-command-buffer scenario on
+// npu4 with cmd_chain enabled. Verifies output correctness and that the PDI
+// cache returned the SAME hw context for both executables (cross-executable
+// sharing). Returns the EXEC_CMD ioctl count observed on the shared hw queue
+// so each TEST can assert on it.
+//
+// If `forced_max_slots != 0`, sets `device->chain_max_slots` to that value
+// before submission to exercise the chunking path (a single accumulated
+// group is split across multiple ERT_CMD_CHAIN submits when its slot count
+// exceeds the exec BO capacity).
+static uint64_t RunCrossExecChainScenario(uint32_t forced_max_slots) {
+  iree_allocator_t host_allocator = iree_allocator_system();
+
+  struct iree_hal_xrt_lite_driver_options driver_options;
+  iree_hal_xrt_lite_driver_options_initialize(&driver_options);
+  struct iree_hal_xrt_lite_device_params device_params;
+  iree_hal_xrt_lite_device_options_initialize(&device_params);
+  device_params.n_core_rows = 4;
+  device_params.n_core_cols = 1;
+  device_params.cmd_chain = 1;
+  iree_hal_driver_t* driver = nullptr;
+  IREE_EXPECT_OK(
+      iree_hal_xrt_lite_driver_create(IREE_SV("xrt-lite"), &driver_options,
+                                      &device_params, host_allocator, &driver));
+
+  uint32_t node_id = 0;
+  iree_async_proactor_pool_t* proactor_pool = nullptr;
+  IREE_EXPECT_OK(iree_async_proactor_pool_create(
+      /*node_count=*/1, &node_id, iree_async_proactor_pool_options_default(),
+      host_allocator, &proactor_pool));
+  iree_hal_device_create_params_t create_params =
+      iree_hal_device_create_params_default();
+  create_params.proactor_pool = proactor_pool;
+  iree_hal_device_t* device = nullptr;
+  IREE_EXPECT_OK(iree_hal_driver_create_default_device(
+      driver, &create_params, host_allocator, &device));
+  iree_hal_allocator_t* allocator = iree_hal_device_allocator(device);
+
+  // Force a small chain_max_slots to exercise chunking (covers a path that
+  // never trips for realistic dispatch counts on a 4KB exec BO, where the
+  // ceiling is ~506 slots).
+  if (forced_max_slots != 0) {
+    iree_hal_xrt_lite_device* dev_xrt = iree_hal_xrt_lite_device_cast(device);
+    EXPECT_NE(dev_xrt, nullptr);
+    dev_xrt->chain_max_slots = forced_max_slots;
+  }
+
+  iree_hal_executable_cache_t* cache = nullptr;
+  IREE_EXPECT_OK(
+      iree_hal_executable_cache_create(device, IREE_SV("xexec"), &cache));
+  iree_hal_executable_params_t params;
+  iree_hal_executable_params_initialize(&params);
+  params.executable_format = IREE_SV("amdaie-pdi-fb");
+  params.executable_data = GetTestExecutableData();
+  params.caching_mode = 0;
+  iree_hal_executable_t* exe0 = nullptr;
+  iree_hal_executable_t* exe1 = nullptr;
+  IREE_EXPECT_OK(
+      iree_hal_executable_cache_prepare_executable(cache, &params, &exe0));
+  IREE_EXPECT_OK(
+      iree_hal_executable_cache_prepare_executable(cache, &params, &exe1));
+  EXPECT_NE(exe0, exe1);  // distinct hal.executable structs
+
+  // A(8x4) = 2.0, B(4x8) = 3.0  ->  C(8x8) = 24.0 (sum of 4 products of 6.0).
+  constexpr size_t kA = 8 * 4, kB = 4 * 8, kC = 8 * 8;
+  auto alloc_buf = [&](size_t size) {
+    iree_hal_buffer_params_t bp = {};
+    bp.type =
+        IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
+    bp.usage = IREE_HAL_BUFFER_USAGE_DEFAULT | IREE_HAL_BUFFER_USAGE_MAPPING;
+    bp.access = IREE_HAL_MEMORY_ACCESS_ALL;
+    bp.queue_affinity = IREE_HAL_QUEUE_AFFINITY_ANY;
+    iree_hal_buffer_t* out = nullptr;
+    IREE_EXPECT_OK(
+        iree_hal_allocator_allocate_buffer(allocator, bp, size, &out));
+    return out;
+  };
+  iree_hal_buffer_t* A = alloc_buf(kA * sizeof(float));
+  iree_hal_buffer_t* B = alloc_buf(kB * sizeof(float));
+  iree_hal_buffer_t* C0 = alloc_buf(kC * sizeof(float));
+  iree_hal_buffer_t* C1 = alloc_buf(kC * sizeof(float));
+  std::vector<float> hA(kA, 2.0f), hB(kB, 3.0f);
+  IREE_EXPECT_OK(
+      iree_hal_buffer_map_write(A, 0, hA.data(), hA.size() * sizeof(float)));
+  IREE_EXPECT_OK(
+      iree_hal_buffer_map_write(B, 0, hB.data(), hB.size() * sizeof(float)));
+
+  iree_hal_command_buffer_t* cb = nullptr;
+  IREE_EXPECT_OK(iree_hal_command_buffer_create(
+      device, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT,
+      IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,
+      /*binding_capacity=*/0, &cb));
+  IREE_EXPECT_OK(iree_hal_command_buffer_begin(cb));
+  iree_hal_dispatch_config_t config = {};
+  config.workgroup_count[0] = 1;
+  config.workgroup_count[1] = 1;
+  config.workgroup_count[2] = 1;
+  iree_hal_buffer_ref_t binds0[3] = {BufferRefOf(A, kA * sizeof(float)),
+                                     BufferRefOf(B, kB * sizeof(float)),
+                                     BufferRefOf(C0, kC * sizeof(float))};
+  iree_hal_buffer_ref_t binds1[3] = {BufferRefOf(A, kA * sizeof(float)),
+                                     BufferRefOf(B, kB * sizeof(float)),
+                                     BufferRefOf(C1, kC * sizeof(float))};
+  iree_hal_buffer_ref_list_t list0 = {3, binds0};
+  iree_hal_buffer_ref_list_t list1 = {3, binds1};
+  IREE_EXPECT_OK(iree_hal_command_buffer_dispatch(
+      cb, exe0, /*ordinal=*/0, config, iree_const_byte_span_empty(), list0,
+      IREE_HAL_DISPATCH_FLAG_NONE));
+  IREE_EXPECT_OK(iree_hal_command_buffer_dispatch(
+      cb, exe1, /*ordinal=*/0, config, iree_const_byte_span_empty(), list1,
+      IREE_HAL_DISPATCH_FLAG_NONE));
+  IREE_EXPECT_OK(iree_hal_command_buffer_end(cb));
+
+  iree_hal_semaphore_t* sem = nullptr;
+  IREE_EXPECT_OK(iree_hal_semaphore_create(device, IREE_HAL_QUEUE_AFFINITY_ANY,
+                                           0, IREE_HAL_SEMAPHORE_FLAG_NONE,
+                                           &sem));
+  uint64_t signal_value = 1;
+  iree_hal_semaphore_list_t wait_list = iree_hal_semaphore_list_empty();
+  iree_hal_semaphore_list_t signal_list = {1, &sem, &signal_value};
+  iree_hal_buffer_binding_table_t empty_table = {};
+  IREE_EXPECT_OK(iree_hal_device_queue_execute(
+      device, IREE_HAL_QUEUE_AFFINITY_ANY, wait_list, signal_list, cb,
+      empty_table, IREE_HAL_EXECUTE_FLAG_NONE));
+  IREE_EXPECT_OK(iree_hal_semaphore_wait(sem, 1, iree_infinite_timeout(),
+                                         IREE_ASYNC_WAIT_FLAG_NONE));
+
+  // Cross-executable sharing check: the two distinct executables must have
+  // been resolved to the SAME shared hw context by the PDI cache (PDIs are
+  // byte-identical, so a HIT for exe1 returns exe0's cached context).
+  iree_hal_xrt_lite_executable* exe0_xrt =
+      iree_hal_xrt_lite_executable_cast(exe0);
+  iree_hal_xrt_lite_executable* exe1_xrt =
+      iree_hal_xrt_lite_executable_cast(exe1);
+  EXPECT_EQ(exe0_xrt->context.get(), exe1_xrt->context.get());
+
+  // Both dispatches must have run on the (shared) array and produced 24.0.
+  for (iree_hal_buffer_t* out : {C0, C1}) {
+    std::vector<float> got(kC, 0.0f);
+    IREE_EXPECT_OK(iree_hal_buffer_map_read(out, 0, got.data(),
+                                            got.size() * sizeof(float)));
+    for (size_t i = 0; i < kC; ++i) {
+      EXPECT_FLOAT_EQ(got[i], 24.0f)
+          << "out[" << (out == C0 ? 0 : 1) << "][" << i << "]";
+    }
+  }
+
+  // Snapshot the count BEFORE we tear anything down (the hw_q is owned by the
+  // shared context which gets released when the device drops it below).
+  uint64_t exec_cmd_count = exe0_xrt->context->get_hw_queue()->exec_cmd_count();
+
+  iree_hal_semaphore_release(sem);
+  iree_hal_buffer_release(C1);
+  iree_hal_buffer_release(C0);
+  iree_hal_buffer_release(B);
+  iree_hal_buffer_release(A);
+  iree_hal_executable_release(exe1);
+  iree_hal_executable_release(exe0);
+  iree_hal_executable_cache_release(cache);
+  iree_hal_command_buffer_release(cb);
+  iree_hal_device_release(device);
+  iree_hal_driver_release(driver);
+  iree_async_proactor_pool_release(proactor_pool);
+
+  return exec_cmd_count;
+}
+
+// Default chain_max_slots (lazy-computed, ~506 on a 4KB exec BO) easily fits
+// the 4 accumulated slots (two dispatches × [reconfig, exec]) into one chain.
+TEST(XrtLiteCrossExecChain, TwoExecutablesOneCmdChain) {
+  uint64_t exec_cmd_count = RunCrossExecChainScenario(/*forced_max_slots=*/0);
+  EXPECT_EQ(exec_cmd_count, 1u);
+}
+
+// Force chain_max_slots = 2 to exercise the chunking path. The same 4 slots
+// must now split into two chains of 2 slots each — two EXEC_CMD ioctls
+// submitted in recorded order on the shared hw queue, with the device's
+// in-order completion preserving the original semantics.
+TEST(XrtLiteCrossExecChain, ChunkingSplitsLargeChainIntoMultipleSubmits) {
+  uint64_t exec_cmd_count = RunCrossExecChainScenario(/*forced_max_slots=*/2);
+  // 2 dispatches × (reconfig + exec) = 4 slots; max_slots = 2 → 2 chunks.
+  EXPECT_EQ(exec_cmd_count, 2u);
+}
+
+}  // namespace

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/cts/xexec_chain_test.mlir
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/cts/xexec_chain_test.mlir
@@ -1,0 +1,41 @@
+// Control-packet matmul executable used by xexec_chain_test.cc to exercise the
+// cross-executable ERT_CMD_CHAIN path. Shape: 8x4 (f32) @ 4x8 -> 8x8.
+// Compiled with --iree-amdaie-enable-control-packet=true so the produced PDI is
+// the byte-identical "bootstrap" the device PDI cache keys on.
+
+#pipeline_layout = #hal.pipeline.layout<
+  bindings = [
+    #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+    #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">,
+    #hal.pipeline.binding<storage_buffer, Indirect>
+  ],
+  flags = Indirect
+>
+!t_lhs = tensor<8x4xf32>
+!fdt_lhs = !iree_tensor_ext.dispatch.tensor<readonly:tensor<8x4xf32>>
+!t_rhs = tensor<4x8xf32>
+!fdt_rhs = !iree_tensor_ext.dispatch.tensor<readonly:tensor<4x8xf32>>
+!t_res = tensor<8x8xf32>
+!fdt_res = !iree_tensor_ext.dispatch.tensor<writeonly:tensor<8x8xf32>>
+hal.executable.source public @amdaie_fb {
+  hal.executable.export public @mm_8x4_4x8_f32 ordinal(0) layout(#pipeline_layout) count(%arg0: !hal.device) -> (index, index, index) {
+    %x, %y, %z = iree_tensor_ext.dispatch.workgroup_count_from_slice()
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @mm_8x4_4x8_f32() {
+      %c0_f32 = arith.constant 0.0 : f32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !fdt_lhs
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : !fdt_rhs
+      %2 = hal.interface.binding.subspan layout(#pipeline_layout) binding(2) alignment(64) offset(%c0) flags(Indirect) : !fdt_res
+      %3 = iree_tensor_ext.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 4], strides = [1, 1] : !fdt_lhs -> !t_lhs
+      %4 = iree_tensor_ext.dispatch.tensor.load %1, offsets = [0, 0], sizes = [4, 8], strides = [1, 1] : !fdt_rhs -> !t_rhs
+      %5 = tensor.empty() : !t_res
+      %6 = linalg.fill ins(%c0_f32 : f32) outs(%5 : !t_res) -> !t_res
+      %7 = linalg.matmul ins(%3, %4 : !t_lhs, !t_rhs) outs(%6 : !t_res) -> !t_res
+      iree_tensor_ext.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [8, 8], strides = [1, 1] : !t_res -> !fdt_res
+      return
+    }
+  }
+}

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/device.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/device.cc
@@ -54,6 +54,7 @@ iree_hal_xrt_lite_device::iree_hal_xrt_lite_device(
   iree_hal_resource_initialize(&iree_hal_xrt_lite_device_vtable, &resource);
   this->host_allocator = host_allocator;
   this->power_mode = options->power_mode;
+  this->cmd_chain = options->cmd_chain != 0;
   if (iree_string_view_equal(power_mode, IREE_SV("default"))) {
     shim_device = new shim_xdna::device(
         options->n_core_rows, options->n_core_cols, POWER_MODE_DEFAULT);
@@ -662,11 +663,54 @@ static void iree_hal_xrt_lite_device_destroy(iree_hal_device_t* base_device) {
       !iree_string_view_equal(device->power_mode, IREE_SV("default"))) {
     device->shim_device->set_power_mode(POWER_MODE_DEFAULT);
   }
+  // Drop the cache's shared_ptr<hw_ctx> refs before the shim device they
+  // reference is torn down. Per the IREE HAL lifetime contract, executables
+  // (which co-own these via executable->context) are released before their
+  // device, so by the time we get here the cache holds the last refs and
+  // clear() runs the hw_ctx destructors (delete-context ioctls) cleanly.
+  // Lock defensively against the contract being violated (zero cost
+  // uncontended) and so a future audit can't ask "is this clear racy?"
+  {
+    std::lock_guard<std::mutex> lock(device->pdi_context_cache_mutex);
+    device->pdi_context_cache.clear();
+  }
   delete device->shim_device;
-  iree_allocator_free(device->host_allocator, device);
+  // The device struct is placement-new'd in iree_hal_xrt_lite_device_create;
+  // explicitly run the destructor before freeing the storage so non-trivial
+  // members (e.g. the std::map cache, even after clear()) release their
+  // internal bookkeeping cleanly. Save host_allocator first — accessing
+  // `device->` after the destructor is UB.
+  iree_allocator_t host_allocator = device->host_allocator;
+  device->~iree_hal_xrt_lite_device();
+  iree_allocator_free(host_allocator, device);
 
   IREE_TRACE_ZONE_END(z0);
 };
+
+std::shared_ptr<shim_xdna::hw_ctx>
+iree_hal_xrt_lite_device_get_or_create_context(iree_hal_xrt_lite_device* device,
+                                               const std::vector<uint8_t>& pdi,
+                                               const std::string& kernel_name) {
+  // Callers must only pass a non-empty PDI (empty-PDI entry points reuse their
+  // executable's already-resolved context instead of querying the cache).
+  // Lock is held across create_hw_context so two threads racing on the same
+  // (or different) PDI serialize on the cache; concurrent misses on different
+  // PDIs are rare enough that finer-grained locking isn't worth the
+  // complexity.
+  std::lock_guard<std::mutex> lock(device->pdi_context_cache_mutex);
+  auto it = device->pdi_context_cache.find(pdi);
+  if (it != device->pdi_context_cache.end()) return it->second;
+  std::shared_ptr<shim_xdna::hw_ctx> ctx(
+      device->shim_device->create_hw_context(pdi, kernel_name).release());
+  device->pdi_context_cache.emplace(pdi, ctx);
+  return ctx;
+}
+
+iree_hal_xrt_lite_device* iree_hal_xrt_lite_device_cast(
+    iree_hal_device_t* base_device) {
+  return IREE_HAL_XRT_LITE_CHECKED_VTABLE_CAST(
+      base_device, iree_hal_xrt_lite_device_vtable, iree_hal_xrt_lite_device);
+}
 
 static iree_allocator_t iree_hal_xrt_lite_device_host_allocator(
     iree_hal_device_t* base_device) {

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/device.h
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/device.h
@@ -7,9 +7,18 @@
 #ifndef IREE_AMD_AIE_DRIVER_XRT_LITE_XRT_LITE_DEVICE_H_
 #define IREE_AMD_AIE_DRIVER_XRT_LITE_XRT_LITE_DEVICE_H_
 
+#include <atomic>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
 #include "iree-amd-aie/driver/xrt-lite/api.h"
 #include "iree-amd-aie/driver/xrt-lite/async_queue.h"
 #include "iree-amd-aie/driver/xrt-lite/shim/linux/kmq/device.h"
+#include "iree-amd-aie/driver/xrt-lite/shim/linux/kmq/hwctx.h"
 #include "iree/base/internal/arena.h"
 #include "iree/hal/api.h"
 
@@ -54,6 +63,38 @@ struct iree_hal_xrt_lite_device {
   iree_async_axis_t frontier_axis;
 
   shim_xdna::device* shim_device;
+  // When true, dispatches are submitted as a single ERT_CMD_CHAIN instead of
+  // per-command issue/wait (see iree_hal_xrt_lite_device_params::cmd_chain).
+  bool cmd_chain;
+  // Hardware-context cache keyed by PDI bytes, for control-packet designs.
+  // Control-packet designs deliver the array configuration via control packets
+  // each dispatch and ship a byte-identical "bootstrap" PDI, so executables
+  // with the same PDI can share one hw_ctx (and its queue). Sharing loads the
+  // PDI once and lets dispatches from different executables run on a single
+  // queue, the prerequisite for batching them into one cross-executable
+  // ERT_CMD_CHAIN. Keyed by PDI bytes (a byte-identical PDI provably configures
+  // the same partition/CU). Only PDI-carrying entry points populate this;
+  // empty-PDI entry points reuse their executable's resolved context. shared
+  // with iree_hal_xrt_lite_executable::context — destruction at the last
+  // refcount (device destroy clears the cache; any outliving executables drop
+  // their refs first per IREE's lifetime contract).
+  std::map<std::vector<uint8_t>, std::shared_ptr<shim_xdna::hw_ctx>>
+      pdi_context_cache;
+  // Protects pdi_context_cache reads/writes. Today the async queue replays
+  // command buffers from a single worker so the cache sees no contention,
+  // but a multi-worker submission path (which a complete HAL would have to
+  // exploit the driver's depth-4 in-flight cap) would race on find/emplace.
+  // Cheap uncontended; cheap correctness-by-construction.
+  std::mutex pdi_context_cache_mutex;
+  // Maximum slots that fit in one ERT_CMD_CHAIN exec BO (constant per device).
+  // Lazily computed on first flush; the chain flush splits into this many
+  // slots per submitted chain. Atomic because a multi-worker submission path
+  // (which a complete HAL would have, to exploit the driver's depth-4
+  // in-flight cap) could race two first-time probes; the probe is idempotent
+  // (returns the same value every call on a given device) so double-probe is
+  // safe, but we still need atomic load/store to avoid torn reads on the
+  // 0 → max sentinel transition.
+  std::atomic<uint32_t> chain_max_slots{0};
   // should come last; see the definition of total_size below in
   // iree_hal_xrt_lite_device_create
   iree_string_view_t identifier;
@@ -62,5 +103,23 @@ struct iree_hal_xrt_lite_device {
   iree_hal_xrt_lite_device(const iree_hal_xrt_lite_device_params* options,
                            iree_allocator_t host_allocator);
 };
+
+// Casts an opaque iree_hal_device_t* to the xrt-lite implementation type.
+// Verifies the vtable; returns nullptr on a foreign device. Exposed for tests
+// that need to poke implementation-internal state (e.g. force chain_max_slots
+// to a small value to exercise the chunking code path).
+iree_hal_xrt_lite_device* iree_hal_xrt_lite_device_cast(
+    iree_hal_device_t* base_device);
+
+// Returns a shared hw_ctx for the (non-empty) control-packet bootstrap `pdi`,
+// creating and caching it on first use. Control-packet reconfiguration re-arms
+// the array each dispatch, so the context is safely reusable and shareable
+// across executables that ship a byte-identical PDI. The shared_ptr is held by
+// the device cache and the caller (e.g. executable->context); the context is
+// destroyed when the last reference drops (typically device teardown).
+std::shared_ptr<shim_xdna::hw_ctx>
+iree_hal_xrt_lite_device_get_or_create_context(iree_hal_xrt_lite_device* device,
+                                               const std::vector<uint8_t>& pdi,
+                                               const std::string& kernel_name);
 
 #endif  // IREE_AMD_AIE_DRIVER_XRT_LITE_XRT_LITE_DEVICE_H_

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/direct_command_buffer.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/direct_command_buffer.cc
@@ -6,12 +6,45 @@
 
 #include "iree-amd-aie/driver/xrt-lite/direct_command_buffer.h"
 
+#include <algorithm>
+#include <memory>
+#include <vector>
+
 #include "iree-amd-aie/driver/xrt-lite/buffer.h"
 #include "iree-amd-aie/driver/xrt-lite/executable.h"
 #include "iree-amd-aie/driver/xrt-lite/shim/linux/kmq/hwq.h"
 #include "iree-amd-aie/driver/xrt-lite/shim/linux/kmq/kernel.h"
 #include "iree-amd-aie/driver/xrt-lite/util.h"
 #include "iree/hal/utils/resource_set.h"
+
+// One chainable command: a host-patched control-code BO + its ERT_START_NPU
+// exec-buffer. Kept alive (BOs + kernel) until the chain completes.
+struct iree_hal_xrt_lite_chain_cmd {
+  std::unique_ptr<shim_xdna::bo> ctrl_code;
+  std::unique_ptr<shim_xdna::kernel> kernel;
+};
+
+// A contiguous run of dispatches that share one hw queue. Flushed as one
+// ERT_CMD_CHAIN (split into multiple chains only if the slot count exceeds the
+// exec buffer). A chain runs on a single hwctx, so a hw-queue change between
+// dispatches starts a new group.
+struct iree_hal_xrt_lite_chain_group {
+  shim_xdna::hw_q* hwq = nullptr;
+  std::vector<iree_hal_xrt_lite_chain_cmd> cmds;
+  // Control-packet sequence BOs (reconfig arg buffers): referenced by address
+  // from the slots, kept alive + bound for residency until the chain completes.
+  std::vector<std::unique_ptr<shim_xdna::bo>> reconf_bos;
+  // I/O binding BOs: bound for residency and synced device->host after the
+  // chain completes.
+  std::vector<shim_xdna::bo*> binding_bos;
+};
+
+// Accumulates ERT_CMD_CHAIN sub-commands across dispatches so a whole command
+// buffer flushes as one chain per hw queue. Embedded in the command buffer
+// (always default-constructed; stays empty when cmd_chain is off).
+struct iree_hal_xrt_lite_chain_accum {
+  std::vector<iree_hal_xrt_lite_chain_group> groups;
+};
 
 struct iree_hal_xrt_lite_direct_command_buffer {
   iree_hal_command_buffer_t base;
@@ -23,6 +56,10 @@ struct iree_hal_xrt_lite_direct_command_buffer {
   iree_arena_allocator_t arena;
 
   iree_hal_xrt_lite_device* device;
+
+  // Cmd_chain mode: dispatches accumulate sub-commands here and end() flushes
+  // them as ERT_CMD_CHAIN(s). Stays empty when cmd_chain is off.
+  iree_hal_xrt_lite_chain_accum chain_accum;
 };
 
 namespace {
@@ -44,6 +81,17 @@ iree_status_t iree_hal_xrt_lite_direct_command_buffer_create(
     return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
                             "indirect command buffers not yet implemented");
   }
+  // The xrt-lite CB has no replayable state: begin/end are not implemented as
+  // resets, and (in cmd_chain mode) chain_accum is finalized by end(). A
+  // non-ONE_SHOT CB would carry that state across replays. Require ONE_SHOT to
+  // match the only mode IREE creates through us today (queue_execute passes
+  // ONE_SHOT | ALLOW_INLINE_EXECUTION | UNVALIDATED) and to fail loudly if a
+  // future caller hands us a reusable CB.
+  if (!iree_all_bits_set(mode, IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT)) {
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                            "xrt-lite command buffers require "
+                            "IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT");
+  }
 
   IREE_TRACE_ZONE_BEGIN(z0);
 
@@ -55,6 +103,11 @@ iree_status_t iree_hal_xrt_lite_direct_command_buffer_create(
                                 iree_hal_command_buffer_validation_state_size(
                                     mode, binding_capacity),
                             reinterpret_cast<void**>(&command_buffer)));
+  // The struct holds non-trivial members (chain_accum with std::vectors);
+  // placement-new it so default constructors run, paired with an explicit
+  // destructor call in destroy. iree_hal_command_buffer_initialize fills the
+  // base resource header next, then the rest is set procedurally below.
+  new (command_buffer) iree_hal_xrt_lite_direct_command_buffer();
   iree_hal_command_buffer_initialize(
       device->device_allocator, mode, command_categories,
       IREE_HAL_QUEUE_AFFINITY_ANY, binding_capacity,
@@ -90,6 +143,9 @@ static void iree_hal_xrt_lite_direct_command_buffer_destroy(
   iree_allocator_t host_allocator = command_buffer->host_allocator;
   iree_hal_resource_set_free(command_buffer->resource_set);
   iree_arena_deinitialize(&command_buffer->arena);
+  // Run the destructor that pairs with the placement-new in create (releases
+  // chain_accum's vector allocations + sub-command BOs).
+  command_buffer->~iree_hal_xrt_lite_direct_command_buffer();
   iree_allocator_free(host_allocator, command_buffer);
 
   IREE_TRACE_ZONE_END(z0);
@@ -170,6 +226,330 @@ static iree_status_t iree_hal_xrt_lite_direct_command_buffer_copy_buffer(
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
+}
+
+// ===========================================================================
+// ERT_CMD_CHAIN support (opt-in via the `xrt_lite_cmd_chain` device option /
+// `--xrt_lite_cmd_chain=1` flag; see api.h iree_hal_xrt_lite_device_params).
+//
+// Batches the dispatch's commands (control-packet reconfig + kernel exec) into
+// a single ERT_CMD_CHAIN submitted with one issue/wait, removing the
+// per-command host round-trip. Each slot is submitted as ERT_START_NPU
+// (PARTIAL_ELF) with arg[0]=AIE2_EXEC_BUFFER_KERNEL_OP_TXN so the firmware runs
+// the same XAie TXN control code as the default ERT_START_CU path; the I/O
+// addresses that the CU path lets the firmware patch are instead host-patched
+// into the control-code BD registers here (the chainable path carries no
+// per-slot patch args). The default (env unset) ERT_START_CU path is unchanged.
+// ===========================================================================
+namespace {
+// TXN-interpreter selector: tells the firmware to interpret the instruction
+// buffer as an XAie transaction (same value the default ERT_START_CU path
+// passes as its opcode arg).
+constexpr uint32_t kAie2ExecBufferKernelOpTxn = 3;
+// AIE-side aperture base added to every shim-DMA buffer address. Validated for
+// npu4 / AIE2P_STRIX_B0 (the only target the chained path is enabled for);
+// other AIE generations may use a different offset / BD address layout.
+constexpr uint64_t kDdrAieAddrOffset = 0x80000000ULL;
+
+// Apply the compiler-emitted host patch table to a copy of the control code.
+// `patches` is a flat list of (offset, arg_idx, arg_plus) triples (produced by
+// the compiler — see
+// AMDAIETransactionBuilder::deriveHostPatchTableFromTransaction). For each
+// triple this writes the 48-bit shim-DMA address `args[arg_idx] + arg_plus +
+// aperture` into the buffer-descriptor address words at byte `offset`: word
+// bd[1] (low 32) and the low 16 bits of bd[2] (high). The HAL does NOT parse
+// the transaction stream — all XAie-format knowledge stays in the compiler; the
+// only hardware fact here is the BD address split (a DMA-address ABI).
+//
+// Returns false on any malformed/out-of-bounds table entry (compiler-generated,
+// so this is a hard error rather than a recoverable condition).
+bool iree_hal_xrt_lite_apply_patch_table(uint32_t* ctrl_code, size_t ctrl_words,
+                                         const std::vector<uint32_t>& patches,
+                                         const uint64_t* args,
+                                         size_t arg_count) {
+  if (patches.size() % 3 != 0) return false;
+  uint8_t* b = reinterpret_cast<uint8_t*>(ctrl_code);
+  size_t total = ctrl_words * sizeof(uint32_t);
+  for (size_t i = 0; i < patches.size(); i += 3) {
+    uint32_t offset = patches[i];        // byte offset of the BD base word
+    uint32_t arg_idx = patches[i + 1];   // index into `args`
+    uint32_t arg_plus = patches[i + 2];  // byte addend into that buffer
+    if (arg_idx >= arg_count) return false;
+    // We touch bd[1] at offset+4 and bd[2] at offset+8 (4 bytes each).
+    if (static_cast<size_t>(offset) + 12 > total || (offset & 0x3u) != 0) {
+      return false;
+    }
+    uint32_t* bd = reinterpret_cast<uint32_t*>(b + offset);
+    uint64_t base = (static_cast<uint64_t>(bd[2] & 0xFFFF) << 32) | bd[1];
+    base += args[arg_idx] + arg_plus + kDdrAieAddrOffset;
+    bd[1] = static_cast<uint32_t>(base & 0xFFFFFFFC);
+    bd[2] = (bd[2] & 0xFFFF0000) | static_cast<uint32_t>(base >> 32);
+  }
+  return true;
+}
+
+iree_status_t iree_hal_xrt_lite_make_npu_cmd(
+    iree_hal_xrt_lite_direct_command_buffer* command_buffer,
+    shim_xdna::cuidx_t cu_idx, std::vector<uint32_t>& txn,
+    const std::vector<uint32_t>& patches, const uint64_t* args,
+    size_t arg_count, iree_hal_xrt_lite_chain_cmd* out_cmd) {
+  size_t bytes = txn.size() * sizeof(uint32_t);
+  out_cmd->ctrl_code = command_buffer->device->shim_device->alloc_bo(
+      bytes, XCL_BO_FLAGS_CACHEABLE);
+  uint32_t* dst = static_cast<uint32_t*>(out_cmd->ctrl_code->map());
+  memcpy(dst, txn.data(), bytes);
+  if (!iree_hal_xrt_lite_apply_patch_table(dst, txn.size(), patches, args,
+                                           arg_count)) {
+    return iree_make_status(
+        IREE_STATUS_INTERNAL,
+        "xrt-lite cmd-chain: invalid host patch table for control code");
+  }
+  out_cmd->ctrl_code->sync(shim_xdna::direction::host2device);
+  out_cmd->kernel = std::make_unique<shim_xdna::kernel>(
+      command_buffer->device->shim_device->get_pdev(), ERT_START_NPU);
+  out_cmd->kernel->set_cu_idx(cu_idx);
+  out_cmd->kernel->add_ctrl_bo(*out_cmd->ctrl_code);
+  out_cmd->kernel->add_arg_32(kAie2ExecBufferKernelOpTxn);
+  return iree_ok_status();
+}
+}  // namespace
+
+// Accumulate one dispatch's reconfig+exec sub-commands into the command
+// buffer's chain accumulator (cmd_chain mode). Does NOT submit; the whole
+// command buffer is flushed as one chain per hw queue by flush_chains() at
+// end(). Dispatches that share a hw queue (e.g. all entry points of one
+// control-packet executable, or separate executables resolved to the same
+// shared context) accumulate into one group and thus one chain.
+static iree_status_t iree_hal_xrt_lite_direct_command_buffer_accumulate_chained(
+    iree_hal_buffer_ref_list_t& bindings,
+    iree_hal_xrt_lite_direct_command_buffer* command_buffer,
+    shim_xdna::hw_q* hwq, shim_xdna::cuidx_t cu_idx,
+    iree_hal_xrt_lite_kernel_params& kernel_params) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // The chained path host-patches I/O addresses using the compiler-emitted
+  // patch table (parallel to asm_inst_runlist). Require it: an executable
+  // compiled before the patch table existed cannot use cmd-chain.
+  if (kernel_params.patch_runlist.size() !=
+      kernel_params.asm_inst_runlist.size()) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "xrt-lite cmd-chain requires a host patch table in the executable "
+        "(have %zu patch lists for %zu control codes); recompile with a "
+        "patch-table-aware compiler",
+        kernel_params.patch_runlist.size(),
+        kernel_params.asm_inst_runlist.size());
+  }
+
+  // Binding device addresses (exec args). For control packets the reconfig arg
+  // is the per-reconfiguration data buffer (built below).
+  std::vector<uint64_t> binding_addrs(bindings.count);
+  for (iree_host_size_t j = 0; j < bindings.count; ++j) {
+    shim_xdna::bo* bo = iree_hal_xrt_lite_buffer_handle(
+        iree_hal_buffer_allocated_buffer(bindings.values[j].buffer));
+    binding_addrs[j] = bo->get_paddr();
+  }
+
+  // Append to the current group, opening a new one when the hw queue changes
+  // (a chain runs on a single hwctx/queue).
+  auto& groups = command_buffer->chain_accum.groups;
+  if (groups.empty() || groups.back().hwq != hwq) {
+    groups.emplace_back();
+    groups.back().hwq = hwq;
+  }
+  iree_hal_xrt_lite_chain_group& group = groups.back();
+
+  // `run_idx` indexes both asm_inst_runlist and the parallel patch_runlist.
+  auto emit = [&](size_t run_idx, const uint64_t* args,
+                  size_t arg_count) -> iree_status_t {
+    iree_hal_xrt_lite_chain_cmd cmd;
+    IREE_RETURN_IF_ERROR(iree_hal_xrt_lite_make_npu_cmd(
+        command_buffer, cu_idx, kernel_params.asm_inst_runlist[run_idx],
+        kernel_params.patch_runlist[run_idx], args, arg_count, &cmd));
+    group.cmds.push_back(std::move(cmd));
+    return iree_ok_status();
+  };
+
+  // Mirror the per-command repeat counts of the default (non-chain) path so the
+  // chain is semantically identical: `n_reconfigure_runs` reconfig slots and
+  // `n_kernel_runs` exec slots (both default to 1).
+  size_t num_reconfigurations = kernel_params.reconf_data_runlist.size();
+  if (num_reconfigurations == 0) {
+    for (uint32_t r = 0; r < kernel_params.n_kernel_runs; r++) {
+      IREE_RETURN_AND_END_ZONE_IF_ERROR(
+          z0, emit(/*run_idx=*/0, binding_addrs.data(), bindings.count));
+    }
+  } else {
+    for (size_t i = 0; i < num_reconfigurations; i++) {
+      // Control-packet data buffer for this reconfiguration (reconfig arg[0]).
+      std::vector<uint32_t>& seq = kernel_params.reconf_data_runlist[i];
+      size_t seq_bytes = seq.size() * sizeof(uint32_t);
+      auto seq_bo = command_buffer->device->shim_device->alloc_bo(
+          seq_bytes, XRT_BO_FLAGS_HOST_ONLY);
+      memcpy(seq_bo->map(), seq.data(), seq_bytes);
+      seq_bo->sync(shim_xdna::direction::host2device);
+      uint64_t reconf_arg = seq_bo->get_paddr();
+      group.reconf_bos.push_back(std::move(seq_bo));
+      for (uint32_t r = 0; r < kernel_params.n_reconfigure_runs; r++) {
+        IREE_RETURN_AND_END_ZONE_IF_ERROR(
+            z0, emit(/*run_idx=*/2 * i, &reconf_arg, /*arg_count=*/1));
+      }
+      for (uint32_t r = 0; r < kernel_params.n_kernel_runs; r++) {
+        IREE_RETURN_AND_END_ZONE_IF_ERROR(
+            z0,
+            emit(/*run_idx=*/2 * i + 1, binding_addrs.data(), bindings.count));
+      }
+    }
+  }
+
+  // Track I/O binding BOs for residency + final device->host sync at flush.
+  for (iree_host_size_t j = 0; j < bindings.count; ++j) {
+    group.binding_bos.push_back(iree_hal_xrt_lite_buffer_handle(
+        iree_hal_buffer_allocated_buffer(bindings.values[j].buffer)));
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+// Submit a contiguous span [begin, end) of a group's sub-commands as one
+// ERT_CMD_CHAIN on `hwq`, binding the group's referenced BOs for residency.
+static iree_status_t iree_hal_xrt_lite_submit_chain(
+    shim_xdna::device* shim_device, shim_xdna::hw_q* hwq,
+    iree_hal_xrt_lite_chain_group& group, size_t begin, size_t end) {
+  size_t n = end - begin;
+  shim_xdna::kernel chain(shim_device->get_pdev(), ERT_CMD_CHAIN);
+  shim_xdna::bo* chain_bo = chain.get_exec_buf_bo();
+  ert_packet* cp = reinterpret_cast<ert_packet*>(chain_bo->map());
+  // Bound the chain against the fixed-size exec BO before writing into it (the
+  // chain path bypasses kernel::inc_pkt_count's overflow guard).
+  size_t chain_bytes = offsetof(ert_packet, data) + sizeof(ert_cmd_chain_data) +
+                       n * sizeof(uint64_t);
+  if (chain_bytes > chain_bo->size()) {
+    return iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED,
+                            "xrt-lite cmd-chain: %zu slots exceed exec buffer "
+                            "(%zu > %zu bytes)",
+                            n, chain_bytes, chain_bo->size());
+  }
+  cp->state = ERT_CMD_STATE_NEW;
+  cp->opcode = ERT_CMD_CHAIN;
+  ert_cmd_chain_data* cd = reinterpret_cast<ert_cmd_chain_data*>(cp->data);
+  cd->command_count = static_cast<uint32_t>(n);
+  cd->submit_index = 0;
+  cd->error_index = 0;
+  for (size_t i = 0; i < n; i++) {
+    cd->data[i] =
+        group.cmds[begin + i].kernel->get_exec_buf_bo()->get_drm_bo_handle();
+  }
+  cp->count =
+      (sizeof(ert_cmd_chain_data) + n * sizeof(uint64_t)) / sizeof(uint32_t);
+
+  // Register every BO the firmware dereferences (control code + control-packet
+  // data + I/O bindings) as arg BOs on the submitted chain so the driver keeps
+  // them resident; the sub-command slots reference them only by address. (The
+  // driver de-duplicates repeated handles, so binding the whole group's BOs on
+  // each chunk is a harmless residency superset.)
+  //
+  // The shim caps EXEC_CMD's arg-BO count at hwq.cpp::max_arg_bos (1024); a
+  // chain at that ceiling would overflow the kernel-side ioctl buffer. Refuse
+  // up front rather than scribble. Per-chunk worst case = n ctrl_code BOs +
+  // group.reconf_bos.size() + group.binding_bos.size() (post-dedup the driver
+  // sees fewer, but we count the pre-dedup total since bind_at indexes by it).
+  constexpr size_t kArgBoCeiling = 1024;
+  size_t arg_total = n + group.reconf_bos.size() + group.binding_bos.size();
+  if (arg_total > kArgBoCeiling) {
+    return iree_make_status(
+        IREE_STATUS_RESOURCE_EXHAUSTED,
+        "xrt-lite cmd-chain: %zu arg BOs exceeds shim ceiling %zu (chunk "
+        "groups or reduce binding count)",
+        arg_total, kArgBoCeiling);
+  }
+  size_t arg_pos = 0;
+  for (size_t i = begin; i < end; i++) {
+    chain_bo->bind_at(arg_pos++, *group.cmds[i].ctrl_code, 0,
+                      group.cmds[i].ctrl_code->size());
+  }
+  for (std::unique_ptr<shim_xdna::bo>& seq_bo : group.reconf_bos) {
+    chain_bo->bind_at(arg_pos++, *seq_bo, 0, seq_bo->size());
+  }
+  for (shim_xdna::bo* bo : group.binding_bos) {
+    chain_bo->bind_at(arg_pos++, *bo, 0, bo->size());
+  }
+
+  hwq->issue_command(chain_bo);
+  hwq->wait_command(chain_bo, 0);
+
+  // Fail loudly if the chain did not complete (firmware reject / timeout)
+  // rather than silently returning stale buffer contents.
+  if (cp->state != ERT_CMD_STATE_COMPLETED) {
+    return iree_make_status(
+        IREE_STATUS_INTERNAL,
+        "xrt-lite ERT_CMD_CHAIN of %zu slots did not complete: ert state %u "
+        "(error_index %u, submit_index %u)",
+        n, cp->state, cd->error_index, cd->submit_index);
+  }
+  return iree_ok_status();
+}
+
+// Flush all accumulated chain groups (cmd_chain mode). Each group becomes one
+// ERT_CMD_CHAIN on its hw queue (chunked if the slot count exceeds the exec
+// buffer), submitted in recorded order so producer/consumer dependencies across
+// groups are honored by the device's in-order completion.
+static iree_status_t iree_hal_xrt_lite_direct_command_buffer_flush_chains(
+    iree_hal_xrt_lite_direct_command_buffer* command_buffer) {
+  auto& groups = command_buffer->chain_accum.groups;
+  if (groups.empty()) return iree_ok_status();
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  shim_xdna::device* shim_device = command_buffer->device->shim_device;
+  // Max slots per chain that fit the fixed-size exec buffer (constant per
+  // device; computed once and cached). Atomic load with relaxed ordering — a
+  // racing first-time probe is idempotent (same value), and the slot count is
+  // independent data so we don't need ordering against any other state. Use
+  // acquire on the success path / release on the store so a thread observing
+  // the cached value also observes the probe's published writes.
+  std::atomic<uint32_t>& max_slots_atomic =
+      command_buffer->device->chain_max_slots;
+  uint32_t max_slots = max_slots_atomic.load(std::memory_order_acquire);
+  if (max_slots == 0) {
+    shim_xdna::kernel probe(shim_device->get_pdev(), ERT_CMD_CHAIN);
+    size_t cap = probe.get_exec_buf_bo()->size();
+    size_t hdr = offsetof(ert_packet, data) + sizeof(ert_cmd_chain_data);
+    max_slots =
+        cap > hdr ? static_cast<uint32_t>((cap - hdr) / sizeof(uint64_t)) : 1;
+    max_slots_atomic.store(max_slots, std::memory_order_release);
+  }
+
+  // Submit each accumulated group as one ERT_CMD_CHAIN (chunked into
+  // max_slots-sized pieces if a group grew past the exec BO ceiling).
+  iree_status_t status = iree_ok_status();
+  for (iree_hal_xrt_lite_chain_group& group : groups) {
+    for (size_t begin = 0;
+         begin < group.cmds.size() && iree_status_is_ok(status);
+         begin += max_slots) {
+      size_t end = std::min(begin + max_slots, group.cmds.size());
+      status = iree_hal_xrt_lite_submit_chain(shim_device, group.hwq, group,
+                                              begin, end);
+    }
+    if (!iree_status_is_ok(status)) break;
+    // Sync this group's I/O bindings back to host once its chains complete.
+    for (shim_xdna::bo* bo : group.binding_bos) {
+      bo->sync(shim_xdna::direction::device2host);
+    }
+  }
+  // Drop the accumulator unconditionally. On the OK path this is the normal
+  // post-flush reset; on the error path it makes sure the remaining
+  // unsubmitted groups (their control-code BOs, sub-command BOs, reconf BOs)
+  // release HERE rather than during the command-buffer destructor's unwind
+  // while it's already propagating the error up. No leak either way — the
+  // destructor would run them — but this keeps the failure site self-contained
+  // (anything still pending at the error point is gone) and avoids running BO
+  // destructors mid error-unwind, which is hard to read in a crash trace.
+  groups.clear();
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
 }
 
 static iree_status_t iree_hal_xrt_lite_direct_command_buffer_normal_run(
@@ -278,11 +658,14 @@ static iree_status_t iree_hal_xrt_lite_direct_command_buffer_dispatch(
       IREE_HAL_XRT_LITE_CHECKED_VTABLE_CAST(
           base_command_buffer, iree_hal_xrt_lite_direct_command_buffer_vtable,
           iree_hal_xrt_lite_direct_command_buffer);
-  // Lookup kernel parameters used for side-channeling additional launch
-  // information from the compiler.
+  // Look up kernel parameters used for side-channeling additional launch
+  // information from the compiler. Bound by reference: the executable owns
+  // the params for its lifetime and we only read them here, so we avoid
+  // copying the struct (which holds the PDI bytes plus several
+  // std::vector<uint32_t> runlists) on every dispatch.
   iree_hal_xrt_lite_executable* executable =
       iree_hal_xrt_lite_executable_cast(base_executable);
-  iree_hal_xrt_lite_kernel_params kernel_params =
+  iree_hal_xrt_lite_kernel_params& kernel_params =
       executable->entry_points[entry_point];
 
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
@@ -290,20 +673,45 @@ static iree_status_t iree_hal_xrt_lite_direct_command_buffer_dispatch(
                                        &executable));
 
   size_t num_reconfigurations = kernel_params.reconf_data_runlist.size();
-  // Only create the context when either the context does not exist or no
-  // control packet reconfiguration is present.
-  bool create_context =
-      (executable->context == nullptr || num_reconfigurations == 0);
   shim_xdna::cuidx_t cu_idx{.index = 0};
-  if (create_context) {
-    for (size_t i = 0; i < kernel_params.n_pdi_loads; i++) {
-      executable->context =
-          command_buffer->device->shim_device->create_hw_context(
-              kernel_params.pdi, kernel_params.kernel_name);
-    };
+  // Resolve this dispatch's hw_ctx into executable->context (shared_ptr).
+  // Two ownership models converge to the same field:
+  //  - non-control-packet: a fresh context per dispatch (cores run once and
+  //    aren't re-armed), held solely by this executable; the previous shared
+  //    pointer drops to refcount 0 when overwritten.
+  //  - control-packet: a context shared with the device PDI cache (shared
+  //    across executables with a byte-identical bootstrap PDI). The PDI-
+  //    carrying entry point resolves it; empty-PDI entry points reuse what
+  //    the executable's context already holds (the compiler emits PDI only
+  //    for entry point 0 in control-packet designs; see AIETarget.cpp).
+  if (num_reconfigurations == 0) {
+    executable->context.reset(
+        command_buffer->device->shim_device
+            ->create_hw_context(kernel_params.pdi, kernel_params.kernel_name)
+            .release());
     cu_idx = executable->context->open_cu_context(kernel_params.kernel_name);
+  } else if (!kernel_params.pdi.empty()) {
+    executable->context = iree_hal_xrt_lite_device_get_or_create_context(
+        command_buffer->device, kernel_params.pdi, kernel_params.kernel_name);
+  }
+  if (!executable->context) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "xrt-lite: control-packet dispatch with no PDI ran before its "
+        "PDI-carrying entry point loaded the array");
   }
   shim_xdna::hw_q* hwq = executable->context->get_hw_queue();
+
+  if (command_buffer->device->cmd_chain) {
+    // Opt-in: accumulate this dispatch's commands; the whole command buffer is
+    // flushed as one ERT_CMD_CHAIN per hw queue at end().
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_hal_xrt_lite_direct_command_buffer_accumulate_chained(
+                bindings, command_buffer, hwq, cu_idx, kernel_params));
+    IREE_TRACE_ZONE_END(z0);
+    return iree_ok_status();
+  }
 
   if (num_reconfigurations == 0) {
     // Normal kernel dispatch.
@@ -333,12 +741,27 @@ static iree_status_t iree_hal_xrt_lite_direct_command_buffer_dispatch(
   return iree_ok_status();
 }
 
+// In cmd_chain mode, flush the accumulated dispatches as ERT_CMD_CHAIN(s) once
+// the whole command buffer has been recorded/replayed. No-op otherwise.
+static iree_status_t iree_hal_xrt_lite_direct_command_buffer_end(
+    iree_hal_command_buffer_t* base_command_buffer) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_hal_xrt_lite_direct_command_buffer* command_buffer =
+      IREE_HAL_XRT_LITE_CHECKED_VTABLE_CAST(
+          base_command_buffer, iree_hal_xrt_lite_direct_command_buffer_vtable,
+          iree_hal_xrt_lite_direct_command_buffer);
+  iree_status_t status =
+      iree_hal_xrt_lite_direct_command_buffer_flush_chains(command_buffer);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 namespace {
 const iree_hal_command_buffer_vtable_t
     iree_hal_xrt_lite_direct_command_buffer_vtable = {
         .destroy = iree_hal_xrt_lite_direct_command_buffer_destroy,
         .begin = unimplemented_ok_status,
-        .end = unimplemented_ok_status,
+        .end = iree_hal_xrt_lite_direct_command_buffer_end,
         .execution_barrier = unimplemented_ok_status,
         // Command buffers execute synchronously on submission, so events are
         // already implicitly signaled in program order.

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/executable.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/executable.cc
@@ -355,6 +355,14 @@ iree_status_t iree_hal_xrt_lite_native_executable_create(
   iree_amd_aie_hal_xrt_lite_UI32Array2dDef_vec_t reconf_data_runlists_vec =
       iree_amd_aie_hal_xrt_lite_ExecutableDef_reconf_data_runlists_get(
           executable_def);
+  // Host patch table, parallel to `asm_instr_runlists` (xrt-lite cmd-chain
+  // path). Absent on executables produced before this field existed.
+  iree_amd_aie_hal_xrt_lite_UI32Array2dDef_vec_t patch_runlists_vec =
+      iree_amd_aie_hal_xrt_lite_ExecutableDef_patch_runlists_is_present(
+          executable_def)
+          ? iree_amd_aie_hal_xrt_lite_ExecutableDef_patch_runlists_get(
+                executable_def)
+          : nullptr;
   iree_host_size_t entry_point_count =
       flatbuffers_string_vec_len(entry_points_vec);
 
@@ -375,6 +383,11 @@ iree_status_t iree_hal_xrt_lite_native_executable_create(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_allocator_malloc(host_allocator, total_size,
                                 reinterpret_cast<void**>(&executable)));
+  // The struct holds non-trivial members (kernel_params std::vectors, the
+  // context shared_ptr); placement-new it so their default constructors run
+  // before any assignment. Paired with the explicit destructor call in
+  // iree_hal_xrt_lite_native_executable_destroy.
+  new (executable) iree_hal_xrt_lite_executable();
   IREE_TRACE(char* string_table_buffer = reinterpret_cast<char*>(
                  reinterpret_cast<char*>(executable) + sizeof(*executable) +
                  entry_point_count * sizeof(executable->entry_points[0])));
@@ -416,6 +429,21 @@ iree_status_t iree_hal_xrt_lite_native_executable_create(
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
         z0, iree_amd_aie_hal_xrt_lite_executable_parse_UI32Array2dDef(
                 asm_inst_runlist_def, params->asm_inst_runlist));
+
+    // Get the host patch table for the current entry point (parallel to and
+    // indexed the same as `asm_instr_runlists`). Used by the cmd-chain path.
+    if (patch_runlists_vec &&
+        asm_instr_runlist_index <
+            static_cast<int32_t>(
+                iree_amd_aie_hal_xrt_lite_UI32Array2dDef_vec_len(
+                    patch_runlists_vec))) {
+      iree_amd_aie_hal_xrt_lite_UI32Array2dDef_table_t patch_runlist_def =
+          iree_amd_aie_hal_xrt_lite_UI32Array2dDef_vec_at(
+              patch_runlists_vec, asm_instr_runlist_index);
+      IREE_RETURN_AND_END_ZONE_IF_ERROR(
+          z0, iree_amd_aie_hal_xrt_lite_executable_parse_UI32Array2dDef(
+                  patch_runlist_def, params->patch_runlist));
+    }
 
     // Get the reconfiguration data runlist for the current entry point, and
     // store it in the kernel parameters as a 2D std::vector.
@@ -473,6 +501,11 @@ static void iree_hal_xrt_lite_native_executable_destroy(
                                             iree_hal_xrt_lite_executable_vtable,
                                             iree_hal_xrt_lite_executable);
   iree_allocator_t host_allocator = executable->host_allocator;
+  // Pairs with the placement-new in iree_hal_xrt_lite_native_executable_create:
+  // run the destructor so non-trivial members (kernel_params std::vectors, the
+  // context shared_ptr) release their allocations / drop refcounts before the
+  // backing storage is freed.
+  executable->~iree_hal_xrt_lite_executable();
   iree_allocator_free(host_allocator, executable);
 
   IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/executable.h
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/executable.h
@@ -8,6 +8,9 @@
 #define IREE_AMD_AIE_DRIVER_XRT_LITE_NATIVE_EXECUTABLE_H_
 
 #include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "flatbuffers_common_reader.h"
 #include "iree-amd-aie/driver/xrt-lite/shim/linux/kmq/bo.h"
@@ -21,6 +24,11 @@ struct iree_hal_xrt_lite_kernel_params {
   std::vector<uint8_t> pdi;
   std::vector<std::vector<uint32_t>> asm_inst_runlist;
   std::vector<std::vector<uint32_t>> reconf_data_runlist;
+  // Host patch table parallel to `asm_inst_runlist`: each inner vector is a
+  // flat list of (offset, arg_idx, arg_plus) triples for the corresponding
+  // control code, applied by the ERT_CMD_CHAIN path (see
+  // direct_command_buffer.cc).
+  std::vector<std::vector<uint32_t>> patch_runlist;
   std::string kernel_name;
   uint32_t n_kernel_runs{1};
   uint32_t n_reconfigure_runs{1};
@@ -36,7 +44,17 @@ struct iree_hal_xrt_lite_executable {
   iree_allocator_t host_allocator;
   iree_host_size_t entry_point_count;
   iree_hal_xrt_lite_kernel_params entry_points[16];
-  std::unique_ptr<shim_xdna::hw_ctx> context;
+  // The hw_ctx this executable's entry points dispatch on. shared_ptr because
+  // ownership is split by lifetime model:
+  //  - non-control-packet: a fresh context per dispatch (cores run once),
+  //    held solely by this executable (refcount 1); the previous one drops
+  //    when overwritten.
+  //  - control-packet: the same context is shared with the device's PDI
+  //    cache, and with every other executable whose bootstrap PDI is byte-
+  //    identical (refcount >= 2). Resolved by the PDI-carrying entry point
+  //    (entry 0); empty-PDI entry points reuse it.
+  // Both cases use one field and one accessor (`context.get()`).
+  std::shared_ptr<shim_xdna::hw_ctx> context;
 };
 
 // `out_executable` must be released by the caller (see

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/registration/driver_module.c
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/registration/driver_module.c
@@ -16,6 +16,9 @@ IREE_FLAG(int32_t, xrt_lite_n_core_cols, 0,
           "Number of core cols to use on NPU.");
 // see shim/linux/kmq/amdxdna_accel.h#L460 for options
 IREE_FLAG(string, xrt_lite_power_mode, "", "Set the power mode of the NPU.");
+IREE_FLAG(int32_t, xrt_lite_cmd_chain, 0,
+          "Batch each dispatch's commands into a single ERT_CMD_CHAIN "
+          "(removes the per-command host round-trip). 0 = off (default).");
 
 static const iree_string_view_t key_xrt_lite_n_core_rows =
     iree_string_view_literal("xrt_lite_n_core_rows");
@@ -23,6 +26,8 @@ static const iree_string_view_t key_xrt_lite_n_core_cols =
     iree_string_view_literal("xrt_lite_n_core_cols");
 static const iree_string_view_t key_xrt_lite_power_mode =
     iree_string_view_literal("xrt_lite_power_mode");
+static const iree_string_view_t key_xrt_lite_cmd_chain =
+    iree_string_view_literal("xrt_lite_cmd_chain");
 
 static iree_status_t iree_hal_xrt_lite_driver_factory_enumerate(
     void* self, iree_host_size_t* out_driver_info_count,
@@ -50,6 +55,9 @@ static iree_status_t iree_hal_xrt_lite_driver_parse_flags(
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_string_pair_builder_add_int32(builder, key_xrt_lite_n_core_cols,
                                              FLAG_xrt_lite_n_core_cols));
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_string_pair_builder_add_int32(builder, key_xrt_lite_cmd_chain,
+                                             FLAG_xrt_lite_cmd_chain));
   iree_string_view_t power_mode = IREE_SV(FLAG_xrt_lite_power_mode);
   if (!iree_string_view_is_empty(power_mode)) {
     IREE_RETURN_AND_END_ZONE_IF_ERROR(
@@ -106,6 +114,15 @@ static iree_status_t iree_hal_xrt_lite_driver_populate_options(
             (int)value.size, value.data);
       }
       device_params->n_core_cols = ivalue;
+    } else if (iree_string_view_equal(key, key_xrt_lite_cmd_chain)) {
+      if (!iree_string_view_atoi_int32(value, &ivalue)) {
+        IREE_TRACE_ZONE_END(z0);
+        return iree_make_status(
+            IREE_STATUS_FAILED_PRECONDITION,
+            "Option 'xrt_lite_cmd_chain' expected to be int. Got: '%.*s'",
+            (int)value.size, value.data);
+      }
+      device_params->cmd_chain = ivalue;
     } else if (iree_string_view_equal(key, key_xrt_lite_power_mode)) {
       if (!(iree_string_view_equal(value, IREE_SV("default")) ||
             iree_string_view_equal(value, IREE_SV("low")) ||

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/hwq.cpp
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/hwq.cpp
@@ -123,6 +123,7 @@ void hw_q::issue_command(bo *cmd_bo) {
       .arg_count = cmd_bo->get_arg_bo_handles(arg_bo_hdls, max_arg_bos),
   };
   m_pdev.ioctl(DRM_IOCTL_AMDXDNA_EXEC_CMD, &ecmd);
+  m_exec_cmd_count.fetch_add(1, std::memory_order_relaxed);
 
   auto id = ecmd.seq;
   cmd_bo->set_cmd_id(id);

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/hwq.h
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/hwq.h
@@ -4,6 +4,9 @@
 #ifndef _HWQ_XDNA_H_
 #define _HWQ_XDNA_H_
 
+#include <atomic>
+#include <cstdint>
+
 #include "fence.h"
 #include "hwctx.h"
 
@@ -13,6 +16,11 @@ struct hw_q {
   const hw_ctx *m_hwctx;
   const pdev &m_pdev;
   uint32_t m_queue_boh;
+  // Number of DRM_IOCTL_AMDXDNA_EXEC_CMD submissions issued through this queue
+  // (incremented by issue_command). Lets tests assert the count of on-device
+  // submits — e.g. that a deferred ERT_CMD_CHAIN actually batched the
+  // recorded dispatches into one submit rather than fanning out.
+  std::atomic<uint64_t> m_exec_cmd_count{0};
 
   hw_q(const device &device);
   ~hw_q();
@@ -24,6 +32,9 @@ struct hw_q {
   void bind_hwctx(const hw_ctx *ctx);
   void unbind_hwctx();
   void issue_command(bo *);
+  uint64_t exec_cmd_count() const {
+    return m_exec_cmd_count.load(std::memory_order_relaxed);
+  }
 };
 
 int poll_command(bo *);

--- a/runtime/src/iree-amd-aie/schemas/pdi_executable_def.fbs
+++ b/runtime/src/iree-amd-aie/schemas/pdi_executable_def.fbs
@@ -79,6 +79,20 @@ table ExecutableDef {
   //   - The third dimension contains a uint32 array with control packet data required for a single reconfiguration.
   reconf_data_runlists: [UI32Array2dDef];
 
+  // Host patch table for `asm_instr_runlists`, used by the xrt-lite HAL's
+  // ERT_CMD_CHAIN submission path (which cannot rely on firmware-side address
+  // patching). Parallel to `asm_instr_runlists` and indexed the same way (via
+  // `asm_instr_runlist_indices`): `patch_runlists[i]` holds the patches for
+  // `asm_instr_runlists[i]`, with one inner array per run.
+  //
+  // Each inner array is a flat list of (offset, arg_idx, arg_plus) triples (so
+  // its length is a multiple of 3). For each triple the HAL writes the 48-bit
+  // shim-DMA address `args[arg_idx] + arg_plus + aperture` into the
+  // buffer-descriptor address words located at byte `offset` within the run's
+  // control code. This keeps all XAie-transaction-format knowledge in the
+  // compiler; the HAL applies the table without parsing the instruction stream.
+  patch_runlists: [UI32Array2dDef];
+
   source_locations:[FileLineLocDef];
 }
 


### PR DESCRIPTION
Adds an opt-in code path that batches a whole command buffer's dispatches into one on-device `ERT_CMD_CHAIN` per shared hw context, removing the per-command host round-trip (~66 µs/command on npu4). Default OFF; the proven per-command `ERT_START_CU` path is unchanged.

## Why PARTIAL_ELF (and not the CU/CF chain)

The firmware rejects a ≥2-slot NON_ELF (`ERT_START_CU`) `ERT_CMD_CHAIN` with `INVALID_PARAM` (proven content-independent on instrumented driver). The default IREE command form therefore cannot be batched. The chainable path is `ERT_START_NPU` (PARTIAL_ELF) with `args[0]=AIE2_EXEC_BUFFER_KERNEL_OP_TXN` — same TXN binary, different command wrapper. PARTIAL_ELF does not honor `DDR_PATCH` from command args, so shim-DMA buffer addresses are host-patched before submit using a compiler-emitted patch table.

## Compiler side: `patch_runlists`

- `AMDAIETransactionBuilder::deriveHostPatchTableFromTransaction` parses the serialized XAie TXN (the only place in the codebase that understands the binary format) and emits `(offset, arg_idx, arg_plus)` triples for each `DDR_PATCH`, matching each to its covering `BLOCKWRITE`'s register span so wide multi-BD `BLOCKWRITE`s are handled.
- `pdi_executable_def.fbs` gains `patch_runlists` (parallel to `asm_instr_runlists`); `AIETarget.cpp` serializes the table per control code; `executable.cc` parses into `kernel_params`.

## Runtime side: deferral + shared hwctx

The HAL accumulates each dispatch's sub-commands into the command buffer (per hw queue) and flushes one `ERT_CMD_CHAIN` per group at `end()`:

- `iree_hal_xrt_lite_chain_accum` is embedded by value in the command buffer struct; the cb is placement-new'd in create and explicitly destructed in destroy so its `std::vector`s release cleanly (no heap pointer, no leak).
- `iree_hal_xrt_lite_device_get_or_create_context` caches `hw_ctx` in a `std::map<PDI bytes, shared_ptr<hw_ctx>>` on the device. Control-packet designs ship a byte-identical bootstrap PDI, so executables with the same PDI resolve to the **same** context (and queue), enabling cross-executable fusion. The non-control-packet path keeps fresh-per-dispatch semantics (cores run once). Both paths converge on a single `std::shared_ptr<shim_xdna::hw_ctx>` field on the executable.
- The empty-PDI signal that the compiler emits for `entry_point[i>0]` in control-packet designs ("reuse the loaded array") is now honored symmetrically by the runtime: empty PDI ⇒ reuse `executable->context`.
- `direct_command_buffer.cc::apply_patch_table` writes the 48-bit shim-DMA address (`args[arg_idx] + arg_plus + 0x80000000` aperture) into the BD-address words; the HAL has **no** XAie-transaction-format knowledge.
- `submit_chain` bounds against the exec BO (chunks if a group exceeds it) and against the shim's 1024-entry arg-BO ceiling. `flush_chains` caches `chain_max_slots` on the device.
- The command buffer requires `IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT` (the only mode IREE uses through us) so accumulator state can't leak across replays.
- The executable struct is placement-new'd to pair with its destructor call; same pattern as the device and command buffer.

## Device option

Enabled via `xrt_lite_cmd_chain` (`--xrt_lite_cmd_chain=1`); the device option is plumbed through `api.h` / `device_params` / `driver_module.c`.

## Testing

- `build_tools/ci/cpu_comparison/run.py` threads `use_cmd_chain` → `--xrt_lite_cmd_chain=1`; registers npu4 cmd-chain variants for the multi-dispatch control-packet designs (`two_matmul_switching`, `three_matmuls`).
- A new cts hardware test (`xrt-lite/cts/xexec_chain_test`) covers the cross-executable case — the `iree-compile` pipeline can't produce it (the AIE backend co-locates a function's dispatches into one executable), so the test loads a build-time-compiled control-packet matmul PDI as two distinct `hal.executable` objects and dispatches both into one command buffer. Skipped on phoenix (npu4-only artifact).
- The test asserts the fusion three ways at once: (a) `exe0 != exe1` (distinct structs), (b) `exe0->context.get() == exe1->context.get()` (the PDI cache returned the same shared context — i.e. cache HIT), and (c) `exec_cmd_count == 1` on that shared `hw_q` — backed by an atomic `EXEC_CMD` counter added to `shim_xdna::hw_q::issue_command` so the test no longer needs external `strace` to verify the chain count.

Validated on npu4 vs llvm-cpu: `two_matmul_switching` (8 dispatches → 1 chain of 16 slots), `three_matmuls`, single matmul ctrlpkt — all PASS. Non-chain ctrlpkt regression PASS.

## Caveats

- Cross-executable fusion requires byte-identical bootstrap PDIs across executables (true for the 1×1 1040-byte bootstrap; unverified for larger array shapes — different geometry → different PDI → separate chains, still correct).
- The PDI cache is single-threaded (queue replay is single-threaded today); add a mutex when that changes.
- Direction-aware output sync at flush is a follow-up (binding direction is not currently propagated to the HAL).
- Sound chaining across executables implicitly assumes each control-packet reconfig is a complete, position-independent reconfiguration of the array; empirically true (`two_matmul_switching` alternates two configs on one context, 50 reps, matches CPU). A compiler-side assertion is tracked as a follow-up in `iree-amd-aie-workspace/.knowledge/todos/M3-hal-cmd-chain.md`.