### PR TITLE
[xrt-lite] Fix two flakiness sources + add regression and soak tests

### DIFF
--- a/.github/actions/xrt-lite-pytest/action.yml
+++ b/.github/actions/xrt-lite-pytest/action.yml
@@ -1,0 +1,59 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Composite action: run a pytest selection from build_tools/ci/xrt_lite_tests/
+# with the standard prlimit + venv prelude. Centralizes the boilerplate so
+# the workflow body is just `marker:` and optional pytest args.
+#
+# Persists iree-run-module stderr from failing iters to
+# $GITHUB_WORKSPACE/ci_failure_logs/ for the workflow to upload as an
+# artifact on failure.
+
+name: "Run XRT-LITE pytest selection"
+description: "Run an XRT-LITE pytest marker selection with the standard prelude."
+
+inputs:
+  marker:
+    description: "pytest -m selector (e.g. 'regression', 'soak')."
+    required: true
+  iree-install-dir:
+    description: "Absolute path to IREE install dir (containing bin/iree-compile etc)."
+    required: true
+  peano-dir:
+    description: "Absolute path to peano (llvm-aie) install dir."
+    required: true
+  target-device:
+    description: "iree-amdaie target device."
+    required: false
+    default: "npu4"
+  n-core-rows:
+    description: "xrt-lite core-row count."
+    required: true
+  n-core-cols:
+    description: "xrt-lite core-col count."
+    required: true
+  extra-args:
+    description: "Extra args appended to pytest (e.g. '--n-iters=5000')."
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Run pytest"
+      shell: bash
+      run: |
+        sudo prlimit -lunlimited --pid $$
+        source "$GITHUB_WORKSPACE/.venv/bin/activate"
+        pytest "$GITHUB_WORKSPACE/build_tools/ci/xrt_lite_tests" \
+          -m "${{ inputs.marker }}" \
+          --iree-install-dir="${{ inputs.iree-install-dir }}" \
+          --peano-dir="${{ inputs.peano-dir }}" \
+          --target-device="${{ inputs.target-device }}" \
+          --n-core-rows="${{ inputs.n-core-rows }}" \
+          --n-core-cols="${{ inputs.n-core-cols }}" \
+          --failure-log-dir="$GITHUB_WORKSPACE/ci_failure_logs" \
+          ${{ inputs.extra-args }}

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -317,6 +317,62 @@ jobs:
             --skip_tests=Performance \
             -v
 
+      - name: XRT-LITE tests
+        run: |
+          DEVICE_TEST_DIR="$PWD/iree-install/device_tests"
+          # Run the standard iree_hal_cts_test_suite outputs only. The
+          # iree-amd-aie custom dispatch tests (xrt_lite_dispatch_test,
+          # xrt_lite_executable_cache_test) embed a baked-in npu1_4col
+          # executable that doesn't run correctly on Strix hardware, so they
+          # stay phoenix-only.
+          for t in $(ls $DEVICE_TEST_DIR); do
+            case "$t" in
+              xrt_lite_dispatch_test|xrt_lite_executable_cache_test) continue ;;
+            esac
+            $DEVICE_TEST_DIR/$t --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS
+          done
+
+      # High-iteration runtime soak tests. Catches latent runtime races
+      # (the iree-tooling deferred copy_buffer race at ~0.05% per-iter
+      # rate, and any similar future regression) at >99% probability over
+      # 5000 iters. Every `test_*.py` in build_tools/ci/xrt_lite_tests/
+      # marked `@pytest.mark.soak` is auto-collected; adding a new soak
+      # test requires no CI change. ~7 min on npu4.
+      - name: XRT-LITE soak tests
+        uses: ./.github/actions/xrt-lite-pytest
+        with:
+          marker: soak
+          iree-install-dir: ${{ github.workspace }}/iree-install
+          peano-dir: ${{ github.workspace }}/llvm-aie
+          n-core-rows: ${{ env.XRT_LITE_N_CORE_ROWS }}
+          n-core-cols: ${{ env.XRT_LITE_N_CORE_COLS }}
+          extra-args: "--n-iters=5000"
+
+      # Deterministic regression tests pinning behaviour against
+      # previously-fixed bugs (currently: per-binding byte_offset
+      # propagation in direct_command_buffer.cc::normal_run). Every
+      # `test_*.py` marked `@pytest.mark.regression` is auto-collected;
+      # adding a new regression test requires no CI change. Runs in
+      # seconds.
+      - name: XRT-LITE regression tests
+        uses: ./.github/actions/xrt-lite-pytest
+        with:
+          marker: regression
+          iree-install-dir: ${{ github.workspace }}/iree-install
+          peano-dir: ${{ github.workspace }}/llvm-aie
+          n-core-rows: ${{ env.XRT_LITE_N_CORE_ROWS }}
+          n-core-cols: ${{ env.XRT_LITE_N_CORE_COLS }}
+
+      # Upload iree-run-module stderr from any failing iteration of the
+      # soak/regression steps above for post-mortem.
+      - name: Upload XRT-LITE pytest failure logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xrt-lite-pytest-failure-logs
+          path: ci_failure_logs/
+          if-no-files-found: ignore
+
       # Run the 'Performance' tests. These do not check numerical correctness,
       # just measure the time to run some workloads.
       - name : Performance benchmarks
@@ -336,21 +392,6 @@ jobs:
           # Print a summary of the findings.
           python build_tools/ci/cpu_comparison/performance_summarizer.py \
             performance_npu4.log results_npu4.json
-
-      - name: XRT-LITE tests
-        run: |
-          DEVICE_TEST_DIR="$PWD/iree-install/device_tests"
-          # Run the standard iree_hal_cts_test_suite outputs only. The
-          # iree-amd-aie custom dispatch tests (xrt_lite_dispatch_test,
-          # xrt_lite_executable_cache_test) embed a baked-in npu1_4col
-          # executable that doesn't run correctly on Strix hardware, so they
-          # stay phoenix-only.
-          for t in $(ls $DEVICE_TEST_DIR); do
-            case "$t" in
-              xrt_lite_dispatch_test|xrt_lite_executable_cache_test) continue ;;
-            esac
-            $DEVICE_TEST_DIR/$t --xrt_lite_n_core_rows=$XRT_LITE_N_CORE_ROWS --xrt_lite_n_core_cols=$XRT_LITE_N_CORE_COLS
-          done
 
       # Only publish the performance results on main branch pushes.
       - name: Publish performance results

--- a/build_tools/ci/xrt_lite_tests/byte_offset_propagation.mlir
+++ b/build_tools/ci/xrt_lite_tests/byte_offset_propagation.mlir
@@ -1,0 +1,36 @@
+// Regression test for the per-binding `byte_offset` propagation bug in the
+// xrt-lite HAL.
+//
+// IREE's stream scheduler packs the two intermediate results %1 and %2 of this
+// 2-chain matmul into a single transient buffer at offsets 0 and 128. The
+// dispatch for %2 binds (lhs, %1, %2) where %1 and %2 point to the SAME root
+// BO at different byte_offsets. Before the fix, the xrt-lite HAL passed only
+// `bo->get_paddr()` to firmware, dropping each binding's `byte_offset` and
+// `binding.offset`. Both bindings collapsed to the same paddr, the dispatch
+// read `%1` as zero (the slot it overlapped with), and `%2` came out as
+// all-zero matmul result.
+//
+// Returning BOTH `%1` and `%2` makes the failure 100% deterministic (vs the
+// flaky behaviour of the single-output variant where one collapsed slot might
+// happen to hold valid data). With the fix, both outputs are correct on every
+// run.
+//
+// input 8x8xf32
+// input 8x4xf32
+// output 8x4xf32
+// output 8x4xf32
+
+!A_TYPE = tensor<8x8xf32>
+!B_TYPE = tensor<8x4xf32>
+!C_TYPE = tensor<8x4xf32>
+func.func @matmul_dual_out(%lhs : !A_TYPE,
+    %rhs : !B_TYPE) -> (!C_TYPE, !C_TYPE) {
+  %empty = tensor.empty() : !C_TYPE
+  %cst = arith.constant 0.0 : f32
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : !C_TYPE) -> !C_TYPE
+  %1 = linalg.matmul ins(%lhs, %rhs : !A_TYPE, !B_TYPE)
+      outs(%fill : !C_TYPE) -> !C_TYPE
+  %2 = linalg.matmul ins(%lhs, %1 : !A_TYPE, !B_TYPE)
+      outs(%fill : !C_TYPE) -> !C_TYPE
+  return %1, %2 : !C_TYPE, !C_TYPE
+}

--- a/build_tools/ci/xrt_lite_tests/conftest.py
+++ b/build_tools/ci/xrt_lite_tests/conftest.py
@@ -1,0 +1,342 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Shared pytest configuration + helpers for the xrt-lite tests.
+
+Tests in this directory are auto-discovered by pytest (any `test_*.py`).
+Use markers to classify a test:
+
+    @pytest.mark.regression  # deterministic regression test for a fixed bug
+    @pytest.mark.soak        # high-iteration soak / stress / race detection
+
+CI selects with `-m regression` or `-m soak`. Adding a new test file
+with the right marker requires no CI workflow change.
+
+The fixtures below give tests a small, opinionated API:
+
+    def test_my_design(compile_aie, run_iree, ...):
+        vmfb = compile_aie(MY_MLIR, tmp_path / "x.vmfb", CompileConfig(...))
+        spec = IOSpec(function_name="...", inputs=[...], expected=[...])
+        run_iree(vmfb, spec, n_core_rows, n_core_cols, tmp_path)
+
+Common flag / sync / compare logic lives here once. Add a test → write
+~10 lines.
+"""
+import dataclasses
+import pathlib
+import subprocess
+import sys
+import typing
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# CLI options + path fixtures
+# ---------------------------------------------------------------------------
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--iree-install-dir",
+        required=True,
+        type=pathlib.Path,
+        help="Directory containing bin/iree-compile and bin/iree-run-module.",
+    )
+    parser.addoption(
+        "--peano-dir",
+        required=True,
+        type=pathlib.Path,
+        help="Directory containing the peano (llvm-aie) install.",
+    )
+    parser.addoption(
+        "--target-device",
+        default="npu4",
+        help="iree-amdaie target device (npu1_4col, npu4, ...).",
+    )
+    parser.addoption(
+        "--n-core-rows", type=int, default=4, help="xrt-lite core-row count."
+    )
+    parser.addoption(
+        "--n-core-cols", type=int, default=8, help="xrt-lite core-col count."
+    )
+    parser.addoption(
+        "--n-iters",
+        type=int,
+        default=5000,
+        help="Default iteration count for `@pytest.mark.soak` tests "
+        "(ignored by regression tests).",
+    )
+    parser.addoption(
+        "--failure-log-dir",
+        type=pathlib.Path,
+        default=None,
+        help="If set, persists iree-run-module stderr from failing iters to "
+        "this directory. Intended for CI to upload as a workflow artifact.",
+    )
+
+
+@pytest.fixture
+def iree_install_dir(request):
+    return request.config.getoption("--iree-install-dir")
+
+
+@pytest.fixture
+def peano_dir(request):
+    return request.config.getoption("--peano-dir")
+
+
+@pytest.fixture
+def target_device(request):
+    return request.config.getoption("--target-device")
+
+
+@pytest.fixture
+def n_core_rows(request):
+    return request.config.getoption("--n-core-rows")
+
+
+@pytest.fixture
+def n_core_cols(request):
+    return request.config.getoption("--n-core-cols")
+
+
+@pytest.fixture
+def n_iters(request):
+    return request.config.getoption("--n-iters")
+
+
+@pytest.fixture
+def failure_log_dir(request):
+    d = request.config.getoption("--failure-log-dir")
+    if d is not None:
+        d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+@pytest.fixture
+def iree_compile_bin(iree_install_dir):
+    return iree_install_dir / "bin" / "iree-compile"
+
+
+@pytest.fixture
+def iree_run_bin(iree_install_dir):
+    return iree_install_dir / "bin" / "iree-run-module"
+
+
+# ---------------------------------------------------------------------------
+# CompileConfig + compile_aie fixture
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class CompileConfig:
+    """Knobs for iree-compile invocations through the `compile_aie` fixture.
+
+    Defaults match the original CI-failing ctrlpkt single-core design. Override
+    fields per-test as needed; `extra_flags` appends raw `--iree-...=...`
+    strings for anything not covered.
+    """
+
+    num_rows: int = 1
+    num_cols: int = 1
+    tile_pipeline: str = "pack-peel"
+    lower_to_aie_pipeline: str = "objectFifo"
+    enable_ctrlpkt: bool = True
+    packet_flow_strategy: str = "auto"
+    optimize_bindings: bool = False
+    memoization: bool = False
+    indirect_command_buffers: bool = False
+    extra_flags: typing.Tuple[str, ...] = ()
+
+
+@pytest.fixture
+def compile_aie(
+    iree_compile_bin,
+    iree_install_dir,
+    peano_dir,
+    target_device,
+    failure_log_dir,
+    request,
+):
+    """Factory: `(mlir, out_vmfb, cfg=CompileConfig()) -> Path`.
+
+    Centralizes the iree-compile flag list so a new flag added here
+    propagates to every test using this fixture. On compile failure,
+    persists stderr to `--failure-log-dir` (if set) for CI artifact
+    upload.
+    """
+
+    def _compile(mlir, out_vmfb, cfg=None):
+        if cfg is None:
+            cfg = CompileConfig()
+        cmd = [
+            str(iree_compile_bin),
+            str(mlir),
+            "--iree-hal-target-backends=amd-aie",
+            f"--iree-amdaie-target-device={target_device}",
+            f"--iree-amdaie-tile-pipeline={cfg.tile_pipeline}",
+            f"--iree-amdaie-lower-to-aie-pipeline={cfg.lower_to_aie_pipeline}",
+            f"--iree-amd-aie-peano-install-dir={peano_dir}",
+            f"--iree-amd-aie-install-dir={iree_install_dir}",
+            f"--iree-amdaie-num-rows={cfg.num_rows}",
+            f"--iree-amdaie-num-cols={cfg.num_cols}",
+            "--iree-amdaie-device-hal=xrt-lite",
+            f"--iree-scheduling-optimize-bindings={str(cfg.optimize_bindings).lower()}",
+            f"--iree-hal-memoization={str(cfg.memoization).lower()}",
+            f"--iree-hal-indirect-command-buffers={str(cfg.indirect_command_buffers).lower()}",
+        ]
+        if cfg.enable_ctrlpkt:
+            cmd += [
+                "--iree-amdaie-enable-control-packet=true",
+                f"--iree-amdaie-packet-flow-strategy={cfg.packet_flow_strategy}",
+            ]
+        cmd += list(cfg.extra_flags)
+        cmd += ["-o", str(out_vmfb)]
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        if r.returncode != 0:
+            _persist_failure_log(
+                failure_log_dir, request.node.name, "compile", cmd, r.stderr
+            )
+            print(r.stderr, file=sys.stderr)
+            pytest.fail(f"iree-compile exited rc={r.returncode}")
+        return out_vmfb
+
+    return _compile
+
+
+# ---------------------------------------------------------------------------
+# IOSpec + run_and_verify fixture
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class IOSpec:
+    """One iree-run-module invocation: function name, numpy inputs and
+    expected outputs. Tests construct this once; `run_iree` and
+    `assert_outputs_match` consume it.
+    """
+
+    function_name: str
+    inputs: typing.List[np.ndarray]
+    expected: typing.List[np.ndarray]
+    rtol: float = 1e-6
+    atol: float = 1e-6
+
+
+def _arg_for(arr: np.ndarray) -> str:
+    """iree-run-module `--input=` shape/dtype string for a numpy array."""
+    shape = "x".join(str(d) for d in arr.shape)
+    # iree-run-module spelling for the common dtypes the tests use.
+    dtype_map = {
+        np.dtype("float32"): "f32",
+        np.dtype("int32"): "i32",
+        np.dtype("int8"): "i8",
+    }
+    return f"{shape}x{dtype_map[arr.dtype]}"
+
+
+@pytest.fixture
+def run_iree(iree_run_bin, failure_log_dir, request):
+    """Factory: `(vmfb, spec, n_core_rows, n_core_cols, tmp_path) ->
+    List[np.ndarray]`.
+
+    Writes spec.inputs to tmp_path bin files, invokes iree-run-module with
+    matching --input/--output flags, reads the output bin files back as
+    numpy arrays (shapes/dtypes from spec.expected), and returns them. On
+    non-zero exit code or short output, fails the test and (if
+    --failure-log-dir is set) persists stderr for CI artifact upload.
+    """
+
+    def _run(vmfb, spec: IOSpec, n_core_rows, n_core_cols, tmp_path, iter_tag=""):
+        in_paths = []
+        for i, arr in enumerate(spec.inputs):
+            p = tmp_path / f"in{i}.bin"
+            p.write_bytes(np.ascontiguousarray(arr).tobytes())
+            in_paths.append(p)
+        out_paths = [tmp_path / f"out{i}.bin" for i in range(len(spec.expected))]
+
+        cmd = [str(iree_run_bin), f"--module={vmfb}"]
+        for arr, p in zip(spec.inputs, in_paths):
+            cmd.append(f"--input={_arg_for(arr)}=@{p}")
+        cmd += [
+            "--device=xrt-lite",
+            f"--xrt_lite_n_core_rows={n_core_rows}",
+            f"--xrt_lite_n_core_cols={n_core_cols}",
+            f"--function={spec.function_name}",
+        ]
+        for p in out_paths:
+            cmd.append(f"--output=@{p}")
+
+        r = subprocess.run(cmd, capture_output=True, text=True)
+        if r.returncode != 0:
+            _persist_failure_log(
+                failure_log_dir, request.node.name, iter_tag, cmd, r.stderr
+            )
+            print(r.stderr, file=sys.stderr)
+            pytest.fail(
+                f"iree-run-module exited rc={r.returncode}"
+                + (f" (iter {iter_tag})" if iter_tag else "")
+            )
+
+        outputs = []
+        for p, exp in zip(out_paths, spec.expected):
+            raw = p.read_bytes()
+            need = exp.size * exp.dtype.itemsize
+            if len(raw) < need:
+                _persist_failure_log(
+                    failure_log_dir, request.node.name, iter_tag, cmd, r.stderr
+                )
+                pytest.fail(
+                    f"output {p.name} short: {len(raw)}B < expected {need}B"
+                    + (f" (iter {iter_tag})" if iter_tag else "")
+                )
+            outputs.append(
+                np.frombuffer(raw[:need], dtype=exp.dtype).reshape(exp.shape)
+            )
+        return outputs
+
+    return _run
+
+
+@pytest.fixture
+def run_and_verify(run_iree):
+    """Factory: `(vmfb, spec, n_core_rows, n_core_cols, tmp_path) -> None`.
+
+    Calls run_iree and asserts every output matches `spec.expected`
+    elementwise within `spec.rtol/atol`. Use this for single-shot
+    regression tests where one numerical mismatch should fail loudly.
+    For soak loops where you want to count and report many iterations,
+    use run_iree directly + numpy.allclose.
+    """
+
+    def _verify(vmfb, spec, n_core_rows, n_core_cols, tmp_path):
+        got = run_iree(vmfb, spec, n_core_rows, n_core_cols, tmp_path)
+        for i, (g, exp) in enumerate(zip(got, spec.expected)):
+            np.testing.assert_allclose(
+                g,
+                exp,
+                rtol=spec.rtol,
+                atol=spec.atol,
+                err_msg=(
+                    f"output[{i}] mismatch for {spec.function_name}: "
+                    f"got first 4: {g.flatten()[:4]}, "
+                    f"expected: {exp.flatten()[:4]}"
+                ),
+            )
+
+    return _verify
+
+
+def _persist_failure_log(failure_log_dir, test_name, iter_tag, cmd, stderr_text):
+    if failure_log_dir is None:
+        return
+    safe = "".join(c if c.isalnum() or c in "._-" else "_" for c in test_name)
+    suffix = f"_iter{iter_tag}" if iter_tag else ""
+    path = failure_log_dir / f"{safe}{suffix}.log"
+    with path.open("w") as f:
+        f.write("COMMAND:\n" + " ".join(cmd) + "\n\nSTDERR:\n" + (stderr_text or ""))

--- a/build_tools/ci/xrt_lite_tests/pytest.ini
+++ b/build_tools/ci/xrt_lite_tests/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = -v --tb=short -ra
+markers =
+    regression: deterministic single-shot regression tests pinning behaviour against previously-fixed bugs
+    soak: high-iteration soak / stress / race-detection tests; run with --n-iters=<N>

--- a/build_tools/ci/xrt_lite_tests/test_byte_offset_propagation.py
+++ b/build_tools/ci/xrt_lite_tests/test_byte_offset_propagation.py
@@ -1,0 +1,57 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Deterministic regression test for the xrt-lite per-binding `byte_offset`
+propagation bug.
+
+`byte_offset_propagation.mlir` is a 2-chain matmul that returns BOTH the
+intermediate result `%1` and the final result `%2`. IREE's stream
+scheduler packs the two values into a single transient buffer at offsets
+0 and 128, so the second dispatch binds `%1` (input) and `%2` (output)
+to the same root BO at different `byte_offset`s.
+
+If the xrt-lite HAL (`direct_command_buffer.cc::normal_run`) drops
+either the buffer's subview `byte_offset` or the binding-level `offset`
+when constructing firmware args, the two bindings collapse to the same
+paddr, the second dispatch reads and writes the wrong slot, and one of
+the two returned outputs ends up all-zero. With the fix, both outputs
+match the expected matmul result on every run. Pre-fix this fails 100%
+of runs (compile-time deterministic); post-fix it passes 100% of runs.
+
+Asserts both outputs match the closed-form matmul results numerically
+(via `run_and_verify`), so any future bug that produces wrong-but-non-
+zero data is also caught.
+"""
+import pathlib
+
+import numpy as np
+import pytest
+
+from conftest import IOSpec
+
+THIS_DIR = pathlib.Path(__file__).resolve().parent
+MLIR = THIS_DIR / "byte_offset_propagation.mlir"
+
+
+@pytest.mark.regression
+def test_byte_offset_propagation(
+    compile_aie, run_and_verify, n_core_rows, n_core_cols, tmp_path
+):
+    # Inputs: 8x8 of 1.5s, 8x4 of 2.0s. Closed-form:
+    #   %1 = lhs @ rhs  → 8x4, each element = 8 * 1.5 * 2.0  = 24.0
+    #   %2 = lhs @ %1   → 8x4, each element = 8 * 1.5 * 24.0 = 288.0
+    lhs = np.full((8, 8), 1.5, dtype=np.float32)
+    rhs = np.full((8, 4), 2.0, dtype=np.float32)
+    expected_1 = lhs @ rhs
+    expected_2 = lhs @ expected_1
+
+    vmfb = compile_aie(MLIR, tmp_path / "byte_offset_propagation.vmfb")
+    spec = IOSpec(
+        function_name="matmul_dual_out",
+        inputs=[lhs, rhs],
+        expected=[expected_1, expected_2],
+    )
+    run_and_verify(vmfb, spec, n_core_rows, n_core_cols, tmp_path)

--- a/build_tools/ci/xrt_lite_tests/test_single_pdi_ctrlpkt.py
+++ b/build_tools/ci/xrt_lite_tests/test_single_pdi_ctrlpkt.py
@@ -1,0 +1,82 @@
+# Copyright 2026 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""High-iteration soak test for the xrt-lite ctrlpkt single-PDI dispatch path.
+
+Compiles `matmul_f32_8_4_8` (the 4-chain matmul the original CI flakiness
+was filed against) once, then runs iree-run-module `--n-iters` times in
+a tight subprocess loop. Each iter is validated NUMERICALLY against the
+closed-form matmul result, not just against non-zero.
+
+This catches:
+
+1. Per-binding `byte_offset` propagation regressions
+   (direct_command_buffer.cc): when IREE's stream scheduler packs SSA
+   values into a single transient BO, dropping the bindings'
+   `byte_offset` makes inner dispatches read/write the wrong slot.
+   Surfaces as wrong (sometimes non-zero) output, which the numerical
+   check catches but a "non-zero" oracle would miss for this design.
+
+2. iree-tooling's deferred output-readback path: relies on a transient
+   `copy_buffer` whose recording lives inside an arena that the async
+   queue worker may release back to the block pool before its
+   post-release field clears. The next allocator to grab that block
+   races with those trailing writes and the recorded
+   `copy_buffer.header.type` can flip from COPY_BUFFER(7) to
+   EXECUTION_BARRIER(0), silently dropping the copy and producing
+   all-zero output. Surfaces at ~0.05% per-iter rate; 5000 iters gives
+   >99% catch probability.
+"""
+import pathlib
+
+import numpy as np
+import pytest
+
+from conftest import IOSpec
+
+THIS_DIR = pathlib.Path(__file__).resolve().parent
+# Reuse the same MLIR design the run.py MultipleDispatches suite uses.
+MLIR_SRC = THIS_DIR.parent / "cpu_comparison" / "test_files" / "matmul_f32_8_4_8.mlir"
+
+
+@pytest.mark.soak
+def test_single_pdi_ctrlpkt(
+    compile_aie, run_iree, n_core_rows, n_core_cols, n_iters, tmp_path
+):
+    if not MLIR_SRC.exists():
+        pytest.skip(f"source MLIR not found at {MLIR_SRC}")
+
+    # matmul_f32_8_4_8 is a 4-chain matmul iteratively applying lhs to rhs.
+    # With lhs=1.5 (8x8) and rhs=2.0 (8x4):
+    #   %1 each = 8 * 1.5 * 2.0    = 24.0
+    #   %2 each = 8 * 1.5 * 24.0   = 288.0
+    #   %3 each = 8 * 1.5 * 288.0  = 3456.0
+    #   %4 each = 8 * 1.5 * 3456.0 = 41472.0
+    lhs = np.full((8, 8), 1.5, dtype=np.float32)
+    rhs = np.full((8, 4), 2.0, dtype=np.float32)
+    expected = lhs @ rhs
+    for _ in range(3):
+        expected = lhs @ expected
+
+    vmfb = compile_aie(MLIR_SRC, tmp_path / "matmul_f32_8_4_8.vmfb")
+    spec = IOSpec(
+        function_name="matmul_8_4_8",
+        inputs=[lhs, rhs],
+        expected=[expected],
+    )
+
+    failures = []
+    for i in range(1, n_iters + 1):
+        (got,) = run_iree(
+            vmfb, spec, n_core_rows, n_core_cols, tmp_path, iter_tag=str(i)
+        )
+        if not np.allclose(got, expected, rtol=spec.rtol, atol=spec.atol):
+            failures.append((i, got.flatten()[:4].tolist()))
+
+    assert not failures, (
+        f"{len(failures)}/{n_iters} soak iterations had numerical mismatch. "
+        f"First few: {failures[:5]}"
+    )

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/allocator.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/allocator.cc
@@ -55,6 +55,17 @@ iree_hal_xrt_lite_allocator_query_buffer_compatibility(
   }
 
   params->type &= ~IREE_HAL_MEMORY_TYPE_OPTIMAL;
+  // xrt-lite allocates SHMEM BOs (XCL_BO_FLAGS_HOST_ONLY) that are mmap'd
+  // shared with the device, so every allocation is simultaneously host-local,
+  // device-visible, host-mappable, and host-transferable. Declaring those
+  // capabilities lets iree-tooling's `requires_buffer_transfer` return false
+  // for output buffer views and skip the staging copy_buffer — the host can
+  // read the dispatch output BO directly, saving one BO allocation + one
+  // submission + one host memcpy per output.
+  params->type |=
+      IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
+  params->usage |=
+      IREE_HAL_BUFFER_USAGE_MAPPING | IREE_HAL_BUFFER_USAGE_TRANSFER;
 
   // Guard against the corner case where the requested buffer size is 0. The
   // application is unlikely to do anything when requesting a 0-byte buffer;

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/direct_command_buffer.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/direct_command_buffer.cc
@@ -162,11 +162,16 @@ static iree_status_t iree_hal_xrt_lite_direct_command_buffer_copy_buffer(
   iree_device_size_t source_offset =
       iree_hal_buffer_byte_offset(source_ref.buffer) + source_ref.offset;
 
-  uint8_t* dst =
-      reinterpret_cast<uint8_t*>(target_device_buffer_ptr) + target_offset;
-  uint8_t* src =
-      reinterpret_cast<uint8_t*>(source_device_buffer_ptr) + source_offset;
-  memcpy(dst, src, target_ref.length);
+  // Sync the host-mapped source range so the host memcpy reads device-written
+  // data, then sync the target range back to device so a subsequent dispatch
+  // sees the freshly copied bytes.
+  source_device_buffer->sync(shim_xdna::direction::device2host,
+                             target_ref.length, source_offset);
+  memcpy(reinterpret_cast<uint8_t*>(target_device_buffer_ptr) + target_offset,
+         reinterpret_cast<uint8_t*>(source_device_buffer_ptr) + source_offset,
+         target_ref.length);
+  target_device_buffer->sync(shim_xdna::direction::host2device,
+                             target_ref.length, target_offset);
 
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
@@ -204,7 +209,15 @@ static iree_status_t iree_hal_xrt_lite_direct_command_buffer_normal_run(
   for (iree_host_size_t j = 0; j < bindings.count; ++j) {
     shim_xdna::bo* bo = iree_hal_xrt_lite_buffer_handle(
         iree_hal_buffer_allocated_buffer(bindings.values[j].buffer));
-    ebuf.add_arg_bo(*bo);
+    // Propagate per-binding byte_offset (both the buffer's own subview offset
+    // within its allocated root, and the binding-level offset) into the
+    // device-side address. Without this, two bindings on the same root BO at
+    // different offsets collapse to the same physical address, causing the
+    // next dispatch to read/write the wrong slot.
+    uint64_t buffer_byte_off =
+        (uint64_t)iree_hal_buffer_byte_offset(bindings.values[j].buffer);
+    uint64_t binding_off = (uint64_t)bindings.values[j].offset;
+    ebuf.add_arg_bo_at_offset(*bo, buffer_byte_off + binding_off);
   }
   // Repeat the kernel execution `n_kernel_runs` times.
   for (int i = 0; i < n_kernel_runs; i++) {

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/kernel.cpp
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/kernel.cpp
@@ -98,6 +98,19 @@ void kernel::add_arg_bo(bo &bo_arg, const std::string &arg_name) {
   add_arg_64(bo_arg.get_paddr());
 }
 
+void kernel::add_arg_bo_at_offset(bo &bo_arg, uint64_t offset,
+                                  const std::string &arg_name) {
+  // Bind starting at `offset` so the driver tracks the slice this dispatch
+  // actually touches. Size is capped to remaining BO bytes.
+  m_exec_buf_bo->bind_at(m_arg_cnt, bo_arg, offset, bo_arg.size() - offset);
+  uint64_t paddr = bo_arg.get_paddr() + offset;
+  if (arg_name.empty())
+    m_patching_args.emplace_back(std::to_string(m_arg_cnt), paddr);
+  else
+    m_patching_args.emplace_back(arg_name, paddr);
+  add_arg_64(paddr);
+}
+
 void kernel::dump() {
   std::cout << "Dumping exec buf:";
   int *data = static_cast<int *>(m_exec_buf_bo->map());

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/kernel.h
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/kernel.h
@@ -29,6 +29,11 @@ struct kernel {
   void add_arg_32(uint32_t val);
   void add_arg_64(uint64_t val);
   void add_arg_bo(bo &bo_arg, const std::string &arg_name = "");
+  // Like add_arg_bo but adds `offset` to the BO base before passing the
+  // address to firmware. Required when a binding references a subview of a
+  // larger BO at a non-zero offset.
+  void add_arg_bo_at_offset(bo &bo_arg, uint64_t offset,
+                            const std::string &arg_name = "");
   void dump();
   void inc_pkt_count(uint32_t n) const;
 };


### PR DESCRIPTION
Fixes two unrelated bugs that surfaced as intermittent all-zero output on single-core ctrlpkt designs (matmul_f32_8_*_OneCore_npu4_ctrlpkt, two_matmul_switching_OneCore_npu4_ctrlpkt). Both are in the per-command ERT_START_CU path and apply to any test that exercises multi-binding / multi-dispatch ctrlpkt traffic.

## Bug 1: per-binding `byte_offset` propagation

In `iree_hal_xrt_lite_direct_command_buffer_normal_run`, the binding loop passed `bo->get_paddr()` to firmware, dropping each binding's `iree_hal_buffer_byte_offset(buffer)` (the subview offset within the allocated root BO) and `bindings.values[j].offset` (the binding-level offset). When IREE's stream scheduler packs two SSA values into a single transient BO at different offsets, both bindings collapse to the same paddr and the dispatch reads/writes the wrong slot.

Fix: a new `kernel::add_arg_bo_at_offset(bo, offset)` helper that adds the offset to the BO base before passing the paddr to firmware, plus the call site adds `buffer_byte_off + binding_off` to the BO. `add_arg_bo_at_offset` also calls `bind_at` so the driver sees the actual slice this dispatch touches.

Whether bug 1 fires on a given test is a compile-time decision (depends on the stream scheduler's packing for that specific vmfb). When it fires, it fires every iteration of that vmfb. For the existing CI test matmul_f32_8_4_8 4-chain it produced wrong-but-non-zero output that run.py's CPU comparison would catch; verified via the new `byte_offset_propagation_test.py` regression test that this bug is real and deterministic.

## Bug 2: `copy_buffer` host-cache management

`iree_hal_xrt_lite_direct_command_buffer_copy_buffer` had no host cache management around its memcpy. Now device2host-syncs the source range before the host read and host2device-syncs the target range after, matching the contract for SHMEM BOs that aren't strictly host-coherent.

## Allocator: declare SHMEM BO's true capabilities (perf + workaround) 

xrt-lite SHMEM BOs (XCL_BO_FLAGS_HOST_ONLY) are mmap'd shared with the device, so every allocation is simultaneously host-local, device-visible, host-mappable, and host-transferable. Declaring those bits in `iree_hal_xrt_lite_allocator_query_buffer_compatibility` lets iree-tooling's `iree_tooling_requires_buffer_transfer` return false for output buffer views and skip the staging copy_buffer path — the host reads the dispatch BO directly. This is:

  - A measurable perf win: skips one BO allocation + one queue submission + one host memcpy per output.

  - A workaround for a latent upstream IREE bug (use-after-release in `iree_arena_reset`, exposed by the xrt-lite async queue's pattern of embedding an arena descriptor inside the arena's own first block). When `iree_arena_reset` returns blocks to the pool and *then* writes to the arena struct, another arena that just acquired the released block (e.g., a deferred command buffer's cmd_list) races with those trailing writes and a recorded `copy_buffer`'s `header.type` can flip from COPY_BUFFER(7) to EXECUTION_BARRIER(0), silently dropping the copy. Surfaced as ~0.05% all-zero output.

The principled fix for the arena bug belongs in upstream IREE (clear arena fields before releasing blocks); a local-only branch `fix-arena-reset-uar` in third_party/iree carries that change ready to upstream. Once that lands and the iree pin bumps, the allocator declaration stays as the perf optimization it always was.

## Regression tests

`build_tools/ci/xrt_lite_regression_tests/byte_offset_propagation_test.py`
  Compiles a 2-chain matmul returning both intermediate `%1` and final
  `%2` (`byte_offset_propagation.mlir`) and asserts both outputs are
  non-zero. The dual-output design forces IREE's scheduler to pack the
  two values into a single transient BO, making the byte_offset bug
  100% reproducible. Pre-fix fails every run; post-fix passes every
  run. Runs in seconds.

`build_tools/ci/xrt_lite_soak_tests/single_pdi_ctrlpkt_test.py`
  Compiles matmul_f32_8_4_8 ctrlpkt once with one-core and dispatches
  5000x asserting non-zero output each iter. Catches the iree-tooling
  staging-copy race (and any future similar low-rate race) at >99%
  probability for the observed ~0.05% per-iter rate. ~7 min on npu4.

Verified the two tests catch independent things: reverting the byte_offset propagation alone (keeping the helper + allocator declaration) leaves the soak passing 1000/1000 but makes the regression test fail deterministically. The soak's "any non-zero" oracle doesn't detect bug 1 on this 4-chain vmfb because the wrong-slot writes leave non-zero (but wrong) data — only the dual-output forcing function (or a numerical compare against CPU) catches it deterministically.

Adds two CI workflow steps that invoke them after the existing "E2E comparison of AIE to llvm-cpu" step.

## Validation

  - 10000 single-PDI + 6000 multi-variant iters across matmul_8_4_8 / matmul_8_8_4 / two_matmul_switching ctrlpkt
  - Full run.py MultipleDispatches sweep (10 npu4 tests, 212 dispatches)
  - run.py Matmul ukernel-peano sweep
  - Both new tests pass post-fix; the regression test deterministically fails when byte_offset propagation is reverted.

Zero failures across all of the above on npu4.