### PR TITLE
[DMA] Bound outermost size for sub-nbIntraDims access patterns

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.cpp
@@ -698,7 +698,17 @@ SmallVector<int64_t> DmaDimConfig::getMaxSizes(
   assert(intraStart >= 0 &&
          "The start index for intra dimensions should be greater than or equal "
          "to zero");
-  if (intraStart < maxSizes.size())
+  // The highest intra dimension (e.g. shim/NOC D2) has no `wrap` register, so
+  // its size is implicit (derived from the buffer length) and effectively
+  // unbounded. This only holds when the access pattern actually occupies all
+  // `nbIntraDims` intra dimensions: the hardware fills the innermost dimension
+  // (D0) first, so a pattern with fewer dims than `nbIntraDims` leaves the
+  // wrap-less highest dim unused and its outermost dim maps to a lower,
+  // wrap-limited dimension (e.g. D1). Marking that dim unbounded would let the
+  // DMA combiner produce a size exceeding the hardware `WrapMax` that later
+  // lowering demotes into a wrap-limited dimension, which the hardware rejects.
+  if (nbIntraDimsToBeFilled == (int64_t)nbIntraDims &&
+      intraStart < maxSizes.size())
     maxSizes[intraStart] = std::numeric_limits<int64_t>::max();
   int64_t nbInterDimsToBeFilled = std::min((int64_t)nbInterDims, intraStart);
   int64_t interStart = intraStart - nbInterDimsToBeFilled;

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIEDmaUtilsTest.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/AMDAIEDmaUtilsTest.cpp
@@ -761,10 +761,12 @@ TEST_P(DmaDimConfigTest, ShimTileSizes) {
   SmallVector<int64_t> expectedMaxSizes = {
       63, std::numeric_limits<int64_t>::max(), 1023, 1023};
   EXPECT_EQ(maxSizes, expectedMaxSizes);
-  EXPECT_EQ(config.getMaxSizes(1),
-            SmallVector<int64_t>{std::numeric_limits<int64_t>::max()});
-  SmallVector<int64_t> expectedMaxSizes2 = {std::numeric_limits<int64_t>::max(),
-                                            1023};
+  // The highest intra dim (shim D2) has no `wrap` register and is therefore
+  // unbounded, but only when the access pattern actually occupies all
+  // `nbIntraDims` (3) intra dims. Patterns with fewer dims map their outermost
+  // dim to a lower, wrap-limited dim (D1/D0), so no entry is unbounded.
+  EXPECT_EQ(config.getMaxSizes(1), SmallVector<int64_t>{1023});
+  SmallVector<int64_t> expectedMaxSizes2 = {1023, 1023};
   EXPECT_EQ(config.getMaxSizes(2), expectedMaxSizes2);
   SmallVector<int64_t> expectedMaxSizes3 = {std::numeric_limits<int64_t>::max(),
                                             1023, 1023};
@@ -805,13 +807,13 @@ TEST_P(DmaDimConfigTest, MemTileSizes) {
   SmallVector<int64_t> expectedMaxSizes = {std::numeric_limits<int64_t>::max(),
                                            1023, 1023, 1023};
   EXPECT_EQ(maxSizes, expectedMaxSizes);
-  EXPECT_EQ(config.getMaxSizes(1),
-            SmallVector<int64_t>{std::numeric_limits<int64_t>::max()});
-  SmallVector<int64_t> expectedMaxSizes2 = {std::numeric_limits<int64_t>::max(),
-                                            1023};
+  // The highest intra dim is only unbounded when the access pattern occupies
+  // all `nbIntraDims` (4) intra dims; narrower patterns map their outermost dim
+  // to a wrap-limited dim.
+  EXPECT_EQ(config.getMaxSizes(1), SmallVector<int64_t>{1023});
+  SmallVector<int64_t> expectedMaxSizes2 = {1023, 1023};
   EXPECT_EQ(config.getMaxSizes(2), expectedMaxSizes2);
-  SmallVector<int64_t> expectedMaxSizes3 = {std::numeric_limits<int64_t>::max(),
-                                            1023, 1023};
+  SmallVector<int64_t> expectedMaxSizes3 = {1023, 1023, 1023};
   EXPECT_EQ(config.getMaxSizes(3), expectedMaxSizes3);
   EXPECT_EQ(config.getMaxSizes(4), expectedMaxSizes);
   SmallVector<int64_t> expectedMaxSizes5 = {
@@ -847,10 +849,11 @@ TEST_P(DmaDimConfigTest, CoreTileSizes) {
   SmallVector<int64_t> expectedMaxSizes = {std::numeric_limits<int64_t>::max(),
                                            255, 255};
   EXPECT_EQ(maxSizes, expectedMaxSizes);
-  EXPECT_EQ(config.getMaxSizes(1),
-            SmallVector<int64_t>{std::numeric_limits<int64_t>::max()});
-  SmallVector<int64_t> expectedMaxSizes2 = {std::numeric_limits<int64_t>::max(),
-                                            255};
+  // The highest intra dim is only unbounded when the access pattern occupies
+  // all `nbIntraDims` (3) intra dims; narrower patterns map their outermost dim
+  // to a wrap-limited dim.
+  EXPECT_EQ(config.getMaxSizes(1), SmallVector<int64_t>{255});
+  SmallVector<int64_t> expectedMaxSizes2 = {255, 255};
   EXPECT_EQ(config.getMaxSizes(2), expectedMaxSizes2);
   EXPECT_EQ(config.getMaxSizes(3), expectedMaxSizes);
   SmallVector<int64_t> expectedMaxSizes4 = {

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_doubly_strided_op_hardware_aware.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/canonicalize_doubly_strided_op_hardware_aware.mlir
@@ -69,3 +69,23 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     return
   }
 }
+
+// -----
+
+// A 2-dim access pattern whose outer dim (1536) exceeds WrapMax (1023). The
+// highest hardware dim (e.g. shim D2) is wrap-less/implicit, but a 2-dim pattern
+// occupies the two innermost (wrap-limited, max 1023) dims and leaves the
+// wrap-less dim unused, so the 1536 must be split rather than left in a
+// wrap-limited dim. Before the `getMaxSizes` fix the outermost-of-two dim was
+// wrongly treated as unbounded, so this was left as a single [1536] dim that
+// later lowering demoted into a wrap-limited dim, which the hardware rejects.
+// CHECK-LABEL:    func.func @two_dim_outer_exceeds_wrap_max
+// CHECK:          amdaie.dma_cpy_nd(%{{.+}}[0, 0, 0] [2, 768, 32] [49152, 64, 1], %{{.+}}[0, 0, 0] [2, 768, 32] [49152, 64, 1])
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @two_dim_outer_exceeds_wrap_max(%arg0: !amdaie.logicalobjectfifo<memref<49152xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<49152xi32>>) {
+    %0 = amdaie.dma_cpy_nd(%arg0[0, 0] [1536, 32] [64, 1], %arg1[0, 0] [1536, 32] [64, 1]) : (!amdaie.logicalobjectfifo<memref<49152xi32, 1>>, !amdaie.logicalobjectfifo<memref<49152xi32>>)
+    "iree.keep"(%0) : (index) -> ()
+    return
+  }
+}


### PR DESCRIPTION
`DmaDimConfig::getMaxSizes` marked the outermost intra dimension as unbounded (`int64_max`) for every access pattern. This is only correct when the pattern occupies all `nbIntraDims` intra dimensions, because the highest hardware dimension (e.g. shim/NOC D2) is the only one without a `wrap` register. The hardware fills the innermost dimension (D0) first, so a pattern with fewer dims than `nbIntraDims` leaves the wrap-less dim unused and its outermost dim maps to a lower, wrap-limited dimension (D1/D0, max 1023).

Treating that dim as unbounded let the strided-op combiner merge a windowed transfer into a single dimension of size `2 * contraction` which later lowering demotes into a wrap-limited BD dimension. When the contraction exceeds ~511 this overflows the 10-bit wrap field and aie-rt rejects the descriptor (`_XAieMl_DmaSetMultiDim: Invalid stepsize or wrap for dimension`). This blocked fused matmul chains with large reduction dimensions (e.g. FFN second matmul).

Only mark the highest intra dimension unbounded when the access pattern actually reaches it. Update the `DmaDimConfig` unit-test expectations (which encoded the old behavior) and add a hardware-aware canonicalization lit test covering a 2-dim pattern whose outer dim exceeds the wrap max.