### PR TITLE
[InsertDmaBdChain][AssignNpuDmaBdIds] Fix packet-flow chain ordering + BD-id wrap

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignNpuDmaBdIds.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEAssignNpuDmaBdIds.cpp
@@ -392,25 +392,40 @@ class BdIdAssignmentUtil {
       // Only create expression if more than 1 BD ID is needed and if,
       // otherwise, fall back to constant BD ID.
       if (size > 1) {
-        // Assigning BD IDs for all iterations in the loop.
-        SmallVector<uint32_t> bdIds;
-        for (uint32_t i = 0; i < size; i++) {
-          std::optional<uint32_t> bdId = generator.getAndAssignBdId(
-              dmaTileData.channel, BdIdAssignmentMode::Incremental);
-          if (!bdId) return failure();
-          bdIds.push_back(bdId.value());
-        }
-        // Get the BD ID for the first iteration as the offset.
+        // The semi-affine expression `iv % effSize + offset` used below indexes
+        // the loop iterations into the consecutive BD-id run
+        // [offset, offset + effSize - 1], so the reserved ids must be
+        // consecutive. Reserve a consecutive block: a plain incremental
+        // allocation can wrap around the end of the channel's valid range and
+        // produce a non-consecutive set (e.g. [15, 0, 1, ...] on a shim's 0..15
+        // pool), which would make the expression emit out-of-range ids. The
+        // block may be shorter than `size` if the channel can't fit a full run;
+        // the loop then cycles through fewer ids, which is still correct.
+        SmallVector<uint32_t> bdIds =
+            generator.getAndAssignConsecutiveBdIds(dmaTileData.channel, size);
+        if (bdIds.empty()) return failure();
         uint32_t offset = bdIds.front();
+        uint32_t effSize = bdIds.size();
 
-        // Create the semi-affine expression.
-        auto affineApply = rewriter.create<affine::AffineApplyOp>(
-            loop.getLoc(), ivExpr % size + offset,
-            ValueRange{
-                iv,
-            });
+        // When more than one consecutive id is available, use the semi-affine
+        // expression so the loop cycles through them; otherwise (`effSize ==
+        // 1`) the expression would fold to a constant map with a dangling `iv`
+        // operand, so emit a constant id instead.
+        Value bdIdValue;
+        if (effSize > 1) {
+          auto affineApply = rewriter.create<affine::AffineApplyOp>(
+              loop.getLoc(), ivExpr % effSize + offset,
+              ValueRange{
+                  iv,
+              });
+          bdIdValue = affineApply.getResult();
+        } else {
+          auto constant = rewriter.create<arith::ConstantOp>(
+              rewriter.getUnknownLoc(), rewriter.getIndexAttr(offset));
+          bdIdValue = constant.getResult();
+        }
         AMDAIE::BdIdOp bdIdOp = rewriter.create<AMDAIE::BdIdOp>(
-            rewriter.getUnknownLoc(), tileOp, affineApply.getResult());
+            rewriter.getUnknownLoc(), tileOp, bdIdValue);
         bdIdOpToBdIdsMap[bdIdOp] = bdIds;
         if (!shimDmaOpToBdIdMap.contains(dmaOp)) {
           SmallVector<AMDAIE::BdIdOp, 2> bdIdOps = {nullptr, nullptr};

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertDmaBdChain.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIEInsertDmaBdChain.cpp
@@ -184,6 +184,27 @@ LogicalResult insertDmaBdChain(const AMDAIE::AMDAIEDeviceModel &deviceModel,
       }
 
       DmaChain currDmaChain = {tileOp, connectionOp};
+
+      // Packet flows share stream-switch arbiters (routed by packet id), so the
+      // order of their queue-pushes must be preserved. A BD chain defers every
+      // push but the tail (see `AMDAIEControlCodeLowering`), so any chain --
+      // packet or circuit -- that straddles a packet-flow DMA moves a push
+      // across it and corrupts the result. Treat a packet-flow DMA as a
+      // sequence point: close all open chains at it. Breaking only other packet
+      // chains is insufficient; circuit chains must break too. All-circuit
+      // sequences are unaffected and still interleave freely.
+      bool isPacketFlow = false;
+      if (std::optional<AMDAIE::FlowOp> flowOp = connectionOp.getFlowOp())
+        isPacketFlow = flowOp->getIsPacketFlow();
+      if (isPacketFlow) {
+        for (const std::pair<DmaChain, DenseSet<uint32_t>> &entry :
+             dmaChainToBdIds) {
+          if (entry.first != currDmaChain) {
+            chainsToBreak.insert(entry.first);
+          }
+        }
+      }
+
       // Any duplicate BD ID from the same tile indicates that the chain
       // cannot grow further and requires breaking to release the
       // conflicting BD ID.

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_dma_bd_chain.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/insert_dma_bd_chain.mlir
@@ -402,3 +402,151 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     return
   }
 }
+
+// -----
+
+// Same interleaved two-connection pattern as `@two_connections`, but the flows
+// are packet flows. Packet flows share stream-switch arbiters and are routed by
+// packet id, so their push order must be preserved; interleaved chaining would
+// reorder the pushes. Expect NO chaining here (each DMA keeps its own wait) --
+// the two connections' BDs must not be interleaved into chains. Contrast with
+// `@two_connections` (circuit flows), which does chain them.
+// CHECK-LABEL: @two_connections_packet
+// CHECK:       amdaie.controlcode
+// CHECK:         %[[BD_ID_0:.+]] = amdaie.bd_id
+// CHECK:         %[[OF_0:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK:         %[[OF_1:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK:         %[[T0:.+]] = amdaie.npu.half_dma_cpy_nd async %{{.+}}(%[[OF_0]] [] [] [] bd_id = %{{.+}} channel = %{{.+}} start_bd = %{{.+}})
+// CHECK:         %[[T1:.+]] = amdaie.npu.half_dma_cpy_nd async %{{.+}}(%[[OF_1]] [] [] [] bd_id = %{{.+}} channel = %{{.+}} start_bd = %{{.+}})
+// CHECK:         amdaie.npu.dma_wait(%[[T0]] : !amdaie.async_token)
+// CHECK:         amdaie.npu.dma_wait(%[[T1]] : !amdaie.async_token)
+// CHECK:         %[[T2:.+]] = amdaie.npu.half_dma_cpy_nd async %{{.+}}(%[[OF_0]] [] [] [] bd_id = %{{.+}} channel = %{{.+}} start_bd = %{{.+}})
+// CHECK:         %[[T3:.+]] = amdaie.npu.half_dma_cpy_nd async %{{.+}}(%[[OF_1]] [] [] [] bd_id = %{{.+}} channel = %{{.+}} start_bd = %{{.+}})
+// CHECK:         amdaie.npu.dma_wait(%[[T2]] : !amdaie.async_token)
+// CHECK:         amdaie.npu.dma_wait(%[[T3]] : !amdaie.async_token)
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @two_connections_packet() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    amdaie.workgroup {
+      %tile = amdaie.tile(%c0, %c0)
+      %tile_0 = amdaie.tile(%c0, %c1)
+      %buffer = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_4 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_5 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_6 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %lock = amdaie.lock(%tile_0(0), 0)
+      %lock_7 = amdaie.lock(%tile_0(1), 0)
+      %lock_8 = amdaie.lock(%tile_0(2), 0)
+      %lock_9 = amdaie.lock(%tile_0(3), 0)
+      %channel = amdaie.channel(%tile, 0, port_type = DMA, direction = MM2S)
+      %channel_10 = amdaie.channel(%tile_0, 0, port_type = DMA, direction = S2MM)
+      %channel_11 = amdaie.channel(%tile, 1, port_type = DMA, direction = MM2S)
+      %channel_12 = amdaie.channel(%tile_0, 1, port_type = DMA, direction = S2MM)
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<512x512xbf16>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<512x512xbf16>
+      %2 = amdaie.logicalobjectfifo.from_buffers({%buffer, %buffer_4}, {%lock}, {%lock_7}) : memref<1024xbf16, 1 : i32>, memref<1024xbf16, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>
+      %3 = amdaie.logicalobjectfifo.placeholder{%tile} : !amdaie.logicalobjectfifo<memref<512x512xbf16>>
+      %4 = amdaie.flow({%channel} -> {%channel_10}) {is_packet_flow = true}
+      %5 = amdaie.connection(%2 {%channel_10}, %3 {%channel}, flow = %4) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<512x512xbf16>>)
+      %6 = amdaie.logicalobjectfifo.from_buffers({%buffer_5, %buffer_6}, {%lock_8}, {%lock_9}) : memref<1024xbf16, 1 : i32>, memref<1024xbf16, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>
+      %7 = amdaie.logicalobjectfifo.placeholder{%tile} : !amdaie.logicalobjectfifo<memref<512x512xbf16>>
+      %8 = amdaie.flow({%channel_11} -> {%channel_12}) {is_packet_flow = true}
+      %9 = amdaie.connection(%6 {%channel_11}, %7 {%channel_12}, flow = %8) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<512x512xbf16>>)
+      amdaie.controlcode {
+        memref.assume_alignment %0, 64 : memref<512x512xbf16>
+        %10 = amdaie.logicalobjectfifo.from_memref %0, {%tile} : memref<512x512xbf16> -> !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %11 = amdaie.logicalobjectfifo.from_memref %1, {%tile} : memref<512x512xbf16> -> !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %bd_id = amdaie.bd_id(%tile, %c0)
+        %12 = amdaie.npu.half_dma_cpy_nd async %5(%10 [] [] [] bd_id = %bd_id channel = %channel start_bd = %bd_id) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %bd_id_1 = amdaie.bd_id(%tile, %c1)
+        %13 = amdaie.npu.half_dma_cpy_nd async %9(%11 [] [] [] bd_id = %bd_id_1 channel = %channel_11 start_bd = %bd_id_1) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%12 : !amdaie.async_token)
+        amdaie.npu.dma_wait(%13 : !amdaie.async_token)
+        %bd_id_2 = amdaie.bd_id(%tile, %c2)
+        %14 = amdaie.npu.half_dma_cpy_nd async %5(%10 [] [] [] bd_id = %bd_id_2 channel = %channel start_bd = %bd_id_2) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %bd_id_3 = amdaie.bd_id(%tile, %c3)
+        %15 = amdaie.npu.half_dma_cpy_nd async %9(%11 [] [] [] bd_id = %bd_id_3 channel = %channel_11 start_bd = %bd_id_3) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%14 : !amdaie.async_token)
+        amdaie.npu.dma_wait(%15 : !amdaie.async_token)
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// A circuit connection issues two DMAs (which would chain on their own, cf.
+// `@two_connections`), but a packet-flow DMA is issued in between. A packet
+// flow is a sequence point for chaining: no chain may straddle it (otherwise a
+// push would move across the packet's fixed position in the arbiter order).
+// So the circuit connection's two DMAs must NOT be chained here -- each keeps
+// its own wait. (Breaking only other *packet* chains is insufficient; this is
+// the regression guard for that.)
+// CHECK-LABEL: @circuit_chain_broken_by_packet
+// CHECK:       amdaie.controlcode
+// CHECK:         %[[C_OF:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK:         %[[P_OF:.+]] = amdaie.logicalobjectfifo.from_memref
+// CHECK:         %[[CT0:.+]] = amdaie.npu.half_dma_cpy_nd async %{{.+}}(%[[C_OF]] [] [] [] bd_id = %{{.+}} channel = %{{.+}} start_bd = %{{.+}})
+// CHECK:         %[[PT:.+]] = amdaie.npu.half_dma_cpy_nd async %{{.+}}(%[[P_OF]] [] [] [] bd_id = %{{.+}} channel = %{{.+}} start_bd = %{{.+}})
+// CHECK:         amdaie.npu.dma_wait(%[[CT0]] : !amdaie.async_token)
+// CHECK:         amdaie.npu.dma_wait(%[[PT]] : !amdaie.async_token)
+// CHECK:         %[[CT1:.+]] = amdaie.npu.half_dma_cpy_nd async %{{.+}}(%[[C_OF]] [] [] [] bd_id = %{{.+}} channel = %{{.+}} start_bd = %{{.+}})
+// CHECK:         amdaie.npu.dma_wait(%[[CT1]] : !amdaie.async_token)
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+#pipeline_layout = #hal.pipeline.layout<bindings = [#hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, "ReadOnly|Indirect">, #hal.pipeline.binding<storage_buffer, Indirect>], flags = Indirect>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @circuit_chain_broken_by_packet() {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    amdaie.workgroup {
+      %tile = amdaie.tile(%c0, %c0)
+      %tile_0 = amdaie.tile(%c0, %c1)
+      %buffer = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_4 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_5 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %buffer_6 = amdaie.buffer(%tile_0) : memref<1024xbf16, 1 : i32>
+      %lock = amdaie.lock(%tile_0(0), 0)
+      %lock_7 = amdaie.lock(%tile_0(1), 0)
+      %lock_8 = amdaie.lock(%tile_0(2), 0)
+      %lock_9 = amdaie.lock(%tile_0(3), 0)
+      %channel = amdaie.channel(%tile, 0, port_type = DMA, direction = MM2S)
+      %channel_10 = amdaie.channel(%tile_0, 0, port_type = DMA, direction = S2MM)
+      %channel_11 = amdaie.channel(%tile, 1, port_type = DMA, direction = MM2S)
+      %channel_12 = amdaie.channel(%tile_0, 1, port_type = DMA, direction = S2MM)
+      %0 = hal.interface.binding.subspan layout(#pipeline_layout) binding(0) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<512x512xbf16>
+      %1 = hal.interface.binding.subspan layout(#pipeline_layout) binding(1) alignment(64) offset(%c0) flags("ReadOnly|Indirect") : memref<512x512xbf16>
+      %2 = amdaie.logicalobjectfifo.from_buffers({%buffer, %buffer_4}, {%lock}, {%lock_7}) : memref<1024xbf16, 1 : i32>, memref<1024xbf16, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>
+      %3 = amdaie.logicalobjectfifo.placeholder{%tile} : !amdaie.logicalobjectfifo<memref<512x512xbf16>>
+      %4 = amdaie.flow({%channel} -> {%channel_10}) {is_packet_flow = false}
+      %5 = amdaie.connection(%2 {%channel_10}, %3 {%channel}, flow = %4) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<512x512xbf16>>)
+      %6 = amdaie.logicalobjectfifo.from_buffers({%buffer_5, %buffer_6}, {%lock_8}, {%lock_9}) : memref<1024xbf16, 1 : i32>, memref<1024xbf16, 1 : i32> -> !amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>
+      %7 = amdaie.logicalobjectfifo.placeholder{%tile} : !amdaie.logicalobjectfifo<memref<512x512xbf16>>
+      %8 = amdaie.flow({%channel_11} -> {%channel_12}) {is_packet_flow = true}
+      %9 = amdaie.connection(%6 {%channel_11}, %7 {%channel_12}, flow = %8) {connection_type = #amdaie<connection_type Packet>} : (!amdaie.logicalobjectfifo<memref<1024xbf16, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<512x512xbf16>>)
+      amdaie.controlcode {
+        memref.assume_alignment %0, 64 : memref<512x512xbf16>
+        %10 = amdaie.logicalobjectfifo.from_memref %0, {%tile} : memref<512x512xbf16> -> !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %11 = amdaie.logicalobjectfifo.from_memref %1, {%tile} : memref<512x512xbf16> -> !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %bd_id = amdaie.bd_id(%tile, %c0)
+        %12 = amdaie.npu.half_dma_cpy_nd async %5(%10 [] [] [] bd_id = %bd_id channel = %channel start_bd = %bd_id) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        %bd_id_1 = amdaie.bd_id(%tile, %c1)
+        %13 = amdaie.npu.half_dma_cpy_nd async %9(%11 [] [] [] bd_id = %bd_id_1 channel = %channel_11 start_bd = %bd_id_1) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%12 : !amdaie.async_token)
+        amdaie.npu.dma_wait(%13 : !amdaie.async_token)
+        %bd_id_2 = amdaie.bd_id(%tile, %c2)
+        %14 = amdaie.npu.half_dma_cpy_nd async %5(%10 [] [] [] bd_id = %bd_id_2 channel = %channel start_bd = %bd_id_2) : !amdaie.logicalobjectfifo<memref<262144xbf16>>
+        amdaie.npu.dma_wait(%14 : !amdaie.async_token)
+        amdaie.end
+      }
+    }
+    return
+  }
+}

--- a/runtime/src/iree-amd-aie/aie_runtime/Utils/ChannelBdIdGenerator.cpp
+++ b/runtime/src/iree-amd-aie/aie_runtime/Utils/ChannelBdIdGenerator.cpp
@@ -46,4 +46,33 @@ std::optional<uint32_t> ChannelBdIdGenerator::getAndAssignBdId(
   return std::nullopt;
 }
 
+SmallVector<uint32_t> ChannelBdIdGenerator::getAndAssignConsecutiveBdIds(
+    uint32_t channel, uint32_t num) {
+  SmallVector<uint32_t> result;
+  if (num == 0 || !channelToValidBdIds.contains(channel)) return result;
+  const SmallVector<uint32_t> &valid = channelToValidBdIds[channel];
+  // Scan the valid ids in order and track the longest run of consecutive
+  // (contiguous-value) unassigned ids, stopping early once a run reaches `num`.
+  // Scanning ascending makes `best` the lowest-offset such run.
+  SmallVector<uint32_t> best, cur;
+  for (uint32_t id : valid) {
+    if (isBdIdAssigned(id)) {
+      cur.clear();
+      continue;
+    }
+    if (!cur.empty() && id == cur.back() + 1)
+      cur.push_back(id);
+    else
+      cur.assign(1, id);
+    if (cur.size() > best.size()) best = cur;
+    if (best.size() >= num) break;
+  }
+  uint32_t n = std::min<uint32_t>(best.size(), num);
+  for (uint32_t i = 0; i < n; ++i) {
+    assignBdId(best[i]);
+    result.push_back(best[i]);
+  }
+  return result;
+}
+
 }  // namespace mlir::iree_compiler::AMDAIE

--- a/runtime/src/iree-amd-aie/aie_runtime/Utils/ChannelBdIdGenerator.h
+++ b/runtime/src/iree-amd-aie/aie_runtime/Utils/ChannelBdIdGenerator.h
@@ -43,6 +43,17 @@ class ChannelBdIdGenerator {
   std::optional<uint32_t> getAndAssignBdId(
       uint32_t channel, BdIdAssignmentMode mode = BdIdAssignmentMode::Smallest);
 
+  /// Find and assign the lowest-offset run of `num` consecutive (contiguous in
+  /// value) unassigned BD ids for `channel`. If no run of length `num` exists,
+  /// assigns and returns the largest available consecutive run instead (which
+  /// may be a single id). Returns an empty vector only if the channel is
+  /// unknown or fully assigned. Consecutiveness is required by callers that
+  /// index the ids with an affine expression `iv % n + offset` (see
+  /// `AMDAIEAssignNpuDmaBdIds`); a plain incremental allocation can wrap around
+  /// the end of the valid range and break that invariant.
+  SmallVector<uint32_t> getAndAssignConsecutiveBdIds(uint32_t channel,
+                                                     uint32_t num);
+
   /// Check whether the provided BD id is currently assigned.
   bool isBdIdAssigned(uint32_t bdId) const { return assignedBdIds.count(bdId); }
 

--- a/runtime/src/iree-amd-aie/aie_runtime/Utils/test/ChannelBdIdGeneratorTest.cpp
+++ b/runtime/src/iree-amd-aie/aie_runtime/Utils/test/ChannelBdIdGeneratorTest.cpp
@@ -22,6 +22,13 @@ getTestSingleRangeChannelToValidBdIds() {
   return channelToValidBdIds;
 }
 
+DenseMap<uint32_t, SmallVector<uint32_t>> getTestRangeChannelToValidBdIds(
+    uint32_t n) {
+  SmallVector<uint32_t> range(n);
+  std::iota(range.begin(), range.end(), 0);
+  return {{0, range}, {1, range}};
+}
+
 DenseMap<uint32_t, SmallVector<uint32_t>> getTestEvenOddChannelToValidBdIds() {
   SmallVector<uint32_t> evenRange(4);
   std::iota(evenRange.begin(), evenRange.end(), 0);
@@ -126,6 +133,65 @@ TEST(ChannelBdIdGeneratorTest, IncrementalWrap) {
       generator.getAndAssignBdId(0, BdIdAssignmentMode::Incremental).value(),
       0);
   generator.releaseBdId(0);
+}
+
+TEST(ChannelBdIdGeneratorTest, ConsecutiveBlockFull) {
+  ChannelBdIdGenerator generator(getTestRangeChannelToValidBdIds(8));
+  EXPECT_EQ(generator.getAndAssignConsecutiveBdIds(0, 3),
+            SmallVector<uint32_t>({0, 1, 2}));
+  EXPECT_TRUE(generator.isBdIdAssigned(0));
+  EXPECT_TRUE(generator.isBdIdAssigned(2));
+  // The next block continues after the first.
+  EXPECT_EQ(generator.getAndAssignConsecutiveBdIds(0, 3),
+            SmallVector<uint32_t>({3, 4, 5}));
+}
+
+TEST(ChannelBdIdGeneratorTest, ConsecutiveBlockShorterWhenFragmented) {
+  ChannelBdIdGenerator generator(getTestRangeChannelToValidBdIds(4));
+  // Reserve id 2, splitting the pool into {0, 1} and {3}.
+  generator.assignBdId(2);
+  // A run of 4 doesn't exist; the longest available run is {0, 1}.
+  EXPECT_EQ(generator.getAndAssignConsecutiveBdIds(0, 4),
+            SmallVector<uint32_t>({0, 1}));
+}
+
+TEST(ChannelBdIdGeneratorTest, ConsecutiveBlockNeverWrapsOutOfRange) {
+  // Regression: a plain incremental allocation marches `lastUsedBdId` toward
+  // the top of the pool and then wraps, yielding a non-consecutive set (e.g.
+  // [3, 0]) whose use as `offset + iv % n` would emit out-of-range ids. The
+  // consecutive allocator must always return an in-range, consecutive run.
+  ChannelBdIdGenerator generator(getTestRangeChannelToValidBdIds(4));  // 0..3
+  generator.getAndAssignBdId(0, BdIdAssignmentMode::Incremental);      // 0
+  generator.getAndAssignBdId(0, BdIdAssignmentMode::Incremental);      // 1
+  generator.getAndAssignBdId(0, BdIdAssignmentMode::Incremental);      // 2
+  generator.releaseBdId(0);
+  generator.releaseBdId(1);
+  // Free now: {0, 1, 3}, incremental cursor at 2 (an incremental block of 2
+  // would wrap to [3, 0]). The consecutive run must be the in-range [0, 1].
+  SmallVector<uint32_t> block = generator.getAndAssignConsecutiveBdIds(0, 2);
+  EXPECT_EQ(block, SmallVector<uint32_t>({0, 1}));
+  for (uint32_t id : block) EXPECT_LT(id, 4u);
+}
+
+TEST(ChannelBdIdGeneratorTest, ConsecutiveBlockSingleWhenFullyFragmented) {
+  ChannelBdIdGenerator generator(getTestRangeChannelToValidBdIds(4));  // 0..3
+  // Reserve 1 and 2, leaving only the isolated singles {0} and {3}.
+  generator.assignBdId(1);
+  generator.assignBdId(2);
+  // No run of length > 1 exists; the lowest single is returned (this is what
+  // collapses `AMDAIEAssignNpuDmaBdIds` to its constant-id branch).
+  EXPECT_EQ(generator.getAndAssignConsecutiveBdIds(0, 3),
+            SmallVector<uint32_t>({0}));
+}
+
+TEST(ChannelBdIdGeneratorTest, ConsecutiveBlockEmptyWhenExhausted) {
+  ChannelBdIdGenerator generator(getTestRangeChannelToValidBdIds(2));  // 0..1
+  generator.assignBdId(0);
+  generator.assignBdId(1);
+  // Channel fully assigned -> empty (drives the pass's failure path).
+  EXPECT_TRUE(generator.getAndAssignConsecutiveBdIds(0, 2).empty());
+  // Unknown channel -> empty too.
+  EXPECT_TRUE(generator.getAndAssignConsecutiveBdIds(7, 1).empty());
 }
 
 }  // namespace


### PR DESCRIPTION
Two independent correctness fixes exposed by hand-authored / loop-subsumed controlcode (the LOF pipeline), but general to both passes:

1. AMDAIEInsertDmaBdChain: a BD chain defers every queue-push except the chain tail's (ControlCodeLowering), so building chains interleaved reorders their pushes. Packet flows share stream-switch arbiters and their global push order is observable, so interleaved packet-flow chains corrupt the output. Treat a packet-flow DMA as a sequence point: close all open chains when one is reached (circuit flows, which have dedicated routes, still interleave freely). This re-establishes the non-interleaving invariant from #1210 that #1248 relaxed in favor of `barrier` ops -- but those are only inserted for control packets, so data packet flows regressed. Tests: @two_connections_packet, @circuit_chain_broken_by_packet.

2. AMDAIEAssignNpuDmaBdIds: the affine BD-id expression `iv % size + offset` indexes loop iterations into the contiguous id block [offset, offset+size); it reserved them with getAndAssignBdId(Incremental), which can wrap the channel's valid range (e.g. [15,0,1,2,3] on a shim's 0..15 pool) and emit out-of-range ids (XAie "Invalid Next Bd"/"Invalid BD number"). Add ChannelBdIdGenerator::getAndAssignConsecutiveBdIds to reserve a consecutive run (shorter under fragmentation -> fewer distinct ids, still correct). Unit tests incl an anti-wrap regression case.

HW-validated on npu4 across i32 + bf16 fused matmul-chain sweeps (subsume-loops on and off, grids up to 8x4 incl the SmolLM FFN [64,576,1536,576]).