### PR TITLE
[xrt-lite] Validate command completion; don't abort on ioctl errors

### DIFF
--- a/runtime/src/iree-amd-aie/driver/xrt-lite/direct_command_buffer.cc
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/direct_command_buffer.cc
@@ -482,8 +482,21 @@ static iree_status_t iree_hal_xrt_lite_submit_chain(
     chain_bo->bind_at(arg_pos++, *bo, 0, bo->size());
   }
 
-  hwq->issue_command(chain_bo);
-  hwq->wait_command(chain_bo, 0);
+  if (int err = hwq->issue_command(chain_bo)) {
+    return iree_make_status(
+        IREE_STATUS_INTERNAL,
+        "xrt-lite ERT_CMD_CHAIN submit (EXEC_CMD ioctl) failed: errno %d", err);
+  }
+  int rc = hwq->wait_command(chain_bo, 0);
+  if (rc < 0) {
+    return iree_make_status(
+        IREE_STATUS_INTERNAL,
+        "xrt-lite ERT_CMD_CHAIN wait ioctl failed: errno %d", -rc);
+  }
+  if (rc == 0) {
+    return iree_make_status(IREE_STATUS_DEADLINE_EXCEEDED,
+                            "xrt-lite ERT_CMD_CHAIN of %zu slots timed out", n);
+  }
 
   // Fail loudly if the chain did not complete (firmware reject / timeout)
   // rather than silently returning stale buffer contents.
@@ -602,8 +615,36 @@ static iree_status_t iree_hal_xrt_lite_direct_command_buffer_normal_run(
   // Repeat the kernel execution `n_kernel_runs` times.
   for (int i = 0; i < n_kernel_runs; i++) {
     ebuf.m_cmd_pkt->state = ERT_CMD_STATE_NEW;
-    hwq->issue_command(ebuf.get_exec_buf_bo());
-    hwq->wait_command(ebuf.get_exec_buf_bo(), 0);
+    if (int err = hwq->issue_command(ebuf.get_exec_buf_bo())) {
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(
+          IREE_STATUS_INTERNAL,
+          "xrt-lite dispatch submit (EXEC_CMD ioctl) failed: errno %d", err);
+    }
+    int rc = hwq->wait_command(ebuf.get_exec_buf_bo(), 0);
+    if (rc < 0) {
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(IREE_STATUS_INTERNAL,
+                              "xrt-lite dispatch wait ioctl failed: errno %d",
+                              -rc);
+    }
+    if (rc == 0) {
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(IREE_STATUS_DEADLINE_EXCEEDED,
+                              "xrt-lite dispatch timed out");
+    }
+    // The driver signals the command fence even on a TDR abort or timeout, so
+    // the wait returning is not proof of success. Trust the firmware-written
+    // ert state: anything other than COMPLETED means the output buffers are
+    // stale/garbage, so surface it instead of syncing wrong results back to the
+    // host. Mirrors the chain path's check.
+    if (ebuf.m_cmd_pkt->state != ERT_CMD_STATE_COMPLETED) {
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(
+          IREE_STATUS_INTERNAL,
+          "xrt-lite dispatch did not complete: ert state %u",
+          ebuf.m_cmd_pkt->state);
+    }
   }
   // Sync the bindings back to the host.
   for (iree_host_size_t j = 0; j < bindings.count; ++j) {
@@ -652,8 +693,37 @@ static iree_status_t iree_hal_xrt_lite_direct_command_buffer_reconfigure(
   // Execute the reconfiguration for `n_reconfigure_runs` times.
   for (int i = 0; i < n_reconfigure_runs; ++i) {
     ebuf.m_cmd_pkt->state = ERT_CMD_STATE_NEW;
-    hwq->issue_command(ebuf.get_exec_buf_bo());
-    hwq->wait_command(ebuf.get_exec_buf_bo(), 0);
+    if (int err = hwq->issue_command(ebuf.get_exec_buf_bo())) {
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(
+          IREE_STATUS_INTERNAL,
+          "xrt-lite reconfiguration submit (EXEC_CMD ioctl) failed: errno %d",
+          err);
+    }
+    int rc = hwq->wait_command(ebuf.get_exec_buf_bo(), 0);
+    if (rc < 0) {
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(
+          IREE_STATUS_INTERNAL,
+          "xrt-lite reconfiguration wait ioctl failed: errno %d", -rc);
+    }
+    if (rc == 0) {
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(IREE_STATUS_DEADLINE_EXCEEDED,
+                              "xrt-lite control-packet reconfiguration timed "
+                              "out");
+    }
+    // A failed reconfiguration leaves the array partially programmed; the next
+    // dispatch would run against a bad config and produce wrong results. Reject
+    // a non-COMPLETED ert state here rather than proceeding silently.
+    if (ebuf.m_cmd_pkt->state != ERT_CMD_STATE_COMPLETED) {
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(
+          IREE_STATUS_INTERNAL,
+          "xrt-lite control-packet reconfiguration did not complete: ert "
+          "state %u",
+          ebuf.m_cmd_pkt->state);
+    }
   }
 
   IREE_TRACE_ZONE_END(z0);

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/device.cpp
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/device.cpp
@@ -130,6 +130,13 @@ void pdev::ioctl(unsigned long cmd, void *arg) const {
   }
 }
 
+int pdev::try_ioctl(unsigned long cmd, void *arg) const {
+  if (::ioctl(m_dev_fd, cmd, arg) == -1) {
+    return errno;
+  }
+  return 0;
+}
+
 void *pdev::mmap(void *addr, size_t len, int prot, int flags,
                  off_t offset) const {
   void *ret = ::mmap(addr, len, prot, flags, m_dev_fd, offset);

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/device.h
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/device.h
@@ -24,6 +24,11 @@ struct pdev {
   ~pdev();
 
   void ioctl(unsigned long cmd, void *arg) const;
+  // Non-aborting variant of ioctl(): returns 0 on success or the failing errno,
+  // instead of std::abort()-ing through shim_err(). Use on recoverable hot
+  // paths (command submit/wait) so a transient or bad-input ioctl surfaces as
+  // an iree_status_t rather than a process SIGABRT.
+  int try_ioctl(unsigned long cmd, void *arg) const;
   void *mmap(void *addr, size_t len, int prot, int flags, off_t offset) const;
 };
 

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/hwq.cpp
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/hwq.cpp
@@ -49,8 +49,9 @@ int wait_cmd(const shim_xdna::pdev &pdev, const shim_xdna::hw_ctx *ctx,
       if (errno == ETIME) {
         ret = 0;
       } else {
-        shim_xdna::shim_err(errno,
-                            "DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT IOCTL failed");
+        // Don't abort the process on a hard wait failure; let the caller turn
+        // it into an iree_status_t.
+        return -errno;
       }
     }
   } else {
@@ -63,7 +64,9 @@ int wait_cmd(const shim_xdna::pdev &pdev, const shim_xdna::hw_ctx *ctx,
       if (errno == ETIME) {
         ret = 0;
       } else {
-        shim_xdna::shim_err(errno, "DRM_IOCTL_AMDXDNA_WAIT_CMD IOCTL failed");
+        // Don't abort the process on a hard wait failure; let the caller turn
+        // it into an iree_status_t.
+        return -errno;
       }
     }
   }
@@ -107,7 +110,7 @@ void hw_q::submit_signal(const fence_handle *f) { f->submit_signal(m_hwctx); }
 
 hw_q::~hw_q() { SHIM_DEBUG("Destroying KMQ HW queue"); }
 
-void hw_q::issue_command(bo *cmd_bo) {
+int hw_q::issue_command(bo *cmd_bo) {
   // Assuming 1024 max args per cmd bo
   const size_t max_arg_bos = 1024;
 
@@ -122,17 +125,25 @@ void hw_q::issue_command(bo *cmd_bo) {
       .cmd_count = 1,
       .arg_count = cmd_bo->get_arg_bo_handles(arg_bo_hdls, max_arg_bos),
   };
-  m_pdev.ioctl(DRM_IOCTL_AMDXDNA_EXEC_CMD, &ecmd);
+  int err = m_pdev.try_ioctl(DRM_IOCTL_AMDXDNA_EXEC_CMD, &ecmd);
+  if (err) return err;
   m_exec_cmd_count.fetch_add(1, std::memory_order_relaxed);
 
   auto id = ecmd.seq;
   cmd_bo->set_cmd_id(id);
   SHIM_DEBUG("Submitted command (%ld)", id);
+  return 0;
 }
 
 int poll_command(bo *cmd) {
   ert_packet *cmdpkt = reinterpret_cast<ert_packet *>(cmd->map());
-  if (cmdpkt->state >= ERT_CMD_STATE_COMPLETED) {
+  // Only ERT_CMD_STATE_COMPLETED means "finished successfully". The ert state
+  // enum is NOT monotonic past COMPLETED(4): SUBMITTED(7) is a pre-completion
+  // state, and ERROR(5)/ABORT(6)/TIMEOUT(8)/NORESPONSE(9) are terminal
+  // failures. A `>= COMPLETED` test wrongly reported all of those as done. Let
+  // terminal-error states fall through to the syncobj wait (their fence is
+  // signaled) so the caller's ert-state check surfaces the failure.
+  if (cmdpkt->state == ERT_CMD_STATE_COMPLETED) {
     return 1;
   }
   return 0;

--- a/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/hwq.h
+++ b/runtime/src/iree-amd-aie/driver/xrt-lite/shim/linux/kmq/hwq.h
@@ -25,13 +25,18 @@ struct hw_q {
   hw_q(const device &device);
   ~hw_q();
 
+  // Returns: >0 the command was signaled (check its ert state for COMPLETED vs
+  // a terminal error), 0 on ETIME timeout, or -errno on a hard wait-ioctl
+  // failure (no longer aborts).
   int wait_command(bo *, uint32_t timeout_ms) const;
   void submit_wait(const fence_handle *);
   void submit_wait(const std::vector<fence_handle *> &);
   void submit_signal(const fence_handle *);
   void bind_hwctx(const hw_ctx *ctx);
   void unbind_hwctx();
-  void issue_command(bo *);
+  // Returns 0 on success or the failing errno from the EXEC_CMD ioctl (no
+  // longer aborts).
+  int issue_command(bo *);
   uint64_t exec_cmd_count() const {
     return m_exec_cmd_count.load(std::memory_order_relaxed);
   }


### PR DESCRIPTION
The command submit/wait path had two robustness gaps:

- normal_run and reconfigure ignored the wait result and never checked the firmware-written ert state, so a TDR-aborted or timed-out command (whose fence the driver still signals) looked like success and returned stale output buffers. Both now require ERT_CMD_STATE_COMPLETED after the wait, map a timed-out wait to DEADLINE_EXCEEDED, and mirror the chain path's existing check. poll_command is tightened from `>= COMPLETED` to `== COMPLETED` (the ert enum is not monotonic past it: SUBMITTED=7, and ERROR/ABORT/ TIMEOUT are terminal failures).

- A hard EXEC_CMD or wait ioctl failure funneled through shim_err -> std::abort(), turning a recoverable driver errno into a process SIGABRT. Add pdev::try_ioctl (returns errno), have issue_command return errno and wait_command return -errno, and translate both into an iree_status_t at the call sites.

Validated on npu4: i32 matmul and control-packet matmul both return correct results (256), confirming the standalone ERT_START_CU path writes COMPLETED so the new check does not over-reject.