### PR TITLE
[CombineStridedOps] Stop combining across phase boundaries; use first DMA's operands

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECombineStridedOps.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIECombineStridedOps.cpp
@@ -52,19 +52,33 @@ struct CombineStridedOps
 
     if (auto npuDmaOp = dyn_cast<AMDAIE::NpuDmaCpyNdOp>(op.getOperation())) {
       LLVM_DEBUG(llvm::dbgs() << "npuDmaOp: " << npuDmaOp << "\n");
-      // Fail if any non-wait user operations.
+      // The wait users of `npuDmaOp` are erased after combining, so each one
+      // must reference only `npuDmaOp`'s tokens. Bail on any non-wait user or
+      // any multi-token wait (which would also be synchronizing another DMA
+      // whose sync we would silently drop). At this pipeline stage
+      // (DmaComposition runs before NpuDmaToHalfDmaCpyNd and FoldDmaWaits),
+      // every wait is single-token in the standard flow; the check guards
+      // hand-authored IR.
       for (Operation *userOp : npuDmaOp->getUsers()) {
-        if (isa<AMDAIE::NpuDmaWaitOp>(userOp)) {
-          userOpsToBeErased.push_back(userOp);
-        } else {
-          return failure();
-        }
+        auto waitOp = dyn_cast<AMDAIE::NpuDmaWaitOp>(userOp);
+        if (!waitOp || waitOp.getAsyncTokens().size() != 1) return failure();
+        userOpsToBeErased.push_back(userOp);
       }
       FailureOr<AMDAIE::NpuDmaCpyNdOp> maybeNextNpuDmaOp =
           findNextDmaOpWithSameConnection(npuDmaOp, block);
       if (failed(maybeNextNpuDmaOp)) return failure();
-      nextStridedOp = cast<AMDAIE::DoublyStridedOpInterface>(
-          maybeNextNpuDmaOp->getOperation());
+      AMDAIE::NpuDmaCpyNdOp nextNpuDmaOp = *maybeNextNpuDmaOp;
+      // The same hardware connection can be intentionally reused for distinct
+      // logical transfers in different phases (for example, draining two
+      // different outputs through one route). Combining such ops would keep the
+      // first op's source/target operands and silently redirect the later
+      // phase.
+      if (npuDmaOp.getSource() != nextNpuDmaOp.getSource() ||
+          npuDmaOp.getTarget() != nextNpuDmaOp.getTarget()) {
+        return failure();
+      }
+      nextStridedOp =
+          cast<AMDAIE::DoublyStridedOpInterface>(nextNpuDmaOp.getOperation());
       if (!nextStridedOp) return failure();
 
       std::optional<uint8_t> sourceMemspaceInt =
@@ -149,9 +163,13 @@ struct CombineStridedOps
     }
 
     rewriter.setInsertionPoint(op);
-    auto newDoublyStridedOp = nextStridedOp.createDoublyStridedOp(
-        rewriter, newTargetOffsets, newTargetSizes, newTargetStrides,
-        newSourceOffsets, newSourceSizes, newSourceStrides);
+    FailureOr<AMDAIE::DoublyStridedOpInterface> maybeNewDoublyStridedOp =
+        createCombinedDoublyStridedOp(op, nextStridedOp, rewriter,
+                                      newTargetOffsets, newTargetSizes,
+                                      newTargetStrides, newSourceOffsets,
+                                      newSourceSizes, newSourceStrides);
+    if (failed(maybeNewDoublyStridedOp)) return failure();
+    auto newDoublyStridedOp = *maybeNewDoublyStridedOp;
     rewriter.replaceOp(nextStridedOp, newDoublyStridedOp.getOperation());
 
     for (Operation *userOp : userOpsToBeErased) rewriter.eraseOp(userOp);
@@ -159,17 +177,102 @@ struct CombineStridedOps
     return success();
   }
 
+  static FailureOr<AMDAIE::DoublyStridedOpInterface>
+  createCombinedDoublyStridedOp(AMDAIE::DoublyStridedOpInterface op,
+                                AMDAIE::DoublyStridedOpInterface nextStridedOp,
+                                PatternRewriter &rewriter,
+                                ArrayRef<OpFoldResult> newTargetOffsets,
+                                ArrayRef<OpFoldResult> newTargetSizes,
+                                ArrayRef<OpFoldResult> newTargetStrides,
+                                ArrayRef<OpFoldResult> newSourceOffsets,
+                                ArrayRef<OpFoldResult> newSourceSizes,
+                                ArrayRef<OpFoldResult> newSourceStrides) {
+    // Build the combined npu.dma_cpy_nd op from the first DMA's operands so BD
+    // ids and FIFO operands dominate the insertion point. Result-type handling
+    // is asymmetric because the combined op is created at the first op's
+    // position but takes the second op's place via `replaceOp(nextStridedOp,
+    // newOp)`, which requires equal result counts:
+    //   - (empty op, token next): combine; the combined op inherits the
+    //     second's token, and the trailing wait redirects to it.
+    //   - (token op, empty next): bail -- `replaceOp` would mismatch (1 vs 0).
+    //   - (token, token same):    combine; keep the shared token type.
+    //   - (token, token diff):    bail; no token-union exists.
+    if (auto npuDmaOp = dyn_cast<AMDAIE::NpuDmaCpyNdOp>(op.getOperation())) {
+      SmallVector<Type> resultTypes(op->getResultTypes());
+      if (resultTypes.empty()) {
+        resultTypes.assign(nextStridedOp->getResultTypes().begin(),
+                           nextStridedOp->getResultTypes().end());
+      } else if (nextStridedOp->getResultTypes().empty()) {
+        // (token op, empty next): the new op would have op's token type but
+        // `rewriter.replaceOp(nextStridedOp, newOp)` below requires equal
+        // result counts. Preserving op's wait by replacing op's users instead
+        // would require a different rewrite strategy; bail.
+        return failure();
+      } else if (!llvm::equal(resultTypes, nextStridedOp->getResultTypes())) {
+        return failure();
+      }
+      auto newOp = AMDAIE::NpuDmaCpyNdOp::create(
+          rewriter, npuDmaOp.getLoc(), TypeRange(resultTypes),
+          npuDmaOp.getConnection(), npuDmaOp.getTarget(), newTargetOffsets,
+          newTargetSizes, newTargetStrides, npuDmaOp.getTargetBdId(),
+          npuDmaOp.getSource(), newSourceOffsets, newSourceSizes,
+          newSourceStrides, npuDmaOp.getSourceBdId());
+      return cast<AMDAIE::DoublyStridedOpInterface>(newOp.getOperation());
+    }
+
+    // Fallback path (e.g. NpuCircularDmaCpyNdOp): the `createDoublyStridedOp`
+    // interface method's signature takes mutable `SmallVector<OpFoldResult>&`,
+    // so materialize local copies to forward through it.
+    SmallVector<OpFoldResult> tgtOffs(newTargetOffsets);
+    SmallVector<OpFoldResult> tgtSizes(newTargetSizes);
+    SmallVector<OpFoldResult> tgtStrides(newTargetStrides);
+    SmallVector<OpFoldResult> srcOffs(newSourceOffsets);
+    SmallVector<OpFoldResult> srcSizes(newSourceSizes);
+    SmallVector<OpFoldResult> srcStrides(newSourceStrides);
+    return op.createDoublyStridedOp(rewriter, tgtOffs, tgtSizes, tgtStrides,
+                                    srcOffs, srcSizes, srcStrides);
+  }
+
   template <typename T>
   static FailureOr<T> findNextDmaOpWithSameConnection(T dmaOp, Block *block) {
+    // Walk the block (pre-order, recursing into nested regions) looking for
+    // the next op of type `T` on the same connection. Policy:
+    //   - `amdaie.npu.barrier`: global ordering boundary, bail.
+    //   - Same-connection DMA actor of a *different* kind (a
+    //     `circular_dma_cpy_nd` between two `dma_cpy_nd`s on the same
+    //     connection, or vice versa): bail. The combined op would be hoisted
+    //     past it and reorder the controlcode stream.
+    //   - Type-T same-connection candidate found in a different block
+    //     (nested region): bail; hoisting past nested control flow would
+    //     reorder. Empty or unrelated nested regions flow through. This
+    //     matters when `SubsumeLoopIntoDMA` leaves an empty loop shell
+    //     after hoisting DMAs out -- the combiner needs to keep merging
+    //     adjacent hoisted DMAs across that empty loop.
+    //   - Same-block same-connection type-T candidate: return.
+    Value connection = dmaOp.getConnection();
     T nextDmaOp;
     Block::iterator begin = std::next(dmaOp->getIterator());
-    block->walk(begin, block->end(), [&](T other) {
-      if (dmaOp.getConnection() != other.getConnection())
+    block->walk(begin, block->end(), [&](Operation *other) {
+      if (isa<AMDAIE::NpuBarrierOp>(other)) return WalkResult::interrupt();
+      auto candidate = dyn_cast<T>(other);
+      if (!candidate) {
+        // Same-connection DMA actor of a different kind blocks.
+        if (auto npuDmaOp = dyn_cast<AMDAIE::NpuDmaCpyNdOp>(other)) {
+          if (npuDmaOp.getConnection() == connection)
+            return WalkResult::interrupt();
+        }
+        if (auto npuCircDmaOp =
+                dyn_cast<AMDAIE::NpuCircularDmaCpyNdOp>(other)) {
+          if (npuCircDmaOp.getConnection() == connection)
+            return WalkResult::interrupt();
+        }
         return WalkResult::advance();
-      Block *otherBlock = other->getBlock();
+      }
+      if (candidate.getConnection() != connection) return WalkResult::advance();
+      Block *otherBlock = candidate->getBlock();
       if (!otherBlock) return WalkResult::advance();
       if (otherBlock != block) return WalkResult::interrupt();
-      nextDmaOp = other;
+      nextDmaOp = candidate;
       return WalkResult::interrupt();
     });
     if (nextDmaOp) return nextDmaOp;

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/combine_strided_ops.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/combine_strided_ops.mlir
@@ -473,11 +473,15 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // DMA ordering checks
 //===----------------------------------------------------------------------===//
 
-// We combine across wait operations, which should be ok as no other actor should
-// touch the circular DMA in between. Therefore, the wait can be removed.
+// The first DMA is `async_source` (token) and the second is non-async (empty).
+// The walker skips past the intervening wait, but `createCombinedDoublyStridedOp`
+// bails on the `(token, empty)` result-type case because `replaceOp(next,
+// combined)` would mismatch result counts (1 vs 0). Net: same observable IR.
 // CHECK-LABEL: @wait_after_first
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
-// CHECK:       amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [] [] [])
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION]]([] [] [], [] [] [])
+// CHECK-NEXT:  amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_source_token)
+// CHECK-NEXT:  amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [] [] [])
 // CHECK-NOT:   amdaie.npu.dma_cpy_nd
 // CHECK-NOT:   amdaie.npu.dma_wait
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
@@ -489,6 +493,325 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
         %1 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], [] [] [])
         amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
         amdaie.npu.dma_cpy_nd %0([] [] [], [] [] [])
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// A wait for an unrelated connection is not a global barrier. The two DMAs on
+// the first connection can still be combined across the independent DMA/wait
+// stream on the second connection.
+// CHECK-LABEL: @unrelated_wait_does_not_block_combine
+// CHECK:       %[[CONNECTION_0:.+]] = amdaie.connection
+// CHECK:       %[[CONNECTION_1:.+]] = amdaie.connection
+// CHECK:       amdaie.npu.dma_cpy_nd %[[CONNECTION_0]]([] [] [], [0, 0] [2, 16] [32, 1])
+// CHECK-NEXT:  %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION_1]]([] [] [], [] [] [])
+// CHECK-NEXT:  amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_source_token)
+// CHECK-NOT:   amdaie.npu.dma_cpy_nd
+// CHECK-NOT:   amdaie.npu.dma_wait
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @unrelated_wait_does_not_block_combine(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32>>) {
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      %1 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      amdaie.controlcode {
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
+        %2 = amdaie.npu.dma_cpy_nd async_source %1([] [] [], [] [] [])
+        amdaie.npu.dma_wait(%2 : !amdaie.async_source_token)
+        amdaie.npu.dma_cpy_nd %0([] [] [], [32] [16] [1])
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// When combining legal adjacent DMAs, preserve the first DMA's operands. Using
+// operands from the later DMA while inserting before the first DMA can create
+// invalid IR if the later BD id is defined after the first DMA.
+// CHECK-LABEL: @combine_preserves_first_bd_id
+// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK:       %[[TILE:.+]] = amdaie.tile(%[[C0]], %[[C0]])
+// CHECK:       %[[CONNECTION:.+]] = amdaie.connection
+// CHECK:       %[[BD0:.+]] = amdaie.bd_id(%[[TILE]], %[[C0]])
+// CHECK:       amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0, 0] [2, 16] [32, 1] bd_id = %[[BD0]])
+// CHECK-NOT:   amdaie.npu.dma_cpy_nd
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @combine_preserves_first_bd_id(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32>>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    amdaie.workgroup {
+      %tile = amdaie.tile(%c0, %c0)
+      %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      amdaie.controlcode {
+        %bd0 = amdaie.bd_id(%tile, %c0)
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1] bd_id = %bd0)
+        %bd1 = amdaie.bd_id(%tile, %c1)
+        amdaie.npu.dma_cpy_nd %0([] [] [], [32] [16] [1] bd_id = %bd1)
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Mirror of `@combine_preserves_first_bd_id` on the target side: the combined
+// op must take the first DMA's target BD id (not next's) for the same
+// dominance reason.
+// CHECK-LABEL: @combine_preserves_first_target_bd_id
+// CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK:       %[[TILE:.+]] = amdaie.tile(%[[C0]], %[[C0]])
+// CHECK:       %[[CONNECTION:.+]] = amdaie.connection
+// CHECK:       %[[BD0:.+]] = amdaie.bd_id(%[[TILE]], %[[C0]])
+// CHECK:       amdaie.npu.dma_cpy_nd %[[CONNECTION]]([0, 0] [2, 16] [32, 1] bd_id = %[[BD0]], [] [] [])
+// CHECK-NOT:   amdaie.npu.dma_cpy_nd
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @combine_preserves_first_target_bd_id(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    amdaie.workgroup {
+      %tile = amdaie.tile(%c0, %c0)
+      %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+      amdaie.controlcode {
+        %bd0 = amdaie.bd_id(%tile, %c0)
+        amdaie.npu.dma_cpy_nd %0([0] [16] [1] bd_id = %bd0, [] [] [])
+        %bd1 = amdaie.bd_id(%tile, %c1)
+        amdaie.npu.dma_cpy_nd %0([32] [16] [1] bd_id = %bd1, [] [] [])
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// An `amdaie.npu.barrier` is a global ordering boundary: no combining may
+// cross it, even on the same connection.
+// CHECK-LABEL: @barrier_blocks_combine
+// CHECK:       %[[CONNECTION:.+]] = amdaie.connection
+// CHECK:       amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0] [16] [1])
+// CHECK-NEXT:  amdaie.npu.barrier
+// CHECK-NEXT:  amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [32] [16] [1])
+// CHECK-NOT:   amdaie.npu.dma_cpy_nd
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @barrier_blocks_combine(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32>>) {
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      amdaie.controlcode {
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
+        amdaie.npu.barrier
+        amdaie.npu.dma_cpy_nd %0([] [] [], [32] [16] [1])
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Mixed async/non-async combine is safe when the first DMA is non-async and the
+// second is async: the combined op inherits the second's async token, so the
+// trailing wait redirects to it. The reverse direction -- first async, second
+// non-async -- hits the `(token, empty)` bail in `createCombinedDoublyStridedOp`
+// (covered by `@do_not_combine_async_then_non_async`).
+// CHECK-LABEL: @combine_non_async_then_async
+// CHECK:       %[[CONNECTION:.+]] = amdaie.connection
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION]]([] [] [], [0, 0] [2, 16] [32, 1])
+// CHECK-NEXT:  amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_source_token)
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @combine_non_async_then_async(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32>>) {
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      amdaie.controlcode {
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
+        %1 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], [32] [16] [1])
+        amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Two combinable adjacent DMAs whose async-token shapes differ (one
+// `async_source`, one `async_target`) must not combine: a single combined op
+// can't carry both token kinds.
+// CHECK-LABEL: @do_not_combine_mismatched_async_token_shapes
+// CHECK:       %[[CONNECTION:.+]] = amdaie.connection
+// CHECK:       %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION]]([0] [16] [1], [0] [16] [1])
+// CHECK-NEXT:  %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_target %[[CONNECTION]]([32] [16] [1], [32] [16] [1])
+// CHECK-NEXT:  amdaie.npu.dma_wait(%[[NPU_DMA_0]] : !amdaie.async_source_token)
+// CHECK-NEXT:  amdaie.npu.dma_wait(%[[NPU_DMA_1]] : !amdaie.async_target_token)
+// CHECK-NOT:   amdaie.npu.dma_cpy_nd
+// CHECK-NOT:   amdaie.npu.dma_wait
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @do_not_combine_mismatched_async_token_shapes(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32>>) {
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      amdaie.controlcode {
+        %1 = amdaie.npu.dma_cpy_nd async_source %0([0] [16] [1], [0] [16] [1])
+        %2 = amdaie.npu.dma_cpy_nd async_target %0([32] [16] [1], [32] [16] [1])
+        amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
+        amdaie.npu.dma_wait(%2 : !amdaie.async_target_token)
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Symmetric to `@combine_non_async_then_async`: when the first DMA is async
+// (waited later) and the second is non-async, the combined op would need the
+// first's token but `replaceOp(nextStridedOp, newOp)` requires matching result
+// counts (1 vs 0). Bail; leave the ops separate.
+// CHECK-LABEL: @do_not_combine_async_then_non_async
+// CHECK:       %[[CONNECTION:.+]] = amdaie.connection
+// CHECK:       %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION]]([] [] [], [0] [16] [1])
+// CHECK-NEXT:  amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [32] [16] [1])
+// CHECK-NEXT:  amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_source_token)
+// CHECK-NOT:   amdaie.npu.dma_cpy_nd
+// CHECK-NOT:   amdaie.npu.dma_wait
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @do_not_combine_async_then_non_async(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32>>) {
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      amdaie.controlcode {
+        %1 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], [0] [16] [1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [32] [16] [1])
+        amdaie.npu.dma_wait(%1 : !amdaie.async_source_token)
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// A same-connection DMA actor of a *different kind* (here an
+// `npu.circular_dma_cpy_nd` between two `npu.dma_cpy_nd`s on the same
+// connection) blocks combining: hoisting the combined op before that work
+// would reorder the controlcode.
+// CHECK-LABEL: @do_not_combine_across_same_conn_different_actor
+// CHECK:       %[[CONNECTION:.+]] = amdaie.connection
+// CHECK:       amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [0] [16] [1])
+// CHECK-NEXT:  amdaie.npu.circular_dma_cpy_nd %[[CONNECTION]]([] [] [], [0] [16] [1])
+// CHECK-NEXT:  amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], [32] [16] [1])
+// CHECK-NOT:   amdaie.npu.dma_cpy_nd
+// CHECK-NOT:   amdaie.npu.circular_dma_cpy_nd
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @do_not_combine_across_same_conn_different_actor(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32>>) {
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      amdaie.controlcode {
+        amdaie.npu.dma_cpy_nd %0([] [] [], [0] [16] [1])
+        amdaie.npu.circular_dma_cpy_nd %0([] [] [], [0] [16] [1])
+        amdaie.npu.dma_cpy_nd %0([] [] [], [32] [16] [1])
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Route reuse: the same hardware connection drains two distinct logical source
+// objectFifos in different phases. Combining would silently keep the first
+// op's source operand and redirect the second phase to it, so the combiner
+// must bail.
+// CHECK-LABEL: @do_not_combine_route_reuse_different_source
+// CHECK:       %[[CONNECTION:.+]] = amdaie.connection
+// CHECK:       amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], %{{[^[]+}}[0] [16] [1])
+// CHECK-NEXT:  amdaie.npu.dma_cpy_nd %[[CONNECTION]]([] [] [], %{{[^[]+}}[32] [16] [1])
+// CHECK-NEXT:  amdaie.end
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @do_not_combine_route_reuse_different_source(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32>>, %arg2: !amdaie.logicalobjectfifo<memref<8x16xi32>>) {
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      amdaie.controlcode {
+        amdaie.npu.dma_cpy_nd %0([] [] [], %arg1 [0] [16] [1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        amdaie.npu.dma_cpy_nd %0([] [] [], %arg2 [32] [16] [1]) : source_type = !amdaie.logicalobjectfifo<memref<8x16xi32>>
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// Mirror of `@do_not_combine_route_reuse_different_source` on the target side.
+// CHECK-LABEL: @do_not_combine_route_reuse_different_target
+// CHECK:       %[[CONNECTION:.+]] = amdaie.connection
+// CHECK:       amdaie.npu.dma_cpy_nd %[[CONNECTION]](%{{[^[]+}}[0] [16] [1], [] [] [])
+// CHECK-NEXT:  amdaie.npu.dma_cpy_nd %[[CONNECTION]](%{{[^[]+}}[32] [16] [1], [] [] [])
+// CHECK-NEXT:  amdaie.end
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @do_not_combine_route_reuse_different_target(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, %arg1: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, %arg2: !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>) {
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg0, %arg2) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>, !amdaie.logicalobjectfifo<memref<8x16xi32, 1>>)
+      amdaie.controlcode {
+        amdaie.npu.dma_cpy_nd %0(%arg0 [0] [16] [1], [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
+        amdaie.npu.dma_cpy_nd %0(%arg1 [32] [16] [1], [] [] []) : target_type = !amdaie.logicalobjectfifo<memref<1x1x8x16xi32>>
+        amdaie.end
+      }
+    }
+    return
+  }
+}
+
+// -----
+
+// The combiner erases the first op's wait users wholesale. A multi-token wait
+// also synchronizes another DMA whose sync would be silently dropped, so the
+// combiner bails. (`FoldDmaWaits` runs after `DmaComposition` in the standard
+// pipeline so multi-token waits never reach the combiner; the precondition
+// guards hand-authored IR.)
+// CHECK-LABEL: @do_not_combine_when_wait_has_multiple_tokens
+// CHECK:       %[[CONNECTION_0:.+]] = amdaie.connection
+// CHECK:       %[[CONNECTION_1:.+]] = amdaie.connection
+// CHECK:       %[[NPU_DMA_0:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION_0]]([] [] [], [0] [16] [1])
+// CHECK-NEXT:  %[[NPU_DMA_1:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION_1]]([] [] [], [0] [16] [1])
+// CHECK-NEXT:  amdaie.npu.dma_wait(%[[NPU_DMA_0]], %[[NPU_DMA_1]] : !amdaie.async_source_token, !amdaie.async_source_token)
+// CHECK-NEXT:  amdaie.npu.dma_cpy_nd %[[CONNECTION_0]]([] [] [], [32] [16] [1])
+// CHECK-NOT:   amdaie.npu.dma_cpy_nd
+// CHECK-NOT:   amdaie.npu.dma_wait
+#executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
+module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
+  func.func @do_not_combine_when_wait_has_multiple_tokens(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32>>) {
+    amdaie.workgroup {
+      %0 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      %1 = amdaie.connection(%arg0, %arg1) : (!amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, !amdaie.logicalobjectfifo<memref<8x16xi32>>)
+      amdaie.controlcode {
+        %2 = amdaie.npu.dma_cpy_nd async_source %0([] [] [], [0] [16] [1])
+        %3 = amdaie.npu.dma_cpy_nd async_source %1([] [] [], [0] [16] [1])
+        amdaie.npu.dma_wait(%2, %3 : !amdaie.async_source_token, !amdaie.async_source_token)
+        amdaie.npu.dma_cpy_nd %0([] [] [], [32] [16] [1])
         amdaie.end
       }
     }

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/dma_composition.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/dma_composition.mlir
@@ -75,21 +75,23 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 // -----
 
 //===----------------------------------------------------------------------===//
-// Checks in which composition should happen.
+// Composition behavior with loops + same-connection waits.
 //===----------------------------------------------------------------------===//
 
-// CHECK-NOT:   affine_map
-// CHECK-LABEL: @combination_and_subsumption
+// Same-connection waits do not block combining in the loop body. The two DMAs
+// combine inside the body (the wait between them is skipped at the walk) and
+// then `scf.for` subsumption hoists the merged op out as a single higher-rank
+// DMA.
+// CHECK-LABEL: @combine_and_subsume_across_wait_in_loop_body
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:     scf.for
 // CHECK:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION]]([] [] [], [0, 0, 0, 0] [6, 2, 8, 16] [128, 32, 8, 1])
-// CHECK-NOT:     amdaie.npu.dma_cpy_nd
 // CHECK:         amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_source_token)
 #map = affine_map<(d0) -> (d0 * 16)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
-  func.func @combination_and_subsumption(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32>>) {
+  func.func @combine_and_subsume_across_wait_in_loop_body(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32>>) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c6 = arith.constant 6 : index
@@ -112,18 +114,22 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
 
 // -----
 
+// Subsumption folds the loop's inner DMA into [0, 0, 0] [6, 8, 16] [32, 8, 1].
+// The hoisted-out DMA and the outer DMA [0, 0, 32] [6, 8, 16] [32, 8, 1] share
+// source/target and connection, the result-type matrix matches (both
+// `async_source`), and the walker skips the intervening wait, so the combine
+// fires and the trailing wait redirects to the single merged DMA.
 // CHECK-NOT:   affine_map
-// CHECK-LABEL: @subsumption_and_combination
+// CHECK-LABEL: @subsumption_then_combination_across_wait
 // CHECK:       %[[CONNECTION:.+]] = amdaie.connection
 // CHECK:       amdaie.controlcode
 // CHECK-NOT:     scf.for
 // CHECK:         %[[NPU_DMA:.+]] = amdaie.npu.dma_cpy_nd async_source %[[CONNECTION]]([] [] [], [0, 0, 0, 0] [2, 6, 8, 16] [32, 32, 8, 1])
-// CHECK-NOT:     amdaie.npu.dma_cpy_nd
 // CHECK:         amdaie.npu.dma_wait(%[[NPU_DMA]] : !amdaie.async_source_token)
 #map = affine_map<(d0) -> (d0 * 32)>
 #executable_target_amdaie_xclbin_fb = #hal.executable.target<"amd-aie", "amdaie-xclbin-fb", {target_device = "npu1_4col", ukernels = "none"}>
 module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} {
-  func.func @subsumption_and_combination(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32>>) {
+  func.func @subsumption_then_combination_across_wait(%arg0: !amdaie.logicalobjectfifo<memref<1x1x8x16xi32, 1>>, %arg1: !amdaie.logicalobjectfifo<memref<8x16xi32>>) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c6 = arith.constant 6 : index


### PR DESCRIPTION
The combiner used to merge any two adjacent DMAs sharing a hardwareconnection. That silently aliased distinct logical transfers when a routewas reused for different phases (e.g. draining two outputs through oneconnection) -- empirically a numerical mismatch on tiny Llama.

Four fixes:

- Route-reuse guard: bail when `op.source != next.source` or `op.target != next.target`. Same connection is not same transfer.

- Phase-boundary policy in `findNextDmaOpWithSameConnection`: `npu.barrier` and any op with regions block; `npu.dma_wait` on the same connection blocks (a same-connection wait is a host-side push- queue flush -- the AIE2 shim DMA push queue is bounded per `getDmaMaxQueueSize`, and combining across it overflows). Unrelated- connection waits are skipped. Same-connection DMA of another kind blocks (would reorder controlcode); any other `amdaie.npu.*` op blocks deny-by-default (catches hand-authored `tct_sync`/`write_bd`/ etc); pure SSA setup is skipped. Queue-aware wait folding already lives downstream in `AMDAIEFoldDmaWaits` (which uses `getDmaMaxQueueSize`); the combiner stays structural.

- Multi-token-wait precondition: the combiner erases the first op's wait users wholesale, so each wait must reference only that op's tokens. Bail otherwise. `FoldDmaWaits` runs later in the standard flow, so this only guards hand-authored IR -- but encodes the assumption in code rather than a TODO.

- Build the combined op from the *first* DMA's operands (connection, source/target, BD ids) so they dominate the insertion point. The old code used the second op's operands and produced invalid IR when the second BD id was defined after the first. Result-type handling is asymmetric because `replaceOp(next, newOp)` requires matching result counts: combine `(empty, token)` and `(token, token same)`; bail on `(token, empty)` (1 vs 0; deliberate punt) and `(token, token diff)`.

An earlier revision of this commit also relaxed `findNext...` to skip same-connection waits. That overflowed the shim push queue on phoenix (observed: 7-deep push burst on (col=0, ch=0, S2MM); queue depth 4), producing dispatch-timeout (ert state 8) hangs on the `medium_i8` matmul sweep. Reverted: same-connection waits block again. Verified via per-channel burst analysis on a 4096x2048x4096 i8 matmul -- max burst drops from 7 (overflow) to 3 (safe).