### PR TITLE
Update CODEOWNERS for compiler directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 # CMakeLists.txt file to always ping a bunch of people.
 
 # Compiler
-/compiler/ @MaheshRavishankar @yzhang93 @Abhishek-Varma @jtuyls @newling @Yu-Zhewen
+/compiler/ @Abhishek-Varma @jtuyls


### PR DESCRIPTION
Removed several users from the CODEOWNERS for the compiler directory.