### PR TITLE
[Ukernel] Add Softmax ukernel for Peano NPU4

### DIFF
--- a/build_tools/ci/cpu_comparison/run.py
+++ b/build_tools/ci/cpu_comparison/run.py
@@ -22,6 +22,8 @@ import numpy as np
 
 from convolution_template.convolution_generator import ConvolutionMlirGenerator
 from input_generator import (
+    bf16_to_f32,
+    f32_to_bf16,
     generate_inputs,
     get_output_type,
     np_from_binfile,
@@ -2558,6 +2560,33 @@ class Tests:
         #                 ),
         #             )
         #         )
+
+        softmax_rng = np.random.default_rng(seed=0)
+        softmax_in_f32 = softmax_rng.uniform(-2.0, 2.0, size=(4, 128)).astype(
+            np.float32
+        )
+        softmax_in_bf16 = bf16_to_f32(f32_to_bf16(softmax_in_f32))
+        softmax_shifted = softmax_in_bf16 - softmax_in_bf16.max(axis=1, keepdims=True)
+        softmax_exp = np.exp(softmax_shifted)
+        softmax_out_ref = softmax_exp / softmax_exp.sum(axis=1, keepdims=True)
+        self.register(
+            Softmax(
+                4,
+                128,
+                "bf16",
+                test_params=TestParams(
+                    run_on_target=["npu4"],
+                    name_suffix="npu4_peano",
+                    use_chess=False,
+                    use_chess_for_ukernel=False,
+                    use_ukernel=True,
+                    tile_pipeline="general-copy",
+                    rtol=8e-2,
+                    preset_inputs={1: softmax_in_bf16},
+                    preset_output=softmax_out_ref,
+                ),
+            )
+        )
 
         # Reduction op tests:
         self.register(

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_c_embed_data(
     "uKernels/npu4/chess/trunci.cc"
     "uKernels/npu4/chess/zero_fill.cc"
     "uKernels/npu4/peano/matmul.cc"
+    "uKernels/npu4/peano/softmax.cc"
     "uKernels/npu4/peano/trunci.cc"
     "uKernels/npu4/peano/zero_fill.cc"
   C_FILE_OUTPUT

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/uKernels/npu4/peano/softmax.cc
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/uKernels/npu4/peano/softmax.cc
@@ -10,30 +10,32 @@ constexpr int kVecLanes = 32;
 
 // Horizontal max-reduce a v32bfloat16 to a single bf16.
 INTRINSIC(bfloat16) reduce_max_v32bf16(v32bfloat16 v) {
-  bfloat16 m = ext_elem(v, 0);
-  for (int i = 1; i < kVecLanes; ++i) {
-    bfloat16 e = ext_elem(v, i);
-    m = (e > m) ? e : m;
-  }
-  return m;
+  const v32bfloat16 z = broadcast_zero_to_v32bfloat16();
+  v = max(v, shift(v, z, 16));
+  v = max(v, shift(v, z, 8));
+  v = max(v, shift(v, z, 4));
+  v = max(v, shift(v, z, 2));
+  v = max(v, shift(v, z, 1));
+  return ext_elem(v, 0);
 }
 
 // Horizontal add-reduce a v32accfloat to a scalar float.
 INTRINSIC(float) reduce_add_v32accf(v32accfloat acc) {
-  v16accfloat r16 =
-      add(extract_v16accfloat(acc, 0), extract_v16accfloat(acc, 1));
-  v16bfloat16 r16b = to_v16bfloat16(r16);
-  v32bfloat16 r32b = set_v32bfloat16(0, r16b);
-  float s = 0.0f;
-  for (int i = 0; i < 16; ++i) {
-    s += (float)ext_elem(r32b, i);
-  }
-  return s;
+  const v16accfloat z = broadcast_zero_to_v16accfloat();
+  // Fold 32 -> 16 lanes (lossless), then a log2(16) = 4-step shift/add
+  // butterfly down to lane 0, all in accfloat.
+  v16accfloat r = add(extract_v16accfloat(acc, 0), extract_v16accfloat(acc, 1));
+  r = add(r, shift(r, z, 8));
+  r = add(r, shift(r, z, 4));
+  r = add(r, shift(r, z, 2));
+  r = add(r, shift(r, z, 1));
+  // Lane 0 holds the full f32 sum; narrow just that scalar to read it out.
+  return (float)ext_elem(set_v32bfloat16(0, to_v16bfloat16(r)), 0);
 }
 
 // Three-pass softmax over a contiguous bf16 row of length `n`, where
-// `n % 32 == 0`. Math involved in this implementation:
-//   pass 1: m = max_i(x_i * log2e)
+// `n % 32 == 0`. Math:
+//   pass 1: m = max_i(x_i) * log2e
 //   pass 2: e_i = 2^(x_i * log2e - m) ; sum = sum_i e_i ; out[i] = e_i
 //   pass 3: out[i] = e_i * (1 / sum)
 inline void softmax_bf16_impl(bfloat16 *restrict in, bfloat16 *restrict out,
@@ -42,43 +44,47 @@ inline void softmax_bf16_impl(bfloat16 *restrict in, bfloat16 *restrict out,
 
   const int32_t iters = n / kVecLanes;
 
-  // bf16 representable value of log2(e).
+  // bf16-representable value of log2(e). 1.4453125 = 0x3FB9 in bf16, same
+  // constant mlir-aie's aie_kernels/aie2p/softmax.cc uses.
   const v32bfloat16 log2e_v = broadcast_to_v32bfloat16((bfloat16)1.4453125f);
 
-  // ---- Pass 1: max-track of (x_i * log2e), in bf16 ---------------------
+  // ---- Pass 1: running max of the raw row -----------------------------
+  // 2^(x*log2e) is monotonic in x and log2e > 0, so
+  //   max_i(x_i * log2e) = log2e * max_i(x_i).
+  // Take the max in the raw x domain (no per-element multiply / demote)
+  // and fold the log2e factor into the single scalar multiply below.
   v32bfloat16 max_v = broadcast_to_v32bfloat16((bfloat16)-32768.0f);
   {
     const v32bfloat16 *restrict pIn = (const v32bfloat16 *)in;
     for (int32_t i = 0; i < iters; ++i) {
-      v32bfloat16 x = *pIn++;
-      v32accfloat scaled_acc = mul_elem_32(x, /*sgn_x=*/1, log2e_v,
-                                           /*sgn_y=*/1);
-      v32bfloat16 scaled_bf = to_v32bfloat16(scaled_acc);
-      max_v = max(max_v, scaled_bf);
+      max_v = max(max_v, *pIn++);
     }
   }
-  bfloat16 max_scalar = reduce_max_v32bf16(max_v);
-  v32accfloat max_acc = ups(broadcast_to_v32bfloat16(max_scalar));
+  // m = max_i(x_i) * log2e (one scalar multiply, kept in f32). Pre-negate
+  // and broadcast so pass 2 can fuse the scale-and-shift into one MAC.
+  const float neg_m = -((float)reduce_max_v32bf16(max_v) * 1.4453125f);
+  const v16accfloat neg_m16 = broadcast_to_v16accfloat(neg_m);
+  const v32accfloat neg_m_acc = concat(neg_m16, neg_m16);
 
   // ---- Pass 2: e_i = exp2(x_i * log2e - m); accumulate sum; store e_i --
-  v32accfloat sum_acc = ups(broadcast_to_v32bfloat16((bfloat16)0.0f));
+  // shifted = x_i * log2e - m in a single fused multiply-accumulate:
+  // mac_elem_32 computes neg_m_acc + x * log2e.
+  v32accfloat sum_acc = ups(broadcast_zero_to_v32bfloat16());
   {
     const v32bfloat16 *restrict pIn = (const v32bfloat16 *)in;
     v32bfloat16 *restrict pOut = (v32bfloat16 *)out;
     for (int32_t i = 0; i < iters; ++i) {
       v32bfloat16 x = *pIn++;
-      v32accfloat scaled = mul_elem_32(x, /*sgn_x=*/1, log2e_v,
-                                       /*sgn_y=*/1);
-      v32accfloat shifted = sub(scaled, max_acc);
+      v32accfloat shifted = mac_elem_32(x, /*sgn_x=*/1, log2e_v,
+                                        /*sgn_y=*/1, neg_m_acc);
       v32bfloat16 e = exp2(shifted);
       *pOut++ = e;
       sum_acc = add(sum_acc, ups(e));
     }
   }
 
-  // ---- Pass 3: out_i = e_i * (1 / sum) ---------------------------------
-  float total = reduce_add_v32accf(sum_acc);
-  bfloat16 inv_sum = (bfloat16)inv(total);
+  // ---- Pass 3: out_i = e_i * (1 / sum) --------------------------------
+  bfloat16 inv_sum = (bfloat16)inv(reduce_add_v32accf(sum_acc));
   v32bfloat16 inv_sum_v = broadcast_to_v32bfloat16(inv_sum);
   {
     const v32bfloat16 *restrict pIn = (const v32bfloat16 *)out;

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/uKernels/npu4/peano/softmax.cc
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/uKernels/npu4/peano/softmax.cc
@@ -1,0 +1,141 @@
+// Copyright 2026 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+namespace {
+
+constexpr int kVecLanes = 32;
+
+// Horizontal max-reduce a v32bfloat16 to a single bf16.
+INTRINSIC(bfloat16) reduce_max_v32bf16(v32bfloat16 v) {
+  bfloat16 m = ext_elem(v, 0);
+  for (int i = 1; i < kVecLanes; ++i) {
+    bfloat16 e = ext_elem(v, i);
+    m = (e > m) ? e : m;
+  }
+  return m;
+}
+
+// Horizontal add-reduce a v32accfloat to a scalar float.
+INTRINSIC(float) reduce_add_v32accf(v32accfloat acc) {
+  v16accfloat r16 =
+      add(extract_v16accfloat(acc, 0), extract_v16accfloat(acc, 1));
+  v16bfloat16 r16b = to_v16bfloat16(r16);
+  v32bfloat16 r32b = set_v32bfloat16(0, r16b);
+  float s = 0.0f;
+  for (int i = 0; i < 16; ++i) {
+    s += (float)ext_elem(r32b, i);
+  }
+  return s;
+}
+
+// Three-pass softmax over a contiguous bf16 row of length `n`, where
+// `n % 32 == 0`. Math involved in this implementation:
+//   pass 1: m = max_i(x_i * log2e)
+//   pass 2: e_i = 2^(x_i * log2e - m) ; sum = sum_i e_i ; out[i] = e_i
+//   pass 3: out[i] = e_i * (1 / sum)
+inline void softmax_bf16_impl(bfloat16 *restrict in, bfloat16 *restrict out,
+                              int32_t n) {
+  event0();
+
+  const int32_t iters = n / kVecLanes;
+
+  // bf16 representable value of log2(e).
+  const v32bfloat16 log2e_v = broadcast_to_v32bfloat16((bfloat16)1.4453125f);
+
+  // ---- Pass 1: max-track of (x_i * log2e), in bf16 ---------------------
+  v32bfloat16 max_v = broadcast_to_v32bfloat16((bfloat16)-32768.0f);
+  {
+    const v32bfloat16 *restrict pIn = (const v32bfloat16 *)in;
+    for (int32_t i = 0; i < iters; ++i) {
+      v32bfloat16 x = *pIn++;
+      v32accfloat scaled_acc = mul_elem_32(x, /*sgn_x=*/1, log2e_v,
+                                           /*sgn_y=*/1);
+      v32bfloat16 scaled_bf = to_v32bfloat16(scaled_acc);
+      max_v = max(max_v, scaled_bf);
+    }
+  }
+  bfloat16 max_scalar = reduce_max_v32bf16(max_v);
+  v32accfloat max_acc = ups(broadcast_to_v32bfloat16(max_scalar));
+
+  // ---- Pass 2: e_i = exp2(x_i * log2e - m); accumulate sum; store e_i --
+  v32accfloat sum_acc = ups(broadcast_to_v32bfloat16((bfloat16)0.0f));
+  {
+    const v32bfloat16 *restrict pIn = (const v32bfloat16 *)in;
+    v32bfloat16 *restrict pOut = (v32bfloat16 *)out;
+    for (int32_t i = 0; i < iters; ++i) {
+      v32bfloat16 x = *pIn++;
+      v32accfloat scaled = mul_elem_32(x, /*sgn_x=*/1, log2e_v,
+                                       /*sgn_y=*/1);
+      v32accfloat shifted = sub(scaled, max_acc);
+      v32bfloat16 e = exp2(shifted);
+      *pOut++ = e;
+      sum_acc = add(sum_acc, ups(e));
+    }
+  }
+
+  // ---- Pass 3: out_i = e_i * (1 / sum) ---------------------------------
+  float total = reduce_add_v32accf(sum_acc);
+  bfloat16 inv_sum = (bfloat16)inv(total);
+  v32bfloat16 inv_sum_v = broadcast_to_v32bfloat16(inv_sum);
+  {
+    const v32bfloat16 *restrict pIn = (const v32bfloat16 *)out;
+    v32bfloat16 *restrict pOut = (v32bfloat16 *)out;
+    for (int32_t i = 0; i < iters; ++i) {
+      v32bfloat16 e = *pIn++;
+      v32accfloat scaled = mul_elem_32(e, /*sgn_x=*/1, inv_sum_v,
+                                       /*sgn_y=*/1);
+      *pOut++ = to_v32bfloat16(scaled);
+    }
+  }
+
+  event1();
+}
+
+}  // namespace
+
+// Entry-point factory.
+// TODO(avarma): Revisit this to have just one ABI.
+//
+// Two ABIs are exposed here, so the same softmax.o serves both the `.aiec`
+// per-row flow and the linalg.softmax -> ukernel matcher flow.
+//
+//   1. Bareptr-friendly per-N row specialisations.
+//
+//   2. Per-(M,N) tile specialisations.
+extern "C" {
+
+#define SOFTMAX_BF16_PER_N(N)                                                \
+  void softmax_bf16_##N(bfloat16 *restrict input, unsigned input_offset,     \
+                        bfloat16 *restrict output, unsigned output_offset) { \
+    softmax_bf16_impl(input + input_offset, output + output_offset, (N));    \
+  }
+
+SOFTMAX_BF16_PER_N(32)
+SOFTMAX_BF16_PER_N(64)
+SOFTMAX_BF16_PER_N(128)
+SOFTMAX_BF16_PER_N(256)
+SOFTMAX_BF16_PER_N(512)
+SOFTMAX_BF16_PER_N(1024)
+SOFTMAX_BF16_PER_N(2048)
+
+#undef SOFTMAX_BF16_PER_N
+
+#define SOFTMAX_BF16_PER_MxN(M, N)                                             \
+  void softmax_bf16_##M##x##N(bfloat16 *restrict input, unsigned input_offset, \
+                              bfloat16 *restrict output,                       \
+                              unsigned output_offset) {                        \
+    bfloat16 *restrict in = input + input_offset;                              \
+    bfloat16 *restrict out = output + output_offset;                           \
+    for (int32_t r = 0; r < (M); ++r) {                                        \
+      softmax_bf16_impl(in + r * (N), out + r * (N), (N));                     \
+    }                                                                          \
+  }
+
+SOFTMAX_BF16_PER_MxN(4, 128)
+
+#undef SOFTMAX_BF16_PER_MxN
+
+}  // extern "C"

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/uKernels/npu4/peano/zero_fill.cc
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Target/uKernels/npu4/peano/zero_fill.cc
@@ -24,6 +24,20 @@ void zero_fill_vectorized(v16float *__restrict pC, unsigned offsetC) {
   }
 }
 
+// bf16 overload. aie2p has no broadcast_zero_to_v32bfloat16 helper, so we
+// splat a (bfloat16)0 via broadcast_to_v32bfloat16 (same intrinsic family
+// the softmax.cc kernel uses). Vector width r = 32 lanes (= 512 bits,
+// matching the i32/f32 overloads above on a per-store basis).
+template <int M, int N, int r, int u>
+void zero_fill_vectorized(v32bfloat16 *__restrict pC, unsigned offsetC) {
+  static_assert(M * N / r / u > 0);
+  v32bfloat16 zeros = broadcast_to_v32bfloat16((bfloat16)0.0f);
+#pragma clang loop unroll_count(M *N / r / u)
+  for (unsigned i = offsetC / r; i < offsetC / r + M * N / r; i++) {
+    pC[i] = zeros;
+  }
+}
+
 // clang-format off
 extern "C" {
 
@@ -32,6 +46,9 @@ extern "C" {
 
 #define zero_fill_combos_f32(X, M, N)  \
   X(v16float, f32, M, N, 16, 8)
+
+#define zero_fill_combos_bf16(X, M, N)  \
+  X(v32bfloat16, bf16, M, N, 32, 4)
 
 // A vectorized zeroization function on a buffer of size M * N with vectorization size
 // 'r' and unrolling factor 'u'. The unrolling factor is typically found experimentally.
@@ -47,6 +64,10 @@ zero_fill_combos_i32(zero_fill_vectorized_c_func, 64, 64)
 zero_fill_combos_f32(zero_fill_vectorized_c_func, 16, 8)
 zero_fill_combos_f32(zero_fill_vectorized_c_func, 16, 16)
 zero_fill_combos_f32(zero_fill_vectorized_c_func, 32, 32)
+
+// Matches the (M=4, N=128) per-core L1 tile chosen by
+// setRootConfigForSoftmaxCopyPipeline for the Softmax(4,128,"bf16") test.
+zero_fill_combos_bf16(zero_fill_vectorized_c_func, 4, 128)
 
 }  // extern "C"
 // clang-format on


### PR DESCRIPTION
This PR adds softmax ukernel for Peano npu4.
It currently exposes two ABIs : One for the HRX path and one for the iree-amd-aie codegen path (to be able to add tests). The latter can be removed once we have a stable workflow.

Signed-off-by: Abhishek Varma <abhvarma@amd.com>