### PR TITLE
Fix Utils library's dep on HAL::IR::IR

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/CMakeLists.txt
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/Utils/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_cc_library(
     "AMDAIEUtils.cpp"
   DEPS
     iree::compiler::Utils
+    iree::compiler::Dialect::HAL::IR::IR
     iree-amd-aie::aie_runtime::iree_aie_runtime_static
     iree::target::amd-aie::IR::AMDAIEDialect
   PUBLIC


### PR DESCRIPTION
-- AMDAIEUtils.cpp calls ExecutableTargetAttr::lookup and
   getConfiguration, but the Utils library's CMakeLists.txt was
   missing iree::compiler::Dialect::HAL::IR::IR as a dependency,
   causing linker issues.