### PR TITLE
[LowerToAIE] Fuse circuit DMA chains that share one channel

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.cpp
@@ -15,6 +15,7 @@
 
 #include <memory>
 #include <numeric>
+#include <tuple>
 
 #include "aie/AIEDialect.h"
 #include "aie/AIEXDialect.h"
@@ -24,6 +25,8 @@
 #include "iree-amd-aie/Transforms/Passes.h"
 #include "iree-amd-aie/Transforms/Utils/AMDAIEDmaUtils.h"
 #include "iree-amd-aie/Transforms/Utils/AMDAIEUtils.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
@@ -189,6 +192,111 @@ LogicalResult AIEDeviceBuilder::createDMABlocks(
       createDMAOps(succ, bufferOps[blockIndex], dims, isFirst, isLast,
                    transferLength, offset + addOffset);
       curr = succ;
+    }
+  }
+  return success();
+}
+
+LogicalResult AIEDeviceBuilder::mergeSharedChannelDmaChains(Operation *memOp) {
+  Region &region = memOp->getRegion(0);
+
+  // Group `aie.dma_start` ops by (direction, channel index), preserving the
+  // order in which they were created. A group with more than one entry means
+  // several object FIFOs were independently lowered onto one physical channel
+  // and must be fused into a single BD chain.
+  llvm::MapVector<std::pair<int, int>, SmallVector<AIE::DMAStartOp>> groups;
+  for (Block &block : region) {
+    for (AIE::DMAStartOp dmaStart : block.getOps<AIE::DMAStartOp>()) {
+      std::pair<int, int> key = {static_cast<int>(dmaStart.getChannelDir()),
+                                 static_cast<int>(dmaStart.getChannelIndex())};
+      groups[key].push_back(dmaStart);
+    }
+  }
+
+  for (auto &entry : groups) {
+    SmallVector<AIE::DMAStartOp> &dmaStarts = entry.second;
+    if (dmaStarts.size() < 2) continue;
+
+    // Collect each chain's BD blocks in chain order. A chain starts at the
+    // `dma_start`'s `dest` successor and is linked by `aie.next_bd` until it
+    // loops back to the first block.
+    SmallVector<SmallVector<Block *>> chains;
+    chains.reserve(dmaStarts.size());
+    bool mergeable = true;
+    for (AIE::DMAStartOp dmaStart : dmaStarts) {
+      SmallVector<Block *> bdBlocks;
+      Block *first = dmaStart.getDest();
+      Block *curr = first;
+      do {
+        // Only fuse pure circuit chains.
+        if (!curr->getOps<AIE::DMABDPACKETOp>().empty()) {
+          mergeable = false;
+          break;
+        }
+        bdBlocks.push_back(curr);
+        auto nextBd = dyn_cast<AIE::NextBDOp>(curr->getTerminator());
+        if (!nextBd) {
+          mergeable = false;
+          break;
+        }
+        curr = nextBd.getDest();
+      } while (curr != first);
+      if (!mergeable) break;
+      chains.push_back(std::move(bdBlocks));
+    }
+    if (!mergeable) continue;
+
+    // All chains must have equal length to round-robin interleave cleanly
+    // (they correspond to the same producer double-buffering depth).
+    size_t depth = chains.front().size();
+    if (llvm::any_of(chains, [&](const SmallVector<Block *> &c) {
+          return c.size() != depth;
+        })) {
+      return memOp->emitOpError()
+             << "cannot fuse DMA chains sharing channel " << entry.first.second
+             << ": chains have differing buffer-descriptor counts";
+    }
+
+    // Round-robin interleave: chain0[d], chain1[d], ..., for each depth `d`.
+    // This reproduces the producer's send order (values BD, then ids BD, ...)
+    // at the consuming end.
+    SmallVector<Block *> interleaved;
+    interleaved.reserve(depth * chains.size());
+    for (size_t d = 0; d < depth; ++d)
+      for (SmallVector<Block *> &c : chains) interleaved.push_back(c[d]);
+
+    // Relink the `aie.next_bd` terminators into one cyclic chain.
+    for (size_t i = 0; i < interleaved.size(); ++i) {
+      Block *next = interleaved[(i + 1) % interleaved.size()];
+      interleaved[i]->getTerminator()->setSuccessor(next, 0);
+    }
+
+    // Keep `dmaStarts[0]` as the single entry point for the channel; its `dest`
+    // already points at `interleaved[0]` (== chains[0][0]). Remove the other
+    // `dma_start` ops by bypassing them in the dma_start linked list (each
+    // `dma_start`'s second successor `chain` points at the next dma_start
+    // block) and erasing their (now BD-less) blocks.
+    for (size_t k = 1; k < dmaStarts.size(); ++k) {
+      AIE::DMAStartOp dead = dmaStarts[k];
+      Block *deadBlock = dead->getBlock();
+      Block *deadChain = dead.getChain();
+      AIE::DMAStartOp pred;
+      for (Block &block : region) {
+        auto candidate = dyn_cast<AIE::DMAStartOp>(block.getTerminator());
+        if (candidate && candidate != dead &&
+            candidate.getChain() == deadBlock) {
+          pred = candidate;
+          break;
+        }
+      }
+      if (!pred) {
+        return memOp->emitOpError()
+               << "failed to fuse shared-channel DMA chains: could not find "
+                  "the predecessor dma_start for channel "
+               << entry.first.second;
+      }
+      pred->setSuccessor(deadChain, 1);
+      rewriter.eraseBlock(deadBlock);
     }
   }
   return success();
@@ -944,6 +1052,34 @@ LogicalResult AIEDeviceBuilder::workgroupToAIE(AMDAIE::WorkgroupOp workgroupOp,
         });
   });
   if (res.wasInterrupted()) return failure();
+
+  // Fuse DMA chains that were independently lowered onto a single shared
+  // channel (e.g. a core's values + ids object FIFOs sent sequentially on one
+  // MM2S channel and collected on one memtile S2MM channel) into one BD chain.
+  // For channels owned by a single object FIFO this is a no-op.
+  for (auto &[tile, memOp] : tileToMemOpMap) {
+    if (failed(mergeSharedChannelDmaChains(memOp))) return failure();
+  }
+
+  // Remove duplicate `aie.flow` ops that arise when multiple connections share
+  // one circuit (e.g. the values + ids collects sharing a channel emit the same
+  // source->dest flow). A duplicate circuit flow would otherwise route the same
+  // stream-switch connection more than once.
+  {
+    llvm::DenseSet<std::tuple<const void *, int, int, const void *, int, int>>
+        seen;
+    SmallVector<AIE::FlowOp> deadFlows;
+    for (AIE::FlowOp flow : deviceBlock->getOps<AIE::FlowOp>()) {
+      auto key = std::make_tuple(flow.getSource().getAsOpaquePointer(),
+                                 static_cast<int>(flow.getSourceBundle()),
+                                 static_cast<int>(flow.getSourceChannel()),
+                                 flow.getDest().getAsOpaquePointer(),
+                                 static_cast<int>(flow.getDestBundle()),
+                                 static_cast<int>(flow.getDestChannel()));
+      if (!seen.insert(key).second) deadFlows.push_back(flow);
+    }
+    for (AIE::FlowOp flow : deadFlows) rewriter.eraseOp(flow);
+  }
 
   // Merge core operations into end of the device block
   rewriter.inlineBlockBefore(deviceCoreBlock, deviceBlock,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.h
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/AMDAIELowerToAIE.h
@@ -83,6 +83,18 @@ class AIEDeviceBuilder {
       const std::pair<AIE::LockOp, AIE::LockOp> &locks,
       std::optional<uint8_t> pktId);
 
+  /// Post-process a memory op (`aie.mem` or `aie.memtile_dma`) so that when two
+  /// or more *circuit* DMA chains were independently created for the SAME DMA
+  /// channel, they are fused into a single `aie.dma_start` whose BD chain
+  /// round-robin-interleaves the per-chain buffer descriptors. Hardware allows
+  /// only one BD-chain entry point per channel, so two object FIFOs that
+  /// intentionally share one channel (e.g. a core's values + ids outputs sent
+  /// sequentially on one MM2S channel and collected on one memtile S2MM
+  /// channel) must be merged here. The relative order of the chains is
+  /// preserved (chain 0's d-th BD, then chain 1's d-th BD, ...), so the same
+  /// send order is reproduced at both the producing and consuming ends.
+  LogicalResult mergeSharedChannelDmaChains(Operation *memOp);
+
   /// Utility to create flow ops from connection ops.
   SmallVector<Operation *> createFlowOps(
       AMDAIE::FlowOp flowOp, ArrayRef<AMDAIE::ChannelOp> producerChannels,

--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/Transforms/test/lower_to_aie.mlir
@@ -1422,3 +1422,75 @@ module attributes {hal.executable.target = #executable_target_amdaie_xclbin_fb} 
     return
   }
 }
+
+// -----
+
+// CHECK-LABEL: aie.device(npu4)
+// CHECK:      aie.flow(%{{.+}}, DMA : 0, %{{.+}}, DMA : 1)
+// CHECK-NOT:  aie.flow(%{{.+}}, DMA : 0, %{{.+}}, DMA : 1)
+// Shared memtile S2MM=1: one dma_start, BDs round-robin V0, I0, V1, I1 into the
+// two L2 FIFOs (f32 values, i32 ids).
+// CHECK:      aie.memtile_dma
+// CHECK:      aie.dma_start(S2MM, 1, ^[[V0:bb[0-9]+]], ^{{bb[0-9]+}})
+// CHECK:      ^[[V0]]:
+// CHECK:        aie.dma_bd(%{{.+}} : memref<2xf32, 1 : i32>)
+// CHECK:        aie.next_bd ^[[I0:bb[0-9]+]]
+// CHECK:      ^[[V1:bb[0-9]+]]:
+// CHECK:        aie.dma_bd(%{{.+}} : memref<2xf32, 1 : i32>)
+// CHECK:        aie.next_bd ^[[I1:bb[0-9]+]]
+// CHECK:      ^[[I0]]:
+// CHECK:        aie.dma_bd(%{{.+}} : memref<2xi32, 1 : i32>)
+// CHECK:        aie.next_bd ^[[V1]]
+// CHECK:      ^[[I1]]:
+// CHECK:        aie.dma_bd(%{{.+}} : memref<2xi32, 1 : i32>)
+// CHECK:        aie.next_bd ^[[V0]]
+#executable_target_amdaie_pdi_fb1 = #hal.executable.target<"amd-aie", "amdaie-pdi-fb", {num_cols = 8 : i32, num_rows = 4 : i32, target_device = "npu4", ukernels = "all"}>
+module attributes {hal.executable.target = #executable_target_amdaie_pdi_fb1} {
+  func.func @shared_channel_collect() attributes {translation_info = #iree_codegen.translation_info<pipeline = Custom>} {
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+    amdaie.workgroup {
+      %tile_0_0 = amdaie.tile(%c0, %c0)
+      %tile_0_1 = amdaie.tile(%c0, %c1)
+      %tile_0_2 = amdaie.tile(%c0, %c2)
+      // VALUES (f32): L1 on the core, L2 on the memtile.
+      %v_l1_b0 = amdaie.buffer(%tile_0_2) : memref<2xf32, 2 : i32>
+      %v_l1_b1 = amdaie.buffer(%tile_0_2) : memref<2xf32, 2 : i32>
+      %v_l1_s = amdaie.lock(%tile_0_2(0), 2)
+      %v_l1_d = amdaie.lock(%tile_0_2(1), 0)
+      %v_l1 = amdaie.logicalobjectfifo.from_buffers({%v_l1_b0, %v_l1_b1}, {%v_l1_s}, {%v_l1_d}) : memref<2xf32, 2 : i32>, memref<2xf32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<2xf32, 2 : i32>, 2>
+      %v_l2_b0 = amdaie.buffer(%tile_0_1) : memref<2xf32, 1 : i32>
+      %v_l2_b1 = amdaie.buffer(%tile_0_1) : memref<2xf32, 1 : i32>
+      %v_l2_s = amdaie.lock(%tile_0_1(0), 2)
+      %v_l2_d = amdaie.lock(%tile_0_1(1), 0)
+      %v_l2 = amdaie.logicalobjectfifo.from_buffers({%v_l2_b0, %v_l2_b1}, {%v_l2_s}, {%v_l2_d}) : memref<2xf32, 1 : i32>, memref<2xf32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2xf32, 1 : i32>, 2>
+      // IDS (i32): L1 on the core, L2 on the memtile.
+      %i_l1_b0 = amdaie.buffer(%tile_0_2) : memref<2xi32, 2 : i32>
+      %i_l1_b1 = amdaie.buffer(%tile_0_2) : memref<2xi32, 2 : i32>
+      %i_l1_s = amdaie.lock(%tile_0_2(2), 2)
+      %i_l1_d = amdaie.lock(%tile_0_2(3), 0)
+      %i_l1 = amdaie.logicalobjectfifo.from_buffers({%i_l1_b0, %i_l1_b1}, {%i_l1_s}, {%i_l1_d}) : memref<2xi32, 2 : i32>, memref<2xi32, 2 : i32> -> !amdaie.logicalobjectfifo<memref<2xi32, 2 : i32>, 2>
+      %i_l2_b0 = amdaie.buffer(%tile_0_1) : memref<2xi32, 1 : i32>
+      %i_l2_b1 = amdaie.buffer(%tile_0_1) : memref<2xi32, 1 : i32>
+      %i_l2_s = amdaie.lock(%tile_0_1(2), 2)
+      %i_l2_d = amdaie.lock(%tile_0_1(3), 0)
+      %i_l2 = amdaie.logicalobjectfifo.from_buffers({%i_l2_b0, %i_l2_b1}, {%i_l2_s}, {%i_l2_d}) : memref<2xi32, 1 : i32>, memref<2xi32, 1 : i32> -> !amdaie.logicalobjectfifo<memref<2xi32, 1 : i32>, 2>
+      // VALUES + IDS collect L1->L2 SHARE core mm2s=0 and memtile s2mm=1.
+      %v_mm2s = amdaie.channel(%tile_0_2, 0, port_type = DMA, direction = MM2S)
+      %v_s2mm = amdaie.channel(%tile_0_1, 1, port_type = DMA, direction = S2MM)
+      %v_flow = amdaie.flow({%v_mm2s} -> {%v_s2mm}) {is_packet_flow = false}
+      %v_collect = amdaie.connection(%v_l2 {%v_s2mm}, %v_l1 {%v_mm2s}, flow = %v_flow) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<2xf32, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<2xf32, 2 : i32>, 2>)
+      %i_mm2s = amdaie.channel(%tile_0_2, 0, port_type = DMA, direction = MM2S)
+      %i_s2mm = amdaie.channel(%tile_0_1, 1, port_type = DMA, direction = S2MM)
+      %i_flow = amdaie.flow({%i_mm2s} -> {%i_s2mm}) {is_packet_flow = false}
+      %i_collect = amdaie.connection(%i_l2 {%i_s2mm}, %i_l1 {%i_mm2s}, flow = %i_flow) {connection_type = #amdaie<connection_type Circuit>} : (!amdaie.logicalobjectfifo<memref<2xi32, 1 : i32>, 2>, !amdaie.logicalobjectfifo<memref<2xi32, 2 : i32>, 2>)
+      amdaie.controlcode {
+        %a = amdaie.npu.circular_dma_cpy_nd %v_collect([0] [2] [1], [0] [2] [1])
+        %b = amdaie.npu.circular_dma_cpy_nd %i_collect([0] [2] [1], [0] [2] [1])
+        amdaie.end
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
When two object FIFOs are intentionally lowered onto the same physical DMA channel, each FIFO emits its own aie.dma_start, leaving two BD-chain entry points on one channel, which is invalid on hardware.

This PR thus adds a mergeSharedChannelDmaChains, which :-
1. Groups dma_start ops by (direction, channel)
2. Round-robin interleave their BD blocks into a single cyclic next_bd chain,
3. Drops the redundant dma_start ops.

Only pure-circuit chains are supported.
Also dedup the identical aie.flow ops the shared connections emit.